### PR TITLE
Added warning about check_perm.

### DIFF
--- a/source/user-manual/reference/ossec-conf/syscheck.rst
+++ b/source/user-manual/reference/ossec-conf/syscheck.rst
@@ -113,6 +113,8 @@ Attributes:
 | **check_perm**           | Check the permission of the files/directories.                                                                      |
 +                          +                                                                                                                     +
 |                          | On Windows, a list of denied and allowed permissions will be given for each user or group since version 3.8.0.      |
++                          +                                                                                                                     +
+|                          | Only works on NTFS partitions on Windows systems.
 +                          +------------------------------------------------------------+--------------------------------------------------------+
 |                          | Allowed values                                             | yes, no                                                |
 +--------------------------+------------------------------------------------------------+--------------------------------------------------------+


### PR DESCRIPTION
Hi team, this PR adds a new line on the "syscheck" attributes table to warn that it only works on NTFS partitions.

Related issue #1052.

Regards.
