### PR TITLE
Update Elastic to 6.2.2

### DIFF
--- a/source/installation-guide/installing-elastic-stack/elastic_server_deb.rst
+++ b/source/installation-guide/installing-elastic-stack/elastic_server_deb.rst
@@ -51,7 +51,7 @@ Elasticsearch is a highly scalable full-text search and analytics engine. For mo
 
   .. code-block:: console
 
-    # apt-get install elasticsearch=6.2.1
+    # apt-get install elasticsearch=6.2.2
 
 2. Enable and start the Elasticsearch service:
 
@@ -99,7 +99,7 @@ Logstash is the tool that collects, parses, and forwards data to Elasticsearch f
 
   .. code-block:: console
 
-    # apt-get install logstash=1:6.2.1-1
+    # apt-get install logstash=1:6.2.2-1
 
 2. Download the Wazuh configuration file for Logstash:
 
@@ -152,7 +152,7 @@ Kibana is a flexible and intuitive web interface for mining and visualizing the 
 
   .. code-block:: console
 
-   # apt-get install kibana=6.2.1
+   # apt-get install kibana=6.2.2
 
 2. Install the Wazuh App plugin for Kibana:
 

--- a/source/installation-guide/installing-elastic-stack/elastic_server_rpm.rst
+++ b/source/installation-guide/installing-elastic-stack/elastic_server_rpm.rst
@@ -59,7 +59,7 @@ Elasticsearch is a highly scalable full-text search and analytics engine. For mo
 
   .. code-block:: console
 
-	 # yum install elasticsearch-6.2.1
+	 # yum install elasticsearch-6.2.2
 
 2. Enable and start the Elasticsearch service:
 
@@ -107,7 +107,7 @@ Logstash is the tool that collects, parses, and forwards data to Elasticsearch f
 
   .. code-block:: console
 
-    # yum install logstash-6.2.1
+    # yum install logstash-6.2.2
 
 2. Download the Wazuh configuration file for Logstash:
 
@@ -168,7 +168,7 @@ Kibana is a flexible and intuitive web interface for mining and visualizing the 
 
   .. code-block:: console
 
-	 # yum install kibana-6.2.1
+	 # yum install kibana-6.2.2
 
 2. Install the Wazuh App plugin for Kibana:
 

--- a/source/installation-guide/installing-wazuh-server/wazuh_server_deb.rst
+++ b/source/installation-guide/installing-wazuh-server/wazuh_server_deb.rst
@@ -138,7 +138,7 @@ The DEB package is suitable for Debian, Ubuntu, and other Debian-based systems.
 
 	.. code-block:: console
 
-		# apt-get install filebeat=6.2.1
+		# apt-get install filebeat=6.2.2
 
 3. Download the Filebeat config file from the Wazuh repository. This is pre-configured to forward Wazuh alerts to Logstash:
 

--- a/source/installation-guide/installing-wazuh-server/wazuh_server_rpm.rst
+++ b/source/installation-guide/installing-wazuh-server/wazuh_server_rpm.rst
@@ -178,7 +178,7 @@ The RPM package is suitable for installation on Red Hat, CentOS and other modern
 
   .. code-block:: console
 
-	 # yum install filebeat-6.2.1
+	 # yum install filebeat-6.2.2
 
 3. Download the Filebeat configuration file from the Wazuh repository. This is pre-configured to forward Wazuh alerts to Logstash:
 

--- a/source/installation-guide/upgrading/different_major.rst
+++ b/source/installation-guide/upgrading/different_major.rst
@@ -172,14 +172,14 @@ Upgrade Elasticsearch
 
     .. code-block:: console
 
-      # yum install elasticsearch-6.2.1
+      # yum install elasticsearch-6.2.2
 
   b) For Debian/Ubuntu:
 
     .. code-block:: console
 
       # apt-get update
-      # apt-get install elasticsearch=6.2.1
+      # apt-get install elasticsearch=6.2.2
 
 
 2. Start Elasticsearch:
@@ -218,13 +218,13 @@ Upgrade Logstash
 
     .. code-block:: console
 
-      # yum install logstash-6.2.1
+      # yum install logstash-6.2.2
 
   b) For Debian/Ubuntu:
 
     .. code-block:: console
 
-      # apt-get install logstash=1:6.2.1-1
+      # apt-get install logstash=1:6.2.2-1
 
 
 2. Download and set the Wazuh configuration for Logstash:
@@ -263,13 +263,13 @@ Upgrade Kibana
 
     .. code-block:: console
 
-      # yum install kibana-6.2.1
+      # yum install kibana-6.2.2
 
   b) For Debian/Ubuntu:
 
     .. code-block:: console
 
-      # apt-get install kibana=6.2.1
+      # apt-get install kibana=6.2.2
 
 
 2. Remove the Wazuh Kibana App plugin from Kibana:
@@ -319,13 +319,13 @@ Upgrade Filebeat
 
     .. code-block:: console
 
-      # yum install filebeat-6.2.1
+      # yum install filebeat-6.2.2
 
   b) For Debian/Ubuntu:
 
     .. code-block:: console
 
-      # apt-get install filebeat=6.2.1
+      # apt-get install filebeat=6.2.2
 
 2. Download the Filebeat configuration file from the Wazuh repository:
 


### PR DESCRIPTION
Hello all,

This PR updates the documentation to the latest release of the Elastic Stack, v6.2.2, released February 20th, 2018.

This commit should be merged once we finished the new Wazuh App package for Wazuh 3.2 and this new release of Elastic.