### PR TITLE
Update reference.rst to fix the compilation errors

### DIFF
--- a/source/user-manual/api/reference.rst
+++ b/source/user-manual/api/reference.rst
@@ -8,7 +8,7 @@ Reference
 ======================
 This API reference is organized by resources:
 
-* `Active Response`_
+* `Active_Response`_
 * `Agents`_
 * `Cache`_
 * `Ciscat`_
@@ -28,7 +28,7 @@ Below is the `Request List`_ that shows all of the available requests.
 Request List
 ---------------------------------
 
-`Active Response`_
+`Active_Response`_
 	* PUT /active-response/:agent_id  (`Run an AR command in the agent`_)
 
 `Agents`_


### PR DESCRIPTION
/root/wazuh-documentation/source/user-manual/api/reference.rst:11: ERROR: Unknown target name: "active response".
/root/wazuh-documentation/source/user-manual/api/reference.rst:32: ERROR: Unknown target name: "active response".

Fixed those errors.

Closes #893  