### PR TITLE
Update for FIM migration tool documentation

### DIFF
--- a/source/user-manual/reference/tools/fim_migrate.rst
+++ b/source/user-manual/reference/tools/fim_migrate.rst
@@ -18,13 +18,16 @@ This tool is not included in the Wazuh installation, but you can download it fro
 
     # curl -so fim_migrate https://raw.githubusercontent.com/wazuh/wazuh/v3.7.0/tools/migration/fim_migrate.py
 
-Add execution permission and run this tool as follows:
+Add execution permission and run this tool on the manager instance as follows:
 
 .. code-block:: console
 
     # chmod +x fim_migrate
 
     # ./fim_migrate
+
+.. note::
+    After completing the migration process, the old FIM databases won't be removed automatically. To do so, remove the contents from the ``/var/ossec/queue/syscheck`` folder.
 
 Options
 -------
@@ -43,7 +46,6 @@ Options
 +--------------------------+----------------------------------------------------------------------------------------+
 | ``-d``                   | Debug mode.                                                                            |
 +--------------------------+----------------------------------------------------------------------------------------+
-
 
 Example of use
 --------------

--- a/source/user-manual/reference/tools/fim_migrate.rst
+++ b/source/user-manual/reference/tools/fim_migrate.rst
@@ -7,7 +7,10 @@ fim_migrate
 
 .. versionadded:: 3.7.0
 
-The *fim_migrate* tool allows to migrate FIM databases older than Wazuh v3.7.0 to the new format included in Wazuh-DB.
+The *fim_migrate* tool allows to migrate FIM databases older than Wazuh v3.7.0 to the new format included in Wazuh-DB. This tool must be executed after the :ref:`upgrading process <upgrading_wazuh>` has been completed.
+
+.. note::
+    The new database will be available at ``/var/ossec/queue/db``.
 
 Usage
 -----
@@ -26,8 +29,8 @@ Add execution permission and run this tool on the manager instance as follows:
 
     # ./fim_migrate
 
-.. note::
-    After completing the migration process, the old FIM databases won't be removed automatically. To do so, remove the contents from the ``/var/ossec/queue/syscheck`` folder.
+.. warning::
+    After completing the migration process, the old FIM databases won't be removed automatically. To do so, remove the ``/var/ossec/queue/syscheck`` folder.
 
 Options
 -------


### PR DESCRIPTION
Hello team,

This PR will update the FIM migration tool documentation in order to clarify some concepts.

- The tool must be executed on the manager instance.
- After the migration process is completed, the old database won't be removed automatically.

Regards,
Juanjo