### PR TITLE
Fix to not recommend a 3rdparty PPA for recent Ubuntu/Debian versions

### DIFF
--- a/source/installation-guide/installing-elastic-stack/elastic_server_deb.rst
+++ b/source/installation-guide/installing-elastic-stack/elastic_server_deb.rst
@@ -12,30 +12,33 @@ The DEB package is suitable for Debian, Ubuntu and other Debian-based systems.
 Preparation
 -----------
 
-1. Oracle Java JRE 8 is required by Logstash and Elasticsearch:
+1. Oracle Java JRE or OpenJDK 8 is required by Logstash and Elasticsearch:
 
-  a) For Debian:
+  a) For Debian >= 8/Jessie or Ubuntu >= 16.04/Xenial:
+  
+  .. code-block:: console
+  
+    # apt-get update
+    # apt-get install openjdk-8-jre
+
+  b) For Debian < 8/Jessie:
 
   .. code-block:: console
 
     # echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu xenial main" | tee /etc/apt/sources.list.d/webupd8team-java.list
-    # echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu xenial main" | tee -a /etc/apt/sources.list.d/webupd8team-java.list
     # apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886
+    # apt-get update
+    # apt-get install oracle-java8-installer
 
-  b) For Ubuntu:
+  c) For Ubuntu < 16.04/Xenial:
 
   .. code-block:: console
 
     # add-apt-repository ppa:webupd8team/java
-
-2. Once the repository is added, install Java JRE:
-
-  .. code-block:: console
-
     # apt-get update
     # apt-get install oracle-java8-installer
 
-3. Install the Elastic repository and its GPG key:
+2. Install the Elastic repository and its GPG key:
 
   .. code-block:: console
 


### PR DESCRIPTION
Fixes #285

See the linked issue for background information why it shouldn't be required/recommended to add 3rdparty PPAs to recent versions of Debian/Ubuntu already providing the OpenJDK 8.

The required openjdk-8 version 1.8.0.111+ which is listed as fully compatible in the compatibility matrix of Elastic in:

https://www.elastic.co/support/matrix#matrix_jvm

is shipped already in both mentioned Ubuntu/Debian versions since a few releases:

https://packages.debian.org/search?keywords=openjdk-8-jre
https://packages.ubuntu.com/search?keywords=openjdk-8-jre

Also removed the "deb-src" line for older Debian versions. Having the source repositories included by default is not required for nearly every standard installation.