### PR TITLE
There is a minor typo in example

### DIFF
--- a/source/user-manual/capabilities/policy-monitoring/openscap/oscap-configuration.rst
+++ b/source/user-manual/capabilities/policy-monitoring/openscap/oscap-configuration.rst
@@ -59,7 +59,7 @@ Manager ``shared/agent.conf``:
   <agent_config profile="redhat7">
 
     <wodle name="open-scap">
-      <content type="xccdf" path="ssg-rhel7-ds.xml">
+      <content type="xccdf" path="ssg-rhel-7-ds.xml">
         <profile>xccdf_org.ssgproject.content_profile_pci-dss</profile>
       </content>
     </wodle>


### PR DESCRIPTION
Minor typo of rhel7 for the example file configuration - which should be rhel-7-ds.xml on line 62.
As shown in the files on disk:
-rw-r-----. 1 root ossec 6074837 Sep 18 22:13 cve-redhat-7-ds.xml
-rw-r-----. 1 root ossec 8594571 Sep 18 22:13 ssg-rhel-7-ds.xml