### PR TITLE
Freeze the Elastic Stack for 5.6.5 on the 2.1 documentation

### DIFF
--- a/source/installation-guide/installing-elastic-stack/elastic_server_deb.rst
+++ b/source/installation-guide/installing-elastic-stack/elastic_server_deb.rst
@@ -51,7 +51,7 @@ Elasticsearch is a highly scalable full-text search and analytics engine. For mo
 
   .. code-block:: bash
 
-    $ apt-get install elasticsearch
+    $ apt-get install elasticsearch=5.6.5
 
 2. Enable and start the Elasticsearch service:
 
@@ -95,7 +95,7 @@ Logstash is the tool that will collect, parse, and forward to Elasticsearch for 
 
   .. code-block:: bash
 
-    $ apt-get install logstash
+    $ apt-get install logstash=1:5.6.5-1
 
 2. Download the Wazuh config for Logstash:
 
@@ -150,7 +150,7 @@ Kibana is a flexible and intuitive web interface for mining and visualizing the 
 
   .. code-block:: bash
 
-   $ apt-get install kibana
+   $ apt-get install kibana=5.6.5
 
 2. Install the Wazuh App plugin for Kibana:
 

--- a/source/installation-guide/installing-elastic-stack/elastic_server_deb.rst
+++ b/source/installation-guide/installing-elastic-stack/elastic_server_deb.rst
@@ -189,6 +189,14 @@ Kibana is a flexible and intuitive web interface for mining and visualizing the 
    $ update-rc.d kibana defaults 95 10
    $ service kibana start
 
+5. Disable the Elastic repository:
+
+  We recommend to disable the Elasticsearch repository in order to prevent an upgrade to a newer Elastic Stack version due to possible breaking changes with our App, so you should do it as follow:
+
+  .. code-block:: console
+
+    $ sed -i -r '/deb https:\/\/artifacts.elastic.co\/packages\/5.x\/apt stable main/ s/^(.*)$/#\1/g' /etc/apt/sources.list.d/elastic-5.x.list
+
 Connecting the Wazuh App with the API
 -------------------------------------
 

--- a/source/installation-guide/installing-elastic-stack/elastic_server_rpm.rst
+++ b/source/installation-guide/installing-elastic-stack/elastic_server_rpm.rst
@@ -59,7 +59,7 @@ Elasticsearch is a highly scalable full-text search and analytics engine. For mo
 
   .. code-block:: bash
 
-	 $ yum install elasticsearch
+	 $ yum install elasticsearch-5.6.5
 
 2. Enable and start the Elasticsearch service:
 
@@ -103,7 +103,7 @@ Logstash is the tool that will collect, parse, and forward to Elasticsearch for 
 
   .. code-block:: bash
 
-    $ yum install logstash
+    $ yum install logstash-5.6.5
 
 2. Download the Wazuh config for Logstash:
 
@@ -167,7 +167,7 @@ Kibana is a flexible and intuitive web interface for mining and visualizing the 
 
   .. code-block:: bash
 
-	 $ yum install kibana
+	 $ yum install kibana-5.6.5
 
 2. Install the Wazuh App plugin for Kibana:
 

--- a/source/installation-guide/installing-elastic-stack/elastic_server_rpm.rst
+++ b/source/installation-guide/installing-elastic-stack/elastic_server_rpm.rst
@@ -206,6 +206,14 @@ Kibana is a flexible and intuitive web interface for mining and visualizing the 
   	$ chkconfig --add kibana
   	$ service kibana start
 
+5. Disable the Elasticsearch repository:
+
+  We recommend to disable the Elasticsearch repository in order to prevent an upgrade to a newer Elastic Stack version due to possible breaking changes with our App, so you should do it as follow:
+
+  .. code-block:: console
+
+    $ sed -i "s/^enabled=1/enabled=0/" /etc/yum.repos.d/elastic.repo
+
 Connecting the Wazuh App with the API
 -------------------------------------
 

--- a/source/installation-guide/installing-wazuh-server/wazuh_server_deb.rst
+++ b/source/installation-guide/installing-wazuh-server/wazuh_server_deb.rst
@@ -144,7 +144,7 @@ The DEB package is suitable for Debian, Ubuntu, and other Debian-based systems.
 
 	.. code-block:: bash
 
-		$ apt-get install filebeat
+		$ apt-get install filebeat=5.6.5
 
 3. Download the Filebeat config file from the Wazuh repository, which is preconfigured to forward Wazuh alerts to Logstash:
 

--- a/source/installation-guide/installing-wazuh-server/wazuh_server_rpm.rst
+++ b/source/installation-guide/installing-wazuh-server/wazuh_server_rpm.rst
@@ -200,7 +200,7 @@ The RPM package is suitable for installation on Red Hat, CentOS and other modern
 
   .. code-block:: bash
 
-	 $ yum install filebeat
+	 $ yum install filebeat-5.6.5
 
 3. Download the Filebeat config file from the Wazuh repository, which is preconfigured to forward Wazuh alerts to Logstash:
 


### PR DESCRIPTION
Hi everyone,

This PR modifies the 2.1 documentation in order to freeze the installation process to the 5.6.5 version of the Elastic Stack since we're not providing more support for the latest versions of Elastic 5.x.

This PR adds the commands to install the specific package, and later disable the Elastic repositories for avoiding package upgrades.