### PR TITLE
Fixed copyright year

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -61,7 +61,7 @@ master_doc = 'index'
 # General information about the project.
 project = u'Wazuh'
 author = u'Wazuh, Inc.'
-copyright = u'2018 - Wazuh, Inc'
+copyright = u'2019 - Wazuh, Inc'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
This PR changes the copyright year throughout the documentation site. 
In the future, this will be automatic, but for now, it's hardcoded.

This fixes issue #877 