### PR TITLE
Eliminate permalinks

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -191,6 +191,9 @@ html_show_sphinx = False
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
 html_show_copyright = True
 
+# If empty string, we eliminate permalinks from documentation.
+html_add_permalinks = ""
+
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the
 # base URL from which the finished HTML is served.


### PR DESCRIPTION
This PR closes issue #866

Sphinx created permalinks for defect and that caused the sections to not charge the CSS files properly.
With this option, we eliminate those permalinks and now the sections charge well the background.

Tested in different environments.