### PR TITLE
Note "email_to" option is required.

### DIFF
--- a/source/user-manual/reference/ossec-conf/email_alerts.rst
+++ b/source/user-manual/reference/ossec-conf/email_alerts.rst
@@ -40,6 +40,8 @@ This specifies a single email address to which to send email alerts. If you want
 +--------------------+-------------------------------------+
 | **Allowed values** | Any valid email address is allowed. |
 +--------------------+-------------------------------------+
+| use                | Required.                           |
++--------------------+-------------------------------------+
 
 
 level


### PR DESCRIPTION
The [code](https://github.com/wazuh/wazuh/blob/master/src/config/email-alerts-config.c#L101) that parses the [email_alerts](https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/email_alerts.html) tag generates an [error](https://github.com/wazuh/wazuh/blob/master/src/config/email-alerts-config.c#L206) when the [email_to](https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/email_alerts.html#email-to) option is missing or empty.