### PR TITLE
Fix global/prelude_output default.

### DIFF
--- a/source/user-manual/reference/ossec-conf/global.rst
+++ b/source/user-manual/reference/ossec-conf/global.rst
@@ -267,7 +267,7 @@ prelude_output
 This toggles Prelude output.
 
 +--------------------+---------+
-| **Default value**  | yes     |
+| **Default value**  | no      |
 +--------------------+---------+
 | **Allowed values** | yes, no |
 +--------------------+---------+


### PR DESCRIPTION
The [`prelude_output`](https://github.com/wazuh/wazuh/blob/master/src/config/global-config.c#L137) default is [`0`](https://github.com/wazuh/wazuh/blob/master/src/analysisd/config.c#L32) which corresponds to [`no`](https://github.com/wazuh/wazuh/blob/master/src/config/global-config.c#L247).