### PR TITLE
Replaces policycoreutils-python-utils dependency with policycoreutils

### DIFF
--- a/source/installation-guide/installing-wazuh-agent/wazuh_agent_sources.rst
+++ b/source/installation-guide/installing-wazuh-agent/wazuh_agent_sources.rst
@@ -27,7 +27,7 @@ Installing Linux agent
 
   .. code-block:: console
 
-      # apt-get install make gcc libc6-dev curl policycoreutils-python-utils automake autoconf libtool
+      # apt-get install make gcc libc6-dev curl policycoreutils automake autoconf libtool
 
 2. Download and extract the latest version:
 

--- a/source/installation-guide/installing-wazuh-server/sources_installation.rst
+++ b/source/installation-guide/installing-wazuh-server/sources_installation.rst
@@ -24,7 +24,7 @@ Installing Wazuh manager
 
     .. code-block:: console
 
-      # apt-get install python gcc make libc6-dev curl policycoreutils-python-utils automake autoconf libtool
+      # apt-get install python gcc make libc6-dev curl policycoreutils automake autoconf libtool
 
 2. Download and extract the latest version:
 


### PR DESCRIPTION
The _policycoreutils-python-utils dependency_ is not found on as many systems as the _policycoreutils_ dependency, which can be replaced for compiling Wazuh. 

Tested on Debian 8 and Ubuntu 18.04.