### PR TITLE
Add information about agent registration in cluster

### DIFF
--- a/source/user-manual/manager/wazuh-cluster.rst
+++ b/source/user-manual/manager/wazuh-cluster.rst
@@ -150,6 +150,14 @@ Follow these steps to deploy a Wazuh cluster:
         # systemctl restart wazuh-manager
 
 
+.. _agent-registration-cluster:
+
+Agent registration in the cluster
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**All agents must be registered in the master node**. The master is responsible for replicating the new agent's information across all client nodes. If an agent is registered in a client node, it will be deleted by the master node.
+
+
 Configuring the Wazuh Kibana App
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/source/user-manual/registering/registration-process.rst
+++ b/source/user-manual/registering/registration-process.rst
@@ -52,3 +52,7 @@ Here are three ways to register an agent:
 +               +-----------------------------------------------------------------+------------------------------------------------------------------------+
 |               | :ref:`Using the RESTful API <restful-api-register>`             | Register an agent by scripting (bash, python, powershell) and the API. |
 +---------------+-----------------------------------------------------------------+------------------------------------------------------------------------+
+
+.. note::
+
+	If you're running Wazuh in cluster mode, refer to the :ref:`Configuring a cluster section <agent-registration-cluster>` to get more details about the registration process in the cluster.


### PR DESCRIPTION
Hello,

This PR fixes #234. It adds a subsection explaining how to register agents in the cluster and, also, a note in the _registering agents_ section that links directly to the cluster page.

Best regards,
Marta