### PR TITLE
Change active-response example to pass logtest

### DIFF
--- a/source/user-manual/capabilities/active-response/how-it-works.rst
+++ b/source/user-manual/capabilities/active-response/how-it-works.rst
@@ -52,12 +52,12 @@ Active responses are configured in the manager by modifying the :ref:`ossec.conf
 
 	Example::
 
-		<active‐response>
+		<active-response>
 		  <command>host‐deny</command>
 		  <location>local</location>
 		  <level>7</level>
 		  <timeout>600</timeout>
-		</active‐response>
+		</active-response>
 
 	In this example, the active response is configured to execute the command that was defined in the previous step. The *where* of the action is defined as the local host and the *when* is defined as any time the rule has a level higher than 6.  The timeout that was allowed in the command configuration is also defined in the above example.
 


### PR DESCRIPTION
Hello team,

I was testing `active-response` following the docs when I copied this example:

```xml
<active‐response>
  <command>host‐deny</command>
  <location>local</location>
  <level>7</level>
  <timeout>600</timeout>
</active‐response>
```

I realized that `ossec-logtest` returned an error in that section:

```
# /var/ossec/bin/ossec-logtest
2018/06/11 16:16:21 ossec-testrule: ERROR: (1230): Invalid element in the configuration: 'active‐response'.
2018/06/11 16:16:21 ossec-testrule: ERROR: (1202): Configuration error at '/var/ossec/etc/ossec.conf'.
2018/06/11 16:16:21 ossec-testrule: CRITICAL: (1202): Configuration error at '/var/ossec/etc/ossec.conf'.
```

And with the help of @vikman90, we discovered that the `-` character was wrong. 

This PR fixes this issue.

Best regards,
Marta