### PR TITLE
Removes some OS from the vulnerability-detector compatibility table

### DIFF
--- a/source/user-manual/capabilities/vulnerability-detection.rst
+++ b/source/user-manual/capabilities/vulnerability-detection.rst
@@ -33,11 +33,11 @@ The following table shows the operating systems that the vulnerability detector 
 +---------------+-------------+
 | Distribution  | Versions    |
 +===============+=============+
-| Redhat        | 5, 6, 7     |
+| Redhat        | 6, 7        |
 +---------------+-------------+
-| Centos        | 5, 6, 7     |
+| Centos        | 6, 7        |
 +---------------+-------------+
-| Ubuntu        | 12, 14, 16  |
+| Ubuntu        | 14, 16      |
 +---------------+-------------+
 
 Use case: Running a vulnerability scan
@@ -48,7 +48,7 @@ The following example shows how to configure the necessary components to run the
 1. Enable the agent module used to collect installed packages on the monitored system.
 
   You can do this adding the following block of settings to your agent configuration file:
-  
+
   .. code-block:: xml
 
       <wodle name="syscollector">
@@ -56,9 +56,9 @@ The following example shows how to configure the necessary components to run the
         <interval>1h</interval>
         <packages>yes</packages>
       </wodle>
- 
- Remember to restart the agent to apply changes: ``/var/ossec/bin/ossec-control restart``     
- 
+
+ Remember to restart the agent to apply changes: ``/var/ossec/bin/ossec-control restart``
+
  Check :doc:`Syscollector settings<../reference/ossec-conf/wodle-syscollector>` for more details.
 
 2. Enable the manager module used to detect vulnerabilities.
@@ -75,7 +75,7 @@ The following example shows how to configure the necessary components to run the
         <update_redhat_oval interval="15h" version="7,6">yes</update_redhat_oval>
       </wodle>
 
- Remember to restart the manager to apply changes: ``/var/ossec/bin/ossec-control restart``     
+ Remember to restart the manager to apply changes: ``/var/ossec/bin/ossec-control restart``
 
  Check :doc:`Vulnerability detector settings<../reference/ossec-conf/wodle-vuln-detector>` for more details.
 


### PR DESCRIPTION
Syscollector does not collect the packages for the deleted operating systems, so they are not taken into account.