### PR TITLE
Adding missing options to "agent.conf" section

### DIFF
--- a/source/user-manual/reference/centralized-configuration.rst
+++ b/source/user-manual/reference/centralized-configuration.rst
@@ -18,8 +18,7 @@ Agents can be configured remotely by using the ``agent.conf`` file. The followin
 - :doc:`Anti-flooding mechanism <../capabilities/antiflooding>` (**bucket options**)
 - :doc:`Labels for agent alerts <../capabilities/labels>` (**labels**)
 - :doc:`System inventory <../capabilities/syscollector>` (**syscollector**)
-- :doc:`Active Response <../capabilities/active-response/index>` (**active-response**)
-- :doc:`Avoid events flooding <ossec.conf/client_buffer>` (**client_buffer**)
+- :doc:`Avoid events flooding <ossec-conf/client_buffer>` (**client_buffer**)
 - :doc:`Configure osquery wodle <ossec-conf/wodle-osquery>` (**wodle name="osquery"**)
 
 .. note::

--- a/source/user-manual/reference/centralized-configuration.rst
+++ b/source/user-manual/reference/centralized-configuration.rst
@@ -16,6 +16,8 @@ Agents can be configured remotely by using the ``agent.conf`` file. The followin
 - :doc:`Security policy monitoring <../capabilities/policy-monitoring/index>` (**rootcheck**, **wodle name="open-scap"**, **wodle name="cis-cat"**)
 - :doc:`Remote commands <ossec-conf/wodle-command>` (**wodle name="command"**)
 - :doc:`Anti-flooding mechanism <../capabilities/antiflooding>` (**bucket options**)
+- :doc:`Labels for agent alerts <../capabilities/labels>` (**labels**)
+- :doc:`System inventory <../capabilities/syscollector>` (**syscollector**)
 
 .. note::
   When setting up remote commands in the shared agent configuration, **you must enable remote commands for Agent Modules**. This is enabled by adding the following line to the ``/var/ossec/etc/local_internal_options.conf`` file in the agent:

--- a/source/user-manual/reference/centralized-configuration.rst
+++ b/source/user-manual/reference/centralized-configuration.rst
@@ -16,7 +16,6 @@ Agents can be configured remotely by using the ``agent.conf`` file. The followin
 - :doc:`Security policy monitoring <../capabilities/policy-monitoring/index>` (**rootcheck**, **wodle name="open-scap"**, **wodle name="cis-cat"**)
 - :doc:`Remote commands <ossec-conf/wodle-command>` (**wodle name="command"**)
 - :doc:`Anti-flooding mechanism <../capabilities/antiflooding>` (**bucket options**)
-- :doc:`Labels for agent alerts <../capabilities/labels>` (**labels**)
 
 .. note::
   When setting up remote commands in the shared agent configuration, **you must enable remote commands for Agent Modules**. This is enabled by adding the following line to the ``/var/ossec/etc/local_internal_options.conf`` file in the agent:

--- a/source/user-manual/reference/centralized-configuration.rst
+++ b/source/user-manual/reference/centralized-configuration.rst
@@ -20,12 +20,12 @@ Agents can be configured remotely by using the ``agent.conf`` file. The followin
 - :doc:`System inventory <../capabilities/syscollector>` (**syscollector**)
 - :doc:`Active Response <../capabilities/active-response/index>` (**active-response**)
 - :doc:`Configure connection <ossec-conf/client>`(**client**)
-- :doc:`Avoid events flooding <ossec.conf/client_buffer>` (**client_buffer**)
-- :doc:`Format of Internal Logs <ossec.conf/logging>` (**logging**)
-- :doc:`Defining output sockets <ossec.conf/socket>` (**socket**)
-- :doc:`Configure AWS-S3 wodle <ossec.conf/wodle-s3>` (**wodle name="aws-s3"**)
-- :doc:`Configure osquery wodle <ossec.conf/wodle-osquery>` (**wodle name="osquery"**)
-- :doc:`Configure Docker wodle <ossec.conf/wodle-docker>` (**wodle name="docker-listener"**)
+- :doc:`Avoid events flooding <ossec-conf/client_buffer>` (**client_buffer**)
+- :doc:`Format of Internal Logs <ossec-conf/logging>` (**logging**)
+- :doc:`Defining output sockets <ossec-conf/socket>` (**socket**)
+- :doc:`Configure AWS-S3 wodle <ossec-conf/wodle-s3>` (**wodle name="aws-s3"**)
+- :doc:`Configure osquery wodle <ossec-conf/wodle-osquery>` (**wodle name="osquery"**)
+- :doc:`Configure Docker wodle <ossec-conf/wodle-docker>` (**wodle name="docker-listener"**)
 
 .. note::
   When setting up remote commands in the shared agent configuration, **you must enable remote commands for Agent Modules**. This is enabled by adding the following line to the ``/var/ossec/etc/local_internal_options.conf`` file in the agent:

--- a/source/user-manual/reference/centralized-configuration.rst
+++ b/source/user-manual/reference/centralized-configuration.rst
@@ -23,7 +23,6 @@ Agents can be configured remotely by using the ``agent.conf`` file. The followin
 - :doc:`Avoid events flooding <ossec-conf/client_buffer>` (**client_buffer**)
 - :doc:`Format of Internal Logs <ossec-conf/logging>` (**logging**)
 - :doc:`Defining output sockets <ossec-conf/socket>` (**socket**)
-- :doc:`Configure AWS-S3 wodle <ossec-conf/wodle-s3>` (**wodle name="aws-s3"**)
 - :doc:`Configure osquery wodle <ossec-conf/wodle-osquery>` (**wodle name="osquery"**)
 - :doc:`Configure Docker wodle <ossec-conf/wodle-docker>` (**wodle name="docker-listener"**)
 

--- a/source/user-manual/reference/centralized-configuration.rst
+++ b/source/user-manual/reference/centralized-configuration.rst
@@ -19,7 +19,6 @@ Agents can be configured remotely by using the ``agent.conf`` file. The followin
 - :doc:`Labels for agent alerts <../capabilities/labels>` (**labels**)
 - :doc:`System inventory <../capabilities/syscollector>` (**syscollector**)
 - :doc:`Active Response <../capabilities/active-response/index>` (**active-response**)
-- :doc:`Configure connection <ossec-conf/client>`(**client**)
 - :doc:`Avoid events flooding <ossec-conf/client_buffer>` (**client_buffer**)
 - :doc:`Format of Internal Logs <ossec-conf/logging>` (**logging**)
 - :doc:`Defining output sockets <ossec-conf/socket>` (**socket**)

--- a/source/user-manual/reference/centralized-configuration.rst
+++ b/source/user-manual/reference/centralized-configuration.rst
@@ -18,12 +18,6 @@ Agents can be configured remotely by using the ``agent.conf`` file. The followin
 - :doc:`Anti-flooding mechanism <../capabilities/antiflooding>` (**bucket options**)
 - :doc:`Labels for agent alerts <../capabilities/labels>` (**labels**)
 - :doc:`System inventory <../capabilities/syscollector>` (**syscollector**)
-- :doc:`Active Response <../capabilities/active-response/index>` (**active-response**)
-- :doc:`Avoid events flooding <ossec-conf/client_buffer>` (**client_buffer**)
-- :doc:`Format of Internal Logs <ossec-conf/logging>` (**logging**)
-- :doc:`Defining output sockets <ossec-conf/socket>` (**socket**)
-- :doc:`Configure osquery wodle <ossec-conf/wodle-osquery>` (**wodle name="osquery"**)
-- :doc:`Configure Docker wodle <ossec-conf/wodle-docker>` (**wodle name="docker-listener"**)
 
 .. note::
   When setting up remote commands in the shared agent configuration, **you must enable remote commands for Agent Modules**. This is enabled by adding the following line to the ``/var/ossec/etc/local_internal_options.conf`` file in the agent:

--- a/source/user-manual/reference/centralized-configuration.rst
+++ b/source/user-manual/reference/centralized-configuration.rst
@@ -18,6 +18,9 @@ Agents can be configured remotely by using the ``agent.conf`` file. The followin
 - :doc:`Anti-flooding mechanism <../capabilities/antiflooding>` (**bucket options**)
 - :doc:`Labels for agent alerts <../capabilities/labels>` (**labels**)
 - :doc:`System inventory <../capabilities/syscollector>` (**syscollector**)
+- :doc:`Active Response <../capabilities/active-response/index>` (**active-response**)
+- :doc:`Avoid events flooding <ossec.conf/client_buffer>` (**client_buffer**)
+- :doc:`Configure osquery wodle <ossec-conf/wodle-osquery>` (**wodle name="osquery"**)
 
 .. note::
   When setting up remote commands in the shared agent configuration, **you must enable remote commands for Agent Modules**. This is enabled by adding the following line to the ``/var/ossec/etc/local_internal_options.conf`` file in the agent:

--- a/source/user-manual/reference/centralized-configuration.rst
+++ b/source/user-manual/reference/centralized-configuration.rst
@@ -18,6 +18,14 @@ Agents can be configured remotely by using the ``agent.conf`` file. The followin
 - :doc:`Anti-flooding mechanism <../capabilities/antiflooding>` (**bucket options**)
 - :doc:`Labels for agent alerts <../capabilities/labels>` (**labels**)
 - :doc:`System inventory <../capabilities/syscollector>` (**syscollector**)
+- :doc:`Active Response <../capabilities/active-response/index>` (**active-response**)
+- :doc:`Configure connection <ossec-conf/client>`(**client**)
+- :doc:`Avoid events flooding <ossec.conf/client_buffer>` (**client_buffer**)
+- :doc:`Format of Internal Logs <ossec.conf/logging>` (**logging**)
+- :doc:`Defining output sockets <ossec.conf/socket>` (**socket**)
+- :doc:`Configure AWS-S3 wodle <ossec.conf/wodle-s3>` (**wodle name="aws-s3"**)
+- :doc:`Configure osquery wodle <ossec.conf/wodle-osquery>` (**wodle name="osquery"**)
+- :doc:`Configure Docker wodle <ossec.conf/wodle-docker>` (**wodle name="docker-listener"**)
 
 .. note::
   When setting up remote commands in the shared agent configuration, **you must enable remote commands for Agent Modules**. This is enabled by adding the following line to the ``/var/ossec/etc/local_internal_options.conf`` file in the agent:


### PR DESCRIPTION
Hi team,

this PR solves issue #1018 

I've tested the different capabilities usable in `agent.conf`, and finally, I've added the `<syscollector>` option.

Regards.
