### PR TITLE
Add allowed interval to chunk option

### DIFF
--- a/source/user-manual/reference/tools/agent_upgrade.rst
+++ b/source/user-manual/reference/tools/agent_upgrade.rst
@@ -33,7 +33,7 @@ The agent_upgrade program allows you to list outdated agents and upgrade them.
 +--------------------------------------------+---------------------------------------------------------+
 | **-t TIMEOUT, --timeout TIMEOUT**          | Timeout where the agent cannot restart while updating.  |
 +--------------------------------------------+---------------------------------------------------------+
-| **-c CHUNK_SIZE, --chunk_size CHUNK_SIZE** | Chunk size sending WPK file.                            |
+| **-c CHUNK_SIZE, --chunk_size CHUNK_SIZE** | Chunk size sending WPK file. Allowed values: [1 - 64000]|
 +--------------------------------------------+---------------------------------------------------------+
 
 .. note:: By default, the timeout will be the maximum allowed by the agent with the ``execd.max_restart_lock`` option in :doc:`internal_options.conf<../internal-options>`.


### PR DESCRIPTION
This PR adds the valid interval for the chunk option in the `agent_upgrade` tool.