### PR TITLE
Lock wazuh repository

### DIFF
--- a/source/installation-guide/installing-wazuh-server/wazuh_server_deb.rst
+++ b/source/installation-guide/installing-wazuh-server/wazuh_server_deb.rst
@@ -127,6 +127,22 @@ Installing the Wazuh API
         }
     ];
 
+5. Disable the Wazuh updates:
+
+  It is recommended that the Wazuh repository be disabled in order to prevent accidental upgrades. To do this, use the following command:
+
+  .. code-block:: console
+
+    # sed -i "s/^deb/#deb/" /etc/apt/sources.list.d/wazuh.list
+    # apt-get update
+
+  Alternately, you can set the package state to 'hold', which will stop updates (you can still upgrade it manually with the apt-get install)
+
+  .. code-block:: console
+
+    # echo "wazuh-manager hold" | sudo dpkg --set-selections
+    # echo "wazuh-api hold" | sudo dpkg --set-selections
+
 .. _wazuh_server_deb_filebeat:
 
 Installing Filebeat
@@ -183,6 +199,21 @@ The DEB package is suitable for Debian, Ubuntu, and other Debian-based systems.
 
     # update-rc.d filebeat defaults 95 10
     # service filebeat start
+
+6. Disable the Elasticsearch updates:
+
+  It is recommended that the Elasticsearch repository be disabled in order to prevent an upgrade to a newer Elastic Stack version due to the possibility of undoing changes with the App.  To do this, use the following command:
+
+  .. code-block:: console
+
+    # sed -i "s/^deb/#deb/" /etc/apt/sources.list.d/elastic-6.x.list
+    # apt-get update
+
+  Alternately, you can set the package state to 'hold', which will stop updates (you can still upgrade it manually with the apt-get install)
+
+  .. code-block:: console
+
+    # echo "elasfilebeatticsearch hold" | sudo dpkg --set-selections
 
 Next steps
 ----------

--- a/source/installation-guide/installing-wazuh-server/wazuh_server_deb.rst
+++ b/source/installation-guide/installing-wazuh-server/wazuh_server_deb.rst
@@ -213,7 +213,7 @@ The DEB package is suitable for Debian, Ubuntu, and other Debian-based systems.
 
   .. code-block:: console
 
-    # echo "elasfilebeatticsearch hold" | sudo dpkg --set-selections
+    # echo "filebeat hold" | sudo dpkg --set-selections
 
 Next steps
 ----------

--- a/source/installation-guide/installing-wazuh-server/wazuh_server_rpm.rst
+++ b/source/installation-guide/installing-wazuh-server/wazuh_server_rpm.rst
@@ -147,6 +147,14 @@ Installing the Wazuh API
 
     # service wazuh-api status
 
+5. Disable the Wazuh repository:
+
+  It is recommended that the Wazuh repository be disabled in order to prevent accidental upgrades.  To do this, use the following command:
+
+  .. code-block:: console
+
+    # sed -i "s/^enabled=1/enabled=0/" /etc/yum.repos.d/wazuh.repo
+
 .. _wazuh_server_rpm_filebeat:
 
 Installing Filebeat
@@ -212,6 +220,14 @@ The RPM package is suitable for installation on Red Hat, CentOS and other modern
 
     # chkconfig --add filebeat
     # service filebeat start
+
+6. Disable the Elasticsearch repository:
+
+  It is recommended that the Elasticsearch repository be disabled in order to prevent an upgrade to a newer Elastic Stack version due to the possibility of undoing changes with the App.  To do this, use the following command:
+
+  .. code-block:: console
+
+    # sed -i "s/^enabled=1/enabled=0/" /etc/yum.repos.d/elastic.repo
 
 Next steps
 ----------


### PR DESCRIPTION
Hello team

  Regarding the issue #284, I have modified the documentation in order to include the lock of Wazuh repository. Additionally, I have included the locking of Elastic repositories because Filebeat could be accidentally upgraded.  

Best regards, 