### PR TITLE
Fix global geoip config docs.

### DIFF
--- a/source/user-manual/reference/ossec-conf/global.rst
+++ b/source/user-manual/reference/ossec-conf/global.rst
@@ -18,7 +18,6 @@ Options
 -------
 
 - `alerts_log`_
-- `compress_alerts`_
 - `email_notification`_
 - `email_to`_
 - `email_from`_

--- a/source/user-manual/reference/ossec-conf/global.rst
+++ b/source/user-manual/reference/ossec-conf/global.rst
@@ -18,6 +18,7 @@ Options
 -------
 
 - `alerts_log`_
+- `compress_alerts`_
 - `email_notification`_
 - `email_to`_
 - `email_from`_
@@ -36,7 +37,7 @@ Options
 - `prelude_output`_
 - `zeromq_output`_
 - `zeromq_uri`_
-- `geoip_db_path`_
+- `geoipdb`_
 - `rotate_interval`_
 - `max_output_size`_
 - `queue_size`_
@@ -314,8 +315,8 @@ This will listen for zeromq on the Unix Domain socket /alerts-zmq.
 
   <zeromq_uri>ipc:///alerts-zmq</zeromq_uri>
 
-geoip_db_path
-^^^^^^^^^^^^^
+geoipdb
+^^^^^^^
 
 This indicates the full path of the MaxMind GeoIP IPv4 database file.
 
@@ -329,7 +330,7 @@ For example:
 
 .. code-block:: xml
 
-  <geoip_db_path>/etc/GeoLiteCity.dat</geoip_db_path>
+  <geoipdb>/etc/GeoLiteCity.dat</geoipdb>
 
 rotate_interval
 ^^^^^^^^^^^^^^^


### PR DESCRIPTION
The [code](https://github.com/wazuh/wazuh/blob/master/src/config/global-config.c#L255) looks for a [`geoipdb`](https://github.com/wazuh/wazuh/blob/master/src/config/global-config.c#L140) option, but the legacy [`geoip_db_path`](https://github.com/wazuh/wazuh/blob/master/src/config/global-config.c#L165) and [`geoip6_db_path`](https://github.com/wazuh/wazuh/blob/master/src/config/global-config.c#L166) options are unused.

```sh
bobvin@T560:~/github/wazuh egrep -r 'geoip(6?)_db_path *'
src/config/global-config.h:    char *geoip_db_path;
src/config/global-config.h:    char *geoip6_db_path;
src/config/global-config.c:    const char *xml_geoip_db_path = "geoip_db_path";
src/config/global-config.c:    const char *xml_geoip6_db_path = "geoip6_db_path";
src/config/global-config.c:        else if (strcmp(node[i]->element, xml_geoip_db_path) == 0) {
src/config/global-config.c:                os_strdup(node[i]->content, Config->geoip_db_path);
src/config/global-config.c:        else if (strcmp(node[i]->element, xml_geoip6_db_path) == 0) {
src/config/global-config.c:                os_strdup(node[i]->content, Config->geoip6_db_path);
bobvin@T560:~/github/wazuh
```