### PR TITLE
Updated Wazuh Ruleset link in 3.8

### DIFF
--- a/source/user-manual/ruleset/getting-started.rst
+++ b/source/user-manual/ruleset/getting-started.rst
@@ -23,7 +23,7 @@ In the ruleset repository you will find:
 Resources
 ^^^^^^^^^
 * Visit our repository to view the rules in detail at `Github Wazuh Ruleset <https://github.com/wazuh/wazuh-ruleset>`_
-* Find a complete description of the available rules at `Wazuh Ruleset Summary <http://www.wazuh.com/resources/OSSEC_Ruleset.pdf>`_
+* Find a complete description of the available rules at `Wazuh Ruleset Summary <http://www.wazuh.com/resources/Wazuh_Ruleset.pdf>`_
 
 
 Rule and Rootcheck example


### PR DESCRIPTION
With the last web deployment, we launched the updated PDF documents, including the Ruleset PDF, which name changed from `OSSEC_Ruleset` to `Wazuh_Ruleset`.

This fixes this problem in branch `3.8`.
The rest of the branches will probably need this fix as well.