### PR TITLE
fix typo in Docker command

### DIFF
--- a/source/ossec_docker.rst
+++ b/source/ossec_docker.rst
@@ -92,7 +92,7 @@ OSSEC HIDS  Container
 These Docker container source files can be found in our `ossec-server Github repository <https://github.com/wazuh/docker-ossec>`_. To install it run this command: ::
 
    $ docker run --name ossec-server -d -p 1514:1514/udp -p 1515:1515\
-  -e SYSLOG_FORWADING_ENABLED=true -e SYSLOG_FORWARDING_SERVER_IP=X.X.X.X\
+  -e SYSLOG_FORWARDING_ENABLED=true -e SYSLOG_FORWARDING_SERVER_IP=X.X.X.X\
   -v /somepath/ossec_mnt:/var/ossec/data wazuh/docker-ossec
 
 The ``/var/ossec/data`` directory allows the container to be replaced without configuration or data loss: logs, etc, stats,rules, and queue. In addition to those directories, the bin/.process_list file is symlinked to process_list in the data volume.


### PR DESCRIPTION
Fixed a typo in the "docker run" command for OSSEC HIDS Container where "SYSLOG_FORWARDING_ENABLED" was missing a letter.