### PR TITLE
Changes related to Wazuh Agent for Windows

### DIFF
--- a/source/installation-guide/installing-wazuh-agent/wazuh_agent_sources.rst
+++ b/source/installation-guide/installing-wazuh-agent/wazuh_agent_sources.rst
@@ -33,7 +33,7 @@ Installing Linux agent
 
   .. code-block:: console
 
-    # curl -Ls https://github.com/wazuh/wazuh/archive/v3.7.0.tar.gz | tar zx
+    # curl -Ls https://github.com/wazuh/wazuh/archive/v3.7.1.tar.gz | tar zx
 
 3. Run the ``install.sh`` script. This will run a wizard that will guide you through the installation process using the Wazuh sources:
 
@@ -59,50 +59,76 @@ Installing Windows agent
 
 This section describes how to download and build the Wazuh HIDS Windows agent from sources. This process begins with compiling the agent on a Linux system to generate the .msi installer for the Windows installation.
 
-.. note:: The following procedure has been tested on Ubuntu 16.04 and other Debian based distributions and may work with other Debian/Ubuntu versions as well.
+.. note:: The following procedure has been tested on Ubuntu 16.04, other Debian based distributions and CentOS 7. It may work with other Debian/Ubuntu versions and RPM based distributions as well.
 
-1. Set up the Ubuntu build environment. Install these dependencies to build the Windows Wazuh agent installer on Ubuntu:
+1. Set up the build environment. Install these dependencies to build the Wazuh Agent for Windows under Linux:
+
+  a) For RPM-based distributions: the `EPEL repository <https://fedoraproject.org/wiki/EPEL>`_ is added to install the needed cross-compilers. Follow the instructions over there to accomplish this.
+  
+    .. code-block:: console
+    
+      # yum install mingw32-gcc
+      # yum install mingw64-gcc
+      # yum install nsis
+  
+  b) For Debian-based distributions:
+
+    .. code-block:: console
+
+      # apt-get install gcc-mingw-w64
+      # apt-get install nsis
+      # apt-get install make
+
+2. Download the Wazuh source code and unzip it:
 
   .. code-block:: console
 
-   # apt-get install gcc-mingw-w64
-   # apt-get install nsis
-   # apt-get install make
-
-2. Set up Windows build environment. To generate the installer, the following dependencies must be in place on the Windows machine:
-
-* `WiX Toolset <http://wixtoolset.org/>`_.
-* .NET framework 3.5.1.
-* Microsoft Windows SDK.
-
-3. Download the Wazuh source code and unzip it:
-
-  .. code-block:: console
-
-    # curl -Ls https://github.com/wazuh/wazuh/archive/v3.7.0.tar.gz | tar zx
+    # curl -Ls https://github.com/wazuh/wazuh/archive/v3.7.1.tar.gz | tar zx
     # cd wazuh-*/src
 
-4. Compile the agent by running the ``make`` command:
+3. Compile the agent by running the ``make`` command:
 
-  .. code-block:: console
+  a) To build the 32-bit Windows agent:
 
-    # make deps
-    # make TARGET=winagent
+    .. code-block:: console
+
+      # make deps
+      # make TARGET=winagent
+
+  b) To build the 64-bit Windows agent:
+
+    .. code-block:: console
+
+      # make deps
+      # make TARGET=winagent-x64
 
 The following output will appear at the end of the building process:
 
+  a) Building the 32-bit Windows agent:
+
+    .. code-block:: console
+
+      Done building winagent
+
+  b) Building the 64-bit Windows agent:
+
+    .. code-block:: console
+
+      Done building winagent-x64
+
+4. Once the agent has been compiled, transfer the Wazuh folder to the target Windows system. It is recommended that this folder be compressed at first to speed up the process.
+
   .. code-block:: console
 
-   Done building winagent
+    # zip -r wazuh.zip ../../wazuh-3.7.1
 
+5. Set up Windows build environment. To generate the installer, the following dependencies must be in place on the Windows machine:
 
-5. Once the agent has been compiled, transfer the Wazuh folder to the target Windows system. It is recommended that this folder be compressed at first to speed up the process.
+* `WiX Toolset <http://wixtoolset.org/>`_.
+* Microsoft Windows SDK v7.0 (or greater).
+* .NET Framework v3.5.1 (or greater, depending on the installed SDK version).
 
-  .. code-block:: console
-
-    # zip -r wazuh.zip ../../wazuh-3.7.0
-
-6. Once in Windows, run the ``wazuh-3.7.0/src/win32/wazuh-installer-build-msi.bat`` file to start the installer generation. If you do not want to sign the installer, you will have to comment or delete the signtool line.
+6. Once in Windows, run the ``wazuh-3.7.1/src/win32/wazuh-installer-build-msi.bat`` script and follow the instructions to generate the MSI installer. Make sure to select the proper architecture for the compiled binaries (x86 / x86_64). If you do not want to sign the installer, you will have to comment or delete the ``signtool`` line.
 
 .. note:: The installer is now ready.  It can be launched with a normal or unattended installation. For more information about this process, please visit our :doc:`installation section for Windows<./wazuh_agent_windows>`.
 

--- a/source/installation-guide/installing-wazuh-agent/wazuh_agent_windows.rst
+++ b/source/installation-guide/installing-wazuh-agent/wazuh_agent_windows.rst
@@ -7,7 +7,7 @@ Install Wazuh agent on Windows
 
 .. note:: You will need administrator privileges to perform this installation.
 
-The first step to installing the Wazuh agent on a Windows machine is to download the Windows installer from the :doc:`packages list<../packages-list/index>`. Once this is downloaded, the Windows agent can be installed in one of two ways:
+The first step to installing the Wazuh agent on a Windows machine is to download the appropiate Windows installer for your processor architecture from the :doc:`packages list<../packages-list/index>`. Once this is downloaded, the Windows agent can be installed in one of two ways:
 
 - `Using the GUI`_
 - `Using the command line`_
@@ -23,30 +23,31 @@ Once installed, the agent uses a graphical user interface for configuration, ope
       :align: center
       :width: 320 px
 
-By default, all agent files will be found in: ``C:\Program Files(x86)\ossec-agent``.
+By default, all agent files will be found in: ``C:\Program Files\ossec-agent``.
 
 .. note:: Now that the agent is installed, the next step is to register and configure it to communicate with the manager. For more information about this process, please visit the :doc:`user manual<../../user-manual/registering/index>`.
 
 Using the command line
 ----------------------
 
-.. note::
-    Unattended installations must be run with administrator permissions.
+.. note:: Unattended installations must be run with administrator permissions.
+
+.. note:: For the following steps, replace the MSI package filename with the one matching your processor architecture.
 
 To install the Windows agent from the command line, run the installer using the following command (the ``/q`` argument is used for unattended installations)::
 
-    wazuh-agent-3.7.0-1.msi /q
+    wazuh-agent-3.7.1.msi /q
 
 To uninstall the agent, the original MSI file will be needed to perform the unattended process::
 
-    msiexec.exe /x wazuh-agent-3.7.0-1.msi /qn
+    msiexec.exe /x wazuh-agent-3.7.1.msi /qn
 
 You can automate the agent registration with authd using the following parameters:
 
 +-----------------------+------------------------------------------------------------------------------------------------------------------------------+
 | Option                | Description                                                                                                                  |
 +=======================+==============================================================================================================================+
-|   APPLICATIONFOLDER   |  Sets the installation path. Default C:\\Program Files (x86)\\ossec-agent\\.                                                 |
+|   APPLICATIONFOLDER   |  Sets the installation path. Default C:\\Program Files\\ossec-agent\\.                                                 |
 +-----------------------+------------------------------------------------------------------------------------------------------------------------------+
 |   ADDRESS             |  Specifies the managers IP address or hostname. This option also accepts a list of IPs or hostnames separated by semicolons. |
 +-----------------------+------------------------------------------------------------------------------------------------------------------------------+
@@ -83,28 +84,28 @@ Below there are some examples to install and register a Windows agent.
 
 Registration with password::
 
-    wazuh-agent-3.7.0-1.msi /q ADDRESS="192.168.1.1" AUTHD_SERVER="192.168.1.1" PASSWORD="TopSecret" AGENT_NAME="W2012"
+    wazuh-agent-3.7.1.msi /q ADDRESS="192.168.1.1" AUTHD_SERVER="192.168.1.1" PASSWORD="TopSecret" AGENT_NAME="W2012"
 
 Registration with password and assigning a group::
 
-    wazuh-agent-3.7.0-1.msi /q ADDRESS="192.168.1.1" AUTHD_SERVER="192.168.1.1" PASSWORD="TopSecret" GROUP="my-group"
+    wazuh-agent-3.7.1.msi /q ADDRESS="192.168.1.1" AUTHD_SERVER="192.168.1.1" PASSWORD="TopSecret" GROUP="my-group"
 
 Registration with relative path to CA. It will be searched at your `APPLICATIONFOLDER` folder::
 
-    wazuh-agent-3.7.0-1.msi /q ADDRESS="192.168.1.1" AUTHD_SERVER="192.168.1.1" AGENT_NAME="W2019" CERTIFICATE="rootCA.pem"
+    wazuh-agent-3.7.1.msi /q ADDRESS="192.168.1.1" AUTHD_SERVER="192.168.1.1" AGENT_NAME="W2019" CERTIFICATE="rootCA.pem"
 
 Absolute paths to CA, certificate or key that contain spaces can be written as shown below::
 
-    wazuh-agent-3.7.0-1.msi /q ADDRESS="192.168.1.1" AUTHD_SERVER="192.168.1.1" KEY="C:\Progra~2\sslagent.key" PEM="C:\Progra~2\sslagent.cert"
+    wazuh-agent-3.7.1.msi /q ADDRESS="192.168.1.1" AUTHD_SERVER="192.168.1.1" KEY="C:\Progra~1\sslagent.key" PEM="C:\Progra~1\sslagent.cert"
 
-The number "2" means that the file will be searched at the second occurrence of the "Progra" word, thus, the key and certificate would be searched at the folder "C:\\Program Files (x86)". In case this number was "1", it would be searched at "Program Files".
+The number "1" means that the file will be searched at the first occurrence of the "Progra" word, thus, the key and certificate would be searched at the folder "C:\\Program Files".
 
 .. note::
     To verify agents via SSL, it's necessary to use both KEY and PEM options. See the :ref:`verify hosts with SSL <verify-hosts>` section.
 
 Registration with protocol::
 
-    wazuh-agent-3.7.0-1.msi /q ADDRESS="192.168.1.1" AUTHD_SERVER="192.168.1.1" AGENT_NAME="W2016" PROTOCOL="TCP"
+    wazuh-agent-3.7.1.msi /q ADDRESS="192.168.1.1" AUTHD_SERVER="192.168.1.1" AGENT_NAME="W2016" PROTOCOL="TCP"
 
 .. warning::
     In Windows versions older than Windows Server 2008 or Windows 7, it's necessary to run the ``ossec-authd`` program on the Wazuh manager with the ``-a`` flag or set the ``<ssl_auto_negotiate>`` option to ``yes`` on the :ref:`auth configuration <reference_ossec_auth>` to avoid compatibility errors.

--- a/source/learning-wazuh/build-lab/access-ec2-instances.rst
+++ b/source/learning-wazuh/build-lab/access-ec2-instances.rst
@@ -35,7 +35,7 @@ Putty is a popular Windows SSH client.  Download and run the MSI installer for P
 Use PuTTYgen to convert your key file into a form Putty can authenticate with
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-    - Run PuTTYgen (**c:\\Program Files (x86)\\PuTTY\\puttygen.exe**)
+    - Run PuTTYgen (**c:\\Program Files\\PuTTY\\puttygen.exe**)
     - File -> Load private key
     - Change file type selector to "All Files"
     - Browse to and Open your WazuhLab.pem file.  It will be imported and look like this:
@@ -48,7 +48,7 @@ Use PuTTYgen to convert your key file into a form Putty can authenticate with
     - Click **[Save private key]**, confirm that you don't want to use a password and click **[Yes]**.
     - Store the key in a location convenient to you.  For the following example, we will assume you put it in **c:\\ssh\\** under the name "WazuhLab" with .ppk file type.
     - Close PuTTYgen.
-    - Run PuTTY (**c:\\Program Files (x86)\\PuTTY\\putty.exe**)
+    - Run PuTTY (**c:\\Program Files\\PuTTY\\putty.exe**)
     - Under *Host Name* put the Elastic IP associated with the Linux EC2 instance.
     - Under *Saved Session* put the instance name (i.e. Wazuh Server)
     - Under Connection->Data, set the *Auto-login username* to "centos".

--- a/source/learning-wazuh/build-lab/install-linux-agents.rst
+++ b/source/learning-wazuh/build-lab/install-linux-agents.rst
@@ -82,6 +82,6 @@ You should see output like this:
     status='connected'
 
 .. note::
-  The **/var/ossec/var/run/ossec-agentd.state** file on \*NIX platforms and the **C:\\Program Files (x86)\\ossec-agent\\ossec-agent.state**
+  The **/var/ossec/var/run/ossec-agentd.state** file on \*NIX platforms and the **C:\\Program Files\\ossec-agent\\ossec-agent.state**
   file on Windows platforms contain several useful pieces of information about the state of the Wazuh agent's connection with the Wazuh
   manager.  See the file content itself for more information.

--- a/source/learning-wazuh/detect-fs-changes.rst
+++ b/source/learning-wazuh/detect-fs-changes.rst
@@ -22,7 +22,7 @@ To turn on Wazuh agent and syscheck debug logging on windows-agent, start Notepa
         rootcheck.sleep=0
         syscheck.sleep=0
 
-Save this as a new file called "C:\\Program Files (x86)\\ossec-agent\\local_internal_options.conf", making sure under "Save as type:" to choose "All Files" so that the file does not get a .txt extension appended to it.
+Save this as a new file called "C:\\Program Files\\ossec-agent\\local_internal_options.conf", making sure under "Save as type:" to choose "All Files" so that the file does not get a .txt extension appended to it.
 
 Open the Windows Command Prompt, using the "Run as administrator" option. Then create a couple of lab directories:
 


### PR DESCRIPTION
- Added steps for building the 64-bit Windows agent.
- Added steps for building the Windows agent under RPM-based distributions.
- Replaced all references to "Program Files (x86)" with "Program Files".

Preparing the documentation before the [3.7-winagent-x64 PR](https://github.com/wazuh/wazuh/pull/1888) is merged into Wazuh.