### PR TITLE
Fixed owner:group for some Kibana folders when upgrading

### DIFF
--- a/source/installation-guide/upgrading/different_major.rst
+++ b/source/installation-guide/upgrading/different_major.rst
@@ -341,8 +341,6 @@ Upgrade Kibana
   .. code-block:: console
 
       # rm -rf /usr/share/kibana/optimize/bundles
-      # chown -R kibana:kibana /usr/share/kibana/optimize
-      # chown -R kibana:kibana /usr/share/kibana/plugins
       # sudo -u kibana /usr/share/kibana/bin/kibana-plugin install https://packages.wazuh.com/wazuhapp/wazuhapp-3.6.1_6.4.0.zip
 
 

--- a/source/installation-guide/upgrading/different_major.rst
+++ b/source/installation-guide/upgrading/different_major.rst
@@ -305,12 +305,19 @@ Upgrade Kibana
       # apt-get install kibana=6.4.0
 
 
-2. Remove the Wazuh Kibana App plugin from Kibana:
+2. Uninstall the Wazuh app from Kibana:
+
+    a) Update file permissions. This will avoid several errors prior to updating the app:
 
     .. code-block:: console
 
       # chown -R kibana:kibana /usr/share/kibana/optimize
       # chown -R kibana:kibana /usr/share/kibana/plugins
+
+    b) Remove the Wazuh app:
+
+    .. code-block:: console
+
       # sudo -u kibana /usr/share/kibana/bin/kibana-plugin remove wazuh
 
 

--- a/source/installation-guide/upgrading/different_major.rst
+++ b/source/installation-guide/upgrading/different_major.rst
@@ -309,6 +309,8 @@ Upgrade Kibana
 
     .. code-block:: console
 
+      # chown -R kibana:kibana /usr/share/kibana/optimize
+      # chown -R kibana:kibana /usr/share/kibana/plugins
       # sudo -u kibana /usr/share/kibana/bin/kibana-plugin remove wazuh
 
 

--- a/source/installation-guide/upgrading/different_major.rst
+++ b/source/installation-guide/upgrading/different_major.rst
@@ -332,6 +332,8 @@ Upgrade Kibana
   .. code-block:: console
 
       # rm -rf /usr/share/kibana/optimize/bundles
+      # chown -R kibana:kibana /usr/share/kibana/optimize
+      # chown -R kibana:kibana /usr/share/kibana/plugins
       # sudo -u kibana /usr/share/kibana/bin/kibana-plugin install https://packages.wazuh.com/wazuhapp/wazuhapp-3.6.1_6.4.0.zip
 
 

--- a/source/installation-guide/upgrading/latest_wazuh3_minor.rst
+++ b/source/installation-guide/upgrading/latest_wazuh3_minor.rst
@@ -248,6 +248,8 @@ Upgrade Kibana
   .. code-block:: console
 
     # rm -rf /usr/share/kibana/optimize/bundles
+    # chown -R kibana:kibana /usr/share/kibana/optimize
+    # chown -R kibana:kibana /usr/share/kibana/plugins
     # sudo -u kibana /usr/share/kibana/bin/kibana-plugin install https://packages.wazuh.com/wazuhapp/wazuhapp-3.6.1_6.4.0.zip
 
 .. warning::

--- a/source/installation-guide/upgrading/latest_wazuh3_minor.rst
+++ b/source/installation-guide/upgrading/latest_wazuh3_minor.rst
@@ -231,10 +231,17 @@ Upgrade Kibana
 
 2. Uninstall the Wazuh app from Kibana:
 
+  a) Update file permissions. This will avoid several errors prior to updating the app:
+
   .. code-block:: console
 
     # chown -R kibana:kibana /usr/share/kibana/optimize
     # chown -R kibana:kibana /usr/share/kibana/plugins
+
+  b) Remove the Wazuh app:
+
+  .. code-block:: console
+
     # sudo -u kibana /usr/share/kibana/bin/kibana-plugin remove wazuh
 
 3. Upgrade the Wazuh app:
@@ -250,8 +257,6 @@ Upgrade Kibana
   .. code-block:: console
 
     # rm -rf /usr/share/kibana/optimize/bundles
-    # chown -R kibana:kibana /usr/share/kibana/optimize
-    # chown -R kibana:kibana /usr/share/kibana/plugins
     # sudo -u kibana /usr/share/kibana/bin/kibana-plugin install https://packages.wazuh.com/wazuhapp/wazuhapp-3.6.1_6.4.0.zip
 
 .. warning::

--- a/source/installation-guide/upgrading/latest_wazuh3_minor.rst
+++ b/source/installation-guide/upgrading/latest_wazuh3_minor.rst
@@ -233,6 +233,8 @@ Upgrade Kibana
 
   .. code-block:: console
 
+    # chown -R kibana:kibana /usr/share/kibana/optimize
+    # chown -R kibana:kibana /usr/share/kibana/plugins
     # sudo -u kibana /usr/share/kibana/bin/kibana-plugin remove wazuh
 
 3. Upgrade the Wazuh app:

--- a/source/installation-guide/upgrading/same_major.rst
+++ b/source/installation-guide/upgrading/same_major.rst
@@ -64,6 +64,8 @@ Upgrade the Wazuh Kibana App
 
     .. code-block:: console
 
+        # chown -R kibana:kibana /usr/share/kibana/optimize
+        # chown -R kibana:kibana /usr/share/kibana/plugins
         # /usr/share/kibana/bin/kibana-plugin remove wazuh
 
 2) Once the process is complete, stop Kibana:

--- a/source/installation-guide/upgrading/same_major.rst
+++ b/source/installation-guide/upgrading/same_major.rst
@@ -62,11 +62,18 @@ Upgrade the Wazuh Kibana App
 
 1) On your terminal, remove the current Wazuh Kibana App:
 
+  a) Update file permissions. This will avoid several errors prior to updating the app:
+
     .. code-block:: console
 
-        # chown -R kibana:kibana /usr/share/kibana/optimize
-        # chown -R kibana:kibana /usr/share/kibana/plugins
-        # /usr/share/kibana/bin/kibana-plugin remove wazuh
+      # chown -R kibana:kibana /usr/share/kibana/optimize
+      # chown -R kibana:kibana /usr/share/kibana/plugins
+
+  b) Remove the Wazuh app:
+
+    .. code-block:: console
+
+      # sudo -u kibana /usr/share/kibana/bin/kibana-plugin remove wazuh
 
 2) Once the process is complete, stop Kibana:
 

--- a/source/installation-guide/upgrading/same_major.rst
+++ b/source/installation-guide/upgrading/same_major.rst
@@ -109,7 +109,7 @@ Upgrade the Wazuh Kibana App
 
     .. code-block:: console
 
-        # /usr/share/kibana/bin/kibana-plugin install https://packages.wazuh.com/wazuhapp/wazuhapp-2.1.1_5.6.5.zip
+        # sudo -u kibana /usr/share/kibana/bin/kibana-plugin install https://packages.wazuh.com/wazuhapp/wazuhapp-2.1.1_5.6.5.zip
 
 5) Once the process is complete, restart Kibana:
 


### PR DESCRIPTION
Hello team, this PR avoids permission problems with old Wazuh application installations. As we are using `sudo -u kibana` some environments need to change the owner of the `optimization` and `plugins` folders.

```
# chown -R kibana:kibana /usr/share/kibana/optimize
# chown -R kibana:kibana /usr/share/kibana/plugins
```

Regards!