### PR TITLE
[2.1] Update version selector and tab titles

### DIFF
--- a/source/_static/my-script.js
+++ b/source/_static/my-script.js
@@ -1,9 +1,21 @@
+/*
+ * Wazuh documentation - Version selector script
+ * Copyright (C) 2018 Wazuh, Inc.
+ */
+
 var versions = [
-    {name: "3.x (current)", url: "/3.x"},
+    {name: "3.7 (current)", url: "/3.7"},
+    {name: "3.6", url: "/3.6"},
+    {name: "3.5", url: "/3.5"},
+    {name: "3.4", url: "/3.4"},
+    {name: "3.3", url: "/3.3"},
+    {name: "3.2", url: "/3.2"},
+    {name: "3.1", url: "/3.1"},
+    {name: "3.0", url: "/3.0"},
     {name: "2.1", url: "/2.1"},
 ];
 
-var current_version = "3.x";
+var current_version = "3.7";
 
 $( document ).ready(function() {
     addVersions();

--- a/source/_templates/layout.html
+++ b/source/_templates/layout.html
@@ -1,10 +1,11 @@
 {# TEMPLATE VAR SETTINGS #}
+{% set dash_separator = " &dash; " %}
 {%- set url_root = pathto('', 1) %}
 {% set script_files = script_files + ["_static/my-script.js"] %}
 {% set css_files = css_files + ["_static/my-styles.css"] %}
 {%- if url_root == '#' %}{% set url_root = '' %}{% endif %}
 {%- if not embedded and docstitle %}
-  {%- set titlesuffix = " &mdash; "|safe + docstitle|e %}
+  {%- set titlesuffix = " &dash; "|safe + docstitle|e %}
 {%- else %}
   {%- set titlesuffix = "" %}
 {%- endif %}
@@ -17,7 +18,11 @@
   {{ metatags }}
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   {% block htmltitle %}
-  <title>{{ title|striptags|e }}{{ titlesuffix }}</title>
+    {%- if not parents[-1] %}
+      <title>{{ title|striptags|e }}{{ titlesuffix }}</title>
+    {%- else %}
+      <title>{{ title|striptags|e }}{{ dash_separator }}{{ parents[-1].title|striptags|e }}{{ titlesuffix }}</title>
+    {%- endif %}
   {% endblock %}
 
   {# Google Analytics #}
@@ -107,7 +112,7 @@
           {% if logo and theme_logo_only %}
             <a href="{{ pathto(master_doc) }}">
           {% else %}
-            <a href="{{ pathto(master_doc) }}" class="icon icon-home"> {{ project }}
+            <a href="{{ pathto(master_doc) }}" class="icon icon-home"> Documentation
           {% endif %}
 
           {% if logo %}

--- a/source/conf.py
+++ b/source/conf.py
@@ -59,9 +59,9 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'Documentation'
-copyright = u'2017, Wazuh, Inc'
+project = u'Wazuh'
 author = u'Wazuh, Inc.'
+copyright = u'2018 - Wazuh, Inc'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -189,7 +189,7 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 html_show_sphinx = False
 
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
-#html_show_copyright = True
+html_show_copyright = True
 
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the


### PR DESCRIPTION
Hello team,

This PR is part of #261 and for the `2.1` branch.

It will update the documentation version selector with the latest releases and also the tab titles.

Regards,
Juanjo