### PR TITLE
Logcollector out format

### DIFF
--- a/source/release-notes/release_3_3_0.rst
+++ b/source/release-notes/release_3_3_0.rst
@@ -20,7 +20,7 @@ Logcollector now supports socket connection for log output mirroring. This featu
 
 The analysis engine includes new options for the :ref:`plugin decoders <decoders_syntax>` to set the input offset with respect to the prematch expression or the parent decoder. See an example about this on :ref:`this section <json_decoder_example_3.3>`. In addition, plugin decoders and multi-regex decoders can be used together.
 
-We have also introduced an event formatter in the log collector to build custom events, this allows to add some data into the event.
+We have also introduced an :ref:`event formatter <ossec_localfile_out_format>` in the log collector to build custom events, this allows to add some data into the event.
 
 As of this version, the timestamp of the alerts in JSON format will include milliseconds.
 

--- a/source/user-manual/reference/ossec-conf/localfile.rst
+++ b/source/user-manual/reference/ossec-conf/localfile.rst
@@ -24,6 +24,7 @@ Options
 - `only-future-events`_
 - `query`_
 - `label`_
+- `target`_
 - `log_format`_
 
 location
@@ -178,6 +179,8 @@ The additional fields configured above would appear in the resulting event as be
 
 target
 ^^^^^^
+
+.. versionadded:: 3.3.0
 
 Target specifies the name of the socket where the output will be redirected. The socket must be defined previously to use it with this option.
 

--- a/source/user-manual/reference/ossec-conf/localfile.rst
+++ b/source/user-manual/reference/ossec-conf/localfile.rst
@@ -129,7 +129,7 @@ For example, the following configuration will only process events with an ID of 
 label
 ^^^^^
 
-  .. versionadded:: 3.0.0
+.. versionadded:: 3.0.0
 
 This option allows for the addition of custom data in JSON events and is available when `log_format`_ is set to ``json``.
 
@@ -197,7 +197,6 @@ log_format
 This specifies the format of the log being read. **It is required field.**
 
 .. note:: For most of the text log files that only have one entry per line, syslog may be used.
-
 
 +--------------------+-------------------------------------------------------------------------------------------------------------------+
 | **Default value**  | n/a                                                                                                               |
@@ -282,6 +281,8 @@ Sample Log message as analyzed by ossec-analysisd:
 .. code-block:: console
 
 	Aug 9 14:22:47 hostname log line one Aug 9 14:22:47 hostname log line two Aug 9 14:22:47 hostname log line three Aug 9 14:22:47 hostname log line four Aug 9 14:22:47 hostname log line five
+
+.. _ossec_localfile_out_format:
 
 out_format
 ^^^^^^^^^^

--- a/source/user-manual/reference/ossec-conf/localfile.rst
+++ b/source/user-manual/reference/ossec-conf/localfile.rst
@@ -26,6 +26,7 @@ Options
 - `label`_
 - `target`_
 - `log_format`_
+- `out_format`_
 
 location
 ^^^^^^^^
@@ -281,6 +282,39 @@ Sample Log message as analyzed by ossec-analysisd:
 .. code-block:: console
 
 	Aug 9 14:22:47 hostname log line one Aug 9 14:22:47 hostname log line two Aug 9 14:22:47 hostname log line three Aug 9 14:22:47 hostname log line four Aug 9 14:22:47 hostname log line five
+
+out_format
+^^^^^^^^^^
+
+.. versionadded:: 3.3.0
+
+This option allows formatting logs from Logcollector using field substitution.
+
+The syntax is:
+
+::
+
+	$(parameter)
+
+The list of available parameters is:
+
++------------------------+-----------------------------------------------------------------------+
+| **Parameter**          | **Description**                                                       |
++========================+=======================================================================+
+| ``log``                | Message from the log.                                                 |
++------------------------+-----------------------------------------------------------------------+
+| ``output``             | Output from a command. Alias of ``log``.                              |
++------------------------+-----------------------------------------------------------------------+
+| ``location``           | Path to the source log file.                                          |
++------------------------+-----------------------------------------------------------------------+
+| ``command``            | Command line or alias defined for the command. Alias of ``location``. |
++------------------------+-----------------------------------------------------------------------+
+| ``timestamp``          | Current timestamp (when the log is sent), in RFC3164 format.          |
++------------------------+-----------------------------------------------------------------------+
+| ``timestamp <format>`` | Custom timestamp, in ``strftime`` string format.                      |
++------------------------+-----------------------------------------------------------------------+
+| ``hostname``           | System's host name.                                                   |
++------------------------+-----------------------------------------------------------------------+
 
 Configuration examples
 ----------------------


### PR DESCRIPTION
This adds the reference of the option `out_format` for Logcollector.
Development PR: https://github.com/wazuh/wazuh/pull/423