### PR TITLE
Changed ossec-control command with systemctl/service alternative

### DIFF
--- a/source/amazon/installation.rst
+++ b/source/amazon/installation.rst
@@ -334,13 +334,35 @@ To monitor logs for multiple AWS accounts, configure multiple ``<bucket>`` optio
 
 *Check the user manual reference to read more details about each setting:* :doc:`AWS S3 settings <../user-manual/reference/ossec-conf/wodle-s3>`
 
-
 3. Restart your Wazuh system to apply the changes:
 
-.. code-block:: console
+  * If you're configuring a Wazuh manager:
 
-    # /var/ossec/bin/ossec-control restart
+    a. For Systemd:
 
+      .. code-block:: console
+
+        # systemctl restart wazuh-manager
+
+    b. For SysV Init:
+
+      .. code-block:: console
+
+        # service wazuh-manager restart
+
+  * If you're configuring a Wazuh agent:
+
+    a. For Systemd:
+
+      .. code-block:: console
+
+        # systemctl restart wazuh-agent
+
+    b. For SysV Init:
+
+      .. code-block:: console
+
+        # service wazuh-agent restart
 
 Authenticating options
 ----------------------

--- a/source/installation-guide/installing-wazuh-server/sources_installation.rst
+++ b/source/installation-guide/installing-wazuh-server/sources_installation.rst
@@ -49,15 +49,31 @@ Installing Wazuh manager
 
 5. The installer asks if you want to start Wazuh at the end of the installation. If you chosen not to, you can start it later with:
 
-  .. code-block:: console
+  a. For Systemd:
 
-    # /var/ossec/bin/ossec-control start
+    .. code-block:: console
+
+      # systemctl start wazuh-manager
+
+  b. For SysV Init:
+
+    .. code-block:: console
+
+      # service wazuh-manager start
 
   If you want to confirm that it started:
 
-  .. code-block:: console
+  a. For Systemd:
 
-    $ /var/ossec/bin/ossec-control status
+    .. code-block:: console
+
+      # systemctl status wazuh-manager
+
+  b. For SysV Init:
+
+    .. code-block:: console
+
+      # service wazuh-manager status
 
 Installing Wazuh API
 --------------------

--- a/source/learning-wazuh/audit-commands.rst
+++ b/source/learning-wazuh/audit-commands.rst
@@ -146,17 +146,25 @@ a list of commands that Wazuh should give us a special alert about when they are
         tcpdump:
         ping:
 
-2. On wazuh-manager, add this to the ``<ruleset>`` section of ossec.configuration
+2. On wazuh-manager, add this to the ``<ruleset>`` section of ossec.configuration:
 
     .. code-block:: console
 
         <list>etc/lists/suspicious-programs</list>
 
-3. Restart the Wazuh manager
+3. Restart the Wazuh manager:
 
-    .. code-block:: console
+    a. For Systemd:
 
-        # ossec-control restart
+      .. code-block:: console
+
+        # systemctl restart wazuh-manager
+
+    b. For SysV Init:
+
+      .. code-block:: console
+
+        # service wazuh-manager restart
 
 4. Wazuh now knows to compile this file into a CDB database of the same name but with a ``.cdb`` extension.  Initiate the compile:
 
@@ -189,7 +197,19 @@ Make a rule to watch for the listed programs
     In this case we are simply checking to see if the decoded ``audit.command`` value appears in our new CDB lists at all,
     with no checking of a value.
 
-2. Restart Wazuh manager with ``ossec-control restart``.
+2. Restart the Wazuh manager:
+
+  a. For Systemd:
+
+    .. code-block:: console
+
+      # systemctl restart wazuh-manager
+
+  b. For SysV Init:
+
+    .. code-block:: console
+
+      # service wazuh-manager restart
 
 3. On linux-agent, install and run tcpdump to trip our new rule:
 
@@ -222,10 +242,7 @@ Let's make this list a little smarter by including values that indicate how alar
         # ossec-makelists
 
     .. note::
-        The ``ossec-makelists`` program not only recompiles any CDB files that have been changed, but it causes ossec-analysisd
-        to reload the changed lists without Wazuh manager restarting.  You do not need to run ``ossec-control restart`` after
-        running ``ossec-makelists`` to make Wazuh use your updated lists.
-
+        The ``ossec-makelists`` program not only recompiles any CDB files that have been changed, but it causes ossec-analysisd to reload the changed lists without Wazuh manager restarting. You do not need to restart Wazuh after running ``ossec-makelists`` to make it use your updated lists.
 
 Make a smarter rule
 -------------------
@@ -244,7 +261,19 @@ instances when a "red" program is executed.
             <group>audit_command,</group>
         </rule>
 
-2. Restart Wazuh manager with ``ossec-control restart``.
+2. Restart the Wazuh manager:
+
+  a. For Systemd:
+
+    .. code-block:: console
+
+      # systemctl restart wazuh-manager
+
+  b. For SysV Init:
+
+    .. code-block:: console
+
+      # service wazuh-manager restart
 
 3. On linux-agent install and run a "red" program (netcat):
 
@@ -276,7 +305,19 @@ you don't want these events to be logged.  Another child rule of 80297, with a l
 
     The rule does no lookup.  It just checks any auditd command records in which the ``ping`` command is called and the target IP address 8.8.8.8 is mentioned.
 
-2. Restart Wazuh manager with ``ossec-control restart``.
+2. Restart the Wazuh manager:
+
+  a. For Systemd:
+
+    .. code-block:: console
+
+      # systemctl restart wazuh-manager
+
+  b. For SysV Init:
+
+    .. code-block:: console
+
+      # service wazuh-manager restart
 
 3. Test the rule by installing tcpdump on linux-agent and then pinging both 8.8.8.8 and 8.8.4.4.
 

--- a/source/learning-wazuh/audit-commands.rst
+++ b/source/learning-wazuh/audit-commands.rst
@@ -242,7 +242,7 @@ Let's make this list a little smarter by including values that indicate how alar
         # ossec-makelists
 
     .. note::
-        The ``ossec-makelists`` program not only recompiles any CDB files that have been changed, but it causes ossec-analysisd to reload the changed lists without Wazuh manager restarting. You do not need to restart Wazuh after running ``ossec-makelists`` to make it use your updated lists.
+        The ``ossec-makelists`` program not only recompiles any CDB files that have been changed, but it causes ``ossec-analysisd`` to reload the changed lists without Wazuh manager restarting. You do not need to restart Wazuh after running ``ossec-makelists`` to make it use your updated lists.
 
 Make a smarter rule
 -------------------

--- a/source/learning-wazuh/build-lab/install-linux-agents.rst
+++ b/source/learning-wazuh/build-lab/install-linux-agents.rst
@@ -57,11 +57,22 @@ Make Wazuh Agent register itself with the Wazuh Manager, presenting the required
     # agent-auth -m 172.30.0.10 -P please123
 
 
-Restart Wazuh Agent and confirm it successfully connected with the Manager.  Run this on the Wazuh Agent side.
+Restart Wazuh Agent and confirm it successfully connected with the Manager. Run this on the Wazuh Agent side:
+
+  a. For Systemd:
+
+    .. code-block:: console
+
+      # systemctl restart wazuh-agent
+
+  b. For SysV Init:
+
+    .. code-block:: console
+
+      # service wazuh-agent restart
 
   .. code-block:: console
 
-    # ossec-control restart
     # grep ^status /var/ossec/var/run/ossec-agentd.state
 
 You should see output like this:

--- a/source/learning-wazuh/build-lab/install-wazuh-server.rst
+++ b/source/learning-wazuh/build-lab/install-wazuh-server.rst
@@ -38,8 +38,18 @@ Install the Wazuh Manager software and confirm it is running
   .. code-block:: console
 
     # yum -y install wazuh-manager
-    # ossec-control status
 
+  a. For Systemd:
+
+    .. code-block:: console
+
+      # systemctl status wazuh-manager
+
+  b. For SysV Init:
+
+    .. code-block:: console
+
+      # service wazuh-manager status
 
 Configure Wazuh Manager to listen for agent connections on tcp instead of udp
 
@@ -60,13 +70,23 @@ Configure Wazuh Manager to allow self registration of new agents with authentica
     # echo "please123" > /var/ossec/etc/authd.pass # this is the password agents will use for self-registration
     # ossec-control enable auth
 
-Restart Wazuh Manager and confirm the agent listener and the self-registration listener are in place
+Restart Wazuh Manager and confirm the agent listener and the self-registration listener are in place:
+
+  a. For Systemd:
+
+    .. code-block:: console
+
+      # systemctl restart wazuh-manager
+
+  b. For SysV Init:
+
+    .. code-block:: console
+
+      # service wazuh-manager restart
 
   .. code-block:: console
 
-    # ossec-control restart
     # netstat -natp | egrep "(:1514|:1515)"
-
 
 Install Wazuh API
 -----------------

--- a/source/learning-wazuh/hidden-processes.rst
+++ b/source/learning-wazuh/hidden-processes.rst
@@ -115,9 +115,17 @@ at which rootcheck commences its first scan for the sake of this lab.
 
     Restart the agent.
 
-    .. code-block:: console
+    a. For Systemd:
 
-        # ossec-control restart
+      .. code-block:: console
+
+        # systemctl restart wazuh-agent
+
+    b. For SysV Init:
+
+      .. code-block:: console
+
+        # service wazuh-agent restart
 
     Now our next rootcheck scan should run shortly.  It should alert about the ryslogd process which we hid with Diamorphine.
 
@@ -207,6 +215,14 @@ at which rootcheck commences its first scan for the sake of this lab.
 
 17. Restart the Wazuh agent on linux-agent
 
-        .. code-block:: console
+  a. For Systemd:
 
-            ossec-control restart
+    .. code-block:: console
+
+      # systemctl restart wazuh-agent
+
+  b. For SysV Init:
+
+    .. code-block:: console
+
+      # service wazuh-agent restart

--- a/source/learning-wazuh/shellshock.rst
+++ b/source/learning-wazuh/shellshock.rst
@@ -134,9 +134,17 @@ with this:
 
 and then restart Wazuh manager:
 
+  a. For Systemd:
+
     .. code-block:: console
 
-        # ossec-control restart
+      # systemctl restart wazuh-manager
+
+  b. For SysV Init:
+
+    .. code-block:: console
+
+      # service wazuh-manager restart
 
 Run the same curl probe just like last time, remembering to substitute for ES_SERVER_EIP:
 
@@ -243,9 +251,17 @@ from responding to any packets from the attacker.  Note that packets are still r
 
 Restart the manager:
 
-    .. code-block:: console
+    a. For Systemd:
 
-        ossec-control restart
+      .. code-block:: console
+
+        # systemctl restart wazuh-manager
+
+    b. For SysV Init:
+
+      .. code-block:: console
+
+        # service wazuh-manager restart
 
 Run the same probe again from linux-agent.  Observe that the output of the Windows command line "route print /4" now shows a null route for the Elastic IP of linux-agent.  It will be in the "Persistent Routes:" section of the output.
 

--- a/source/learning-wazuh/suricata.rst
+++ b/source/learning-wazuh/suricata.rst
@@ -190,8 +190,21 @@ the shared configuration with their local configuration.
         verify-agent-conf: Verifying [/var/ossec/etc/shared/linux/agent.conf]
         verify-agent-conf: OK
 
-4.  Since the config is proven valid, restart Wazuh manager with ``ossec-control restart`` to deploy the new agent.conf to the agents.  Each agent should pull down and apply this additional config almost immediately.  You can find the fetched agent.conf file on each agent at ``/var/ossec/etc/shared/agent.conf``:
+4. Since the config is proven valid, restart Wazuh manager to deploy the new agent.conf to the agents.
 
+a. For Systemd:
+
+  .. code-block:: console
+
+    # systemctl restart wazuh-manager
+
+b. For SysV Init:
+
+  .. code-block:: console
+
+    # service wazuh-manager restart
+
+Each agent should pull down and apply this additional config almost immediately. You can find the fetched agent.conf file on each agent at ``/var/ossec/etc/shared/agent.conf``.
 
 See Suricata NIDS events in Kibana
 ----------------------------------

--- a/source/learning-wazuh/suricata.rst
+++ b/source/learning-wazuh/suricata.rst
@@ -190,7 +190,7 @@ the shared configuration with their local configuration.
         verify-agent-conf: Verifying [/var/ossec/etc/shared/linux/agent.conf]
         verify-agent-conf: OK
 
-4. Since the config is proven valid, restart Wazuh manager to deploy the new agent.conf to the agents.
+4. Since the config is proven valid, restart Wazuh manager to deploy the new configuration to the agents.
 
 a. For Systemd:
 
@@ -204,7 +204,7 @@ b. For SysV Init:
 
     # service wazuh-manager restart
 
-Each agent should pull down and apply this additional config almost immediately. You can find the fetched agent.conf file on each agent at ``/var/ossec/etc/shared/agent.conf``.
+Each agent should pull down and apply this additional configuration almost immediately. You can find the fetched configuration on each agent at ``/var/ossec/etc/shared/agent.conf``.
 
 See Suricata NIDS events in Kibana
 ----------------------------------

--- a/source/learning-wazuh/survive-flood.rst
+++ b/source/learning-wazuh/survive-flood.rst
@@ -43,9 +43,17 @@ Configure the Wazuh agent client buffer on linux-agent
 
 3. Restart the Wazuh agent
 
-    .. code-block:: console
+    a. For Systemd:
 
-        # ossec-control restart
+      .. code-block:: console
+
+        # systemctl restart wazuh-agent
+
+    b. For SysV Init:
+
+      .. code-block:: console
+
+        # service wazuh-agent restart
 
     .. note::
         The client buffer is explained in detail in the Wazuh User manual.  Search for "Anti-flooding mechanism".  In brief, it
@@ -95,10 +103,17 @@ levels less than 3, so for this lab we will lower the threshold.
 
 2. Restart Wazuh Manager.
 
+  a. For Systemd:
+
     .. code-block:: console
 
-        # ossec-control restart
+      # systemctl restart wazuh-manager
 
+  b. For SysV Init:
+
+    .. code-block:: console
+
+      # service wazuh-manager restart
 
 Generate a log flood on linux-agent
 -----------------------------------
@@ -186,8 +201,16 @@ Return linux-agent to normal client buffer settings
 
 2. Restart the Wazuh agent
 
-    .. code-block:: console
+    a. For Systemd:
 
-        # ossec-control restart
+      .. code-block:: console
 
-Congratulations on completing this lab.  You survived the log flood!
+        # systemctl restart wazuh-agent
+
+    b. For SysV Init:
+
+      .. code-block:: console
+
+        # service wazuh-agent restart
+
+Congratulations on completing this lab. You survived the log flood!

--- a/source/learning-wazuh/vuln-detection.rst
+++ b/source/learning-wazuh/vuln-detection.rst
@@ -69,9 +69,19 @@ there are matches:
       <packages>yes</packages>
     </wodle>
 
-Restart the manager with ``ossec-control restart``.  This will also cause the agents to restart as they pick up their new ``agent.conf``.
+Restart the Wazuh manager. This will also cause the agents to restart as they pick up their new ``agent.conf``:
 
+a. For Systemd:
 
+  .. code-block:: console
+
+    # systemctl restart wazuh-manager
+
+b. For SysV Init:
+
+  .. code-block:: console
+
+    # service wazuh-manager restart
 
 Look at the logs
 ----------------

--- a/source/learning-wazuh/vuln-detection.rst
+++ b/source/learning-wazuh/vuln-detection.rst
@@ -69,7 +69,7 @@ there are matches:
       <packages>yes</packages>
     </wodle>
 
-Restart the Wazuh manager. This will also cause the agents to restart as they pick up their new ``agent.conf``:
+Restart the Wazuh manager. This will also cause the agents to restart as they pick up their new configuration:
 
 a. For Systemd:
 

--- a/source/user-manual/agents/command-line/register.rst
+++ b/source/user-manual/agents/command-line/register.rst
@@ -98,9 +98,17 @@ In this example, we'll add an agent with name "Example", dynamic IP (`any`) and 
 
 9. Restart the agent:
 
-.. code-block:: console
+a. For Systemd:
 
-	# /var/ossec/bin/ossec-control restart
+  .. code-block:: console
+
+    # systemctl restart wazuh-agent
+
+b. For SysV Init:
+
+  .. code-block:: console
+
+    # service wazuh-agent restart
 
 Forcing insertion
 ^^^^^^^^^^^^^^^^^

--- a/source/user-manual/agents/restful-api/register.rst
+++ b/source/user-manual/agents/restful-api/register.rst
@@ -44,6 +44,14 @@ Basically, the scripts perform the following steps:
 
 **Step 4:** Restart the agent.
 
-.. code-block:: console
+a. For Systemd:
 
-    # /var/ossec/bin/ossec-control restart
+  .. code-block:: console
+
+    # systemctl restart wazuh-agent
+
+b. For SysV Init:
+
+  .. code-block:: console
+
+    # service wazuh-agent restart

--- a/source/user-manual/capabilities/policy-monitoring/openscap/oscap-configuration.rst
+++ b/source/user-manual/capabilities/policy-monitoring/openscap/oscap-configuration.rst
@@ -74,12 +74,25 @@ Manager ``/var/ossec/etc/shared/default/agent.conf`` file (assuming that the age
 
 **Step 3: Restart manager and agents**
 
-To apply the new configuration, restart the manager and agents:
+To apply the new configuration, restart the manager:
 
-::
+  a. For Systemd:
 
-  # /var/ossec/bin/ossec-control restart
-  # /var/ossec/bin/agent_control -R -a
+    .. code-block:: console
+
+      # systemctl restart wazuh-manager
+
+  b. For SysV Init:
+
+    .. code-block:: console
+
+      # service wazuh-manager restart
+
+And now, restart all the agents:
+
+  .. code-block:: console
+
+    # /var/ossec/bin/agent_control -R -a
 
 If you prefer, you can restart a specific agent with the option ``-u <id>`` where **id** is the agent's id number.
 
@@ -157,12 +170,25 @@ Manager ``shared/agent.conf``:
 
 **Step 3: Restart manager and agents**
 
-To apply the new configuration, restart the manager and agents:
+To apply the new configuration, restart the manager:
 
-.. code-block:: console
+  a. For Systemd:
 
-  # /var/ossec/bin/ossec-control restart
-  # /var/ossec/bin/agent_control -R -a
+    .. code-block:: console
+
+      # systemctl restart wazuh-manager
+
+  b. For SysV Init:
+
+    .. code-block:: console
+
+      # service wazuh-manager restart
+
+And now, restart all the agents:
+
+  .. code-block:: console
+
+    # /var/ossec/bin/agent_control -R -a
 
 If you prefer, you can restart a specific agent with option ``-u <id>``.
 

--- a/source/user-manual/capabilities/system-calls-monitoring/audit-configuration.rst
+++ b/source/user-manual/capabilities/system-calls-monitoring/audit-configuration.rst
@@ -85,13 +85,22 @@ Wazuh must be aware of the events detected by Audit. So, it is needs to be confi
       <location>/var/log/audit/audit.log</location>
     </localfile>
 
-Restarting OSSEC
-~~~~~~~~~~~~~~~~~
+Restarting Wazuh
+~~~~~~~~~~~~~~~~
+
 Finally, we must restart Wazuh agent in order to apply the changes:
 
-.. code-block:: console
+a. For Systemd:
 
-    # /var/ossec/bin/ossec-control restart
+  .. code-block:: console
+
+    # systemctl restart wazuh-agent
+
+b. For SysV Init:
+
+  .. code-block:: console
+
+    # service wazuh-agent restart
 
 Now everything is ready to process audit events. You only need to create the proper audit rules (via *auditctl* or */etc/audit/audit.rules*). In the next section we will describe some good use cases.
 

--- a/source/user-manual/capabilities/virustotal-scan/integration.rst
+++ b/source/user-manual/capabilities/virustotal-scan/integration.rst
@@ -59,7 +59,20 @@ In order for this integration to function, the first thing that must be complete
 .. code-block:: console
 
     # /var/ossec/bin/ossec-control enable integrator
-    # /var/ossec/bin/ossec-control restart
+
+To restart the Wazuh manager:
+
+a. For Systemd:
+
+  .. code-block:: console
+
+    # systemctl restart wazuh-manager
+
+b. For SysV Init:
+
+  .. code-block:: console
+
+    # service wazuh-manager restart
 
 After this is complete, and FIM alert automatically triggers the VirusTotal integration.
 

--- a/source/user-manual/capabilities/vulnerability-detection.rst
+++ b/source/user-manual/capabilities/vulnerability-detection.rst
@@ -96,9 +96,21 @@ The following example shows how to configure the necessary components to run the
       </feed>
     </wodle>
 
- Remember to restart the manager to apply changes: ``/var/ossec/bin/ossec-control restart``
+  Remember to restart the manager to apply the changes:
 
- Check :doc:`Vulnerability detector settings<../reference/ossec-conf/wodle-vuln-detector>` for more details.
+  a. For Systemd:
+
+    .. code-block:: console
+
+      # systemctl restart wazuh-manager
+
+  b. For SysV Init:
+
+    .. code-block:: console
+
+      # service wazuh-manager restart
+
+Check :doc:`Vulnerability detector settings<../reference/ossec-conf/wodle-vuln-detector>` for more details.
 
 The following fields are captured in every alert:
 

--- a/source/user-manual/manager/manual-integration.rst
+++ b/source/user-manual/manager/manual-integration.rst
@@ -18,11 +18,23 @@ Configuration
 
 The Integrator is not enabled by default, however, it can be enabled using the following command:
 
-.. code-block:: console
+  .. code-block:: console
 
-    # /var/ossec/bin/ossec-control enable integrator
-    # /var/ossec/bin/ossec-control restart
+      # /var/ossec/bin/ossec-control enable integrator
 
+After enabling it, restart the Wazuh manager:
+
+  a. For Systemd:
+
+  .. code-block:: console
+
+    # systemctl restart wazuh-manager
+
+  b. For SysV Init:
+
+  .. code-block:: console
+
+    # service wazuh-manager restart
 
 Integrations are configured in the ``etc/ossec.conf`` file which is located inside your Wazuh installation directory.  Add the following information inside *<ossec_config> </ossec_config>* to configure integration:
 

--- a/source/user-manual/manager/wazuh-cluster.rst
+++ b/source/user-manual/manager/wazuh-cluster.rst
@@ -222,7 +222,7 @@ Python 2.6 is the default python version in CentOS 6. Since Python 2.7 is requir
 
      # sed -i 's#echo -n "Starting OSSEC: "#echo -n "Starting OSSEC (EL6): "; source /opt/rh/python27/enable; export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/var/ossec/framework/lib#' /etc/init.d/wazuh-manager
 
-4. Use ``service`` command instead of ``/var/ossec/bin/ossec-control`` to start, stop and restart Wazuh:
+4. Use the ``service`` command instead of ``/var/ossec/bin/ossec-control`` to start, stop and restart Wazuh:
 
   .. code-block:: console
 

--- a/source/user-manual/reference/tools/ossec-control.rst
+++ b/source/user-manual/reference/tools/ossec-control.rst
@@ -8,7 +8,7 @@ ossec-control
 The ossec-control script is used to start, stop, configure, or check on the status of Wazuh processes. This script can enable or disable client-syslog, the authentication daemon, cluster daemons, database logging, agentless configurations, integration with slack and pagerduty, and debug mode.
 
 .. note::
-    We recommend to use the ``systemctl`` or ``service`` commands (depending on your OS) to **start**, **stop** or **restart** the Wazuh service.
+    We recommend to use the ``systemctl`` or ``service`` commands (depending on your OS) to **start**, **stop** or **restart** the Wazuh service. This will avoid inconsistencies between the *service* status and the *processes* status.
 
 +-------------+---------------------------------------------------------------------------------------------------------+
 | **start**   | Start the Wazuh processes.                                                                              |

--- a/source/user-manual/reference/tools/ossec-control.rst
+++ b/source/user-manual/reference/tools/ossec-control.rst
@@ -5,7 +5,10 @@
 ossec-control
 =============
 
-The ossec-control script is used to start, stop, configure, or check on the status of Wazuh processes.  This script can enable or disable client-syslog, the authentication daemon, cluster daemons, database logging, agentless configurations, integration with slack and pagerduty, and debug mode.
+The ossec-control script is used to start, stop, configure, or check on the status of Wazuh processes. This script can enable or disable client-syslog, the authentication daemon, cluster daemons, database logging, agentless configurations, integration with slack and pagerduty, and debug mode.
+
+.. note::
+    We recommend to use the ``systemctl`` or ``service`` commands (depending on your OS) to **start**, **stop** or **restart** the Wazuh service.
 
 +-------------+---------------------------------------------------------------------------------------------------------+
 | **start**   | Start the Wazuh processes.                                                                              |


### PR DESCRIPTION
Hello team,

This PR closes #560. It updates the `ossec-control` command with `systemctl/service` alternatives when the action is `start`, `stop` or `restart`.

Regards,
Juanjo