### PR TITLE
Clarify 3.8.2 release notes

### DIFF
--- a/source/release-notes/release_2_1.rst
+++ b/source/release-notes/release_2_1.rst
@@ -2,7 +2,7 @@
 
 .. _release_2_1:
 
-2.1 Release Notes
+2.1 Release notes
 ===================
 
 This section shows the most relevant new features of Wazuh v2.1. You will find more detailed information in our `changelog <https://github.com/wazuh/wazuh/blob/2.1/CHANGELOG.md>`_ file.

--- a/source/release-notes/release_3_0_0.rst
+++ b/source/release-notes/release_3_0_0.rst
@@ -2,7 +2,7 @@
 
 .. _release_3_0_0:
 
-3.0.0 Release Notes
+3.0.0 Release notes
 ===================
 
 This section shows the most relevant new features of Wazuh v3.0.0. You will find more detailed information in our `changelog <https://github.com/wazuh/wazuh/blob/3.0/CHANGELOG.md>`_ file.

--- a/source/release-notes/release_3_1_0.rst
+++ b/source/release-notes/release_3_1_0.rst
@@ -2,7 +2,7 @@
 
 .. _release_3_1_0:
 
-3.1.0 Release Notes
+3.1.0 Release notes
 ===================
 
 This section shows the most relevant new features of Wazuh v3.1.0. You will find more detailed information in our `changelog <https://github.com/wazuh/wazuh/blob/3.1/CHANGELOG.md>`_ file.

--- a/source/release-notes/release_3_2_0.rst
+++ b/source/release-notes/release_3_2_0.rst
@@ -2,7 +2,7 @@
 
 .. _release_3_2_0:
 
-3.2.0 Release Notes
+3.2.0 Release notes
 ===================
 
 This section shows the most relevant new features of Wazuh v3.2.0. You will find more detailed information in our `changelog <https://github.com/wazuh/wazuh/blob/3.2/CHANGELOG.md>`_ file.

--- a/source/release-notes/release_3_2_1.rst
+++ b/source/release-notes/release_3_2_1.rst
@@ -2,7 +2,7 @@
 
 .. _release_3_2_1:
 
-3.2.1 Release Notes
+3.2.1 Release notes
 ===================
 
 This release is a bug fix release. This section shows the most relevant improvements and fixes of Wazuh v3.2.1. You will find more detailed information in the `changelog <https://github.com/wazuh/wazuh/blob/3.2/CHANGELOG.md#v321>`_ file.

--- a/source/release-notes/release_3_2_2.rst
+++ b/source/release-notes/release_3_2_2.rst
@@ -2,7 +2,7 @@
 
 .. _release_3_2_2:
 
-3.2.2 Release Notes
+3.2.2 Release notes
 ===================
 
 From the Wazuh team, we continue working hard improving the existing features as well as fixing bugs. This section shows the most relevant improvements and fixes in version 3.2.2. Find more details in each component changelog.

--- a/source/release-notes/release_3_2_3.rst
+++ b/source/release-notes/release_3_2_3.rst
@@ -2,7 +2,7 @@
 
 .. _release_3_2_3:
 
-3.2.3 Release Notes
+3.2.3 Release notes
 ===================
 
 This section shows the most relevant improvements and fixes in version 3.2.3. More details about these changes are provided in each component changelog.

--- a/source/release-notes/release_3_2_4.rst
+++ b/source/release-notes/release_3_2_4.rst
@@ -2,7 +2,7 @@
 
 .. _release_3_2_4:
 
-3.2.4 Release Notes
+3.2.4 Release notes
 ===================
 
 This section shows the most relevant improvements and fixes in version 3.2.4. More details about these changes are provided in each component changelog.

--- a/source/release-notes/release_3_3_0.rst
+++ b/source/release-notes/release_3_3_0.rst
@@ -2,7 +2,7 @@
 
 .. _release_3_3_0:
 
-3.3.0 Release Notes
+3.3.0 Release notes
 ===================
 
 This section shows the most relevant improvements and fixes in version 3.3.0. More details about these changes are provided in each component changelog.

--- a/source/release-notes/release_3_3_1.rst
+++ b/source/release-notes/release_3_3_1.rst
@@ -2,7 +2,7 @@
 
 .. _release_3_3_1:
 
-3.3.1 Release Notes
+3.3.1 Release notes
 ===================
 
 This section shows the most relevant improvements and fixes in version 3.3.1. More details about these changes are provided in each component changelog.

--- a/source/release-notes/release_3_4_0.rst
+++ b/source/release-notes/release_3_4_0.rst
@@ -2,7 +2,7 @@
 
 .. _release_3_4_0:
 
-3.4.0 Release Notes
+3.4.0 Release notes
 ===================
 
 This section shows the most relevant improvements and fixes in version 3.4.0. More details about these changes are provided in each component changelog.

--- a/source/release-notes/release_3_5_0.rst
+++ b/source/release-notes/release_3_5_0.rst
@@ -2,7 +2,7 @@
 
 .. _release_3_5_0:
 
-3.5.0 Release Notes
+3.5.0 Release notes
 ===================
 
 This section shows the most relevant improvements and fixes in version 3.5.0. More details about these changes are provided in each component changelog.

--- a/source/release-notes/release_3_6_0.rst
+++ b/source/release-notes/release_3_6_0.rst
@@ -2,7 +2,7 @@
 
 .. _release_3_6_0:
 
-3.6.0 Release Notes
+3.6.0 Release notes
 ===================
 
 This section shows the most relevant improvements and fixes in version 3.6.0. More details about these changes are provided in each component changelog.

--- a/source/release-notes/release_3_6_1.rst
+++ b/source/release-notes/release_3_6_1.rst
@@ -2,7 +2,7 @@
 
 .. _release_3_6_1:
 
-3.6.1 Release Notes
+3.6.1 Release notes
 ===================
 
 This section shows the most relevant improvements and fixes in version 3.6.1. More details about these changes are provided in each component changelog.

--- a/source/release-notes/release_3_7_0.rst
+++ b/source/release-notes/release_3_7_0.rst
@@ -2,7 +2,7 @@
 
 .. _release_3_7_0:
 
-3.7.0 Release Notes
+3.7.0 Release notes
 ===================
 
 This section shows the most relevant improvements and fixes in version 3.7.0. More details about these changes are provided in each component changelog:

--- a/source/release-notes/release_3_7_1.rst
+++ b/source/release-notes/release_3_7_1.rst
@@ -2,7 +2,7 @@
 
 .. _release_3_7_1:
 
-3.7.1 Release Notes
+3.7.1 Release notes
 ===================
 
 This section shows the most relevant improvements and fixes in version 3.7.1. More details about these changes are provided in each component changelog:

--- a/source/release-notes/release_3_7_2.rst
+++ b/source/release-notes/release_3_7_2.rst
@@ -2,7 +2,7 @@
 
 .. _release_3_7_2:
 
-3.7.2 Release Notes
+3.7.2 Release notes
 ===================
 
 This section shows the most relevant fixes in version 3.7.2. More details about these changes are provided in the component changelog:

--- a/source/release-notes/release_3_8_0.rst
+++ b/source/release-notes/release_3_8_0.rst
@@ -2,7 +2,7 @@
 
 .. _release_3_8_0:
 
-3.8.0 Release Notes
+3.8.0 Release notes
 ===================
 
 This section shows the most relevant improvements and fixes in version 3.8.0. More details about these changes are provided in each component changelog:

--- a/source/release-notes/release_3_8_1.rst
+++ b/source/release-notes/release_3_8_1.rst
@@ -2,7 +2,7 @@
 
 .. _release_3_8_1:
 
-3.8.1 Release Notes
+3.8.1 Release notes
 ===================
 
 This section shows the most relevant improvements and fixes in version 3.8.1. More details about these changes are provided in each component changelog:

--- a/source/release-notes/release_3_8_2.rst
+++ b/source/release-notes/release_3_8_2.rst
@@ -2,7 +2,7 @@
 
 .. _release_3_8_2:
 
-3.8.2 Release Notes
+3.8.2 Release notes
 ===================
 
 This section shows the most relevant fixes in version 3.8.2. A complete list of changes is provided in the `change log <https://github.com/wazuh/wazuh/blob/v3.8.2/CHANGELOG.md>`_.

--- a/source/release-notes/release_3_8_2.rst
+++ b/source/release-notes/release_3_8_2.rst
@@ -5,13 +5,15 @@
 3.8.2 Release Notes
 ===================
 
-This section shows the most relevant improvements and fixes in version 3.8.2. More details about these changes are provided in each component changelog:
+This section shows the most relevant fixes in version 3.8.2. A complete list of changes is provided in the `change log <https://github.com/wazuh/wazuh/blob/v3.8.2/CHANGELOG.md>`_.
 
-- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/v3.8.2/CHANGELOG.md>`_
+Wazuh manager
+-------------
 
-Wazuh core
-----------
+- Fixed a bug crashing Analysisd when accumulating logs. This bug affected decoders that use the option ``<accumulate>``, like the decoder for OpenLDAP logs, provided out of the box.
+- Some fields of alerts related to Windows Eventchannel logs included unwanted backslashes (``\``) and trailing whitespaces. This was due to a log cleaning issue in the manager.
 
-- Fixed a segmentation fault when using ``<accumulate>`` rules attribute.
-- Fixed an issue in Wazuh modules daemon configuration when ``<command>`` was used and no ``<tag>`` was set.
-- Event channel decoder for Windows now escapes backslashes properly and it's not adding spurious trailing spaces in some fields.
+Wazuh agent
+-----------
+
+- Prevent Modulesd from crashing when the configuration contained a ``<wodle name="command">`` stanza without an explicit ``<tag>`` option.


### PR DESCRIPTION
This PR applies the following changes to the 3.8.2 release notes:

1. Do not indicate improvements (there are only fixes).
2. Move the link to the changelog to the heading paragraph.
3. Clarify the explanation of the changes.
4. Sort those changes between Wazuh manager and Wazuh agent.
5. Replace "Release Notes" with "Release notes".