### PR TITLE
Add option <ca_verification> to Active Reponse reference manual

### DIFF
--- a/source/user-manual/reference/ossec-conf/active-response.rst
+++ b/source/user-manual/reference/ossec-conf/active-response.rst
@@ -27,6 +27,7 @@ Options
 - `timeout`_
 - `repeated_offenders`_
 - `ca_store`_
+- `ca_verification`_
 
 disabled
 ^^^^^^^^
@@ -162,9 +163,20 @@ ca_store
 Indicates the path to the root CA certificate. The agent needs the certificate with which the WPK was signed in order to be updated.
 
 +--------------------+-----------------------------+
-| **Default value**  | n/a                         |
+| **Default value**  | wpk_root.pem                |
 +--------------------+-----------------------------+
 | **Allowed values** | Path to root CA certificate |
++--------------------+-----------------------------+
+
+ca_verification
+^^^^^^^^^^^^^^^
+
+This option enables or disables the WPK validation using the root CA certificate. If this parameter is set to ``no`` the agent will accept any WPK package coming from the manager.
+
++--------------------+-----------------------------+
+| **Default value**  | yes                         |
++--------------------+-----------------------------+
+| **Allowed values** | yes, no                     |
 +--------------------+-----------------------------+
 
 Sample Configuration


### PR DESCRIPTION
This PR adds the documentation reference for this option:

```xml
<active-response>
  <ca_verification>no</ca_verification>
</active-response>
```

It also updates the default value of the option `<ca_store>`.

Related PR: https://github.com/wazuh/wazuh/pull/799