### PR TITLE
Update manual-integration.rst

### DIFF
--- a/source/user-manual/manager/manual-integration.rst
+++ b/source/user-manual/manager/manual-integration.rst
@@ -49,6 +49,7 @@ Integration with Slack
     <integration>
       <name>slack</name>
       <hook_url>https://hooks.slack.com/services/...</hook_url>
+      <alert_format>json</alert_format>
     </integration>
 
 


### PR DESCRIPTION
Slack integration fails if alert_format is not set in ossec.conf, can also be found in this part:
https://documentation.wazuh.com/3.x/user-manual/reference/ossec-conf/integration.html#configuration-example