### PR TITLE
Fixing typo in default azure configuration

### DIFF
--- a/source/user-manual/reference/ossec-conf/wodle-azure-logs.rst
+++ b/source/user-manual/reference/ossec-conf/wodle-azure-logs.rst
@@ -785,7 +785,7 @@ Example of all integration
 
             <request>
                 <tag>azure-activity</tag>
-                <query>AzureActivity | where SubscriptionId == "2d7...61d </query>
+                <query>AzureActivity | where SubscriptionId == 2d7...61d </query>
                 <workspace>d6b...efa</workspace>
                 <time_offset>36h</time_offset>
             </request>


### PR DESCRIPTION
Hi team, 

I've found a typo that makes `azure-logs` crash. 

Best regards,
Cerv1.