### PR TITLE
Correct command/timeout_allowed default.

### DIFF
--- a/source/user-manual/reference/ossec-conf/commands.rst
+++ b/source/user-manual/reference/ossec-conf/commands.rst
@@ -89,7 +89,7 @@ timeout_allowed
 Specifies whether the command is *stateful* or *stateless*. If yes, the command is stateful, meaning it will undo its original action after the period of time specified in the active response.
 
 +--------------------+--------+
-| **Default value**  | yes    |
+| **Default value**  | no     |
 +--------------------+--------+
 | **Allowed values** | yes, no|
 +--------------------+--------+


### PR DESCRIPTION
The [default](https://github.com/wazuh/wazuh/blob/master/src/config/active-response.c#L350) for [timeout_allowed](https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/commands.html#timeout-allowed) is `no`.