### PR TITLE
Replaced commas with pipes

### DIFF
--- a/source/user-manual/capabilities/active-response/remediation-configuration.rst
+++ b/source/user-manual/capabilities/active-response/remediation-configuration.rst
@@ -79,7 +79,7 @@ Active response::
     <command>pf-block</command>
     <location>defined-agent</location>
     <agent_id>001</agent_id>
-    <rules_group>authentication_failed,authentication_failures</rules_group>
+    <rules_group>authentication_failed|authentication_failures</rules_group>
   </active-response>
 
 Add an IP to the iptables deny list
@@ -102,7 +102,7 @@ Active response::
   <active-response>
     <command>firewall-drop</command>
     <location>all</location>
-    <rules_group>authentication_failed,authentication_failures</rules_group>
+    <rules_group>authentication_failed|authentication_failures</rules_group>
     <timeout>700</timeout>
     <repeated_offenders>30,60,120</repeated_offenders>
   </active-response>


### PR DESCRIPTION
Hi team, 
this PR changes the commas in the "remediation-configuration" active-response section examples for pipes.

After testing the 2 options, the only one that worked for me is with pipes, as the user says in the issue.

Related issue: #1062 

Best regards.