### PR TITLE
Reference documentation for the network buffer related features in Remoted

### DIFF
--- a/source/user-manual/reference/internal-options.rst
+++ b/source/user-manual/reference/internal-options.rst
@@ -892,6 +892,29 @@ Remoted
 +                                   +               +--------------------------------------------------------------+
 |                                   |               | Any other integer between 1 and 2592000                      |
 +-----------------------------------+---------------+--------------------------------------------------------------+
+| **remoted.receive_chunk**         | Description   | | Reception buffer size for TCP (bytes).                     |
+|                                   |               | | Amount of data that Remoted can receive per operation.     |
+|                                   |               |                                                              |
+|                                   |               | .. versionadded:: 3.9.0                                      |
++                                   +---------------+--------------------------------------------------------------+
+|                                   | Default value | 4096                                                         |
++                                   +---------------+--------------------------------------------------------------+
+|                                   | Allowed value | | Any other integer between 1024 and 16384.                  |
+|                                   |               | | Powers of two are suggested.                               |
++-----------------------------------+---------------+--------------------------------------------------------------+
+| **remoted.buffer_relax**          | Description   | | Method for memory deallocation after accepting input data. |
+|                                   |               | | This option applies in TCP mode only.                      |
+|                                   |               |                                                              |
+|                                   |               | .. versionadded:: 3.9.0                                      |
++                                   +---------------+--------------------------------------------------------------+
+|                                   | Default value | 1                                                            |
++                                   +---------------+--------------------------------------------------------------+
+|                                   | Allowed values| 0: Keep the memory for each TCP session.                     |
++                                   +               +--------------------------------------------------------------+
+|                                   |               | 1: Shrink memory back to ``receive_chunk``.                  |
++                                   +               +--------------------------------------------------------------+
+|                                   |               | 2: Fully deallocate memory after usage.                      |
++-----------------------------------+---------------+--------------------------------------------------------------+
 
 Syscheck
 --------

--- a/source/user-manual/reference/statistics-files/ossec-remoted-state.rst
+++ b/source/user-manual/reference/statistics-files/ossec-remoted-state.rst
@@ -38,3 +38,6 @@ Below you can see an example file:
 
     # Messages sent
     msg_sent='1267'
+
+    # Total number of bytes received
+    recv_bytes='7562892'


### PR DESCRIPTION
|Issue|PR|
|---|---|
|https://github.com/wazuh/wazuh/issues/1908|https://github.com/wazuh/wazuh/pull/2528|

This PR adds these two internal options:
- `remoted.receive_chunk`
- `remoted.buffer_relax`

And this state parameter for Remoted:
- `recv_bytes`

## Snapshot

### New internal options

![screen shot 2019-02-07 at 5 41 35 pm](https://user-images.githubusercontent.com/10536251/52454356-535b5680-2b00-11e9-8f1c-2b31319da9fa.png)


### Updated state file

![screen shot 2019-02-07 at 5 41 50 pm](https://user-images.githubusercontent.com/10536251/52454365-5ce4be80-2b00-11e9-9c60-56e8ac614d4d.png)
