### PR TITLE
Fix typo in certificate generation command

### DIFF
--- a/source/installation-guide/optional-configurations/elastic_ssl.rst
+++ b/source/installation-guide/optional-configurations/elastic_ssl.rst
@@ -50,7 +50,7 @@ Generating a self-signed SSL certificate
 
 	.. code-block:: console
 
-		# openssl req -x509 -batch -nodes -days 3650 -newkey rsa:2048 -keyout /etc/logstash/logstash.key -out /etc/logstash/logstash.crt -config custom_openssl.cnf
+		# openssl req -x509 -batch -nodes -days 365 -newkey rsa:2048 -keyout /etc/logstash/logstash.key -out /etc/logstash/logstash.crt -config custom_openssl.cnf
 
 4. You may remove the custom configuration file:
 

--- a/source/learning-wazuh/build-lab/install-elastic-stack.rst
+++ b/source/learning-wazuh/build-lab/install-elastic-stack.rst
@@ -146,7 +146,7 @@ Generate and sign an SSL certificate and key for Logstash (on Elastic Server)
         # cp /etc/pki/tls/openssl.cnf custom_openssl.cnf
         # LINE=$((`grep -nF "[ v3_ca ]" custom_openssl.cnf | cut -d: -f1`+1))
         # sed -i "$LINE"'isubjectAltName = IP: 172.30.0.20' custom_openssl.cnf
-        # openssl req -x509 -batch -nodes -days 3650 -newkey rsa:2048 -keyout /etc/logstash/logstash.key -out /etc/logstash/logstash.crt -config custom_openssl.cnf
+        # openssl req -x509 -batch -nodes -days 365 -newkey rsa:2048 -keyout /etc/logstash/logstash.key -out /etc/logstash/logstash.crt -config custom_openssl.cnf
         # ls -alh /etc/logstash/logstash.key /etc/logstash/logstash.crt
         # rm -f custom_openssl.cnf
 


### PR DESCRIPTION
Hello team,

This will fix #329. This PR has been redone in order to avoid conflicts when merging.

This will keep consistency on the certificate generation command across the documentation files.

Regards,
Juanjo