### PR TITLE
Lock Wazuh repository in upgrades guide

### DIFF
--- a/source/installation-guide/optional-configurations/elastic_ssl.rst
+++ b/source/installation-guide/optional-configurations/elastic_ssl.rst
@@ -50,7 +50,7 @@ Generating a self-signed SSL certificate
 
 	.. code-block:: console
 
-		# openssl req -x509 -batch -nodes -days 3650 -newkey rsa:2048 -keyout /etc/logstash/logstash.key -out /etc/logstash/logstash.crt -config custom_openssl.cnf
+		# openssl req -x509 -batch -nodes -days 365 -newkey rsa:2048 -keyout /etc/logstash/logstash.key -out /etc/logstash/logstash.crt -config custom_openssl.cnf
 
 4. You may remove the custom configuration file:
 

--- a/source/installation-guide/upgrading/different_major.rst
+++ b/source/installation-guide/upgrading/different_major.rst
@@ -140,6 +140,29 @@ Upgrade Wazuh manager
 
       # apt-get install wazuh-api
 
+5. Disable the Wazuh repository:
+
+  It is recommended that the Wazuh repository be disabled in order to prevent accidental upgrades.  To do this, use the following command:
+
+  a) For CentOS/RHEL/Fedora:
+
+    .. code-block:: console
+
+      # sed -i "s/^enabled=1/enabled=0/" /etc/yum.repos.d/wazuh.repo
+
+  b) For Debian/Ubuntu:
+
+    .. code-block:: console
+
+      # sed -i "s/^deb/#deb/" /etc/apt/sources.list.d/wazuh.list
+      # apt-get update
+
+    Alternately, you can set the package state to 'hold', which will stop updates (you can still upgrade it manually with the apt-get install)
+
+    .. code-block:: console
+
+      # echo "wazuh-manager hold" | sudo dpkg --set-selections
+      # echo "wazuh-api hold" | sudo dpkg --set-selections
 
 Prepare Elastic Stack
 ---------------------

--- a/source/installation-guide/upgrading/latest_wazuh3_minor.rst
+++ b/source/installation-guide/upgrading/latest_wazuh3_minor.rst
@@ -77,6 +77,30 @@ Upgrade the Wazuh manager
 
     # apt-get update && apt-get install --only-upgrade wazuh-api
 
+3. Disable the Wazuh repository:
+
+  It is recommended that the Wazuh repository be disabled in order to prevent accidental upgrades.  To do this, use the following command:
+
+  a) For CentOS/RHEL/Fedora:
+
+    .. code-block:: console
+
+      # sed -i "s/^enabled=1/enabled=0/" /etc/yum.repos.d/wazuh.repo
+
+  b) For Debian/Ubuntu:
+
+    .. code-block:: console
+
+      # sed -i "s/^deb/#deb/" /etc/apt/sources.list.d/wazuh.list
+      # apt-get update
+
+    Alternately, you can set the package state to 'hold', which will stop updates (you can still upgrade it manually with the apt-get install)
+
+    .. code-block:: console
+
+      # echo "wazuh-manager hold" | sudo dpkg --set-selections
+      # echo "wazuh-api hold" | sudo dpkg --set-selections
+
 .. note::
   The installation of the updated packages **will automatically restart the services** for the Wazuh manager, API and agents. Your Wazuh config file will keep **unmodified**, so you'll need to manually add the settings for the new capabilities. Check the :ref:`User Manual <user_manual>` for more information.
 


### PR DESCRIPTION
Hello Team

  This PR include the necessaries steps in order to lock a Wazuh repository if the user follows the upgrade guides. 

Best regards, 