### PR TITLE
Note effect of cluster/disabled option.

### DIFF
--- a/source/user-manual/reference/ossec-conf/cluster.rst
+++ b/source/user-manual/reference/ossec-conf/cluster.rst
@@ -146,10 +146,10 @@ Toggles whether or not to show information about the cluster that generated an a
 disabled
 ^^^^^^^^
 
-Toggles whether the cluster is enabled or not. If this value is set to **yes**, the cluster won't start.
+If set to ``yes``, forces ``hidden`` to ``yes``.
 
 +--------------------+-----------------------------------------+
-| **Default value**  | yes                                     |
+| **Default value**  | no                                      |
 +--------------------+-----------------------------------------+
 | **Allowed values** | yes, no                                 |
 +--------------------+-----------------------------------------+


### PR DESCRIPTION
The [code](https://github.com/wazuh/wazuh/blob/master/src/config/cluster-config.c#L60) that parses the [cluster/disabled](https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/cluster.html#disabled) option sets a [local](https://github.com/wazuh/wazuh/blob/master/src/config/cluster-config.c#L35) variable [`disable_cluster_info = 1;`](https://github.com/wazuh/wazuh/blob/master/src/config/cluster-config.c#L62), whose [effect](https://github.com/wazuh/wazuh/blob/master/src/config/cluster-config.c#L85) is the same as [setting cluster/hidden = yes](https://github.com/wazuh/wazuh/blob/master/src/config/cluster-config.c#L65).

It does not, so far as I can see, prevent the cluster from starting.