### PR TITLE
Updated Oracle Java version for RPM

### DIFF
--- a/source/installation-guide/installing-elastic-stack/elastic_server_rpm.rst
+++ b/source/installation-guide/installing-elastic-stack/elastic_server_rpm.rst
@@ -18,7 +18,7 @@ Preparation
 
   .. code-block:: bash
 
-      $ curl -Lo jre-8-linux-x64.rpm --header "Cookie: oraclelicense=accept-securebackup-cookie" "http://download.oracle.com/otn-pub/java/jdk/8u151-b12/e758a0de34e24606bca991d704f6dcbf/jre-8u151-linux-x64.rpm"
+      $ curl -Lo jre-8-linux-x64.rpm --header "Cookie: oraclelicense=accept-securebackup-cookie" "http://download.oracle.com/otn-pub/java/jdk/8u161-b12/2f38c3b165be4555a1fa6e98c45e0808/jre-8u161-linux-x64.rpm"
 
   Now check if the package was download successfully:
 


### PR DESCRIPTION
Hello all,

This small PR updates the **Oracle Java installer URL** with the latest available version in the Elastic Stack RPM Installation Guide. This fix is necessary since Oracle **archived the previous version** and is no longer available for download.

Regards,
Juanjo