### PR TITLE
3.9 - Clarify agent group v3.7.0

### DIFF
--- a/source/user-manual/agents/grouping-agents.rst
+++ b/source/user-manual/agents/grouping-agents.rst
@@ -19,6 +19,10 @@ Below are the steps to assign agents to a group with a specific configuration:
 
    Using **agent_groups**:
 
+   .. note:: The group must be created and configured before assigning agents.
+
+   .. note:: This behaviour corresponds to ``v3.7.0`` and later.
+   
    .. code-block:: console
 
       # /var/ossec/bin/agent_groups -a -i 002 -g dbms
@@ -28,8 +32,6 @@ Below are the steps to assign agents to a group with a specific configuration:
    .. code-block:: console
 
       # curl -u foo:bar -X PUT "http://localhost:55000/agents/002/group/dbms?pretty"
-
-   .. note:: The group must be created and configured before assigning agents.
 
    An agent's group assignment can be checked using one of the following commands:
 


### PR DESCRIPTION
Close #695 

Modified files to clarify that the use of this functionality is only available in v3.7.0 or later.

