### PR TITLE
Added comment for Docker for OSX

### DIFF
--- a/source/docker/wazuh-container.rst
+++ b/source/docker/wazuh-container.rst
@@ -27,6 +27,12 @@ On distributions which have SELinux enabled out-of-the-box, you will need to eit
   .-root@centos ~
   -$ chcon -R system_u:object_r:admin_home_t:s0 docker-elk/
 
+Docker for OSX
+^^^^^^^^^^
+
+In Docker for OSX there is a default memory limit of 2GB, in order to run `docker-compose up` successfully you have to change default memory settings from 2GB to at least 4 or 5GB. To do so, click on the Docker icon in the menu bar, then "Preferences...", go to "Advanced" tab and set 5GB of memory, then click on "Apply & Restart" and run `docker-compose up`.
+
+
 Usage
 -------------------------------
 


### PR DESCRIPTION
Default memory in Docker for OSX is set to 2GB and has to be to at least 4 or 5GB to make docker-compose work.