### PR TITLE
Fixed wrong path

### DIFF
--- a/source/installation-guide/upgrading/different_major.rst
+++ b/source/installation-guide/upgrading/different_major.rst
@@ -145,7 +145,7 @@ We recommend that the Wazuh repository be disabled in order to prevent accidenta
 
     .. code-block:: console
 
-      # sed -i "s/^enabled=1/enabled=0/" /etc/yum.repos.d/elastic.repo
+      # sed -i "s/^enabled=1/enabled=0/" /etc/yum.repos.d/wazuh.repo
 
   b) For Debian/Ubuntu:
 


### PR DESCRIPTION
Hi team, 
this PR solves the wrong path to disable de Wazuh repository when upgrading Wazuh to a major version.

Related issue: #1053 

Best regards.