### PR TITLE
Add note to alerts/use_geoip option.

### DIFF
--- a/source/user-manual/reference/ossec-conf/alerts.rst
+++ b/source/user-manual/reference/ossec-conf/alerts.rst
@@ -63,6 +63,13 @@ Toggles GeoIP lookups on or off.
 | **Allowed values** | yes, no     |
 +--------------------+-------------+
 
+.. note::
+    This option is only available when wazuh has been compiled with
+    [`LIBGEOIP_ENABLED`](https://github.com/wazuh/wazuh/blob/master/src/config/alerts-config.c#L61).
+    Otherwise, use of this option will result in an
+    [Invalid element](https://github.com/wazuh/wazuh/blob/master/src/error_messages/error_messages.h#L84)
+    error and prevent wazuh from starting.
+
 Default configuration
 ---------------------
 
@@ -72,3 +79,4 @@ Default configuration
       <log_alert_level>3</log_alert_level>
       <email_alert_level>12</email_alert_level>
     </alerts>
+


### PR DESCRIPTION
When running the [current version of wazuh](https://documentation.wazuh.com/current/installation-guide/packages-list/index.html), setting the [`use_geoip`](https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/alerts.html#use-geoip) option will result in an [Invalid element](https://github.com/wazuh/wazuh/blob/master/src/error_messages/error_messages.h#L84) error, preventing wazuh from starting.

This should be noted in the documentation.