### PR TITLE
Document the "max_log" integration option.

### DIFF
--- a/source/user-manual/reference/ossec-conf/integration.rst
+++ b/source/user-manual/reference/ossec-conf/integration.rst
@@ -25,7 +25,7 @@ Options
 - `group`_
 - `event_location`_
 - `alert_format`_
-- `max_count` 
+- `max_count`_
 
 name
 ^^^^

--- a/source/user-manual/reference/ossec-conf/integration.rst
+++ b/source/user-manual/reference/ossec-conf/integration.rst
@@ -25,6 +25,7 @@ Options
 - `group`_
 - `event_location`_
 - `alert_format`_
+- `max_count` 
 
 name
 ^^^^
@@ -122,6 +123,18 @@ This writes the alert file in the JSON format. The Integrator makes use this fil
 +--------------------+-----------------------------------------------------------+
 | **Allowed values** | json                                                      |
 +--------------------+-----------------------------------------------------------+
+
+max_log
+^^^^^^^
+
+The maximum length of an alert snippet that will be sent to the Integrator.  Longer strings will be truncated with ``...``
+
++--------------------+-----------------------------------------------------------+
+| **Default value**  | 165                                                       |
++--------------------+-----------------------------------------------------------+
+| **Allowed values** | Any integer from 165 to 1024 inclusive.                   |
++--------------------+-----------------------------------------------------------+
+
 
 Configuration example
 ---------------------

--- a/source/user-manual/reference/ossec-conf/integration.rst
+++ b/source/user-manual/reference/ossec-conf/integration.rst
@@ -25,7 +25,7 @@ Options
 - `group`_
 - `event_location`_
 - `alert_format`_
-- `max_count`_
+- `max_log`_
 
 name
 ^^^^


### PR DESCRIPTION
There is a [`max_log`](https://github.com/wazuh/wazuh/blob/master/src/config/integrator-config.c#L25) option which is missing from the [docs](https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/integration.html).  In the [code](https://github.com/wazuh/wazuh/blob/master/src/os_integrator/integrator.c#L310), it appears to limit the length of an alert string which is copied to an integrator.