### PR TITLE
Added link to commands section

### DIFF
--- a/source/user-manual/reference/ossec-conf/active-response.rst
+++ b/source/user-manual/reference/ossec-conf/active-response.rst
@@ -56,7 +56,7 @@ Toggles the active-response capability on and off. Setting this option to ``yes`
 command
 ^^^^^^^
 
-Links the active-response to the command.
+Links the active-response to the command. You can find more information at the :doc:`commands <commands>` section.
 
 +--------------------+-------------------------------------------+
 | **Default value**  | n/a                                       |


### PR DESCRIPTION
Hi team,
I added a link in the active-response section <command>, linking to the command section.
Both are related, and we already have a link at the command section linking to the active-response section.
I think it might be useful to find a reference to the command section when looking at the active-response documentation.
Regards,
Miguel