### PR TITLE
Fix typo in ossec-conf/rootcheck documentation.

### DIFF
--- a/source/user-manual/reference/ossec-conf/rootcheck.rst
+++ b/source/user-manual/reference/ossec-conf/rootcheck.rst
@@ -43,7 +43,7 @@ Options
 base_directory
 ^^^^^^^^^^^^^^^
 
-The base directory that will be appended to the following options:
+The base directory that will be prepended to the following options:
 
 - rootkit_files
 - rootkit_trojans


### PR DESCRIPTION
The base directory is [prepended](https://en.oxforddictionaries.com/definition/prepend), not [appended](https://en.oxforddictionaries.com/definition/append) to certain options.