### PR TITLE
Add information about system labels

### DIFF
--- a/source/user-manual/reference/ossec-conf/labels.rst
+++ b/source/user-manual/reference/ossec-conf/labels.rst
@@ -46,7 +46,7 @@ Attributes:
 
 .. note::
     .. versionadded:: 3.9.0
-    The keys started with the character ``_`` are reserved to the system labels. System labels are invisible labels which contain internal information for an agent.
+    The keys starting with character `_` are reserved to the system labels. This labels are invisible and contain agents internal information.
 
 Example of configuration
 ------------------------

--- a/source/user-manual/reference/ossec-conf/labels.rst
+++ b/source/user-manual/reference/ossec-conf/labels.rst
@@ -29,20 +29,24 @@ This option specifies the additional information that will appear in alerts. Lab
 
 Attributes:
 
-+--------------------+-------------------------------------------------------------+
-| **key**            | The title that will describe the information of the label.  |
-+                    +---------------------------------------+---------------------+
-|                    | Allowed value                         | Any string          |
-+--------------------+---------------------------------------+---------------------+
-| **hidden**         | For labels that are hidden by default.                      |
-+                    +---------------------------------------+---------------------+
-|                    | Default value                         | no                  |
-+                    +---------------------------------------+---------------------+
-|                    | Allowed value                         | yes,no              |
-+--------------------+---------------------------------------+---------------------+
++--------------------+------------------------------------------------------------------------------------------+
+| **key**            | The title that will describe the information of the label.                               |
++                    +---------------------------------------+--------------------------------------------------+
+|                    | Allowed value                         | Any string that doesn't start with low bar ( _ ) |
++--------------------+---------------------------------------+--------------------------------------------------+
+| **hidden**         | For labels that are hidden by default.                                                   |
++                    +---------------------------------------+--------------------------------------------------+
+|                    | Default value                         | no                                               |
++                    +---------------------------------------+--------------------------------------------------+
+|                    | Allowed value                         | yes,no                                           |
++--------------------+---------------------------------------+--------------------------------------------------+
 
 .. note::
     In ``internal_options.conf``, hidden labels can be set to be displayed in alerts.
+
+.. note::
+    .. versionadded:: 3.9.0
+    The keys started with the character ``_`` are reserved to the system labels. System labels are invisible labels which contain internal information for an agent.
 
 Example of configuration
 ------------------------

--- a/source/user-manual/reference/ossec-conf/labels.rst
+++ b/source/user-manual/reference/ossec-conf/labels.rst
@@ -29,24 +29,24 @@ This option specifies the additional information that will appear in alerts. Lab
 
 Attributes:
 
-+--------------------+------------------------------------------------------------------------------------------+
-| **key**            | The title that will describe the information of the label.                               |
-+                    +---------------------------------------+--------------------------------------------------+
-|                    | Allowed value                         | Any string that doesn't start with low bar ( _ ) |
-+--------------------+---------------------------------------+--------------------------------------------------+
-| **hidden**         | For labels that are hidden by default.                                                   |
-+                    +---------------------------------------+--------------------------------------------------+
-|                    | Default value                         | no                                               |
-+                    +---------------------------------------+--------------------------------------------------+
-|                    | Allowed value                         | yes,no                                           |
-+--------------------+---------------------------------------+--------------------------------------------------+
++--------------------+-------------------------------------------------------------------------------------------------+
+| **key**            | The title that will describe the information of the label.                                      |
++                    +---------------------------------------+---------------------------------------------------------+
+|                    | Allowed value                         | Any string that does not start with an underscore ( _ ) |
++--------------------+---------------------------------------+---------------------------------------------------------+
+| **hidden**         | For labels that are hidden by default.                                                          |
++                    +---------------------------------------+---------------------------------------------------------+
+|                    | Default value                         | no                                                      |
++                    +---------------------------------------+---------------------------------------------------------+
+|                    | Allowed value                         | yes,no                                                  |
++--------------------+---------------------------------------+---------------------------------------------------------+
 
 .. note::
     In ``internal_options.conf``, hidden labels can be set to be displayed in alerts.
 
 .. note::
     .. versionadded:: 3.9.0
-    The keys starting with character ``_`` are reserved to the system labels. This labels are invisible and contain agents internal information.
+    Keys starting with an underscore character are reserved for the system labels. These labels are invisible and contain internal information of the agents.
 
 Example of configuration
 ------------------------

--- a/source/user-manual/reference/ossec-conf/labels.rst
+++ b/source/user-manual/reference/ossec-conf/labels.rst
@@ -46,7 +46,7 @@ Attributes:
 
 .. note::
     .. versionadded:: 3.9.0
-    The keys starting with character `_` are reserved to the system labels. This labels are invisible and contain agents internal information.
+    The keys starting with character ``_`` are reserved to the system labels. This labels are invisible and contain agents internal information.
 
 Example of configuration
 ------------------------


### PR DESCRIPTION
In 3.9 a new type of label has been add, the system labels. They are invisible and they are useful to send information from an agent to a manager for internal management.
Although the system labels are not design to public use, the documentation needs a change cause the labels keys that start with a low bar are now restricted to the system labels to avoid conflicts.
This PR solves the issue: #927 