### PR TITLE
Fixed missing comma in <group> option.

### DIFF
--- a/source/user-manual/manager/manual-email-report/index.rst
+++ b/source/user-manual/manager/manual-email-report/index.rst
@@ -142,7 +142,7 @@ Email alerts can be configured to send an email based on one or more rule groups
 
  <email_alerts>
    <email_to>you@example.com</email_to>
-   <group>pci_dss_10.6.1</group>
+   <group>pci_dss_10.6.1,</group>
  </email_alerts>
 
 This will send an alert when any rule that is part of the ``pci_dss_10.6.1`` group is triggered on any Wazuh monitored device.


### PR DESCRIPTION
This PR solves issue #987 by adding a missing comma.

Regards,

Juan Anaya Ortiz.