### PR TITLE
Revert "Change wrong info about assign a group to an agent"

### DIFF
--- a/source/user-manual/agents/grouping-agents.rst
+++ b/source/user-manual/agents/grouping-agents.rst
@@ -29,7 +29,7 @@ Below are the steps to assign agents to a group with a specific configuration:
 
       # curl -u foo:bar -X PUT "http://localhost:55000/agents/002/group/dbms?pretty"
 
-   .. note:: The group must be created and configured before assigning agents.
+   .. note:: New groups may be created and configured before assigning agents. If a group does not exist prior to assigning an agent, it will be created when the first agent is added and set up with the files from the *'default'* group.
 
    An agent's group assignment can be checked using one of the following commands:
 


### PR DESCRIPTION
Reverts wazuh/wazuh-documentation#458