### PR TITLE
Deprecate the unused alerts/use_geoip option.

### DIFF
--- a/source/user-manual/reference/ossec-conf/alerts.rst
+++ b/source/user-manual/reference/ossec-conf/alerts.rst
@@ -55,10 +55,12 @@ Sets the minimum severity level for an alert to generate an email notification.
 use_geoip
 ^^^^^^^^^
 
-Toggles GeoIP lookups on or off.
+.. deprecated:: 2.0
+
+This option has no effect, and will result in a parsing error unless compiled with [`LIBGEOIP_ENABLED`](https://github.com/wazuh/wazuh/blob/master/src/config/alerts-config.c#L61).
 
 +--------------------+-------------+
-| **Default value**  | no          |
+| **Default value**  | n/a         |
 +--------------------+-------------+
 | **Allowed values** | yes, no     |
 +--------------------+-------------+


### PR DESCRIPTION
See related issue: [The "use_geoip" option has no apparent effect.](https://github.com/wazuh/wazuh/issues/1489)