### PR TITLE
Service restart correction

### DIFF
--- a/source/user-manual/manager/manual-email-report/index.rst
+++ b/source/user-manual/manager/manual-email-report/index.rst
@@ -68,13 +68,13 @@ a) For Systemd:
 
 .. code-block:: console
 
-  # systemctl status wazuh-manager
+  # systemctl restart wazuh-manager
 
 b) For SysV Init:
 
 .. code-block:: console
 
-  # service wazuh-manager status
+  # service wazuh-manager restart
 
 
 .. warning::


### PR DESCRIPTION
The current documentation here implies the command to restart wazuh-manager is 'systemctl status wazuh-manager' and 'service wazuh-manager status' for Systemd & SysV init respectively. Shouldn't 'status' be replaced with 'restart' in both instances?