### PR TITLE
Minor elastic fix

### DIFF
--- a/source/installation-guide/optional-configurations/elastic-tuning.rst
+++ b/source/installation-guide/optional-configurations/elastic-tuning.rst
@@ -177,7 +177,7 @@ If you want to change these settings, you will need to edit the Elasticsearch te
 
   {
     "order": 0,
-    "template": "wazuh*",
+    "template": "wazuh-alerts-3.x-*",
     "settings": {
       "index.refresh_interval": "5s",
       "number_of_shards" :   1,

--- a/source/installation-guide/upgrading/different_major.rst
+++ b/source/installation-guide/upgrading/different_major.rst
@@ -262,7 +262,7 @@ Upgrade Logstash
 
     .. code-block:: console
 
-      # cp /etc/logstash/conf.d/01-wazuh.conf /etc/logstash/conf.d/01-wazuh.conf.bak
+      # cp /etc/logstash/conf.d/01-wazuh.conf /backup_directory/01-wazuh.conf.bak
       # curl -so /etc/logstash/conf.d/01-wazuh.conf https://raw.githubusercontent.com/wazuh/wazuh/3.2/extensions/logstash/01-wazuh-local.conf
       # usermod -a -G ossec logstash
 
@@ -270,7 +270,7 @@ Upgrade Logstash
 
     .. code-block:: console
 
-      # cp /etc/logstash/conf.d/01-wazuh.conf /etc/logstash/conf.d/01-wazuh.conf.bak
+      # cp /etc/logstash/conf.d/01-wazuh.conf /backup_directory/01-wazuh.conf.bak
       # curl -so /etc/logstash/conf.d/01-wazuh.conf https://raw.githubusercontent.com/wazuh/wazuh/3.2/extensions/logstash/01-wazuh-remote.conf
 
 


### PR DESCRIPTION
Hi team, this pull request fixes two things:

- Replace template from `wazuh*` to `wazuh-alerts-3.x-*` on the Elastic tunning section to avoid conflict with the `wazuh-monitoring` index.
- Change the backup directory from Logstash configuration to avoid multiple configurations being loaded on `/etc/logstash`.

Best,
Jesús