### PR TITLE
Update for VPC configuration

### DIFF
--- a/source/amazon/configuration/considerations.rst
+++ b/source/amazon/configuration/considerations.rst
@@ -11,8 +11,8 @@ Filtering
 If the S3 bucket contains a long history of logs and its directory structure is organized by dates, it's possible to filter which logs will be read by Wazuh. There are multiple configuration options to do so:
 
 * ``only_logs_after``: Allows filtering logs produced after a given date. The date format must be YYYY-MMM-DD, for example, 2018-AUG-21 would filter logs produced after the 21th of August 2018 (that day included).
-* ``aws_account_id``: **This option will only work on CloudTrail buckets**. If you have logs from multiple accounts, you can filter which ones will be read by Wazuh. You can specify multiple ids separating them by commas.
-* ``regions``: **This option will only work on CloudTrail buckets**. If you have logs from multiple regions, you can filter which ones will be read by Wazuh. You can specify multiple regions separating them by commas.
+* ``aws_account_id``: **This option will only work on CloudTrail and VPC buckets**. If you have logs from multiple accounts, you can filter which ones will be read by Wazuh. You can specify multiple ids separating them by commas.
+* ``regions``: **This option will only work on CloudTrail and VPC buckets**. If you have logs from multiple regions, you can filter which ones will be read by Wazuh. You can specify multiple regions separating them by commas.
 * ``path``: If you have your logs stored in a given path, it can be specified using this option. For example, to read logs stored in directory ``vpclogs/`` the path ``vpclogs`` need to be specified. It can also be specified with ``/`` or ``\``.
 
 Older logs


### PR DESCRIPTION
Hi team,

`VPC` service can use `regions` and `aws_accound_id` parameters such as `CloudTrail` and I updated the documentation.

Best regards,

Demetrio.