### PR TITLE
Fix osquery "disabled" default.

### DIFF
--- a/source/user-manual/reference/ossec-conf/wodle-osquery.rst
+++ b/source/user-manual/reference/ossec-conf/wodle-osquery.rst
@@ -54,7 +54,7 @@ disabled
 Disable the osquery wodle.
 
 +--------------------+---------+
-| **Default value**  | yes     |
+| **Default value**  | no      |
 +--------------------+---------+
 | **Allowed values** | yes, no |
 +--------------------+---------+


### PR DESCRIPTION
The osquery [code](https://github.com/wazuh/wazuh/blob/master/src/config/wmodules-osquery-monitor.c#L28) sets `disable = 0`. Therefore, a missing [disabled](https://github.com/wazuh/wazuh/blob/master/src/config/wmodules-osquery-monitor.c#L50) tag would be equivalent to `<disabled>no</disabled>`.