### PR TITLE
Changed package name in wazuh-cluster section

### DIFF
--- a/source/user-manual/manager/wazuh-cluster.rst
+++ b/source/user-manual/manager/wazuh-cluster.rst
@@ -85,7 +85,7 @@ Follow these steps to deploy a Wazuh cluster:
 
     .. code-block:: console
 
-      # yum install python-setuptools python-cryptography
+      # yum install python-setuptools python2-cryptography
 
   b. For Debian-based distributions:
 


### PR DESCRIPTION
Hi team,

this PR actualizes a package name.
It was not an error but, as the contributor said in the issue, if we don't install the actualized we can't list it.

Related issue: #1049.

Best regards.