### PR TITLE
Modified Java JRE install instructions for Ubuntu

### DIFF
--- a/source/installation-guide/installing-elastic-stack/elastic_server_deb.rst
+++ b/source/installation-guide/installing-elastic-stack/elastic_server_deb.rst
@@ -12,28 +12,39 @@ Preparation
 
 1. Oracle Java JRE is required by Logstash and Elasticsearch:
 
-  a) For Debian:
+  .. note::
+
+      The following command accepts the necessary cookies to download Oracle Java JRE. Please, visit `Oracle Java 8 JRE Download Page <https://www.java.com/en/download/manual.jsp>`_ for more information.
+
+  Download the binary package with the latest version:
 
   .. code-block:: console
 
-    # echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu xenial main" | tee /etc/apt/sources.list.d/webupd8team-java.list
-    # echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu xenial main" | tee -a /etc/apt/sources.list.d/webupd8team-java.list
-    # apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886
+      # curl -Lo jre-8-linux-x64.tar.gz --header "Cookie: oraclelicense=accept-securebackup-cookie" http://download.oracle.com/otn-pub/java/jdk/8u161-b12/2f38c3b165be4555a1fa6e98c45e0808/jre-8u161-linux-x64.tar.gz
 
-  b) For Ubuntu:
+  Extract the package and move it to the default Java installation path:
 
   .. code-block:: console
 
-	 # add-apt-repository ppa:webupd8team/java
+      # tar -zxf jre-8-linux-x64.tar.gz
+      # JAVA=$(echo jre1.8*)
+      # mv $JAVA /opt
 
-2. Once the repository is added, install Java JRE:
+  Export the necessary environment variables in order to properly execute the Java binaries:
 
   .. code-block:: console
 
-  	# apt-get update
-  	# apt-get install oracle-java8-installer
+      # echo export PATH=$PATH:/opt/$JAVA/bin >> /etc/profile
+      # echo export JAVA_HOME=/opt/$JAVA >> /etc/profile
 
-3. Install the Elastic repository and its GPG key:
+  And finally, check if the installation process finished successfully:
+
+  .. code-block:: console
+
+      # . /etc/profile
+      # java -version
+
+2. Install the Elastic repository and its GPG key:
 
   .. code-block:: console
 


### PR DESCRIPTION
This PR modifies the Elastic installation guide for Debian systems, using the official Oracle binaries.