### PR TITLE
Fix Integratord reference documentation for <event_location>

### DIFF
--- a/source/user-manual/reference/ossec-conf/integration.rst
+++ b/source/user-manual/reference/ossec-conf/integration.rst
@@ -110,7 +110,7 @@ This filters alerts by where the event originated. `OS_Regex Syntax`_
 +--------------------+-----------------------------------------------------------+
 | **Default value**  | n/a                                                       |
 +--------------------+-----------------------------------------------------------+
-| **Allowed values** | Any single agent name, hostname, ip address, or log file. |
+| **Allowed values** | Any single log file.                                      |
 +--------------------+-----------------------------------------------------------+
 
 alert_format


### PR DESCRIPTION
This pull request closes #575.

Removes incorrect allowed values for `<event_location>` on Integratord reference.