### PR TITLE
Unify curl command usage

### DIFF
--- a/source/installation-guide/installing-elastic-stack/elastic_server_deb.rst
+++ b/source/installation-guide/installing-elastic-stack/elastic_server_deb.rst
@@ -79,7 +79,7 @@ Elasticsearch is a highly scalable full-text search and analytics engine. For mo
 
   .. code-block:: console
 
-    # curl "localhost:9200/?pretty"
+    # curl "http://localhost:9200/?pretty"
 
     {
       "name" : "Zr2Shu_",
@@ -106,7 +106,7 @@ Elasticsearch is a highly scalable full-text search and analytics engine. For mo
 
   .. code-block:: console
 
-    # curl https://raw.githubusercontent.com/wazuh/wazuh/3.7/extensions/elasticsearch/wazuh-elastic6-template-alerts.json | curl -XPUT 'http://localhost:9200/_template/wazuh' -H 'Content-Type: application/json' -d @-
+    # curl https://raw.githubusercontent.com/wazuh/wazuh/3.7/extensions/elasticsearch/wazuh-elastic6-template-alerts.json | curl -X PUT "http://localhost:9200/_template/wazuh" -H 'Content-Type: application/json' -d @-
 
 .. note::
 

--- a/source/installation-guide/installing-elastic-stack/elastic_server_rpm.rst
+++ b/source/installation-guide/installing-elastic-stack/elastic_server_rpm.rst
@@ -84,7 +84,7 @@ Elasticsearch is a highly scalable full-text search and analytics engine. For mo
 
   .. code-block:: console
 
-    # curl "localhost:9200/?pretty"
+    # curl "http://localhost:9200/?pretty"
 
     {
       "name" : "Zr2Shu_",
@@ -111,7 +111,7 @@ Elasticsearch is a highly scalable full-text search and analytics engine. For mo
 
   .. code-block:: console
 
-    # curl https://raw.githubusercontent.com/wazuh/wazuh/3.7/extensions/elasticsearch/wazuh-elastic6-template-alerts.json | curl -XPUT 'http://localhost:9200/_template/wazuh' -H 'Content-Type: application/json' -d @-
+    # curl https://raw.githubusercontent.com/wazuh/wazuh/3.7/extensions/elasticsearch/wazuh-elastic6-template-alerts.json | curl -X PUT "http://localhost:9200/_template/wazuh" -H 'Content-Type: application/json' -d @-
 
 .. note::
 

--- a/source/installation-guide/installing-wazuh-agent/wazuh_agent_sources.rst
+++ b/source/installation-guide/installing-wazuh-agent/wazuh_agent_sources.rst
@@ -33,7 +33,7 @@ Installing Linux agent
 
   .. code-block:: console
 
-    $ curl -Ls https://github.com/wazuh/wazuh/archive/v3.7.0.tar.gz | tar zx
+    # curl -Ls https://github.com/wazuh/wazuh/archive/v3.7.0.tar.gz | tar zx
 
 3. Run the ``install.sh`` script. This will run a wizard that will guide you through the installation process using the Wazuh sources:
 

--- a/source/installation-guide/optional-configurations/elastic-tuning.rst
+++ b/source/installation-guide/optional-configurations/elastic-tuning.rst
@@ -93,7 +93,7 @@ After starting Elasticsearch, you can see whether this setting was successfully 
 
 .. code-block:: console
 
-    # curl "localhost:9200/_nodes?filter_path=**.mlockall&pretty"
+    # curl "http://localhost:9200/_nodes?filter_path=**.mlockall&pretty"
 
 .. code-block:: json
 
@@ -194,7 +194,7 @@ If you want to change these settings, you will need to edit the Elasticsearch te
 
 .. code-block:: console
 
-  # curl -XPUT 'http://localhost:9200/_template/wazuh' -H 'Content-Type: application/json' -d @w-elastic-template.json
+  # curl -X PUT "http://localhost:9200/_template/wazuh" -H 'Content-Type: application/json' -d @w-elastic-template.json
 
 .. code-block:: json
 
@@ -229,7 +229,7 @@ In a cluster with one node, the number of replicas should be set to zero:
 
 .. code-block:: none
 
-  # curl -XPUT 'localhost:9200/wazuh-alerts-*/_settings?pretty' -H 'Content-Type: application/json' -d'
+  # curl -X PUT "http://localhost:9200/wazuh-alerts-*/_settings?pretty" -H 'Content-Type: application/json' -d'
   {
     "settings" : {
       "number_of_replicas" : 0
@@ -245,7 +245,7 @@ Note that we are assuming your target index pattern is **"wazuh-alerts-*"**, how
 
 .. code-block:: console
 
-  # curl "localhost:9200/_cat/indices"
+  # curl "http://localhost:9200/_cat/indices"
 
 Reference:
 

--- a/source/installation-guide/upgrading/different_major.rst
+++ b/source/installation-guide/upgrading/different_major.rst
@@ -214,7 +214,7 @@ Upgrade Elasticsearch
 
   .. code-block:: console
 
-    # curl "localhost:9200/?pretty"
+    # curl "http://localhost:9200/?pretty"
 
     {
       "name" : "Zr2Shu_",
@@ -241,7 +241,7 @@ Upgrade Elasticsearch
 
   .. code-block:: console
 
-    # curl https://raw.githubusercontent.com/wazuh/wazuh/3.7/extensions/elasticsearch/wazuh-elastic6-template-alerts.json | curl -XPUT 'http://localhost:9200/_template/wazuh' -H 'Content-Type: application/json' -d @-
+    # curl https://raw.githubusercontent.com/wazuh/wazuh/3.7/extensions/elasticsearch/wazuh-elastic6-template-alerts.json | curl -X PUT "http://localhost:9200/_template/wazuh" -H 'Content-Type: application/json' -d @-
 
 Upgrade Logstash
 ----------------

--- a/source/installation-guide/upgrading/latest_wazuh3_minor.rst
+++ b/source/installation-guide/upgrading/latest_wazuh3_minor.rst
@@ -143,7 +143,7 @@ Upgrade Elasticsearch
 
   .. code-block:: console
 
-    # curl "localhost:9200/?pretty"
+    # curl "http://localhost:9200/?pretty"
 
     {
       "name" : "Zr2Shu_",
@@ -170,7 +170,7 @@ Upgrade Elasticsearch
 
   .. code-block:: console
 
-    # curl https://raw.githubusercontent.com/wazuh/wazuh/3.7/extensions/elasticsearch/wazuh-elastic6-template-alerts.json | curl -XPUT 'http://localhost:9200/_template/wazuh' -H 'Content-Type: application/json' -d @-
+    # curl https://raw.githubusercontent.com/wazuh/wazuh/3.7/extensions/elasticsearch/wazuh-elastic6-template-alerts.json | curl -X PUT "http://localhost:9200/_template/wazuh" -H 'Content-Type: application/json' -d @-
 
 Upgrade Logstash
 ^^^^^^^^^^^^^^^^

--- a/source/installation-guide/upgrading/restore_alerts.rst
+++ b/source/installation-guide/upgrading/restore_alerts.rst
@@ -74,14 +74,14 @@ Once the reindex of your alerts has finished, you can confirm that it was succes
 
     .. code-block:: console
 
-        $ curl "localhost:9200/_cat/indices?v"
+        $ curl "http://localhost:9200/_cat/indices?v"
 
 
 If everything worked well, the output will appear something like this:
 
     .. code-block:: console
 
-        $ curl "localhost:9200/_cat/indices?v"
+        $ curl "http://localhost:9200/_cat/indices?v"
         health status index                           uuid                   pri rep docs.count docs.deleted store.size pri.store.size
         green open   wazuh-alerts-3.x-2017.12.12     vQ4YXsTuQLSDMnLk_Lp2Kw   5   1         58            0    115.1kb        115.1kb
         green open   .kibana-6                       0jtvjQ4ERLmkKbCJ7Pl4Ww   1   1        241          110    226.5kb        226.5kb

--- a/source/installation-guide/upgrading/restore_alerts.rst
+++ b/source/installation-guide/upgrading/restore_alerts.rst
@@ -74,14 +74,14 @@ Once the reindex of your alerts has finished, you can confirm that it was succes
 
     .. code-block:: console
 
-        $ curl "http://localhost:9200/_cat/indices?v"
+        # curl "http://localhost:9200/_cat/indices?v"
 
 
 If everything worked well, the output will appear something like this:
 
     .. code-block:: console
 
-        $ curl "http://localhost:9200/_cat/indices?v"
+        # curl "http://localhost:9200/_cat/indices?v"
         health status index                           uuid                   pri rep docs.count docs.deleted store.size pri.store.size
         green open   wazuh-alerts-3.x-2017.12.12     vQ4YXsTuQLSDMnLk_Lp2Kw   5   1         58            0    115.1kb        115.1kb
         green open   .kibana-6                       0jtvjQ4ERLmkKbCJ7Pl4Ww   1   1        241          110    226.5kb        226.5kb

--- a/source/learning-wazuh/build-lab/install-elastic-stack.rst
+++ b/source/learning-wazuh/build-lab/install-elastic-stack.rst
@@ -70,14 +70,14 @@ Elasticsearch indexes and stores Wazuh alerts and log records sent to it by Logs
 
   .. code-block:: console
 
-	# curl https://raw.githubusercontent.com/wazuh/wazuh/3.1/extensions/elasticsearch/wazuh-elastic6-template-alerts.json | curl -XPUT 'http://localhost:9200/_template/wazuh' -H 'Content-Type: application/json' -d @-
-	# curl https://raw.githubusercontent.com/wazuh/wazuh/3.1/extensions/elasticsearch/wazuh-elastic6-template-monitoring.json | curl -XPUT 'http://localhost:9200/_template/wazuh-agent' -H 'Content-Type: application/json' -d @-
+	# curl https://raw.githubusercontent.com/wazuh/wazuh/3.1/extensions/elasticsearch/wazuh-elastic6-template-alerts.json | curl -X PUT "http://localhost:9200/_template/wazuh" -H 'Content-Type: application/json' -d @-
+	# curl https://raw.githubusercontent.com/wazuh/wazuh/3.1/extensions/elasticsearch/wazuh-elastic6-template-monitoring.json | curl -X PUT "http://localhost:9200/_template/wazuh-agent" -H 'Content-Type: application/json' -d @-
 
 4. Insert sample alert.  Do not skip this essential step:
 
   .. code-block:: console
 
-	# curl https://raw.githubusercontent.com/wazuh/wazuh/3.1/extensions/elasticsearch/alert_sample.json | curl -XPUT "http://localhost:9200/wazuh-alerts-3.x-"`date +%Y.%m.%d`"/wazuh/sample" -H 'Content-Type: application/json' -d @-
+	# curl https://raw.githubusercontent.com/wazuh/wazuh/3.1/extensions/elasticsearch/alert_sample.json | curl -X PUT "http://localhost:9200/wazuh-alerts-3.x-"`date +%Y.%m.%d`"/wazuh/sample" -H 'Content-Type: application/json' -d @-
 
 5. Optimize Elasticsearch for lab use according to `this <https://documentation.wazuh.com/current/installation-guide/optional-configurations/elastic-tuning.html#elastic-tuning>`_ guide.
 
@@ -87,8 +87,8 @@ Elasticsearch indexes and stores Wazuh alerts and log records sent to it by Logs
 
     # curl https://raw.githubusercontent.com/wazuh/wazuh/3.1/extensions/elasticsearch/wazuh-elastic6-template-alerts.json -o w-elastic-template.json
     # sed -i 's/"index.refresh_interval": "5s"/"index.refresh_interval": "5s",\n    "number_of_shards" :   1,\n    "number_of_replicas" : 0/' w-elastic-template.json
-    # curl -XPUT 'http://localhost:9200/_template/wazuh' -H 'Content-Type: application/json' -d @w-elastic-template.json
-    # curl -XPUT 'localhost:9200/*/_settings?pretty' -H 'Content-Type: application/json' -d'
+    # curl -X PUT "http://localhost:9200/_template/wazuh" -H 'Content-Type: application/json' -d @w-elastic-template.json
+    # curl -X PUT "http://localhost:9200/*/_settings?pretty" -H 'Content-Type: application/json' -d'
     {
           "settings": {
           "number_of_replicas" : 0

--- a/source/release-notes/release_3_6_1.rst
+++ b/source/release-notes/release_3_6_1.rst
@@ -33,7 +33,7 @@ In this version, the API makes it possible to send Active Response requests, inc
 
 For instance: ::
 
-    curl -u foo:bar -k -X PUT -d '{"command":"restart-ossec0", "arguments": ["-", "null", "(from_the_server)", "(no_rule_id)"]}' -H 'Content-Type:application/json' "https://127.0.0.1:55000/active-response/001?pretty"
+    curl -u foo:bar -X PUT -d '{"command":"restart-ossec0", "arguments": ["-", "null", "(from_the_server)", "(no_rule_id)"]}' -H 'Content-Type:application/json' "http://localhost:55000/active-response/001?pretty"
 
     {
       "error": 0,

--- a/source/release-notes/release_3_7_0.rst
+++ b/source/release-notes/release_3_7_0.rst
@@ -24,12 +24,12 @@ In this example, an agent is added to two new groups.
 
 .. code-block:: console
 
-  # curl -u foo:bar -k -X PUT "http://127.0.0.1:55000/agents/001/group/webserver?pretty"
+  # curl -u foo:bar -X PUT "http://localhost:55000/agents/001/group/webserver?pretty"
   {
     "error": 0,
     "data": "Group 'webserver' added to agent '001'."
   }
-  # curl -u foo:bar -k -X PUT "http://127.0.0.1:55000/agents/001/group/apache?pretty"
+  # curl -u foo:bar -X PUT "http://localhost:55000/agents/001/group/apache?pretty"
   {
     "error": 0,
     "data": "Group 'apache' added to agent '001'."
@@ -40,7 +40,7 @@ And on the API, it's possible to check all the groups the agent is added:
 .. code-block:: console
   :emphasize-lines: 7,8,9,10,11
 
-  # curl -u foo:bar -k -X GET "http://127.0.0.1:55000/agents/001?pretty"
+  # curl -u foo:bar -X GET "http://localhost:55000/agents/001?pretty"
   {
     "error": 0,
     "data": {

--- a/source/user-manual/agents/grouping-agents.rst
+++ b/source/user-manual/agents/grouping-agents.rst
@@ -90,12 +90,12 @@ In this example, the agent 001 has been added to `webserver` and `apache` groups
 
     .. code-block:: console
 
-        # curl -u foo:bar -k -X PUT "http://127.0.0.1:55000/agents/001/group/webserver?pretty"
+        # curl -u foo:bar -X PUT "http://localhost:55000/agents/001/group/webserver?pretty"
         {
             "error": 0,
             "data": "Group 'webserver' added to agent '001'."
         }
-        # curl -u foo:bar -k -X PUT "http://127.0.0.1:55000/agents/001/group/apache?pretty"
+        # curl -u foo:bar -X PUT "http://localhost:55000/agents/001/group/apache?pretty"
         {
             "error": 0,
             "data": "Group 'apache' added to agent '001'."
@@ -106,7 +106,7 @@ After that, we can ask the **API** about groups which an agent belongs:
     .. code-block:: console
         :emphasize-lines: 7,8,9,10,11
 
-        # curl -u foo:bar -k -X GET "http://127.0.0.1:55000/agents/001?pretty"
+        # curl -u foo:bar -X GET "http://localhost:55000/agents/001?pretty"
         {
             "error": 0,
             "data": {
@@ -219,7 +219,7 @@ Finally, to check the synchronization status of the group configuration for a si
         # /var/ossec/bin/agent_groups -S -i 001
         The agent '008' sync status is: Agent configuration is synced.
 
-        # curl -u foo:bar -k -X GET "http://127.0.0.1:55000/agents/001/group/is_sync?pretty"
+        # curl -u foo:bar -X GET "http://localhost:55000/agents/001/group/is_sync?pretty"
         {
             "error": 0,
             "data": {

--- a/source/user-manual/agents/remote-upgrading/create-custom-wpk.rst
+++ b/source/user-manual/agents/remote-upgrading/create-custom-wpk.rst
@@ -77,7 +77,7 @@ Canonical WPK package example
 
   .. code-block:: console
 
-    $ curl -Ls https://github.com/wazuh/wazuh/archive/v3.7.0.tar.gz | tar zx
+    # curl -Ls https://github.com/wazuh/wazuh/archive/v3.7.0.tar.gz | tar zx
 
 3. Modify the ``wazuh-3.7.0/etc/preloaded-vars.conf`` file that was downloaded to deploy an :ref:`unattended update <unattended-installation>` in the agent by uncommenting the following lines:
 

--- a/source/user-manual/agents/restful-api/listing.rst
+++ b/source/user-manual/agents/restful-api/listing.rst
@@ -11,7 +11,7 @@ The request :ref:`GET /agents <request_list>` returns the list of available agen
 
 .. code-block:: console
 
-    $ curl -u foo:bar "http://localhost:55000/agents?pretty"
+    # curl -u foo:bar "http://localhost:55000/agents?pretty"
 
 .. code-block:: json
 

--- a/source/user-manual/api/examples.rst
+++ b/source/user-manual/api/examples.rst
@@ -60,7 +60,7 @@ cURL is a command-line tool for sending http/https requests and commands. It is 
 
 .. code-block:: console
 
-    # curl -u foo:bar -X DELETE "https://localhost:55000/rootcheck/001?pretty"
+    # curl -u foo:bar -X DELETE "http://localhost:55000/rootcheck/001?pretty"
     {
        "error": 0,
        "data": "Rootcheck database deleted"

--- a/source/user-manual/api/queries.rst
+++ b/source/user-manual/api/queries.rst
@@ -31,7 +31,7 @@ For example, to filter Ubuntu agents with a version higher than 12, the followin
 
 .. code-block:: javascript
 
-    $ curl -u foo:bar -X GET "http://localhost:55000/agents?pretty&q=os.name=ubuntu;os.version>12&select=id,name,os.name,os.version,os.codename,os.major"
+    # curl -u foo:bar -X GET "http://localhost:55000/agents?pretty&q=os.name=ubuntu;os.version>12&select=id,name,os.name,os.version,os.codename,os.major"
     {
         "error": 0,
         "data": {
@@ -65,7 +65,7 @@ The same field can be used multiple times to get a more accurate result. For exa
 
 .. code-block:: javascript
 
-    $ curl -u foo:bar -X GET "http://localhost:55000/agents?pretty&q=os.name=ubuntu;os.version>12;os.version<18&select=id,name,os.name,os.version,os.codename,os.major"
+    # curl -u foo:bar -X GET "http://localhost:55000/agents?pretty&q=os.name=ubuntu;os.version>12;os.version<18&select=id,name,os.name,os.version,os.codename,os.major"
     {
         "error": 0,
         "data": {
@@ -89,7 +89,7 @@ An example of using the OR operator can be filtering Ubuntu or CentOS agents:
 
 .. code-block:: javascript
 
-    $ curl -u foo:bar -X GET "http://localhost:55000/agents?pretty&q=os.name=ubuntu,os.name=centos+linux&select=id,name,os.name,os.version,os.codename,os.major"
+    # curl -u foo:bar -X GET "http://localhost:55000/agents?pretty&q=os.name=ubuntu,os.name=centos+linux&select=id,name,os.name,os.version,os.codename,os.major"
     {
         "error": 0,
         "data": {
@@ -133,7 +133,7 @@ Another example using the ``~`` operator is the following:
 
 .. code-block:: javascript
 
-    $ curl -u foo:bar -X GET "http://localhost:55000/agents?pretty&q=os.name~cent"
+    # curl -u foo:bar -X GET "http://localhost:55000/agents?pretty&q=os.name~cent"
     {
         "error": 0,
         "data": {
@@ -176,7 +176,7 @@ The following example shows how to check rootcheck events generated in a specifi
 
 .. code-block:: javascript
 
-    $ curl -u foo:bar -X GET "http://localhost:55000/rootcheck/001?pretty&q=oldDay<3h25m&limit=2"
+    # curl -u foo:bar -X GET "http://localhost:55000/rootcheck/001?pretty&q=oldDay<3h25m&limit=2"
     {
         "error": 0,
         "data": {
@@ -203,7 +203,7 @@ A more precise timeframe can be specified using operators ``>`` and ``<`` togeth
 
 .. code-block:: javascript
 
-    $ curl -u foo:bar -X GET "http://localhost:55000/rootcheck/001?pretty&q=oldDay<3h30m;oldDay>3h&limit=2"
+    # curl -u foo:bar -X GET "http://localhost:55000/rootcheck/001?pretty&q=oldDay<3h30m;oldDay>3h&limit=2"
     {
         "error": 0,
         "data": {

--- a/source/user-manual/api/queries.rst
+++ b/source/user-manual/api/queries.rst
@@ -31,7 +31,7 @@ For example, to filter Ubuntu agents with a version higher than 12, the followin
 
 .. code-block:: javascript
 
-    $ curl -u foo:bar "localhost:55000/agents?pretty&q=os.name=ubuntu;os.version>12&select=id,name,os.name,os.version,os.codename,os.major"
+    $ curl -u foo:bar -X GET "http://localhost:55000/agents?pretty&q=os.name=ubuntu;os.version>12&select=id,name,os.name,os.version,os.codename,os.major"
     {
         "error": 0,
         "data": {
@@ -65,7 +65,7 @@ The same field can be used multiple times to get a more accurate result. For exa
 
 .. code-block:: javascript
 
-    $ curl -u foo:bar "localhost:55000/agents?pretty&q=os.name=ubuntu;os.version>12;os.version<18&select=id,name,os.name,os.version,os.codename,os.major"
+    $ curl -u foo:bar -X GET "http://localhost:55000/agents?pretty&q=os.name=ubuntu;os.version>12;os.version<18&select=id,name,os.name,os.version,os.codename,os.major"
     {
         "error": 0,
         "data": {
@@ -89,7 +89,7 @@ An example of using the OR operator can be filtering Ubuntu or CentOS agents:
 
 .. code-block:: javascript
 
-    $ curl -u foo:bar "localhost:55000/agents?pretty&q=os.name=ubuntu,os.name=centos+linux&select=id,name,os.name,os.version,os.codename,os.major"
+    $ curl -u foo:bar -X GET "http://localhost:55000/agents?pretty&q=os.name=ubuntu,os.name=centos+linux&select=id,name,os.name,os.version,os.codename,os.major"
     {
         "error": 0,
         "data": {
@@ -133,7 +133,7 @@ Another example using the ``~`` operator is the following:
 
 .. code-block:: javascript
 
-    $ curl -u foo:bar "localhost:55000/agents?pretty&q=os.name~cent"
+    $ curl -u foo:bar -X GET "http://localhost:55000/agents?pretty&q=os.name~cent"
     {
         "error": 0,
         "data": {
@@ -176,7 +176,7 @@ The following example shows how to check rootcheck events generated in a specifi
 
 .. code-block:: javascript
 
-    $ curl -u foo:bar "localhost:55000/rootcheck/001?pretty&q=oldDay<3h25m&limit=2"
+    $ curl -u foo:bar -X GET "http://localhost:55000/rootcheck/001?pretty&q=oldDay<3h25m&limit=2"
     {
         "error": 0,
         "data": {
@@ -203,7 +203,7 @@ A more precise timeframe can be specified using operators ``>`` and ``<`` togeth
 
 .. code-block:: javascript
 
-    $ curl -u foo:bar "localhost:55000/rootcheck/001?pretty&q=oldDay<3h30m;oldDay>3h&limit=2"
+    $ curl -u foo:bar -X GET "http://localhost:55000/rootcheck/001?pretty&q=oldDay<3h30m;oldDay>3h&limit=2"
     {
         "error": 0,
         "data": {

--- a/source/user-manual/api/reference.rst
+++ b/source/user-manual/api/reference.rst
@@ -188,7 +188,7 @@ Runs an Active Response command on a specified agent
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X PUT -d '{"command":"restart-ossec0", "arguments": ["-", "null", "(from_the_server)", "(no_rule_id)"]}' -H 'Content-Type:application/json' "https://127.0.0.1:55000/active-response/001?pretty"
+	curl -u foo:bar -X PUT -d '{"command":"restart-ossec0", "arguments": ["-", "null", "(from_the_server)", "(no_rule_id)"]}' -H 'Content-Type:application/json' "http://localhost:55000/active-response/001?pretty"
 
 **Example Response:**
 ::
@@ -236,7 +236,7 @@ Add a new agent.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X POST -d '{"name":"NewHost","ip":"10.0.0.9"}' -H 'Content-Type:application/json' "https://127.0.0.1:55000/agents?pretty"
+	curl -u foo:bar -X POST -d '{"name":"NewHost","ip":"10.0.0.9"}' -H 'Content-Type:application/json' "http://localhost:55000/agents?pretty"
 
 **Example Response:**
 ::
@@ -271,7 +271,7 @@ Adds a new agent with name :agent_name. This agent will use ANY as IP.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X PUT "https://127.0.0.1:55000/agents/myNewAgent?pretty"
+	curl -u foo:bar -X PUT "http://localhost:55000/agents/myNewAgent?pretty"
 
 **Example Response:**
 ::
@@ -320,7 +320,7 @@ Insert an agent with an existing id and key.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X POST -d '{"name":"NewHost_2","ip":"10.0.10.10","id":"123","key":"1abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghi64"}' -H 'Content-Type:application/json' "https://127.0.0.1:55000/agents/insert?pretty"
+	curl -u foo:bar -X POST -d '{"name":"NewHost_2","ip":"10.0.10.10","id":"123","key":"1abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghi64"}' -H 'Content-Type:application/json' "http://localhost:55000/agents/insert?pretty"
 
 **Example Response:**
 ::
@@ -427,7 +427,7 @@ Returns the active configuration in JSON format.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/agents/001/config/logcollector/localfile?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/agents/001/config/logcollector/localfile?pretty"
 
 **Example Response:**
 ::
@@ -528,7 +528,7 @@ Removes a list of groups.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X DELETE -H "Content-Type:application/json" -d '{"ids":["webserver","database"]}' "https://127.0.0.1:55000/agents/groups?pretty"
+	curl -u foo:bar -X DELETE -H "Content-Type:application/json" -d '{"ids":["webserver","database"]}' "http://localhost:55000/agents/groups?pretty"
 
 **Example Response:**
 ::
@@ -584,7 +584,7 @@ Removes agents, using a list of them or a criterion based on the status or time 
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X DELETE -H "Content-Type:application/json" -d '{"ids":["003","005"]}' "https://127.0.0.1:55000/agents?pretty&older_than=10s&purge"
+	curl -u foo:bar -X DELETE -H "Content-Type:application/json" -d '{"ids":["003","005"]}' "http://localhost:55000/agents?pretty&older_than=10s&purge"
 
 **Example Response:**
 ::
@@ -626,7 +626,7 @@ Removes an agent.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X DELETE "https://127.0.0.1:55000/agents/008?pretty&purge"
+	curl -u foo:bar -X DELETE "http://localhost:55000/agents/008?pretty&purge"
 
 **Example Response:**
 ::
@@ -667,7 +667,7 @@ Returns the sync status in JSON format
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/agents/001/group/is_sync?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/agents/001/group/is_sync?pretty"
 
 **Example Response:**
 ::
@@ -709,7 +709,7 @@ Adds an agent to the specified group.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X PUT "https://127.0.0.1:55000/agents/004/group/dmz?pretty"
+	curl -u foo:bar -X PUT "http://localhost:55000/agents/004/group/dmz?pretty"
 
 **Example Response:**
 ::
@@ -741,7 +741,7 @@ Creates a new group.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X PUT "https://127.0.0.1:55000/agents/groups/pciserver?pretty"
+	curl -u foo:bar -X PUT "http://localhost:55000/agents/groups/pciserver?pretty"
 
 **Example Response:**
 ::
@@ -784,7 +784,7 @@ Returns the specified file belonging to the group parsed to JSON.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/agents/groups/webserver/files/cis_debian_linux_rcl.txt?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/agents/groups/webserver/files/cis_debian_linux_rcl.txt?pretty"
 
 **Example Response:**
 ::
@@ -850,7 +850,7 @@ Returns the list of agents in a group.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/agents/groups/dmz?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/agents/groups/dmz?pretty"
 
 **Example Response:**
 ::
@@ -936,7 +936,7 @@ Returns a list with the available agents without group.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/agents/no_group?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/agents/no_group?pretty"
 
 **Example Response:**
 ::
@@ -1000,7 +1000,7 @@ Returns the group configuration (agent.conf).
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/agents/groups/dmz/configuration?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/agents/groups/dmz/configuration?pretty"
 
 **Example Response:**
 ::
@@ -1059,7 +1059,7 @@ Returns the files belonging to the group.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/agents/groups/default/files?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/agents/groups/default/files?pretty"
 
 **Example Response:**
 ::
@@ -1199,7 +1199,7 @@ Returns the list of existing agent groups.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/agents/groups?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/agents/groups?pretty"
 
 **Example Response:**
 ::
@@ -1254,7 +1254,7 @@ Remove the group of the agent but will leave the rest of its group if it belongs
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X DELETE "https://127.0.0.1:55000/agents/004/group/dmz?pretty"
+	curl -u foo:bar -X DELETE "http://localhost:55000/agents/004/group/dmz?pretty"
 
 **Example Response:**
 ::
@@ -1286,7 +1286,7 @@ Removes the group of the agent. The agent will automatically revert to the 'defa
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X DELETE "https://127.0.0.1:55000/agents/004/group?pretty"
+	curl -u foo:bar -X DELETE "http://localhost:55000/agents/004/group?pretty"
 
 **Example Response:**
 ::
@@ -1318,7 +1318,7 @@ Removes the group. Agents that were assigned to the removed group will automatic
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X DELETE "https://127.0.0.1:55000/agents/groups/dmz?pretty"
+	curl -u foo:bar -X DELETE "http://localhost:55000/agents/groups/dmz?pretty"
 
 **Example Response:**
 ::
@@ -1370,7 +1370,7 @@ Returns a summary of the OS.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/agents/summary/os?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/agents/summary/os?pretty"
 
 **Example Response:**
 ::
@@ -1399,7 +1399,7 @@ Returns a summary of the available agents.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/agents/summary?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/agents/summary?pretty"
 
 **Example Response:**
 ::
@@ -1474,7 +1474,7 @@ Returns a list with the available agents.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/agents?pretty&offset=0&limit=5&sort=-ip,name"
+	curl -u foo:bar -X GET "http://localhost:55000/agents?pretty&offset=0&limit=5&sort=-ip,name"
 
 **Example Response:**
 ::
@@ -1586,7 +1586,7 @@ Returns various information from an agent.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/agents/000?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/agents/000?pretty"
 
 **Example Response:**
 ::
@@ -1640,7 +1640,7 @@ Returns various information from an agent called :agent_name.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/agents/name/NewHost?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/agents/name/NewHost?pretty"
 
 **Example Response:**
 ::
@@ -1683,7 +1683,7 @@ Returns the key of an agent.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/agents/004/key?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/agents/004/key?pretty"
 
 **Example Response:**
 ::
@@ -1719,7 +1719,7 @@ Restarts a list of agents.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X POST -H "Content-Type:application/json" -d '{"ids":["002","004"]}' "https://127.0.0.1:55000/agents/restart?pretty"
+	curl -u foo:bar -X POST -H "Content-Type:application/json" -d '{"ids":["002","004"]}' "http://localhost:55000/agents/restart?pretty"
 
 **Example Response:**
 ::
@@ -1748,7 +1748,7 @@ Restarts all agents.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X PUT "https://127.0.0.1:55000/agents/restart?pretty"
+	curl -u foo:bar -X PUT "http://localhost:55000/agents/restart?pretty"
 
 **Example Response:**
 ::
@@ -1779,7 +1779,7 @@ Restarts the specified agent.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X PUT "https://127.0.0.1:55000/agents/007/restart?pretty"
+	curl -u foo:bar -X PUT "http://localhost:55000/agents/007/restart?pretty"
 
 **Example Response:**
 ::
@@ -1831,7 +1831,7 @@ Returns all the different combinations that agents have for the selected fields.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/agents/stats/distinct?pretty&fields=os.platform"
+	curl -u foo:bar -X GET "http://localhost:55000/agents/stats/distinct?pretty&fields=os.platform"
 
 **Example Response:**
 ::
@@ -1886,7 +1886,7 @@ Returns the list of outdated agents.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/agents/outdated?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/agents/outdated?pretty"
 
 **Example Response:**
 ::
@@ -1933,7 +1933,7 @@ Returns the upgrade result from an agent.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/agents/003/upgrade_result?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/agents/003/upgrade_result?pretty"
 
 **Example Response:**
 ::
@@ -1968,7 +1968,7 @@ Upgrade the agent using a custom file.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X PUT "https://127.0.0.1:55000/agents/002/upgrade_custom?pretty"
+	curl -u foo:bar -X PUT "http://localhost:55000/agents/002/upgrade_custom?pretty"
 
 **Example Response:**
 ::
@@ -2012,7 +2012,7 @@ Upgrade the agent using a WPK file from online repository.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X PUT "https://127.0.0.1:55000/agents/002/upgrade?pretty"
+	curl -u foo:bar -X PUT "http://localhost:55000/agents/002/upgrade?pretty"
 
 **Example Response:**
 ::
@@ -2050,7 +2050,7 @@ Clears cache of the specified group.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X DELETE "https://127.0.0.1:55000/cache/mygroup?pretty"
+	curl -u foo:bar -X DELETE "http://localhost:55000/cache/mygroup?pretty"
 
 **Example Response:**
 ::
@@ -2087,7 +2087,7 @@ Clears entire cache.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X DELETE "https://127.0.0.1:55000/cache?pretty"
+	curl -u foo:bar -X DELETE "http://localhost:55000/cache?pretty"
 
 **Example Response:**
 ::
@@ -2118,7 +2118,7 @@ Returns current cache index.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/cache?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/cache?pretty"
 
 **Example Response:**
 ::
@@ -2145,7 +2145,7 @@ Returns cache configuration.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/cache/config?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/cache/config?pretty"
 
 **Example Response:**
 ::
@@ -2217,7 +2217,7 @@ Returns the agent's ciscat results info
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/ciscat/000/results?pretty&sort=-score"
+	curl -u foo:bar -X GET "http://localhost:55000/ciscat/000/results?pretty&sort=-score"
 
 **Example Response:**
 ::
@@ -2289,7 +2289,7 @@ Returns ossec.conf in JSON format.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/cluster/node02/configuration?section=global&pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/cluster/node02/configuration?section=global&pretty"
 
 **Example Response:**
 ::
@@ -2329,7 +2329,7 @@ Returns the cluster configuration
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/cluster/config?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/cluster/config?pretty"
 
 **Example Response:**
 ::
@@ -2369,7 +2369,7 @@ Returns whether the cluster is enabled or disabled
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/cluster/status?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/cluster/status?pretty"
 
 **Example Response:**
 ::
@@ -2396,7 +2396,7 @@ Returns the status of the manager processes.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/cluster/node02/status?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/cluster/node02/status?pretty"
 
 **Example Response:**
 ::
@@ -2431,7 +2431,7 @@ Returns basic information about manager.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/cluster/node02/info?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/cluster/node02/info?pretty"
 
 **Example Response:**
 ::
@@ -2473,7 +2473,7 @@ Show cluster health
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/cluster/healthcheck?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/cluster/healthcheck?pretty"
 
 **Example Response:**
 ::
@@ -2574,7 +2574,7 @@ Returns the three last months of ossec.log.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/cluster/node02/logs?offset=0&limit=5&pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/cluster/node02/logs?offset=0&limit=5&pretty"
 
 **Example Response:**
 ::
@@ -2632,7 +2632,7 @@ Returns a summary of the last three months of the <code>ossec.log</code> file.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/cluster/node02/logs/summary?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/cluster/node02/logs/summary?pretty"
 
 **Example Response:**
 ::
@@ -2781,7 +2781,7 @@ Returns the local node info
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/cluster/node?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/cluster/node?pretty"
 
 **Example Response:**
 ::
@@ -2809,7 +2809,7 @@ Returns the node info
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/cluster/nodes/node01?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/cluster/nodes/node01?pretty"
 
 **Example Response:**
 ::
@@ -2856,7 +2856,7 @@ Returns the nodes info
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/cluster/nodes?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/cluster/nodes?pretty"
 
 **Example Response:**
 ::
@@ -2908,7 +2908,7 @@ Returns Wazuh statistical information for the current or specified date.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/cluster/node02/stats?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/cluster/node02/stats?pretty"
 
 **Example Response:**
 ::
@@ -2957,7 +2957,7 @@ Returns Wazuh statistical information per hour. Each number in the averages fiel
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/cluster/node02/stats/hourly?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/cluster/node02/stats/hourly?pretty"
 
 **Example Response:**
 ::
@@ -2991,7 +2991,7 @@ Returns Wazuh statistical information per week. Each number in the hours field r
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/cluster/node02/stats/weekly?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/cluster/node02/stats/weekly?pretty"
 
 **Example Response:**
 ::
@@ -3104,7 +3104,7 @@ Returns all decoders included in ossec.conf.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/decoders?pretty&offset=0&limit=2&sort=+file,position"
+	curl -u foo:bar -X GET "http://localhost:55000/decoders?pretty&offset=0&limit=2&sort=+file,position"
 
 **Example Response:**
 ::
@@ -3183,7 +3183,7 @@ Returns all decoders files included in ossec.conf.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/decoders/files?pretty&offset=0&limit=10&sort=-path"
+	curl -u foo:bar -X GET "http://localhost:55000/decoders/files?pretty&offset=0&limit=10&sort=-path"
 
 **Example Response:**
 ::
@@ -3275,7 +3275,7 @@ Returns all parent decoders included in ossec.conf
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/decoders/parents?pretty&offset=0&limit=2&sort=-file"
+	curl -u foo:bar -X GET "http://localhost:55000/decoders/parents?pretty&offset=0&limit=2&sort=-file"
 
 **Example Response:**
 ::
@@ -3341,7 +3341,7 @@ Returns the decoders with the specified name.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/decoders/apache-errorlog?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/decoders/apache-errorlog?pretty"
 
 **Example Response:**
 ::
@@ -3406,7 +3406,7 @@ Clears the syscheck database for all agents.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X DELETE "https://127.0.0.1:55000/experimental/syscheck?pretty"
+	curl -u foo:bar -X DELETE "http://localhost:55000/experimental/syscheck?pretty"
 
 **Example Response:**
 ::
@@ -3463,7 +3463,7 @@ Returns the agent's hardware info
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/experimental/syscollector/hardware?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/experimental/syscollector/hardware?pretty"
 
 **Example Response:**
 ::
@@ -3573,7 +3573,7 @@ Returns the agent's network address info
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/experimental/syscollector/netaddr?pretty&limit=2&sort=proto"
+	curl -u foo:bar -X GET "http://localhost:55000/experimental/syscollector/netaddr?pretty&limit=2&sort=proto"
 
 **Example Response:**
 ::
@@ -3661,7 +3661,7 @@ Returns the agent's network interface info
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/experimental/syscollector/netiface?pretty&limit=2"
+	curl -u foo:bar -X GET "http://localhost:55000/experimental/syscollector/netiface?pretty&limit=2"
 
 **Example Response:**
 ::
@@ -3765,7 +3765,7 @@ Returns the agent's network protocol info
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/experimental/syscollector/netproto?pretty&limit=2&sort=type"
+	curl -u foo:bar -X GET "http://localhost:55000/experimental/syscollector/netproto?pretty&limit=2&sort=type"
 
 **Example Response:**
 ::
@@ -3839,7 +3839,7 @@ Returns the agent's os info
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/experimental/syscollector/os?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/experimental/syscollector/os?pretty"
 
 **Example Response:**
 ::
@@ -3957,7 +3957,7 @@ Returns the agent's packages info
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/experimental/syscollector/packages?pretty&sort=-name&limit=2"
+	curl -u foo:bar -X GET "http://localhost:55000/experimental/syscollector/packages?pretty&sort=-name&limit=2"
 
 **Example Response:**
 ::
@@ -4055,7 +4055,7 @@ Returns the agent's ports info
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/experimental/syscollector/ports?pretty&limit=2&sort=protocol"
+	curl -u foo:bar -X GET "http://localhost:55000/experimental/syscollector/ports?pretty&limit=2&sort=protocol"
 
 **Example Response:**
 ::
@@ -4171,7 +4171,7 @@ Returns the agent's processes info
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/experimental/syscollector/processes?pretty&limit=2&sort=priority"
+	curl -u foo:bar -X GET "http://localhost:55000/experimental/syscollector/processes?pretty&limit=2&sort=priority"
 
 **Example Response:**
 ::
@@ -4303,7 +4303,7 @@ Returns the agent's ciscat results info
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/experimental/ciscat/results?pretty&sort=-score"
+	curl -u foo:bar -X GET "http://localhost:55000/experimental/ciscat/results?pretty&sort=-score"
 
 **Example Response:**
 ::
@@ -4377,7 +4377,7 @@ Returns ossec.conf in JSON format.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/manager/configuration?section=global&pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/manager/configuration?section=global&pretty"
 
 **Example Response:**
 ::
@@ -4421,7 +4421,7 @@ Returns basic information about manager.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/manager/info?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/manager/info?pretty"
 
 **Example Response:**
 ::
@@ -4455,7 +4455,7 @@ Returns the status of the manager processes.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/manager/status?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/manager/status?pretty"
 
 **Example Response:**
 ::
@@ -4519,7 +4519,7 @@ Returns the three last months of ossec.log.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/manager/logs?offset=0&limit=5&pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/manager/logs?offset=0&limit=5&pretty"
 
 **Example Response:**
 ::
@@ -4577,7 +4577,7 @@ Returns a summary of the last three months of the <code>ossec.log</code> file.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/manager/logs/summary?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/manager/logs/summary?pretty"
 
 **Example Response:**
 ::
@@ -4734,7 +4734,7 @@ Returns a summary of the current analysisd stats.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/manager/stats/analysisd?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/manager/stats/analysisd?pretty"
 
 **Example Response:**
 ::
@@ -4805,7 +4805,7 @@ Returns Wazuh statistical information for the current or specified date.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/manager/stats?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/manager/stats?pretty"
 
 **Example Response:**
 ::
@@ -4854,7 +4854,7 @@ Returns Wazuh statistical information per hour. Each number in the averages fiel
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/manager/stats/hourly?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/manager/stats/hourly?pretty"
 
 **Example Response:**
 ::
@@ -4888,7 +4888,7 @@ Returns Wazuh statistical information per week. Each number in the hours field r
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/manager/stats/weekly?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/manager/stats/weekly?pretty"
 
 **Example Response:**
 ::
@@ -4968,7 +4968,7 @@ Returns a summary of the current remoted stats.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/manager/stats/remoted?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/manager/stats/remoted?pretty"
 
 **Example Response:**
 ::
@@ -5007,7 +5007,7 @@ Clears the rootcheck database for all agents.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X DELETE "https://127.0.0.1:55000/rootcheck?pretty"
+	curl -u foo:bar -X DELETE "http://localhost:55000/rootcheck?pretty"
 
 **Example Response:**
 ::
@@ -5038,7 +5038,7 @@ Clears the rootcheck database for a specific agent.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X DELETE "https://127.0.0.1:55000/rootcheck/000?pretty"
+	curl -u foo:bar -X DELETE "http://localhost:55000/rootcheck/000?pretty"
 
 **Example Response:**
 ::
@@ -5073,7 +5073,7 @@ Returns the timestamp of the last rootcheck scan.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/rootcheck/000/last_scan?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/rootcheck/000/last_scan?pretty"
 
 **Example Response:**
 ::
@@ -5114,7 +5114,7 @@ Returns the CIS requirements of all rootchecks of the specified agent.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/rootcheck/000/cis?offset=0&limit=10&pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/rootcheck/000/cis?offset=0&limit=10&pretty"
 
 **Example Response:**
 ::
@@ -5166,7 +5166,7 @@ Returns the rootcheck database of an agent.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/rootcheck/000?offset=0&limit=2&pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/rootcheck/000?offset=0&limit=2&pretty"
 
 **Example Response:**
 ::
@@ -5220,7 +5220,7 @@ Returns the PCI requirements of all rootchecks of the agent.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/rootcheck/000/pci?offset=0&limit=10&pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/rootcheck/000/pci?offset=0&limit=10&pretty"
 
 **Example Response:**
 ::
@@ -5254,7 +5254,7 @@ Runs syscheck and rootcheck on all agents (Wazuh launches both processes simulta
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X PUT "https://127.0.0.1:55000/rootcheck?pretty"
+	curl -u foo:bar -X PUT "http://localhost:55000/rootcheck?pretty"
 
 **Example Response:**
 ::
@@ -5285,7 +5285,7 @@ Runs syscheck and rootcheck on a specified agent (Wazuh launches both processes 
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X PUT "https://127.0.0.1:55000/rootcheck/000?pretty"
+	curl -u foo:bar -X PUT "http://localhost:55000/rootcheck/000?pretty"
 
 **Example Response:**
 ::
@@ -5350,7 +5350,7 @@ Returns all rules.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/rules?offset=0&limit=2&pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/rules?offset=0&limit=2&pretty"
 
 **Example Response:**
 ::
@@ -5440,7 +5440,7 @@ Returns the files of all rules.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/rules/files?offset=0&limit=10&pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/rules/files?offset=0&limit=10&pretty"
 
 **Example Response:**
 ::
@@ -5532,7 +5532,7 @@ Returns the GDPR requirements of all rules.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/rules/gdpr?offset=0&limit=10&pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/rules/gdpr?offset=0&limit=10&pretty"
 
 **Example Response:**
 ::
@@ -5578,7 +5578,7 @@ Returns the groups of all rules.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/rules/groups?offset=0&limit=10&pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/rules/groups?offset=0&limit=10&pretty"
 
 **Example Response:**
 ::
@@ -5630,7 +5630,7 @@ Returns the PCI requirements of all rules.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/rules/pci?offset=0&limit=10&pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/rules/pci?offset=0&limit=10&pretty"
 
 **Example Response:**
 ::
@@ -5684,7 +5684,7 @@ Returns the rules with the specified id.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/rules/1002?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/rules/1002?pretty"
 
 **Example Response:**
 ::
@@ -5745,7 +5745,7 @@ Clears the syscheck database for the specified agent.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X DELETE "https://127.0.0.1:55000/syscheck/000?pretty"
+	curl -u foo:bar -X DELETE "http://localhost:55000/syscheck/000?pretty"
 
 **Example Response:**
 ::
@@ -5780,7 +5780,7 @@ Return the timestamp of the last syscheck scan.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/syscheck/000/last_scan?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/syscheck/000/last_scan?pretty"
 
 **Example Response:**
 ::
@@ -5849,7 +5849,7 @@ Returns the syscheck files of an agent.
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/syscheck/000?offset=0&limit=2&pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/syscheck/000?offset=0&limit=2&pretty"
 
 **Example Response:**
 ::
@@ -5913,7 +5913,7 @@ Runs syscheck and rootcheck on all agents (Wazuh launches both processes simulta
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X PUT "https://127.0.0.1:55000/syscheck?pretty"
+	curl -u foo:bar -X PUT "http://localhost:55000/syscheck?pretty"
 
 **Example Response:**
 ::
@@ -5944,7 +5944,7 @@ Runs syscheck and rootcheck on an agent (Wazuh launches both processes simultane
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X PUT "https://127.0.0.1:55000/syscheck/000?pretty"
+	curl -u foo:bar -X PUT "http://localhost:55000/syscheck/000?pretty"
 
 **Example Response:**
 ::
@@ -5985,7 +5985,7 @@ Returns the agent's hardware info
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/syscollector/000/hardware?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/syscollector/000/hardware?pretty"
 
 **Example Response:**
 ::
@@ -6053,7 +6053,7 @@ Returns the agent's network address info
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/syscollector/000/netaddr?pretty&limit=2&sort=proto"
+	curl -u foo:bar -X GET "http://localhost:55000/syscollector/000/netaddr?pretty&limit=2&sort=proto"
 
 **Example Response:**
 ::
@@ -6139,7 +6139,7 @@ Returns the agent's network interface info
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/syscollector/000/netiface?pretty&limit=2&sort=state"
+	curl -u foo:bar -X GET "http://localhost:55000/syscollector/000/netiface?pretty&limit=2&sort=state"
 
 **Example Response:**
 ::
@@ -6241,7 +6241,7 @@ Returns the agent's network protocol info
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/syscollector/000/netproto?pretty&limit=2&sort=type"
+	curl -u foo:bar -X GET "http://localhost:55000/syscollector/000/netproto?pretty&limit=2&sort=type"
 
 **Example Response:**
 ::
@@ -6295,7 +6295,7 @@ Returns the agent's OS info
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/syscollector/000/os?pretty"
+	curl -u foo:bar -X GET "http://localhost:55000/syscollector/000/os?pretty"
 
 **Example Response:**
 ::
@@ -6369,7 +6369,7 @@ Returns the agent's packages info
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/syscollector/000/packages?pretty&limit=2&offset=10&sort=-name"
+	curl -u foo:bar -X GET "http://localhost:55000/syscollector/000/packages?pretty&limit=2&offset=10&sort=-name"
 
 **Example Response:**
 ::
@@ -6465,7 +6465,7 @@ Returns the agent's ports info
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/syscollector/000/ports?pretty&sort=-protocol&limit=2"
+	curl -u foo:bar -X GET "http://localhost:55000/syscollector/000/ports?pretty&sort=-protocol&limit=2"
 
 **Example Response:**
 ::
@@ -6581,7 +6581,7 @@ Returns the agent's processes info
 **Example Request:**
 ::
 
-	curl -u foo:bar -k -X GET "https://127.0.0.1:55000/syscollector/000/processes?pretty&limit=2&offset=10&sort=-name"
+	curl -u foo:bar -X GET "http://localhost:55000/syscollector/000/processes?pretty&limit=2&offset=10&sort=-name"
 
 **Example Response:**
 ::

--- a/source/user-manual/capabilities/syscollector.rst
+++ b/source/user-manual/capabilities/syscollector.rst
@@ -419,7 +419,7 @@ The current inventory can be consulted in different ways. Let's see an example q
 
 .. code-block:: console
 
-  # curl -u foo:bar "localhost:55000/syscollector/003/packages?pretty&name=wazuh-agent"
+  # curl -u foo:bar -X GET "http://localhost:55000/syscollector/003/packages?pretty&name=wazuh-agent"
   {
    "error": 0,
    "data": {

--- a/source/user-manual/kibana-app/configure-xpack/configure-xpack-users.rst
+++ b/source/user-manual/kibana-app/configure-xpack/configure-xpack-users.rst
@@ -94,7 +94,7 @@ Using the command-line interface (CLI)
 
   .. code-block:: none
 
-    # curl -XPOST "http://localhost:9200/_xpack/security/role/wazuh-admin" -H 'Content-Type: application/json' -d'
+    # curl -X POST "http://localhost:9200/_xpack/security/role/wazuh-admin" -H 'Content-Type: application/json' -d'
     {
       "cluster": [ "manage", "manage_index_templates" ],
       "indices": [
@@ -111,7 +111,7 @@ Using the command-line interface (CLI)
 
   .. code-block:: none
 
-    # curl -XPOST "http://localhost:9200/_xpack/security/role/wazuh-basic" -H 'Content-Type: application/json' -d'
+    # curl -X POST "http://localhost:9200/_xpack/security/role/wazuh-basic" -H 'Content-Type: application/json' -d'
     {
       "cluster": [],
       "indices": [
@@ -128,7 +128,7 @@ Using the command-line interface (CLI)
 
   .. code-block:: none
 
-    # curl -XPOST "http://localhost:9200/_xpack/security/role/wazuh-api-admin" -H 'Content-Type: application/json' -d'
+    # curl -X POST "http://localhost:9200/_xpack/security/role/wazuh-api-admin" -H 'Content-Type: application/json' -d'
     {
       "cluster": [],
       "indices": [
@@ -149,7 +149,7 @@ Using the command-line interface (CLI)
 
   .. code-block:: none
 
-    # curl -XPOST "http://localhost:9200/_xpack/security/user/wazuhsystem" -H 'Content-Type: application/json' -d'
+    # curl -X POST "http://localhost:9200/_xpack/security/user/wazuhsystem" -H 'Content-Type: application/json' -d'
     {
       "password": "wazuhsystem",
       "roles":["wazuh-admin","kibana_system"],
@@ -163,7 +163,7 @@ Using the command-line interface (CLI)
 
   .. code-block:: none
 
-    # curl -XPOST "http://localhost:9200/_xpack/security/user/jack" -H 'Content-Type: application/json' -d'
+    # curl -X POST "http://localhost:9200/_xpack/security/user/jack" -H 'Content-Type: application/json' -d'
     {
       "password": "jackjack",
       "roles":["wazuh-basic","wazuh-api-admin"],
@@ -181,7 +181,7 @@ Using the command-line interface (CLI)
 
   .. code-block:: none
 
-    # curl -XPOST "http://localhost:9200/_xpack/security/user/john" -H 'Content-Type: application/json' -d'
+    # curl -X POST "http://localhost:9200/_xpack/security/user/john" -H 'Content-Type: application/json' -d'
     {
       "password": "johnjohn",
       "roles":["wazuh-basic"],

--- a/source/user-manual/kibana-app/configure-xpack/index.rst
+++ b/source/user-manual/kibana-app/configure-xpack/index.rst
@@ -42,7 +42,7 @@ Follow these steps to enable X-Pack:
 
   .. code-block:: console
 
-    # curl localhost:9200/?pretty -u elastic:<elastic_password>
+    # curl -u elastic:<elastic_password> "http://localhost:9200/?pretty"
 
     {
       "name" : "116m4ct",

--- a/source/user-manual/kibana-app/configure-xpack/xpack-troubleshooting.rst
+++ b/source/user-manual/kibana-app/configure-xpack/xpack-troubleshooting.rst
@@ -12,7 +12,7 @@ If you are indexing data with a different index pattern, for example ``my-alerts
 
   .. code-block:: none
 
-      # curl -XPOST "http://localhost:9200/_xpack/security/role/my-user" -H 'Content-Type: application/json' -d'
+      # curl -X POST "http://localhost:9200/_xpack/security/role/my-user" -H 'Content-Type: application/json' -d'
       {
       "cluster": [],
       "indices": [
@@ -30,7 +30,7 @@ Now assign it to your desired user(s):
 
   .. code-block:: none
 
-    # curl -XPUT "http://localhost:9200/_xpack/security/user/john" -H 'Content-Type: application/json' -d'
+    # curl -X PUT "http://localhost:9200/_xpack/security/user/john" -H 'Content-Type: application/json' -d'
     {
       "password": "johnjohn",
       "roles":["wazuh-basic","my-user"],

--- a/source/user-manual/kibana-app/troubleshooting.rst
+++ b/source/user-manual/kibana-app/troubleshooting.rst
@@ -29,7 +29,7 @@ Elasticsearch needs a specific template to store Wazuh alerts, otherwise visuali
 
 .. code-block:: console
 
-  # curl https://raw.githubusercontent.com/wazuh/wazuh/3.7/extensions/elasticsearch/wazuh-elastic6-template-alerts.json | curl -XPUT 'http://localhost:9200/_template/wazuh' -H 'Content-Type: application/json' -d @-
+  # curl https://raw.githubusercontent.com/wazuh/wazuh/3.7/extensions/elasticsearch/wazuh-elastic6-template-alerts.json | curl -X PUT "http://localhost:9200/_template/wazuh" -H 'Content-Type: application/json' -d @-
 
   {"acknowledged":true}
 

--- a/source/user-manual/manager/wazuh-cluster.rst
+++ b/source/user-manual/manager/wazuh-cluster.rst
@@ -347,7 +347,7 @@ This information can also be obtained using the Restful API:
 
 .. code-block:: javascript
 
-    $ curl -u foo:bar -X GET "https://localhost:55000/cluster/nodes?pretty"
+    # curl -u foo:bar -X GET "http://localhost:55000/cluster/nodes?pretty"
     {
        "error": 0,
        "data": {

--- a/source/user-manual/manager/wazuh-cluster.rst
+++ b/source/user-manual/manager/wazuh-cluster.rst
@@ -345,7 +345,7 @@ For example, the following snippet shows the connected nodes in the cluster:
 
 This information can also be obtained using the Restful API:
 
-.. code-block:: javascript
+.. code-block:: console
 
     # curl -u foo:bar -X GET "http://localhost:55000/cluster/nodes?pretty"
     {

--- a/source/user-manual/reference/centralized-configuration.rst
+++ b/source/user-manual/reference/centralized-configuration.rst
@@ -145,9 +145,9 @@ The following is an example of how a centralized configuration can be done.
 
 Edit the file corresponding to the agent group. For example, for the ``default`` group, edit the file ``/var/ossec/etc/shared/default/agent.conf``. If the file does not exist, create it::
 
-    $ touch /var/ossec/etc/shared/default/agent.conf
-    $ chown ossec:ossec /var/ossec/etc/shared/default/agent.conf
-    $ chmod 640 /var/ossec/etc/shared/default/agent.conf
+    # touch /var/ossec/etc/shared/default/agent.conf
+    # chown ossec:ossec /var/ossec/etc/shared/default/agent.conf
+    # chmod 640 /var/ossec/etc/shared/default/agent.conf
 
 Several configurations may be created based on the ``name``, ``OS`` or ``profile`` of an agent.
 
@@ -193,7 +193,7 @@ The ``agent_groups`` tool or the API can show whether the group is synchronized 
 
 .. code-block:: console
 
-    $ curl -u foo:bar "localhost:55000/agents/001/group/is_sync?pretty"
+    # curl -u foo:bar -X GET "http://localhost:55000/agents/001/group/is_sync?pretty"
     {
         "error": 0,
         "data": {
@@ -203,7 +203,7 @@ The ``agent_groups`` tool or the API can show whether the group is synchronized 
 
 .. code-block:: console
 
-    $ /var/ossec/bin/agent_groups -S -i 001
+    # /var/ossec/bin/agent_groups -S -i 001
     Agent '001' is synchronized.
 
 5. Restart the agent:
@@ -214,7 +214,7 @@ If ``auto_restart`` has been disabled (in the ``<client>`` section of :doc:`Loca
 
 .. code-block:: console
 
-    $ /var/ossec/bin/agent_control -R -u 1032
+    # /var/ossec/bin/agent_control -R -u 1032
 
     Wazuh agent_control: Restarting agent: 1032
 


### PR DESCRIPTION
Hello team,

This PR closes #289. It will unify the usage of the `curl` command:

- All Wazuh API requests use `http://localhost:55000` without the `-k` flag (except lab docs, where HTTPS is configured)
- Unify HTTP method formats.
- Unify Elasticsearch API commands.
- Fixed some inconsistencies.

Regards,
Juanjo