### PR TITLE
Document the global/helo_server option.

### DIFF
--- a/source/user-manual/reference/ossec-conf/global.rst
+++ b/source/user-manual/reference/ossec-conf/global.rst
@@ -23,6 +23,7 @@ Options
 - `email_from`_
 - `email_reply_to`_
 - `smtp_server`_
+- `helo_server`_
 - `email_maxperhour`_
 - `email_idsname`_
 - `custom_alert_output`_
@@ -109,7 +110,7 @@ This specifies the “reply-to” address contained in the email alerts.
 smtp_server
 ^^^^^^^^^^^
 
-In this option defines what SMTP server to use to deliver alerts.
+This option defines what SMTP server to use to deliver alerts.
 
 +--------------------+-----------------------------------------------+
 | **Default value**  | n/a                                           |
@@ -117,6 +118,17 @@ In this option defines what SMTP server to use to deliver alerts.
 | **Allowed values** | - Valid hostname or IP address.               |
 |                    |                                               |
 |                    | - Full path to a sendmail-like executable.    |
++--------------------+-----------------------------------------------+
+
+helo_server
+^^^^^^^^^^^
+
+This option defines how the ossec server will identify itself when sending mail.
+
++--------------------+-----------------------------------------------+
+| **Default value**  | notify.ossec.net                              |
++--------------------+-----------------------------------------------+
+| **Allowed values** | Any valid hostname.                           |
 +--------------------+-----------------------------------------------+
 
 email_maxperhour


### PR DESCRIPTION
The [code](https://github.com/wazuh/wazuh/blob/master/src/config/global-config.c#L160) parses for a [`helo_server`](https://github.com/wazuh/wazuh/blob/master/src/config/global-config.c#L529) option, which is used by [ossec-maild](https://documentation.wazuh.com/current/user-manual/reference/daemons/ossec-maild.html) to [identify the sending host](https://github.com/wazuh/wazuh/blob/master/src/os_maild/sendmail.c#L91).