### PR TITLE
Edit "check_winaudit" docs for consistency.

### DIFF
--- a/source/user-manual/reference/ossec-conf/rootcheck.rst
+++ b/source/user-manual/reference/ossec-conf/rootcheck.rst
@@ -268,11 +268,11 @@ check_winaudit
 
 Enable or disable the checking of winaudit.
 
-+--------------------+-------+
-| **Default value**  | 1     |
-+--------------------+-------+
-| **Allowed values** | 0 , 1 |
-+--------------------+-------+
++--------------------+---------+
+| **Default value**  | yes     |
++--------------------+---------+
+| **Allowed values** | yes, no |
++--------------------+---------+
 
 check_winmalware
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
All the [`rootcheck`](https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/rootcheck.html#check-dev) subtags are evaluated with the same [`eval_bool`](https://github.com/wazuh/wazuh/blob/master/src/config/rootcheck-config.c#L15) function.  Their documented default and allowed values, therefore, should be consistent.