### PR TITLE
Rework of "Using the registration service" documentation

### DIFF
--- a/source/user-manual/reference/daemons/ossec-authd.rst
+++ b/source/user-manual/reference/daemons/ossec-authd.rst
@@ -5,11 +5,10 @@
 ossec-authd
 ===========
 
-The ossec-authd program can automatically add an agent to a Wazuh manager and provide the key to the agent. The :ref:`agent-auth` application is the client application used with ``ossec-authd``.  ``ossec-authd`` creates an agent with an IP address of "any" instead of using a specific IP address.
+The ``ossec-authd`` program can automatically add an agent to a Wazuh manager and provide the key to the agent. It's used along with the :ref:`agent-auth` application. The program creates an agent with an IP address of ``any`` instead of using a specific IP address.
 
 .. warning::
-
-    By default, there is no authentication or authorization involved in this transaction, so it is recommended that this daemon only be run when a new agent is being added.
+  By default, there is no authentication or authorization involved in this transaction, so it is recommended that this daemon only be run when a new agent is being added.
 
 +------------------+-------------------------------------------------------------------------------------------------------+
 | **-V**           | Version and license message.                                                                          |
@@ -21,8 +20,6 @@ The ossec-authd program can automatically add an agent to a Wazuh manager and pr
 | **-t**           | Test configuration.                                                                                   |
 +------------------+-------------------------------------------------------------------------------------------------------+
 | **-f**           | Run in foreground.                                                                                    |
-+------------------+-------------------------------------------------------------------------------------------------------+
-| **-F <time>**    | Remove old agent with same name or IP if its keepalive has more than the specified number of seconds. |
 +------------------+-------------------------------------------------------------------------------------------------------+
 | **-g <group>**   | Group to run as.                                                                                      |
 +                  +-------------+-----------------------------------------------------------------------------------------+
@@ -60,6 +57,5 @@ The ossec-authd program can automatically add an agent to a Wazuh manager and pr
 +------------------+-------------+-----------------------------------------------------------------------------------------+
 | **-L**           | Force insertion even though agent limit has been reached.                                             |
 +------------------+-------------------------------------------------------------------------------------------------------+
-
 
 .. _`SSL ciphers`: https://www.openssl.org/docs/man1.1.0/apps/ciphers.html

--- a/source/user-manual/reference/tools/agent-auth.rst
+++ b/source/user-manual/reference/tools/agent-auth.rst
@@ -3,14 +3,12 @@
 .. _agent-auth:
 
 agent-auth
-===========
+==========
 
-The agent-auth program is the client application used with :ref:`ossec-authd` to automatically add agents to a Wazuh manager.
+The ``agent-auth`` program is the client application used along with :ref:`ossec-authd` to automatically add agents to a Wazuh manager.
 
 .. warning::
-
-    By default there is no authentication or authorization involved in this transaction, so it is recommended that
-    this daemon only be run when a new agent is being added.
+  By default there is no authentication or authorization involved in this transaction, so it is recommended that this daemon only be run when a new agent is being added.
 
 +---------------------+-------------------------------------------------------------------------------+
 | **-A <agent_name>** | Agent name to be used.                                                        |
@@ -46,7 +44,6 @@ The agent-auth program is the client application used with :ref:`ossec-authd` to
 | **-m <manager_ip>** | IP address of the manager.                                                    |
 +---------------------+-------------------------------------------------------------------------------+
 | **-P <password>**   | Use the specified password instead of searching for it at ``authd.pass``.     |
-|                     |                                                                               |
 |                     |                                                                               |
 |                     | If not provided in the file nor on the console,                               |
 |                     |                                                                               |

--- a/source/user-manual/registering/use-registration-service.rst
+++ b/source/user-manual/registering/use-registration-service.rst
@@ -25,7 +25,7 @@ Simple method
 -------------
 
 Get an SSL certificate
-^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^
 
 The first step is to get an SSL key and certificate. This is required in order to make authd work.
 
@@ -47,7 +47,7 @@ The first step is to get an SSL key and certificate. This is required in order t
       # openssl req -x509 -batch -nodes -days 365 -newkey rsa:2048 -keyout /var/ossec/etc/sslmanager.key -out /var/ossec/etc/sslmanager.cert
 
 Register the agent
-^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^
 
 1. Start the authd server:
 
@@ -90,7 +90,7 @@ On the other hand, **duplicate IPs are not allowed**, so an agent won't be added
 The ``0`` means the minimum time, in seconds, since the last connection of the old agent (the one to be deleted). In this case, ``0`` means to delete the old agent's registration regardless of how recently it has checked in.
 
 Secure methods
-------------------------------
+--------------
 
 Launching the authd daemon with default options would allow any agent to register itself, and then connect to a manager. The following options provide some mechanisms to authorize connections:
 
@@ -110,7 +110,7 @@ Launching the authd daemon with default options would allow any agent to registe
     These methods can be combined.
 
 Use a password to authorize agents
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. note::
   Reference :ref:`ossec-authd`
@@ -160,7 +160,7 @@ On the agent side, the key can be put in a file of the same name or specified as
 .. _verify-hosts:
 
 Use SSL to verify hosts
-^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^
 
 Create a Certificate of Authority
 """""""""""""""""""""""""""""""""
@@ -175,7 +175,7 @@ First we are going to create a certificate of authority (CA) that we will use to
     The file ``rootCA.key`` that we have just created is the **private key** of the certificate of authority. It is needed to sign other certificates and it is critical to keep it secure. Note that we will never copy this file to other hosts.
 
 Verify manager via SSL
-^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^
 
 1. Issue and sign a certificate for the authd server, entering the hostname or the IP address that agents will use to connect to the server. For example, if the server's IP is 192.168.1.2:
 
@@ -203,7 +203,7 @@ Verify manager via SSL
         # /var/ossec/bin/agent-auth -m 192.168.1.2 -v /var/ossec/etc/rootCA.pem
 
 Verify agents via SSL
-^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^
 
 
 **Verify agents via SSL (no host validation)**
@@ -263,14 +263,3 @@ Verify agents via SSL
 
           # cp sslagent.cert sslagent.key /var/ossec/etc
           # /var/ossec/bin/agent-auth -m 192.168.1.2 -x /var/ossec/etc/sslagent.cert -k /var/ossec/etc/sslagent.key
-
-
-Forcing insertion
-----------------------------
-
-If you try to add an agent with an IP already listed in an existing registration, ``ossec-authd`` will generate an error. You can use the argument *-F* to force the insertion.
-
-Example
-^^^^^^^^^^
-
-We previously installed and registered the Wazuh agent on *Server1* with IP 10.0.0.10 and ID 005. For some reason, we then had to completely re-install *Server1* and thus we now need to install and reregister the Wazuh agent on *Server1*. In this case, we can use the "*-F 0*" parameter which results in the previous agent (005) being removed (with a backup) and a new agent being successfully registered. The new agent will have a new ID.

--- a/source/user-manual/registering/use-registration-service.rst
+++ b/source/user-manual/registering/use-registration-service.rst
@@ -5,21 +5,26 @@
 Using the registration service
 ==============================
 
-It's possible to register agents automatically with authd. Choose the method that best meets your needs:
+The ``authd`` daemon allows to register agents automatically. This registration process uses the :ref:`ossec-authd` and :ref:`agent-auth` programs on both manager and agent sides.
 
-+----------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-| Method                                             | Description                                                                                                                 |
-+====================================================+=============================================================================================================================+
-| `Simple method`_                                   | The easiest method. There is no authentication or host verification.                                                        |
-+----------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-| `Use a password to authorize agents`_              | Allows agents to authenticate via a shared password. This method is easy but does not perform host validation.              |
-+----------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-| `Verify manager via SSL`_                          | The manager's certificate is signed by a CA that agents use to validate the server. This may include host checking.         |
-+-------------------------+--------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-| `Verify agents via SSL`_| Host validation          | The same as above, but the manager verifies the agent's certificate and address. There should be one certificate per agent. |
-+                         +--------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-|                         | No host validation       | The manager validates the agent by CA but not the host address. This method allows the use of a shared agent certificate.   |
-+-------------------------+--------------------------+-----------------------------------------------------------------------------------------------------------------------------+
+Launching the daemon with default options would allow any agent to register itself, and then connect to a manager. The secure methods provide some mechanisms to authorize the connections.
+
++------------+-----------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
+| Type       | Method                                        | Description                                                                                                                 |
++============+===============================================+=============================================================================================================================+
+| Not secure | `Simple method`_                              | The easiest method. There is no authentication or host verification.                                                        |
++------------+-----------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
+| Secure     | `Use a password to authorize agents`_         | Allows agents to authenticate via a shared password. This method is easy but does not perform host validation.              |
+|            +-----------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
+|            | `Verify manager via SSL`_                     | The manager's certificate is signed by a CA that agents use to validate the server. This may include host checking.         |
+|            +--------------------------+--------------------+-----------------------------------------------------------------------------------------------------------------------------+
+|            | `Verify agents via SSL`_ | Host validation    | The same as above, but the manager verifies the agent's certificate and address. There should be one certificate per agent. |
+|            |                          +--------------------+-----------------------------------------------------------------------------------------------------------------------------+
+|            |                          | No host validation | The manager validates the agent by CA but not the host address. This method allows the use of a shared agent certificate.   |
++------------+--------------------------+--------------------+-----------------------------------------------------------------------------------------------------------------------------+
+
+.. note::
+  The secure methods can be combined for a stronger security during the registration process.
 
 Simple method
 -------------
@@ -92,28 +97,8 @@ The ``0`` means the minimum time, in seconds, since the last connection of the o
 Secure methods
 --------------
 
-Launching the authd daemon with default options would allow any agent to register itself, and then connect to a manager. The following options provide some mechanisms to authorize connections:
-
-+----------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-| Method                                             | Description                                                                                                                 |
-+====================================================+=============================================================================================================================+
-| `Use a password to authorize agents`_              | Allows agents to authenticate via a shared password. This method is easy but does not perform host validation.              |
-+----------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-| `Verify manager via SSL`_                          | The manager's certificate is signed by a CA that agents use to validate the server. It may include host checking.           |
-+-------------------------+--------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-| `Verify agents via SSL`_| Host validation          | The same as above, but the manager verifies the agent's certificate and address. There should be one certificate per agent. |
-+                         +--------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-|                         | No host validation       | The manager validates the agent by CA but not the host address. This method allows the use of a shared agent certificate.   |
-+-------------------------+--------------------------+-----------------------------------------------------------------------------------------------------------------------------+
-
-.. note::
-    These methods can be combined.
-
 Use a password to authorize agents
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. note::
-  Reference :ref:`ossec-authd`
 
 The manager can be protected from unauthorized registrations by using a password. We can choose one ourselves or let authd generate a random password.
 

--- a/source/user-manual/registering/use-registration-service.rst
+++ b/source/user-manual/registering/use-registration-service.rst
@@ -5,7 +5,10 @@
 Using the registration service
 ==============================
 
-The ``authd`` daemon allows to register agents automatically. This registration process uses :ref:`ossec-authd` on the manager instance, and :ref:`agent-auth` on the agent instances.
+The ``ossec-authd`` daemon allows to register agents automatically.
+
+- The manager uses :ref:`ossec-authd` to launch the registration service.
+- On the agent, :ref:`agent-auth` is used to connect to the registration service.
 
 Launching the daemon on the manager with default options would allow any agent to register itself, and then connect to it. The secure methods provide some mechanisms to authorize the connections.
 
@@ -57,9 +60,17 @@ This is the easiest method to register agents. It doesn't require any kind of au
 
 2. On the agents, run the ``agent-auth`` program, using the manager's IP address:
 
+  a. For Linux systems:
+
   .. code-block:: console
 
     # /var/ossec/bin/agent-auth -m <MANAGER_IP_ADDRESS>
+
+  b. For Windows systems:
+
+  .. code-block:: none
+
+    # C:\Program Files (x86)\ossec-agent\agent-auth.exe -m <MANAGER_IP_ADDRESS>
 
 Password authorization
 ----------------------
@@ -91,16 +102,33 @@ To enable the password authorization, use the ``-P`` flag when running the regis
 
   * Write the password on ``/var/ossec/etc/authd.pass`` and run the ``agent-auth`` program:
 
+    a. For Linux systems:
+
     .. code-block:: console
 
       # echo "abcd1234" > /var/ossec/etc/authd.pass
       # /var/ossec/bin/agent-auth -m <MANAGER_IP_ADDRESS>
 
+    b. For Windows systems:
+
+    .. code-block:: console
+
+      # echo abcd1234 > C:\Program Files (x86)\ossec-agent\authd.pass
+      # C:\Program Files (x86)\ossec-agent\agent-auth.exe -m <MANAGER_IP_ADDRESS>
+
   * Run the program with the ``-P`` flag, and insert the password:
+
+    a. For Linux systems:
 
     .. code-block:: console
 
       # /var/ossec/bin/agent-auth -m <MANAGER_IP_ADDRESS> -P "abcd1234"
+
+    b. For Windows systems:
+
+    .. code-block:: none
+
+      # C:\Program Files (x86)\ossec-agent\agent-auth.exe -m <MANAGER_IP_ADDRESS> -P "abcd1234"
 
 .. _verify-hosts:
 
@@ -138,10 +166,19 @@ Manager verification using SSL
 
 3. Copy the CA (**but not the key**) to the ``/var/ossec/etc`` folder **on the agent**, and run the ``agent-auth`` program:
 
+  a. For Linux systems:
+
   .. code-block:: console
 
     # cp rootCA.pem /var/ossec/etc
     # /var/ossec/bin/agent-auth -m 192.168.1.2 -v /var/ossec/etc/rootCA.pem
+
+  b. For Windows systems, the CA must be copied to ``C:\Program Files (x86)\ossec-agent``:
+
+  .. code-block:: console
+
+    # cp rootCA.pem C:\Program Files (x86)\ossec-agent
+    # C:\Program Files (x86)\ossec-agent\agent-auth.exe -m 192.168.1.2 -v C:\Program Files (x86)\ossec-agent\rootCA.pem
 
 Agent verification using SSL
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -166,10 +203,19 @@ In this example, we are going to create a certificate for agents without specify
 
 3. Copy the newly created certificate (and its key) to the ``/var/ossec/etc`` folder **on the agent**, and run the ``agent-auth`` program. For example, if the manager's IP address is 192.168.1.2:
 
+  a. For Linux systems:
+
   .. code-block:: console
 
     # cp sslagent.cert sslagent.key /var/ossec/etc
     # /var/ossec/bin/agent-auth -m 192.168.1.2 -x /var/ossec/etc/sslagent.cert -k /var/ossec/etc/sslagent.key
+
+  b. For Windows systems, the CA must be copied to ``C:\Program Files (x86)\ossec-agent``:
+
+  .. code-block:: console
+
+    # cp sslagent.cert sslagent.key C:\Program Files (x86)\ossec-agent
+    # C:\Program Files (x86)\ossec-agent\agent-auth.exe -m 192.168.1.2 -x C:\Program Files (x86)\ossec-agent\sslagent.cert -k C:\Program Files (x86)\ossec-agent\sslagent.key
 
 **Agent verification (with host validation)**
 
@@ -191,10 +237,19 @@ This is an alternative method to the previous one. In this case, we will bind th
 
 3. Copy the newly created certificate (and its key) to the ``/var/ossec/etc`` folder **on the agent**, and run the ``agent-auth`` program. For example, if the manager's IP address is 192.168.1.2:
 
+  a. For Linux systems:
+
   .. code-block:: console
 
     # cp sslagent.cert sslagent.key /var/ossec/etc
     # /var/ossec/bin/agent-auth -m 192.168.1.2 -x /var/ossec/etc/sslagent.cert -k /var/ossec/etc/sslagent.key
+
+  b. For Windows systems, the CA must be copied to ``C:\Program Files (x86)\ossec-agent``:
+
+  .. code-block:: console
+
+    # cp sslagent.cert sslagent.key C:\Program Files (x86)\ossec-agent
+    # C:\Program Files (x86)\ossec-agent\agent-auth.exe -m 192.168.1.2 -x C:\Program Files (x86)\ossec-agent\sslagent.cert -k C:\Program Files (x86)\ossec-agent\sslagent.key
 
 Additional configurations
 -------------------------


### PR DESCRIPTION
Hello team,

This PR closes #363 and #685.

It will update the documentation for `ossec-authd` in order to make it clearer and easier to understand. The text has been restructured and reduced. More explanations have been included so the user knows in every moment what is he doing, and why. Old, deprecated documentation has been removed.

Regards,
Juanjo