### PR TITLE
Some grammatical suggestions for easier reading...

### DIFF
--- a/source/installation-guide/installing-wazuh-agent/wazuh_agent_windows.rst
+++ b/source/installation-guide/installing-wazuh-agent/wazuh_agent_windows.rst
@@ -13,7 +13,7 @@ Download the Windows installer from our :doc:`packages list<../packages-list/ind
 
      Double click on the downloaded file and follow the wizard. If unsure, leave default answers.
 
-Once installed, the agent includes a graphic user interface that can be used to configure it, to open the log file or to start/stop the service.
+Once installed, the agent includes a graphical user interface that can be used for configuration, opening the log file or to start/stop the service.
 
   .. thumbnail:: ../../images/manual/windows-agent.png
       :align: center


### PR DESCRIPTION
Also, on the MacOS install page (https://documentation.wazuh.com/current/installation-guide/installing-wazuh-agent/wazuh_agent_macos.html) at the very end the "visit our user manual" has a nice link for "user manual" that takes you to the manual. My I suggest that the link take you directly to the agents page in the manual (https://documentation.wazuh.com/current/user-manual/agents/index.html). ALSO: this suggestion would be great for the other pages: 
https://documentation.wazuh.com/current/installation-guide/installing-wazuh-agent/wazuh_agent_rpm.html
https://documentation.wazuh.com/current/installation-guide/installing-wazuh-agent/wazuh_agent_deb.html
https://documentation.wazuh.com/current/installation-guide/installing-wazuh-agent/wazuh_agent_sources.html (two spots)
Have a great weekend everyone.