### PR TITLE
Added more meta descriptions tags to the documentation

### DIFF
--- a/source/amazon/index.rst
+++ b/source/amazon/index.rst
@@ -5,6 +5,10 @@
 Using Wazuh to Monitor AWS
 ==========================
 
+.. meta::
+  :description: Discover how Wazuh can help you to monitor your Amazon AWS infrastructure.
+  :author: Wazuh, Inc.
+
 .. versionadded:: 3.2.0
 
 Wazuh provides the ability to read AWS logs directly from AWS S3 buckets. Amazon support is now a built-in Wazuh capability, giving you the ability to search, analyze, and alert on AWS CloudTrail, GuardDuty, Macie, IAM, and VPC Flow log data.

--- a/source/amazon/index.rst
+++ b/source/amazon/index.rst
@@ -7,7 +7,6 @@ Using Wazuh to Monitor AWS
 
 .. meta::
   :description: Discover how Wazuh can help you to monitor your Amazon AWS infrastructure.
-  :author: Wazuh, Inc.
 
 .. versionadded:: 3.2.0
 

--- a/source/amazon/installation.rst
+++ b/source/amazon/installation.rst
@@ -5,6 +5,9 @@
 Installation
 ============
 
+.. meta::
+  :description: Learn how to install and configure the Wazuh module to monitor Amazon instances and services.
+
 Prior to enabling the Wazuh rules for Amazon Web Services, follow the steps below to configure AWS to generate log messages, and store them as JSON data files in an Amazon S3 bucket. A detailed description of each of the steps can be found bellow.
 
 .. note::

--- a/source/amazon/troubleshooting.rst
+++ b/source/amazon/troubleshooting.rst
@@ -5,6 +5,9 @@
 Troubleshooting
 ===============
 
+.. meta::
+  :description: Frequently asked questions about the Wazuh module for Amazon.
+
 The below information is intended to assist in troubleshooting issues.
 
 

--- a/source/azure/index.rst
+++ b/source/azure/index.rst
@@ -7,7 +7,6 @@ Using Wazuh to Monitor Microsoft Azure
 
 .. meta::
   :description: Discover how Wazuh can help you to monitor your Microsoft Azure infrastructure.
-  :author: Wazuh, Inc.
 
 .. versionadded:: 3.7.0
 

--- a/source/azure/index.rst
+++ b/source/azure/index.rst
@@ -5,6 +5,10 @@
 Using Wazuh to Monitor Microsoft Azure
 ======================================
 
+.. meta::
+  :description: Discover how Wazuh can help you to monitor your Microsoft Azure infrastructure.
+  :author: Wazuh, Inc.
+
 .. versionadded:: 3.7.0
 
 This section provides instructions for monitoring **Microsoft Azure** infrastructures, such as:

--- a/source/azure/installation.rst
+++ b/source/azure/installation.rst
@@ -5,6 +5,9 @@
 Manager Requierements
 =====================
 
+.. meta::
+  :description: Detailed instructions to install and configure the necessary dependencies to monitor Microsoft Azure instances with Wazuh.
+
 The Wazuh manager is in charge of carrying out the integration with Microsoft Azure when monitoring infrastructure activity services. In order to work properly, the integration requires the installation of some dependencies.
 
 Required dependencies

--- a/source/azure/monitoring activity.rst
+++ b/source/azure/monitoring activity.rst
@@ -2,6 +2,9 @@
 
 .. _azure_monitoring_activity:
 
+.. meta::
+  :description: Discover the numerous ways that Wazuh provides to monitor your Microsoft Azure infrastructure activity.
+
 Monitoring Activity
 ===================
 

--- a/source/azure/monitoring instances.rst
+++ b/source/azure/monitoring instances.rst
@@ -2,6 +2,9 @@
 
 .. _azure_monitoring_instances:
 
+.. meta::
+  :description: Discover the numerous ways that Wazuh provides to monitor your Microsoft Azure instances.
+
 Monitoring Instances
 ====================
 

--- a/source/azure/monitoring services.rst
+++ b/source/azure/monitoring services.rst
@@ -5,6 +5,9 @@
 Monitoring Services
 ===================
 
+.. meta::
+  :description: Discover the numerous ways that Wazuh provides to monitor your Microsoft Azure services.
+
 `Azure Active Directory <https://docs.microsoft.com/en-us/azure/active-directory/fundamentals/active-directory-whatis>`_ is the identity and directory management service that combines basic directory services, application access management, and identity protection in a single solution.
 
 .. thumbnail:: ../images/azure/graph_intro.png

--- a/source/deploying-with-ansible/index.rst
+++ b/source/deploying-with-ansible/index.rst
@@ -7,7 +7,6 @@ Deploying with Ansible
 
 .. meta::
   :description: Find instructions to deploy Wazuh using the Ansible platform.
-  :author: Wazuh, Inc.
 
 Ansible is an open source platform designed for automating tasks. It comes with Playbooks, a descriptive language based on YAML, that make easy to create and describe automation jobs. Also, Ansible communicates with every host over SSH, making it very secure. See `Ansible Overview <https://www.ansible.com/how-ansible-works>`_ for more info.
 

--- a/source/deploying-with-ansible/index.rst
+++ b/source/deploying-with-ansible/index.rst
@@ -3,7 +3,11 @@
 .. _wazuh_ansible:
 
 Deploying with Ansible
-============================
+======================
+
+.. meta::
+  :description: Find instructions to deploy Wazuh using the Ansible platform.
+  :author: Wazuh, Inc.
 
 Ansible is an open source platform designed for automating tasks. It comes with Playbooks, a descriptive language based on YAML, that make easy to create and describe automation jobs. Also, Ansible communicates with every host over SSH, making it very secure. See `Ansible Overview <https://www.ansible.com/how-ansible-works>`_ for more info.
 

--- a/source/deploying-with-puppet/index.rst
+++ b/source/deploying-with-puppet/index.rst
@@ -7,7 +7,6 @@ Deploying with Puppet
 
 .. meta::
   :description: Find instructions to deploy Wazuh using the Puppet tool.
-  :author: Wazuh, Inc.
 
 Puppet is an open-source software tool that gives you an automatic way to inspect, deliver, operate and future-proof all of your software, no matter where it is executed. It runs on many Unix-like systems as well as on Microsoft Windows, and includes its own declarative language to describe system configuration. It is very simple to use and allows you to install and configure Wazuh easily.
 

--- a/source/deploying-with-puppet/index.rst
+++ b/source/deploying-with-puppet/index.rst
@@ -3,7 +3,11 @@
 .. _wazuh_puppet:
 
 Deploying with Puppet
-============================
+=====================
+
+.. meta::
+  :description: Find instructions to deploy Wazuh using the Puppet tool.
+  :author: Wazuh, Inc.
 
 Puppet is an open-source software tool that gives you an automatic way to inspect, deliver, operate and future-proof all of your software, no matter where it is executed. It runs on many Unix-like systems as well as on Microsoft Windows, and includes its own declarative language to describe system configuration. It is very simple to use and allows you to install and configure Wazuh easily.
 

--- a/source/development/index.rst
+++ b/source/development/index.rst
@@ -5,6 +5,9 @@
 Development
 ===========
 
+.. meta::
+  :description: Find useful technical documentation about how Wazuh works, suitable for developers and tech enthusiasts.
+
 This section contains technical documentation for developers.
 
 .. topic:: Contents

--- a/source/docker-monitor/index.rst
+++ b/source/docker-monitor/index.rst
@@ -5,6 +5,10 @@
 Using Wazuh to Monitor Docker
 =============================
 
+.. meta::
+  :description: Discover how Wazuh can help you to monitor your Docker infrastructure.
+  :author: Wazuh, Inc.
+
 .. versionadded:: 3.7.0
 
 This section provides instructions for monitoring Docker servers and container events with Wazuh.

--- a/source/docker-monitor/index.rst
+++ b/source/docker-monitor/index.rst
@@ -7,7 +7,6 @@ Using Wazuh to Monitor Docker
 
 .. meta::
   :description: Discover how Wazuh can help you to monitor your Docker infrastructure.
-  :author: Wazuh, Inc.
 
 .. versionadded:: 3.7.0
 

--- a/source/docker/index.rst
+++ b/source/docker/index.rst
@@ -5,6 +5,10 @@
 Docker
 ======
 
+.. meta::
+  :description: Find instructions to deploy Wazuh using Docker containers.
+  :author: Wazuh, Inc.
+
 `Docker <https://www.docker.com/>`_ is an open-source project that automates the deployment of different applications inside software containers. Docker containers wrap up a piece of software in a complete filesystem that contains everything it needs to run like: code, system tools, libraries, etc. This process guarantees that the system will always run the same, regardless the environment it is running.
 
 We have created our own fork based on `"deviantony" dockerfiles <https://github.com/deviantony/docker-elk>`_ and `"xetus-oss" dockerfiles <https://github.com/xetus-oss/docker-ossec-server>`_. Thank you, Anthony Lapenna, for your contribution to the community. If you want to contribute to the Wazuh fork, please go to our `Docker repository <https://github.com/wazuh/wazuh-docker>`_.

--- a/source/docker/index.rst
+++ b/source/docker/index.rst
@@ -7,7 +7,6 @@ Docker
 
 .. meta::
   :description: Find instructions to deploy Wazuh using Docker containers.
-  :author: Wazuh, Inc.
 
 `Docker <https://www.docker.com/>`_ is an open-source project that automates the deployment of different applications inside software containers. Docker containers wrap up a piece of software in a complete filesystem that contains everything it needs to run like: code, system tools, libraries, etc. This process guarantees that the system will always run the same, regardless the environment it is running.
 

--- a/source/gdpr/index.rst
+++ b/source/gdpr/index.rst
@@ -7,7 +7,6 @@ Using Wazuh for GDPR
 
 .. meta::
   :description: Learn about the GDPR compliance and how Wazuh helps you to implement it.
-  :author: Wazuh, Inc.
 
 The European Union's **General Data Protection Regulation (GDPR)** has been drawn up to agree on data privacy legislation across Europe, with its main focus on providing data protection for all citizens in the European Union.
 

--- a/source/gdpr/index.rst
+++ b/source/gdpr/index.rst
@@ -3,11 +3,15 @@
 .. _gdpr:
 
 Using Wazuh for GDPR
-========================
+====================
 
-The European Union's **General Data Protection Regulation (GDPR)** has been drawn up to agree on data privacy legislation across Europe, with its main focus on providing data protection for all citizens in the European Union. 
+.. meta::
+  :description: Learn about the GDPR compliance and how Wazuh helps you to implement it.
+  :author: Wazuh, Inc.
 
-To this end, it seeks to enhance the privacy of such data and to reform the way in which EU organizations approach data privacy. 
+The European Union's **General Data Protection Regulation (GDPR)** has been drawn up to agree on data privacy legislation across Europe, with its main focus on providing data protection for all citizens in the European Union.
+
+To this end, it seeks to enhance the privacy of such data and to reform the way in which EU organizations approach data privacy.
 
 * Wazuh for GDPR White Paper `(PDF) <https://wazuh.com/resources/Wazuh_GDPR_White_Paper.pdf>`_
 
@@ -18,16 +22,16 @@ Wazuh takes advantage of its file integrity monitoring and access control capabi
 
 The syntax used for rule tagging is **gdpr_** followed by the chapter, article and, where appropriate, the section and paragraph to which the requirement belongs. (e.g. gdpr_II_5.1.f).
 
-GDPR formal requirements content are out of the technical scope and therefore are not considered in this document. 
+GDPR formal requirements content are out of the technical scope and therefore are not considered in this document.
 
 Contents
 --------
 
-The technical requirements that Wazuh supports can be found in the following chapters: 
+The technical requirements that Wazuh supports can be found in the following chapters:
 
 .. toctree::
     :maxdepth: 1
 
-    gdpr-II 
+    gdpr-II
     gdpr-III
     gdpr-IV

--- a/source/getting-started/architecture.rst
+++ b/source/getting-started/architecture.rst
@@ -5,6 +5,9 @@
 Architecture
 ============
 
+.. meta::
+  :description: Learn about different architectures that can be used to install Wazuh.
+
 The Wazuh architecture is based on agents running on monitored hosts that forward log data to a central server. Also, agentless devices (such as firewalls, switches, routers, access points, etc.) are supported and can actively submit log data via syslog and/or a periodic probe of their configuration changes to later forward the data to the central server. The central server decodes and analyzes the incoming information and passes the results along to an Elasticsearch cluster for indexing and storage.
 
 An Elasticsearch cluster is a collection of one or more nodes (servers) that communicate with each other to perform read and write operations on indexes. Small Wazuh deployments (<50 agents), can easily be handled by a single-node cluster. Multi-node clusters are recommended when there is a large number of monitored systems, when a large volume of data is anticipated and/or when high availability is required.

--- a/source/getting-started/index.rst
+++ b/source/getting-started/index.rst
@@ -2,13 +2,11 @@
 
 .. _getting_started:
 
-=================
- Getting started
-=================
+Getting started
+===============
 
 .. meta::
   :description: Get started with the Wazuh components and learn how each one is involved.
-  :keywords: wazuh, elastic stack, openscap, architecture
   :author: Wazuh, Inc.
 
 Wazuh is a security detection, visibility, and compliance open source project. It was born as a fork of OSSEC HIDS, and later was integrated with Elastic Stack and OpenSCAP, evolving into a more comprehensive solution. Below is a brief description of these tools and what they do:

--- a/source/getting-started/index.rst
+++ b/source/getting-started/index.rst
@@ -7,7 +7,6 @@ Getting started
 
 .. meta::
   :description: Get started with the Wazuh components and learn how each one is involved.
-  :author: Wazuh, Inc.
 
 Wazuh is a security detection, visibility, and compliance open source project. It was born as a fork of OSSEC HIDS, and later was integrated with Elastic Stack and OpenSCAP, evolving into a more comprehensive solution. Below is a brief description of these tools and what they do:
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -2,13 +2,11 @@
 
 .. _index:
 
-==================
- Welcome to Wazuh
-==================
+Welcome to Wazuh
+================
 
 .. meta::
   :description: Wazuh is a free, open source and enterprise-ready security monitoring solution for threat detection, integrity monitoring, incident response and compliance.
-  :keywords: wazuh, ossec, security, compliance, intrusion detection, policy monitoring, elasticsearch, openscap, file integrity management, log analysis, vulnerability detection, incident response
   :author: Wazuh, Inc.
 
 Wazuh helps you to gain deeper security visibility into your infrastructure by monitoring hosts at an operating system and application level. This solution, based on lightweight multi-platform agents, provides the following capabilities:

--- a/source/index.rst
+++ b/source/index.rst
@@ -7,7 +7,6 @@ Welcome to Wazuh
 
 .. meta::
   :description: Wazuh is a free, open source and enterprise-ready security monitoring solution for threat detection, integrity monitoring, incident response and compliance.
-  :author: Wazuh, Inc.
 
 Wazuh helps you to gain deeper security visibility into your infrastructure by monitoring hosts at an operating system and application level. This solution, based on lightweight multi-platform agents, provides the following capabilities:
 

--- a/source/installation-guide/index.rst
+++ b/source/installation-guide/index.rst
@@ -7,7 +7,6 @@ Installation guide
 
 .. meta::
   :description: Read this guide to know how to install Wazuh and the Elasticsearch integration.
-  :author: Wazuh, Inc.
 
 This document will guide you through the Wazuh installation process. For interactive help, our `email forum <https://groups.google.com/d/forum/wazuh>`_ is available. You can subscribe to this forum by sending an email to `Wazuh subscribe <mailto:wazuh%2Bsubscribe@googlegroups.com>`_.
 

--- a/source/installation-guide/index.rst
+++ b/source/installation-guide/index.rst
@@ -2,13 +2,11 @@
 
 .. _installation_guide:
 
-====================
- Installation guide
-====================
+Installation guide
+==================
 
 .. meta::
   :description: Read this guide to know how to install Wazuh and the Elasticsearch integration.
-  :keywords: wazuh, elasticsearch, kibana, wazuh installation
   :author: Wazuh, Inc.
 
 This document will guide you through the Wazuh installation process. For interactive help, our `email forum <https://groups.google.com/d/forum/wazuh>`_ is available. You can subscribe to this forum by sending an email to `Wazuh subscribe <mailto:wazuh%2Bsubscribe@googlegroups.com>`_.

--- a/source/installing-splunk/index.rst
+++ b/source/installing-splunk/index.rst
@@ -5,6 +5,9 @@
 Installing Splunk
 =================
 
+.. meta::
+  :description: Wazuh can be integrated with Splunk Enterprise to visualize alerts using our app. Learn more about how to install it.
+
 This guide describes the Splunk Enterprise installation process for two different types of distributed architecture, along with the Splunk forwarder and the Wazuh app for Splunk.
 
 - The **single-instance architecture** is recommended for testing and evaluation purposes, or also for small-medium sized environments.

--- a/source/migrating-from-ossec/index.rst
+++ b/source/migrating-from-ossec/index.rst
@@ -7,7 +7,6 @@ Migrating from OSSEC
 
 .. meta::
   :description: Learn why it's a good reason to upgrade your infrastructure migrating it to Wazuh.
-  :author: Wazuh, Inc.
 
 Why it's time to migrate
 ------------------------

--- a/source/migrating-from-ossec/index.rst
+++ b/source/migrating-from-ossec/index.rst
@@ -2,13 +2,11 @@
 
 .. _upgrading_ossec:
 
-======================
- Migrating from OSSEC
-======================
+Migrating from OSSEC
+====================
 
 .. meta::
   :description: Learn why it's a good reason to upgrade your infrastructure migrating it to Wazuh.
-  :keywords: wazuh, ossec, security, upgrade, recommendations
   :author: Wazuh, Inc.
 
 Why it's time to migrate

--- a/source/pci-dss/index.rst
+++ b/source/pci-dss/index.rst
@@ -7,7 +7,6 @@ Using Wazuh for PCI DSS
 
 .. meta::
   :description: Learn about the PCI DSS compliance and how Wazuh helps you to implement it.
-  :author: Wazuh, Inc.
 
 The **Payment Card Industry Data Security Standard (PCI DSS)** is a proprietary information security standard for organizations that handle branded credit cards from the major card companies including *Visa*, *MasterCard*, *American Express*, *Discover*, and *JCB*. The standard was created to increase controls around cardholder data to reduce credit card fraud.
 

--- a/source/pci-dss/index.rst
+++ b/source/pci-dss/index.rst
@@ -3,7 +3,11 @@
 .. _pci_dss:
 
 Using Wazuh for PCI DSS
-========================
+=======================
+
+.. meta::
+  :description: Learn about the PCI DSS compliance and how Wazuh helps you to implement it.
+  :author: Wazuh, Inc.
 
 The **Payment Card Industry Data Security Standard (PCI DSS)** is a proprietary information security standard for organizations that handle branded credit cards from the major card companies including *Visa*, *MasterCard*, *American Express*, *Discover*, and *JCB*. The standard was created to increase controls around cardholder data to reduce credit card fraud.
 

--- a/source/release-notes/index.rst
+++ b/source/release-notes/index.rst
@@ -7,7 +7,6 @@ Release notes
 
 .. meta::
   :description: Find here a summary of the most important features of each Wazuh release.
-  :author: Wazuh, Inc.
 
 This section summarizes the most important features of each Wazuh release.
 

--- a/source/release-notes/index.rst
+++ b/source/release-notes/index.rst
@@ -2,10 +2,14 @@
 
 .. _release_notes:
 
-Release Notes
+Release notes
 =============
 
-This section summarizes the most important features of each release.
+.. meta::
+  :description: Find here a summary of the most important features of each Wazuh release.
+  :author: Wazuh, Inc.
+
+This section summarizes the most important features of each Wazuh release.
 
 .. topic:: Contents
 

--- a/source/user-manual/agents/index.rst
+++ b/source/user-manual/agents/index.rst
@@ -5,6 +5,9 @@
 Agent management
 ================
 
+.. meta::
+  :description: Learn more about the Wazuh agents and how to group, configure or upgrade them remotely using several tools.
+
 This section describes how to list and remove registered agents and register agents with the Wazuh server. These tasks can be performed via the command line (CLI) or RESTful API. Both methods are secure and valid for agent management depending on your needs.
 
 .. topic:: Contents

--- a/source/user-manual/capabilities/index.rst
+++ b/source/user-manual/capabilities/index.rst
@@ -5,6 +5,9 @@
 Capabilities
 ============
 
+.. meta::
+  :description: Find here a deeper explanation of how each Wazuh capability works, configuration options for each one, frequently asked questions and some practical examples.
+
 In this section, you will find:
 
 - A deeper explanation of how each capability works.

--- a/source/user-manual/index.rst
+++ b/source/user-manual/index.rst
@@ -2,13 +2,11 @@
 
 .. _user_manual:
 
-=============
- User manual
-=============
+User manual
+===========
 
 .. meta::
   :description: The Wazuh user manual helps you to configure, adjust and make use of all of the available capabilities.
-  :keywords: wazuh, kibana, api restful, user manual
   :author: Wazuh, Inc.
 
 Welcome to the Wazuh user manual. Use it as your Wazuh reference library once you have a basic Wazuh installation in place. In the same way that the main components of Wazuh are a fork of the renowned OSSEC HIDS project, so this user manual has been derived from the `OSSEC documentation <http://ossec.github.io/docs/>`_. Kudos to the OSSEC team for their huge contribution to the IT security community.

--- a/source/user-manual/index.rst
+++ b/source/user-manual/index.rst
@@ -7,7 +7,6 @@ User manual
 
 .. meta::
   :description: The Wazuh user manual helps you to configure, adjust and make use of all of the available capabilities.
-  :author: Wazuh, Inc.
 
 Welcome to the Wazuh user manual. Use it as your Wazuh reference library once you have a basic Wazuh installation in place. In the same way that the main components of Wazuh are a fork of the renowned OSSEC HIDS project, so this user manual has been derived from the `OSSEC documentation <http://ossec.github.io/docs/>`_. Kudos to the OSSEC team for their huge contribution to the IT security community.
 

--- a/source/user-manual/kibana-app/index.rst
+++ b/source/user-manual/kibana-app/index.rst
@@ -5,6 +5,9 @@
 Kibana app
 ==========
 
+.. meta::
+  :description: Find information about the Wazuh Kibana app, its different features, configuration reference and how to troubleshoot some of the most common problems.
+
 The Wazuh app for Kibana lets you visualize and analyze Wazuh alerts stored in Elasticsearch. You can obtain statistics per agent, search alerts and filter using different visualizations. It integrates with the Wazuh API to retrieve information about manager and agents configuration, logs, ruleset, groups and much more.
 
 To install the app, you can follow our Elastic Stack installation guides (for :ref:`RPM <install_kibana_app_rpm>` or :ref:`Debian <install_kibana_app_deb>` systems).

--- a/source/user-manual/manager/index.rst
+++ b/source/user-manual/manager/index.rst
@@ -5,6 +5,9 @@
 Wazuh server administration
 ===========================
 
+.. meta::
+  :description: A complete user manual about how to manage and administer the Wazuh manager.
+
 The Wazuh manager is the system that analyzes the data received from all registered agents triggering alerts when an event matches a rule, for example: intrusion detected, file modified, configuration not compliant with policy, possible rootkit, etc. The manager also operates as an agent on the local machine, so it has all the features that an agent has. Also, the manager can forward the alerts it triggers through syslog, emails or integrated external APIs.
 
 .. topic:: Contents

--- a/source/user-manual/overview.rst
+++ b/source/user-manual/overview.rst
@@ -5,6 +5,10 @@
 Overview
 ========
 
+.. meta::
+  :description: The Wazuh user manual describes how to configure and use each of the components, which consist of the Wazuh server, the Wazuh agent, and Elastic Stack.
+  :author: Wazuh, Inc.
+
 Wazuh is an open source project that provides security visibility, compliance and infrastructure monitoring capabilities. The project was born as a fork of OSSEC HIDS and has evolved into a comprehensive solution by implementing new functionalities and integrating additional tools like OpenSCAP and Elasticsearch.
 
 This manual describes how to configure and use each of Wazuh components, which consist of the Wazuh server, the Wazuh agent, and Elastic Stack.

--- a/source/user-manual/overview.rst
+++ b/source/user-manual/overview.rst
@@ -7,7 +7,6 @@ Overview
 
 .. meta::
   :description: The Wazuh user manual describes how to configure and use each of the components, which consist of the Wazuh server, the Wazuh agent, and Elastic Stack.
-  :author: Wazuh, Inc.
 
 Wazuh is an open source project that provides security visibility, compliance and infrastructure monitoring capabilities. The project was born as a fork of OSSEC HIDS and has evolved into a comprehensive solution by implementing new functionalities and integrating additional tools like OpenSCAP and Elasticsearch.
 

--- a/source/user-manual/reference/index.rst
+++ b/source/user-manual/reference/index.rst
@@ -3,10 +3,13 @@
 .. _reference_files:
 
 Reference
-=====================
+=========
 
-This part of the user manual will cover the configuration files used by Wazuh and define the setting options.   Directions are given on how to customize the functionality of Wazuh to the unique environment and specific requirements of each installation.
+.. meta::
+  :description: A full reference of all the configurations and settings that can be customized on Wazuh, for both managers and agents.
+  :author: Wazuh, Inc.
 
+This part of the user manual will cover the configuration files used by Wazuh and define the setting options. Directions are given on how to customize the functionality of Wazuh to the unique environment and specific requirements of each installation.
 
 .. topic:: Contents
 

--- a/source/user-manual/reference/index.rst
+++ b/source/user-manual/reference/index.rst
@@ -7,7 +7,6 @@ Reference
 
 .. meta::
   :description: A full reference of all the configurations and settings that can be customized on Wazuh, for both managers and agents.
-  :author: Wazuh, Inc.
 
 This part of the user manual will cover the configuration files used by Wazuh and define the setting options. Directions are given on how to customize the functionality of Wazuh to the unique environment and specific requirements of each installation.
 

--- a/source/user-manual/registering/index.rst
+++ b/source/user-manual/registering/index.rst
@@ -7,7 +7,6 @@ Registering agents
 
 .. meta::
   :description: Learn more about the different methods that can be used to register agents against the Wazuh manager.
-  :author: Wazuh, Inc.
 
 In this section we describe how the registration process works, and more specifically the different methods that you can use to register agents against the Wazuh manager.
 

--- a/source/user-manual/registering/index.rst
+++ b/source/user-manual/registering/index.rst
@@ -5,7 +5,11 @@
 Registering agents
 ==================
 
-Next, we describe how this process works and more specifically the different methods you can use to register agents against the Wazuh server.
+.. meta::
+  :description: Learn more about the different methods that can be used to register agents against the Wazuh manager.
+  :author: Wazuh, Inc.
+
+In this section we describe how the registration process works, and more specifically the different methods that you can use to register agents against the Wazuh manager.
 
 .. topic:: Contents
 

--- a/source/user-manual/ruleset/index.rst
+++ b/source/user-manual/ruleset/index.rst
@@ -3,7 +3,11 @@
 .. _ruleset:
 
 Ruleset
-=============
+=======
+
+.. meta::
+  :description: Find instructions to update, configure, customize and contribute to the Wazuh ruleset.
+  :author: Wazuh, Inc.
 
 This documentation explains how to install, update, and contribute to Wazuh Ruleset. These rules are used by the system to detect attacks, intrusions, software misuse, configuration problems, application errors, malware, rootkits, system anomalies or security policy violations. OSSEC provides an out-of-the-box set of rules that we update and augment, in order to increase Wazuh detection capabilities.
 

--- a/source/user-manual/ruleset/index.rst
+++ b/source/user-manual/ruleset/index.rst
@@ -7,7 +7,6 @@ Ruleset
 
 .. meta::
   :description: Find instructions to update, configure, customize and contribute to the Wazuh ruleset.
-  :author: Wazuh, Inc.
 
 This documentation explains how to install, update, and contribute to Wazuh Ruleset. These rules are used by the system to detect attacks, intrusions, software misuse, configuration problems, application errors, malware, rootkits, system anomalies or security policy violations. OSSEC provides an out-of-the-box set of rules that we update and augment, in order to increase Wazuh detection capabilities.
 


### PR DESCRIPTION
This PR adds more description tags to some of the main documentation articles. The author tag has been removed since it's not used for SEO purposes.

Related issue: #431 