### PR TITLE
Fix vulnerability_detector "disabled" default.

### DIFF
--- a/source/user-manual/reference/ossec-conf/wodle-vuln-detector.rst
+++ b/source/user-manual/reference/ossec-conf/wodle-vuln-detector.rst
@@ -48,7 +48,7 @@ disabled
 Disable the Vulnerability detector wodle.
 
 +--------------------+-----------------------------+
-| **Default value**  | yes                         |
+| **Default value**  | no                          |
 +--------------------+-----------------------------+
 | **Allowed values** | yes, no                     |
 +--------------------+-----------------------------+


### PR DESCRIPTION
According to the [code](https://github.com/wazuh/wazuh/blob/master/src/config/wmodules-vuln-detector.c#L214), the `vulnerability_detector` wodle defaults to `enabled = 1`.  Therefore, a missing [disabled](https://github.com/wazuh/wazuh/blob/master/src/config/wmodules-vuln-detector.c#L214) tag would be equivalent to `<disabled>no</disabled>`.