### PR TITLE
Several fixes on the documentation

### DIFF
--- a/source/installation-guide/installing-wazuh-server/wazuh_server_deb.rst
+++ b/source/installation-guide/installing-wazuh-server/wazuh_server_deb.rst
@@ -67,7 +67,7 @@ Installing Wazuh API
 
 	.. code-block:: console
 
-		# curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
+		# curl -sL https://deb.nodesource.com/setup_6.x | bash -
 
    and then, install nodejs:
 


### PR DESCRIPTION
* Since now the documentation is written keeping in mind that the user is in `sudo` mode, it's no longer necessary to write the `sudo` command.
* The upgrading guide lacks the commands to restart Kibana after the package upgrade.