### PR TITLE
Add documentation for Splunk agent status polling feature

### DIFF
--- a/source/installing-splunk/index.rst
+++ b/source/installing-splunk/index.rst
@@ -38,3 +38,4 @@ Find more information about how to scale your environments using Splunk Enterpri
     splunk-app
     splunk-forwarder
     splunk-reverse-proxy
+    splunk-polling

--- a/source/installing-splunk/splunk-app.rst
+++ b/source/installing-splunk/splunk-app.rst
@@ -42,11 +42,13 @@ Installation
   The app includes the ``indexes.conf`` file to create Wazuh indexes and the ``inputs.conf`` file to listen to forwarded data on port 9997.
 
   .. warning::
-    If you installed Splunk using the :ref:`distributed architecture <splunk_distributed>`, these two files are already configured on the **search peer** instances, and must be removed from the Wazuh app installation directory::
+    If you installed Splunk using the :ref:`distributed architecture <splunk_distributed>`, these two files are already configured on the **search peer** instances, and must be removed from the Wazuh app installation directory:
 
-    # rm -rf /opt/splunk/etc/apps/SplunkAppForWazuh/default/indexes.conf
-    # rm -rf /opt/splunk/etc/apps/SplunkAppForWazuh/default/inputs.conf
-    # /opt/splunk/bin/splunk restart
+    .. code-block:: none
+
+      # rm -rf /opt/splunk/etc/apps/SplunkAppForWazuh/default/indexes.conf
+      # rm -rf /opt/splunk/etc/apps/SplunkAppForWazuh/default/inputs.conf
+      # /opt/splunk/bin/splunk restart
 
 3. Open Splunk in your desired browser and click on the Wazuh app icon:
 

--- a/source/installing-splunk/splunk-distributed.rst
+++ b/source/installing-splunk/splunk-distributed.rst
@@ -76,7 +76,7 @@ Now that we finished installing the Splunk instances, it's time to choose which 
 
   .. code-block:: console
 
-    # splunk add search-server <host>:<port> -auth <user>:<password> -remoteUsername <user> -remotePassword <passremote>
+    # /opt/splunk/bin/splunk add search-server <host>:<port> -auth <user>:<password> -remoteUsername <user> -remotePassword <passremote>
 
   You must run this command for each search peer that you want to add.
 

--- a/source/installing-splunk/splunk-polling.rst
+++ b/source/installing-splunk/splunk-polling.rst
@@ -7,6 +7,9 @@ Customize agents status indexation
 
 The Wazuh app for Splunk has the ability to collect and index agents' status data periodically. This information is stored on a separate index called ``wazuh-monitoring-3x``. It comes enabled by default, but it's possible to disable it or adjust the polling frequency.
 
+.. warning::
+  At this moment, this feature only works when Splunk is installed using the :ref:`single-instance <splunk_basic>` mode.
+
 To do this, open the inputs file located at ``/opt/splunk/etc/apps/SplunkAppForWazuh/default/inputs.conf``. The ``[script]`` section includes the following basic configuration:
 
 .. code-block:: none
@@ -27,6 +30,9 @@ To do this, open the inputs file located at ``/opt/splunk/etc/apps/SplunkAppForW
   - If you specify the interval as a number, it may have a fractional component; for example, 3.14
   - To specify a cron schedule, use the following format: ``<minute> <hour> <day of month> <month> <day of week>``
   - Cron special characters are acceptable. You can use combinations of ``*``, ``,``, ``/``, and ``-`` to specify wildcards, separate values, specify ranges of values, and step values.
+
+.. warning::
+  Although the default interval value can be ``60.0`` seconds, we recommend a minimum frequency of one hour to avoid overloading issues due to the excessive creation of data into the index.
 
 Save the file when you're done editing it, and restart Splunk:
 

--- a/source/installing-splunk/splunk-polling.rst
+++ b/source/installing-splunk/splunk-polling.rst
@@ -1,0 +1,38 @@
+.. Copyright (C) 2018 Wazuh, Inc.
+
+.. _splunk_polling:
+
+Customize agents status indexation
+==================================
+
+The Wazuh app for Splunk has the ability to collect and index agents' status data periodically. This information is stored on a separate index called ``wazuh-monitoring-3x``. It comes enabled by default, but it's possible to disable it or adjust the polling frequency.
+
+To do this, open the inputs file located at ``/opt/splunk/etc/apps/SplunkAppForWazuh/default/inputs.conf``. The ``[script]`` section includes the following basic configuration:
+
+.. code-block:: none
+  :emphasize-lines: 2,4
+
+  [script:///opt/splunk/etc/apps/SplunkAppForWazuh/bin/get_agents_status.py]
+  disabled = false
+  index = wazuh-monitoring-3x
+  interval = 0 * * * *
+  sourcetype = _json
+
+- To disable the indexation of agents' status data, change the ``disabled`` field to *true*.
+
+- By default, the script is configured to fetch and index agents' status data **every hour**.
+
+- The ``interval`` field can be configured using a decimal number or a cron schedule.
+
+  - If you specify the interval as a number, it may have a fractional component; for example, 3.14
+  - To specify a cron schedule, use the following format: ``<minute> <hour> <day of month> <month> <day of week>``
+  - Cron special characters are acceptable. You can use combinations of ``*``, ``,``, ``/``, and ``-`` to specify wildcards, separate values, specify ranges of values, and step values.
+
+Save the file when you're done editing it, and restart Splunk:
+
+.. code-block:: console
+
+  # /opt/splunk/bin/splunk restart
+
+.. note::
+  You can find useful information about the ``inputs.conf`` file in the `official documentation <http://docs.splunk.com/Documentation/Splunk/7.2.1/Admin/Inputsconf>`_.


### PR DESCRIPTION
This PR adds new documentation for the Splunk app. This time, we explain the agent status polling feature, how to disable and customize it.

Related issue: #254 