### PR TITLE
Fixed compilation warnings

### DIFF
--- a/source/user-manual/reference/internal-options.rst
+++ b/source/user-manual/reference/internal-options.rst
@@ -146,9 +146,9 @@ Analysisd
 +------------------------------------+---------------+--------------------------------------------------------------------+
 |  **analysisd.decoder_order_size**  | Description   | Maximum number of fields in a decoder (order tag).                 |
 +                                    +---------------+--------------------------------------------------------------------+
-|                                    | Default value | 256                                                                 |
+|                                    | Default value | 256                                                                |
 +                                    +---------------+--------------------------------------------------------------------+
-|                                    | Allowed value | Any integer between 10 and 1024                                      |
+|                                    | Allowed value | Any integer between 10 and 1024                                    |
 +------------------------------------+---------------+--------------------------------------------------------------------+
 |     **analysisd.geoip_jsonout**    | Description   | Toggle to turn on or off output of GeoIP data in JSON alerts.      |
 +                                    +---------------+--------------------------------------------------------------------+


### PR DESCRIPTION
This PR fixes a compilation warning in the documentation for the `3.6` branch.