### PR TITLE
Fixed external link not properly formatted

### DIFF
--- a/source/user-manual/reference/ossec-conf/alerts.rst
+++ b/source/user-manual/reference/ossec-conf/alerts.rst
@@ -57,8 +57,7 @@ use_geoip
 
 .. deprecated:: 2.0
 
-This option has no effect, and will result in a parsing error unless compiled with `LIBGEOIP_ENABLED
-<https://github.com/wazuh/wazuh/blob/master/src/config/alerts-config.c#L61>`_.
+This option has no effect, and will result in a parsing error unless compiled with `LIBGEOIP_ENABLED <https://github.com/wazuh/wazuh/blob/master/src/config/alerts-config.c#L61>`_.
 
 +--------------------+-------------+
 | **Default value**  | n/a         |

--- a/source/user-manual/reference/ossec-conf/alerts.rst
+++ b/source/user-manual/reference/ossec-conf/alerts.rst
@@ -57,7 +57,8 @@ use_geoip
 
 .. deprecated:: 2.0
 
-This option has no effect, and will result in a parsing error unless compiled with [`LIBGEOIP_ENABLED`](https://github.com/wazuh/wazuh/blob/master/src/config/alerts-config.c#L61).
+This option has no effect, and will result in a parsing error unless compiled with `LIBGEOIP_ENABLED
+<https://github.com/wazuh/wazuh/blob/master/src/config/alerts-config.c#L61>`_.
 
 +--------------------+-------------+
 | **Default value**  | n/a         |


### PR DESCRIPTION
Hi team,
I saw in branch 3.7 there is a link in the alerts section with github format, corresponding to this PR #442.
With this fix, now the link has the correct format for external links in RST.
Regards,
Miguel