### PR TITLE
Remove attributes that are not in the decoders

### DIFF
--- a/source/user-manual/ruleset/ruleset-xml-syntax/decoders.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/decoders.rst
@@ -29,13 +29,9 @@ The attributes list below defines a decoder.
 +-----------+---------------------------+
 | Attribute | Description               |
 +===========+===========================+
-| id        | The ID of the decoder     |
-+-----------+---------------------------+
 | name      | The name of the decoder   |
 +-----------+---------------------------+
 | type      | The type of the decoder   |
-+-----------+---------------------------+
-| status    | The status of the decoder |
 +-----------+---------------------------+
 
 parent


### PR DESCRIPTION
ID and status are rule options, but not of decoders.