### PR TITLE
Added amount of memory that installing the app requires

### DIFF
--- a/source/installation-guide/installing-elastic-stack/elastic_server_deb.rst
+++ b/source/installation-guide/installing-elastic-stack/elastic_server_deb.rst
@@ -190,9 +190,9 @@ Kibana is a flexible and intuitive web interface for mining and visualizing the 
 
     The Kibana plugin installation process may take several minutes. Please wait patiently.
 
-    Remember that, when installing the App, the **optimizing** process will produce a memory peak of ~2.2GB.
+    While installing the Wazuh app, Kibana needs about 2.2GB of memory.
 
-    Once installed, the App will require much less memory, ~1.6GB (default Node limit).
+    Once installed, Kibana doesn't need more than the default Node.js memory limit (1.6GB).
 
 3. **Optional.** Kibana will only listen on the loopback interface (localhost) by default. To set up Kibana to listen on all interfaces, edit the file ``/etc/kibana/kibana.yml`` uncommenting the setting ``server.host``. Change the value to:
 

--- a/source/installation-guide/installing-elastic-stack/elastic_server_deb.rst
+++ b/source/installation-guide/installing-elastic-stack/elastic_server_deb.rst
@@ -190,6 +190,10 @@ Kibana is a flexible and intuitive web interface for mining and visualizing the 
 
     The Kibana plugin installation process may take several minutes. Please wait patiently.
 
+    Remember that, when installing the App, the **optimizing** process will produce a memory peak of ~2.2GB.
+
+    Once installed, the App will require much less memory, ~1.6GB (default Node limit).
+
 3. **Optional.** Kibana will only listen on the loopback interface (localhost) by default. To set up Kibana to listen on all interfaces, edit the file ``/etc/kibana/kibana.yml`` uncommenting the setting ``server.host``. Change the value to:
 
   .. code-block:: yaml

--- a/source/installation-guide/installing-elastic-stack/elastic_server_rpm.rst
+++ b/source/installation-guide/installing-elastic-stack/elastic_server_rpm.rst
@@ -203,9 +203,9 @@ Kibana is a flexible and intuitive web interface for mining and visualizing the 
 
     The Kibana plugin installation process may take several minutes. Please wait patiently.
 
-    Remember that, when installing the App, the **optimizing** process will produce a memory peak of ~2.2GB.
+    While installing the Wazuh app, Kibana needs about 2.2GB of memory.
 
-    Once installed, the App will require much less memory, ~1.6GB (default Node limit).
+    Once installed, Kibana doesn't need more than the default Node.js memory limit (1.6GB).
 
 3. **Optional.** Kibana will only listen on the loopback interface (localhost) by default. To set up Kibana to listen on all interfaces, edit the file ``/etc/kibana/kibana.yml`` uncommenting the setting ``server.host``. Change the value to:
 

--- a/source/installation-guide/installing-elastic-stack/elastic_server_rpm.rst
+++ b/source/installation-guide/installing-elastic-stack/elastic_server_rpm.rst
@@ -187,6 +187,11 @@ Kibana
 
 Kibana is a flexible and intuitive web interface for mining and visualizing the events and archives stored in Elasticsearch. Find more information at `Kibana <https://www.elastic.co/products/kibana>`_.
 
+.. warning::
+  Remember that, when installing the App, there will be a memory peak of ~2.0 GB.
+
+  Once installed, the App will require much less memory.
+
 1. Install the Kibana package:
 
   .. code-block:: console

--- a/source/installation-guide/installing-elastic-stack/elastic_server_rpm.rst
+++ b/source/installation-guide/installing-elastic-stack/elastic_server_rpm.rst
@@ -187,11 +187,6 @@ Kibana
 
 Kibana is a flexible and intuitive web interface for mining and visualizing the events and archives stored in Elasticsearch. Find more information at `Kibana <https://www.elastic.co/products/kibana>`_.
 
-.. warning::
-  Remember that, when installing the App, there will be a memory peak of ~2.0 GB.
-
-  Once installed, the App will require much less memory.
-
 1. Install the Kibana package:
 
   .. code-block:: console
@@ -207,6 +202,10 @@ Kibana is a flexible and intuitive web interface for mining and visualizing the 
   .. warning::
 
     The Kibana plugin installation process may take several minutes. Please wait patiently.
+
+    Remember that, when installing the App, the **optimizing** process will produce a memory peak of ~2.2GB.
+
+    Once installed, the App will require much less memory, ~1.6GB (default Node limit).
 
 3. **Optional.** Kibana will only listen on the loopback interface (localhost) by default. To set up Kibana to listen on all interfaces, edit the file ``/etc/kibana/kibana.yml`` uncommenting the setting ``server.host``. Change the value to:
 


### PR DESCRIPTION
- [x] When installing the app there is a peak of the memory of ~2GB.
- [x] After installation the app does not require so much memory.

Closes issue #728 
