### PR TITLE
Freeze the installation guide to Elastic 6.1.1

### DIFF
--- a/source/installation-guide/installing-elastic-stack/elastic_server_deb.rst
+++ b/source/installation-guide/installing-elastic-stack/elastic_server_deb.rst
@@ -51,7 +51,7 @@ Elasticsearch is a highly scalable full-text search and analytics engine. For mo
 
   .. code-block:: console
 
-    # apt-get install elasticsearch=6.1.0
+    # apt-get install elasticsearch=6.1.1
 
 2. Enable and start the Elasticsearch service:
 
@@ -99,7 +99,7 @@ Logstash is the tool that will collect, parse, and forward to Elasticsearch for 
 
   .. code-block:: console
 
-    # apt-get install logstash=1:6.1.0-1
+    # apt-get install logstash=1:6.1.1-1
 
 2. Download the Wazuh config for Logstash:
 
@@ -152,7 +152,7 @@ Kibana is a flexible and intuitive web interface for mining and visualizing the 
 
   .. code-block:: console
 
-   # apt-get install kibana=6.1.0
+   # apt-get install kibana=6.1.1
 
 2. Install the Wazuh App plugin for Kibana:
 

--- a/source/installation-guide/installing-elastic-stack/elastic_server_rpm.rst
+++ b/source/installation-guide/installing-elastic-stack/elastic_server_rpm.rst
@@ -59,7 +59,7 @@ Elasticsearch is a highly scalable full-text search and analytics engine. For mo
 
   .. code-block:: console
 
-	 # yum install elasticsearch-6.1.0
+	 # yum install elasticsearch-6.1.1
 
 2. Enable and start the Elasticsearch service:
 
@@ -107,7 +107,7 @@ Logstash is the tool that will collect, parse, and forward to Elasticsearch for 
 
   .. code-block:: console
 
-    # yum install logstash-6.1.0
+    # yum install logstash-6.1.1
 
 2. Download the Wazuh config for Logstash:
 
@@ -168,17 +168,17 @@ Kibana is a flexible and intuitive web interface for mining and visualizing the 
 
   .. code-block:: console
 
-	 # yum install kibana-6.1.0
+	 # yum install kibana-6.1.1
 
 2. Install the Wazuh App plugin for Kibana:
 
-  2.1) Increase the default Node.js heap memory limit to prevent out of memory errors when installing the Wazuh App. 
+  2.1) Increase the default Node.js heap memory limit to prevent out of memory errors when installing the Wazuh App.
   Set the limit as follow:
 
   .. code-block:: console
 
       # export NODE_OPTIONS="--max-old-space-size=3072"
-      
+
   2.2) Install Wazuh App:
 
   .. code-block:: console

--- a/source/installation-guide/installing-wazuh-server/wazuh_server_deb.rst
+++ b/source/installation-guide/installing-wazuh-server/wazuh_server_deb.rst
@@ -138,13 +138,13 @@ The DEB package is suitable for Debian, Ubuntu, and other Debian-based systems.
 
 	.. code-block:: console
 
-		# apt-get install filebeat=6.1.0
+		# apt-get install filebeat=6.1.1
 
 3. Download the Filebeat config file from the Wazuh repository, which is preconfigured to forward Wazuh alerts to Logstash:
 
 	.. code-block:: console
 
-		# curl -so /etc/filebeat/filebeat.yml https://raw.githubusercontent.com/wazuh/wazuh/3.0/extensions/filebeat/filebeat.yml
+		# curl -so /etc/filebeat/filebeat.yml https://raw.githubusercontent.com/wazuh/wazuh/3.1/extensions/filebeat/filebeat.yml
 
 4. Edit the file ``/etc/filebeat/filebeat.yml`` and replace ``ELASTIC_SERVER_IP`` with the IP address or the hostname of the Elastic Stack server. For example:
 

--- a/source/installation-guide/installing-wazuh-server/wazuh_server_rpm.rst
+++ b/source/installation-guide/installing-wazuh-server/wazuh_server_rpm.rst
@@ -175,7 +175,7 @@ The RPM package is suitable for installation on Red Hat, CentOS and other modern
 
   .. code-block:: console
 
-	 # yum install filebeat-6.1.0
+	 # yum install filebeat-6.1.1
 
 3. Download the Filebeat config file from the Wazuh repository, which is preconfigured to forward Wazuh alerts to Logstash:
 

--- a/source/installation-guide/upgrading/different_major.rst
+++ b/source/installation-guide/upgrading/different_major.rst
@@ -172,14 +172,14 @@ Upgrade Elasticsearch
 
     .. code-block:: console
 
-      # yum install elasticsearch-6.1.0
+      # yum install elasticsearch-6.1.1
 
   b) For Debian/Ubuntu:
 
     .. code-block:: console
 
       # apt-get update
-      # apt-get install elasticsearch=6.1.0
+      # apt-get install elasticsearch=6.1.1
 
 
 2. Start Elasticsearch:
@@ -218,13 +218,13 @@ Upgrade Logstash
 
     .. code-block:: console
 
-      # yum install logstash-6.1.0
+      # yum install logstash-6.1.1
 
   b) For Debian/Ubuntu:
 
     .. code-block:: console
 
-      # apt-get install logstash=1:6.1.0-1
+      # apt-get install logstash=1:6.1.1-1
 
 
 2. Download and set the Wazuh configuration for Logstash:
@@ -263,13 +263,13 @@ Upgrade Kibana
 
     .. code-block:: console
 
-      # yum install kibana-6.1.0
+      # yum install kibana-6.1.1
 
   b) For Debian/Ubuntu:
 
     .. code-block:: console
 
-      # apt-get install kibana=6.1.0
+      # apt-get install kibana=6.1.1
 
 
 2. Remove the Wazuh Kibana App plugin from Kibana:
@@ -320,13 +320,13 @@ Upgrade Filebeat
 
     .. code-block:: console
 
-      # yum install filebeat-6.1.0
+      # yum install filebeat-6.1.1
 
   b) For Debian/Ubuntu:
 
     .. code-block:: console
 
-      # apt-get install filebeat=6.1.0
+      # apt-get install filebeat=6.1.1
 
 
 Official Upgrading guides for Elastic Stack:


### PR DESCRIPTION
This PR adapts the installation guide for Elastic Stack v6.1.1, in order to avoid problems when the Elastic team releases a new version of its stack.