### PR TITLE
Remove aws inspector from supported services

### DIFF
--- a/source/amazon/index.rst
+++ b/source/amazon/index.rst
@@ -7,7 +7,7 @@ Using Wazuh to Monitor AWS
 
 .. versionadded:: 3.2.0
 
-Wazuh provides the ability to read AWS logs directly from AWS S3 buckets. Amazon support is now a built-in Wazuh capability, giving you the ability to search, analyze, and alert on AWS CloudTrail, GuardDuty, Macie, Inspector, IAM, and VPC Flow log data.
+Wazuh provides the ability to read AWS logs directly from AWS S3 buckets. Amazon support is now a built-in Wazuh capability, giving you the ability to search, analyze, and alert on AWS CloudTrail, GuardDuty, Macie, IAM, and VPC Flow log data.
 
 This section provides instructions to configure the integration with S3 with both CloudTrail and Custom S3 buckets. In addition, it explains different use cases, as examples of how the rules can be customized for alerting on specific events.
 

--- a/source/amazon/installation.rst
+++ b/source/amazon/installation.rst
@@ -85,10 +85,10 @@ VPC Flow
     :width: 100%
 
 
-Other AWS Services (Guard Duty, Macie, IAM and Inspector)
+Other AWS Services (Guard Duty, Macie and IAM)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This section explains how to get logs from Guard Duty, Macie, IAM and Inspector.
+This section explains how to get logs from Guard Duty, Macie and IAM.
 
 1. Go to Services > Storage > S3:
 

--- a/source/release-notes/release_3_6_0.rst
+++ b/source/release-notes/release_3_6_0.rst
@@ -38,7 +38,7 @@ Two new features have been added to **file integrity monitoring**:
 Wazuh modules
 ^^^^^^^^^^^^^
 
-- Introducing a re-work of the AWS S3 integration, now supporting CloudTrail, GuardDuty, Macie, Inspector, IAM, and VPC Flow log data.
+- Introducing a re-work of the AWS S3 integration, now supporting CloudTrail, GuardDuty, Macie, IAM, and VPC Flow log data.
 - The download of OVAL files for Vulnerability Detector has been fixed since Red Hat has changed its protocol to send this files.
 - Custom command execution (wodle command) supports MD5/SHA1/SHA256 validation of the target binary for execution authorization.
 


### PR DESCRIPTION
Hello team,

This PR removes AWS Inspector from supported AWS services in the AWS S3 integration. The reason is that we're able to save AWS Inspector logs to an S3 bucket but not AWS Inspector alerts. The logs stored doesn't raise any alert since the events aren't security related.

Best regards,
Marta