### PR TITLE
Added interval of values for `windows_audit_interval`

### DIFF
--- a/source/user-manual/reference/ossec-conf/syscheck.rst
+++ b/source/user-manual/reference/ossec-conf/syscheck.rst
@@ -432,7 +432,7 @@ windows_audit_interval
 This option sets the frequency in seconds with which the Windows agent will check that the SACLs of the directories monitored in whodata mode are correct.
 
 +--------------------+------------------------------------+
-| **Default value**  | 5 minutes                          |
+| **Default value**  | 300 seconds                        |
 +--------------------+------------------------------------+
 | **Allowed values** | Any number from 1 to 9999          |
 +--------------------+------------------------------------+

--- a/source/user-manual/reference/ossec-conf/syscheck.rst
+++ b/source/user-manual/reference/ossec-conf/syscheck.rst
@@ -429,12 +429,12 @@ windows_audit_interval
 
 .. versionadded:: 3.5.0
 
-This option sets the frequency with which the Windows agent will check that the SACLs of the directories monitored in whodata mode are correct.
+This option sets the frequency in seconds with which the Windows agent will check that the SACLs of the directories monitored in whodata mode are correct.
 
 +--------------------+------------------------------------+
 | **Default value**  | 5 minutes                          |
 +--------------------+------------------------------------+
-| **Allowed values** | A positive number, time in seconds |
+| **Allowed values** | Any number from 1 to 9999          |
 +--------------------+------------------------------------+
 
 whodata


### PR DESCRIPTION
Hi team,
this PR adds an interval of allowed values to the `windows_audit_interval` option from `syscheck`.

Related issue: #1058.

Best regards.