### PR TITLE
Update Puppet Documentation

### DIFF
--- a/source/deploying-with-puppet/setup-puppet/install-puppet-agent.rst
+++ b/source/deploying-with-puppet/setup-puppet/install-puppet-agent.rst
@@ -40,13 +40,16 @@ Get the appropriate Puppet apt repository, and then the "puppet-agent" package. 
   # apt update
   # apt-get install -y puppet-agent
 
-.. note:: 
+.. note:: For a correct installation we recommend the use of Puppet versions equal or greater than 5. 
+
+
+.. note:: The releases supported by the manifest to install Wazuh are as follows: 
+
+      Ubuntu: **precise | trusty | vivid | wily | xenial | yakketi**
+
+      Debian: **jessie | wheezy | stretch | sid**
   
-  For a correct installation we recommend the use of Puppet versions equal or greater than 5. The releases supported by the manifest to install Wazuh are as follows: 
 
-  Ubuntu: precise|trusty|vivid|wily|xenial|yakketi
-
-  Debian: jessie|wheezy|stretch|sid
 
 Configuration
 ^^^^^^^^^^^^^

--- a/source/deploying-with-puppet/setup-puppet/install-puppet-agent.rst
+++ b/source/deploying-with-puppet/setup-puppet/install-puppet-agent.rst
@@ -10,7 +10,7 @@ In this section we assume you have already installed the ``apt`` or ``yum`` Pupp
 Installation on CentOS/RHEL/Fedora
 ------------------------------------
 
-Install the Puppet yum repository and then the "puppet-server" package. See this `index <https://yum.puppetlabs.com/>`_ to find the correct rpm file needed to install the puppet repo for your Linux distribution. For example, to install Puppet 5 for CentOS 7 or RHEL 7, do the following:
+Install the Puppet yum repository and then the "puppet-agent" package. See this `index <https://yum.puppetlabs.com/>`_ to find the correct rpm file needed to install the puppet repo for your Linux distribution. For example, to install Puppet 5 for CentOS 7 or RHEL 7, do the following:
 
 .. code-block:: console
 
@@ -19,7 +19,7 @@ Install the Puppet yum repository and then the "puppet-server" package. See this
 
 .. note:: 
 
-  For correct installation we recommend the use of Puppet versions equal or greater than 5. 
+  For a correct installation we recommend the use of Puppet versions equal or greater than 5. 
 
 Installation on Debian/Ubuntu
 ------------------------------
@@ -31,7 +31,7 @@ Install ``curl``, ``apt-transport-https`` and ``lsb-release``:
 	# apt-get update
 	# apt-get install curl apt-transport-https lsb-release
 
-Get the appropriate Puppet apt repository, and then the "puppetserver" package. See https://apt.puppetlabs.com to find the correct deb file to install the puppet repo for your Linux distribution.
+Get the appropriate Puppet apt repository, and then the "puppet-agent" package. See https://apt.puppetlabs.com to find the correct deb file to install the puppet repo for your Linux distribution.
 
 .. code-block:: console
 
@@ -42,7 +42,7 @@ Get the appropriate Puppet apt repository, and then the "puppetserver" package. 
 
 .. note:: 
   
-  For correct installation we recommend the use of Puppet versions equal or greater than 5. The releases supported by the manifest to install wazuh are as follows: 
+  For a correct installation we recommend the use of Puppet versions equal or greater than 5. The releases supported by the manifest to install Wazuh are as follows: 
 
   Ubuntu: precise|trusty|vivid|wily|xenial|yakketi
 

--- a/source/deploying-with-puppet/setup-puppet/install-puppet-agent.rst
+++ b/source/deploying-with-puppet/setup-puppet/install-puppet-agent.rst
@@ -8,26 +8,50 @@ Installing Puppet agent
 In this section we assume you have already installed the ``apt`` or ``yum`` Puppet repository on your agent system in the same way that you did on your Puppet Server.
 
 Installation on CentOS/RHEL/Fedora
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+------------------------------------
+
+Install the Puppet yum repository and then the "puppet-server" package. See this `index <https://yum.puppetlabs.com/>`_ to find the correct rpm file needed to install the puppet repo for your Linux distribution. For example, to install Puppet 5 for CentOS 7 or RHEL 7, do the following:
 
 .. code-block:: console
 
-   # yum install puppet
-   # puppet resource package puppet ensure=latest
+   # rpm -ivh https://yum.puppetlabs.com/puppet5/puppet5-release-el-7.noarch.rpm
+   # yum -y install puppet-agent
+
+.. note:: 
+
+  For correct installation we recommend the use of Puppet versions equal or greater than 5. 
 
 Installation on Debian/Ubuntu
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+------------------------------
+
+Install ``curl``, ``apt-transport-https`` and ``lsb-release``:
 
 .. code-block:: console
 
-   # apt-get install puppet
-   # apt-get update
-   # puppet resource package puppet ensure=latest
+	# apt-get update
+	# apt-get install curl apt-transport-https lsb-release
+
+Get the appropriate Puppet apt repository, and then the "puppetserver" package. See https://apt.puppetlabs.com to find the correct deb file to install the puppet repo for your Linux distribution.
+
+.. code-block:: console
+
+  # wget https://apt.puppetlabs.com/puppet5-release-xenial.deb
+  # dpkg -i puppet5-release-xenial.deb
+  # apt update
+  # apt-get install -y puppet-agent
+
+.. note:: 
+  
+  For correct installation we recommend the use of Puppet versions equal or greater than 5. The releases supported by the manifest to install wazuh are as follows: 
+
+  Ubuntu: precise|trusty|vivid|wily|xenial|yakketi
+
+  Debian: jessie|wheezy|stretch|sid
 
 Configuration
 ^^^^^^^^^^^^^
 
-Add the server value to the ``[main]`` section of the node’s ``/etc/puppet/puppet.conf`` file, replacing ``puppet.example.com`` with your Puppet Server’s FQDN::
+Add the server value to the ``[main]`` section of the node’s ``/etc/puppetlabs/puppet/puppet.conf`` file, replacing ``puppet.example.com`` with your Puppet Server’s FQDN::
 
    [main]
    server = puppet.example.com
@@ -36,4 +60,4 @@ Restart the Puppet service:
 
 .. code-block:: console
 
-   # service puppet restart
+   # /opt/puppetlabs/bin/puppet resource service puppet ensure=running enable=true

--- a/source/deploying-with-puppet/setup-puppet/install-puppet-master.rst
+++ b/source/deploying-with-puppet/setup-puppet/install-puppet-master.rst
@@ -8,12 +8,16 @@ Installing Puppet master
 Installation on CentOS/RHEL/Fedora
 ------------------------------------
 
-Install the Puppet yum repository and then the "puppet-server" package. See https://yum.puppetlabs.com to find the correct rpm file needed to install the puppet repo for your Linux distribution. For example, for CentOS 7 or RHEL 7, do the following:
+Install the Puppet yum repository and then the "puppet-server" package. See this `index <https://yum.puppetlabs.com/>`_ to find the correct rpm file needed to install the puppet repo for your Linux distribution. For example, to install Puppet 5 for CentOS 7 or RHEL 7, do the following:
 
 .. code-block:: console
 
-   # rpm -ivh https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm
-   # yum install puppetserver
+   # rpm -ivh https://yum.puppetlabs.com/puppet5/puppet5-release-el-7.noarch.rpm
+   # yum -y install puppetserver
+
+.. note:: 
+
+  For correct installation we recommend the use of Puppet versions equal or greater than 5. 
 
 
 Installation on Debian/Ubuntu
@@ -26,13 +30,23 @@ Install ``curl``, ``apt-transport-https`` and ``lsb-release``:
 	# apt-get update
 	# apt-get install curl apt-transport-https lsb-release
 
-Get the appropriate Puppet apt repository, and then the "puppetserver" package. See https://apt.puppetlabs.com to find the correct deb file to install the puppet repo for your Linux distribution, you can use next script to make installation more silently:
+Get the appropriate Puppet apt repository, and then the "puppetserver" package. See https://apt.puppetlabs.com to find the correct deb file to install the Puppet 5 repo for your Linux distribution.
 
 .. code-block:: console
 
-  # wget "https://apt.puppetlabs.com/puppetlabs-release-pc1-$(lsb_release -cs).deb"
-  # dpkg -i "puppetlabs-release-pc1-$(lsb_release -cs).deb"
-  # apt-get update && sudo apt-get install puppetserver
+  # wget https://apt.puppetlabs.com/puppet5-release-xenial.deb
+  # dpkg -i puppet5-release-xenial.deb
+  # apt update
+  # apt-get install -y puppetserver
+
+.. note:: 
+  
+  For correct installation we recommend the use of Puppet versions equal or greater than 5. The releases supported by the manifest to install wazuh are as follows: 
+
+  Ubuntu: **precise | trusty | vivid | wily | xenial | yakketi**
+
+  Debian: **jessie | wheezy | stretch | sid**
+
 
 Memory Allocation
 --------------------------
@@ -47,7 +61,7 @@ Replace 2g with the amount of memory you want to allocate to Puppet Server. For 
 Configuration
 --------------------------
 
-Edit the ``/etc/puppetlabs/puppet/puppet.conf`` file, adding this line to the ``[main]`` section, and replacing ``puppet.example.com`` with your own FQDN: ::
+Edit the ``/etc/puppetlabs/puppet/puppet.conf`` file, adding this line to the ``[main]`` section (create the section if it does not exist), and replacing ``puppet.example.com`` with your own FQDN: ::
 
    dns_alt_names = puppet,puppet.example.com
 
@@ -60,15 +74,19 @@ Then, restart your Puppet Server to apply changes:
   .. code-block:: console
 
         # systemctl start puppetserver
+        # systemctl enable puppetserver
 
   b) For SysV Init:
 
   .. code-block:: console
 
         # service puppetserver start
+        # update-rc.d puppetserver
 
-PuppetDB installation
----------------------
+PuppetDB installation (Optional)
+--------------------------------
+
+.. warning:: Some of these steps may be outdated. If it is not necessary to install, continue in the next section. 
 
 After configuring Puppet Server to run on Apache with Passenger, the next step is to add PuppetDB so that you can take advantage of exported resources, as well as have a central storage location for Puppet facts and catalogs.
 

--- a/source/deploying-with-puppet/setup-puppet/install-puppet-master.rst
+++ b/source/deploying-with-puppet/setup-puppet/install-puppet-master.rst
@@ -39,13 +39,14 @@ Get the appropriate Puppet apt repository, and then the "puppetserver" package. 
   # apt update
   # apt-get install -y puppetserver
 
-.. note:: 
-  
-  For a correct installation we recommend the use of Puppet versions equal or greater than 5. The releases supported by the manifest to install Wazuh are as follows: 
+.. note:: For a correct installation we recommend the use of Puppet versions equal or greater than 5. 
 
-  Ubuntu: **precise | trusty | vivid | wily | xenial | yakketi**
 
-  Debian: **jessie | wheezy | stretch | sid**
+.. note:: The releases supported by the manifest to install Wazuh are as follows: 
+
+      Ubuntu: **precise | trusty | vivid | wily | xenial | yakketi**
+
+      Debian: **jessie | wheezy | stretch | sid**
 
 
 Memory Allocation

--- a/source/deploying-with-puppet/setup-puppet/install-puppet-master.rst
+++ b/source/deploying-with-puppet/setup-puppet/install-puppet-master.rst
@@ -8,7 +8,7 @@ Installing Puppet master
 Installation on CentOS/RHEL/Fedora
 ------------------------------------
 
-Install the Puppet yum repository and then the "puppet-server" package. See this `index <https://yum.puppetlabs.com/>`_ to find the correct rpm file needed to install the puppet repo for your Linux distribution. For example, to install Puppet 5 for CentOS 7 or RHEL 7, do the following:
+Install the Puppet yum repository and then the "puppetserver" package. See this `index <https://yum.puppetlabs.com/>`_ to find the correct rpm file needed to install the puppet repo for your Linux distribution. For example, to install Puppet 5 for CentOS 7 or RHEL 7, do the following:
 
 .. code-block:: console
 
@@ -17,7 +17,7 @@ Install the Puppet yum repository and then the "puppet-server" package. See this
 
 .. note:: 
 
-  For correct installation we recommend the use of Puppet versions equal or greater than 5. 
+  For a correct installation we recommend the use of Puppet versions equal or greater than 5. 
 
 
 Installation on Debian/Ubuntu
@@ -41,7 +41,7 @@ Get the appropriate Puppet apt repository, and then the "puppetserver" package. 
 
 .. note:: 
   
-  For correct installation we recommend the use of Puppet versions equal or greater than 5. The releases supported by the manifest to install wazuh are as follows: 
+  For a correct installation we recommend the use of Puppet versions equal or greater than 5. The releases supported by the manifest to install Wazuh are as follows: 
 
   Ubuntu: **precise | trusty | vivid | wily | xenial | yakketi**
 

--- a/source/deploying-with-puppet/setup-puppet/setup-puppet-certificates.rst
+++ b/source/deploying-with-puppet/setup-puppet/setup-puppet-certificates.rst
@@ -5,11 +5,15 @@
 Setting up Puppet certificates
 =================================
 
-Run Puppet agent to generate a certificate for the Puppet Server to sign:
+Run in your Puppet agent to generate a certificate for the Puppet Server to sign:
 
 .. code-block:: console
 
    # puppet agent -t
+
+.. note:: 
+
+   You will see a message like this:  ``Exiting; no certificate found and waitforcert is disabled``
 
 Log into to your Puppet Server, and list the certificates that need approval:
 

--- a/source/deploying-with-puppet/wazuh-puppet-module/index.rst
+++ b/source/deploying-with-puppet/wazuh-puppet-module/index.rst
@@ -28,6 +28,10 @@ Download and install the Wazuh module from Puppet Forge:
 
 This module installs and configures Wazuh agent and manager.
 
+.. note:: 
+
+  Wazuh version 2.1.1 will be installed. We are working on the update to install 3.x.
+
 Install manager via Puppet
 -------------------------------------------------------------------
 
@@ -36,6 +40,21 @@ The manager is configured by installing the ``wazuh::server`` class, and optiona
  - ``wazuh::command``: to define active response command (like ``firewall-drop.sh``).
  - ``wazuh::activeresponse``: to link rules to active response commands.
  - ``wazuh::addlog``: to define additional log files to monitor.
+
+.. warning::
+
+  On Debian-based operating systems, we will have to add the following section to the ``/etc/puppetlabs/code/environments/production/modules/wazuh/manifests/repo.pp`` file for proper execution:
+
+  ``server => 'pgp.mit.edu'``. Line 9 to 12, do not forget the ``,`` after source entry.
+
+  .. code-block:: console
+
+    apt::key { 'wazuh':
+        id     => '0DCFCA5547B19D2A6099506096B3EE5F29111145',
+        source => 'https://packages.wazuh.com/key/GPG-KEY-WAZUH',
+        server => 'pgp.mit.edu'
+      }
+
 
 Here is an example of a manifest ``wazuh-manager.pp``::
 
@@ -65,7 +84,12 @@ Here is an example of a manifest ``wazuh-manager.pp``::
      }
   }
 
-Place the file at */etc/puppetlabs/code/environments/production/manifests/* in your Puppet master and it will be executed in the specified node after the *runinterval* time set in puppet.conf.
+Place the file at ``/etc/puppetlabs/code/environments/production/manifests/`` in your Puppet master and it will be executed in the specified node after the *runinterval* time set in puppet.conf. However, if you want to run it first, try the following command in the Puppet agent. 
+
+.. code-block:: console
+
+  # /opt/puppetlabs/bin/puppet agent -t
+
 
 Install agent via Puppet
 -------------------------------------------------------------------
@@ -82,7 +106,11 @@ Here is an example of a manifest ``wazuh-agent.pp`` (please replace with your IP
 
  }
 
-Place the file at */etc/puppetlabs/code/environments/production/manifests/* in your Puppet master and it will be executed in the specified node after the *runinterval* time set in puppet.conf.
+Place the file at ``/etc/puppetlabs/code/environments/production/manifests/`` in your Puppet master and it will be executed in the specified node after the *runinterval* time set in puppet.conf. However, if you want to run it first, try the following command in the Puppet agent. 
+
+.. code-block:: console
+
+  # /opt/puppetlabs/bin/puppet agent -t
 
 Reference Wazuh puppet
 -------------------------------------------------------------------


### PR DESCRIPTION
Hello team, 

If we followed Puppet's documentation step by step we couldn't install either Wazuh's manager or Wazuh's agent.

- We have updated the links to install version 5 of Puppet, as well as advise for any operating system to use this version of Puppet or a greater version.

- We have added necessary commands for the correct execution of the installation.

- We have added tips and warnings regarding outdated components, such as the installation of Wazuh 2.1.1.

- We have added a line with which to complete the manifests of the repository for Wazuh manager installations on Debian and Ubuntu systems.

Regards,

Alfonso