### PR TITLE
Added " " to every "C:\Program Files (x86)" reference

### DIFF
--- a/source/installation-guide/installing-wazuh-agent/wazuh_agent_windows.rst
+++ b/source/installation-guide/installing-wazuh-agent/wazuh_agent_windows.rst
@@ -23,7 +23,7 @@ Once installed, the agent uses a graphical user interface for configuration, ope
       :align: center
       :width: 320 px
 
-By default, all agent files will be found in: ``C:\Program Files(x86)\ossec-agent``.
+By default, all agent files will be found in: ``C:\Program Files (x86)\ossec-agent``.
 
 .. note:: Now that the agent is installed, the next step is to register and configure it to communicate with the manager. For more information about this process, please visit the :doc:`user manual<../../user-manual/registering/index>`.
 

--- a/source/user-manual/registering/use-registration-service.rst
+++ b/source/user-manual/registering/use-registration-service.rst
@@ -70,7 +70,7 @@ This is the easiest method to register agents. It doesn't require any kind of au
 
   .. code-block:: none
 
-    # C:\Program Files (x86)\ossec-agent\agent-auth.exe -m <MANAGER_IP_ADDRESS>
+    # "C:\Program Files (x86)"\ossec-agent\agent-auth.exe -m <MANAGER_IP_ADDRESS>
 
 Password authorization
 ----------------------
@@ -114,7 +114,7 @@ To enable the password authorization, use the ``-P`` flag when running the regis
     .. code-block:: console
 
       # echo abcd1234 > C:\Program Files (x86)\ossec-agent\authd.pass
-      # C:\Program Files (x86)\ossec-agent\agent-auth.exe -m <MANAGER_IP_ADDRESS>
+      # "C:\Program Files (x86)"\ossec-agent\agent-auth.exe -m <MANAGER_IP_ADDRESS>
 
   * Run the program with the ``-P`` flag, and insert the password:
 
@@ -128,7 +128,7 @@ To enable the password authorization, use the ``-P`` flag when running the regis
 
     .. code-block:: none
 
-      # C:\Program Files (x86)\ossec-agent\agent-auth.exe -m <MANAGER_IP_ADDRESS> -P "abcd1234"
+      # "C:\Program Files (x86)"\ossec-agent\agent-auth.exe -m <MANAGER_IP_ADDRESS> -P "abcd1234"
 
 .. _verify-hosts:
 
@@ -178,7 +178,7 @@ Manager verification using SSL
   .. code-block:: console
 
     # cp rootCA.pem C:\Program Files (x86)\ossec-agent
-    # C:\Program Files (x86)\ossec-agent\agent-auth.exe -m 192.168.1.2 -v C:\Program Files (x86)\ossec-agent\rootCA.pem
+    # "C:\Program Files (x86)"\ossec-agent\agent-auth.exe -m 192.168.1.2 -v C:\Program Files (x86)\ossec-agent\rootCA.pem
 
 Agent verification using SSL
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -215,7 +215,7 @@ In this example, we are going to create a certificate for agents without specify
   .. code-block:: console
 
     # cp sslagent.cert sslagent.key C:\Program Files (x86)\ossec-agent
-    # C:\Program Files (x86)\ossec-agent\agent-auth.exe -m 192.168.1.2 -x C:\Program Files (x86)\ossec-agent\sslagent.cert -k C:\Program Files (x86)\ossec-agent\sslagent.key
+    # "C:\Program Files (x86)"\ossec-agent\agent-auth.exe -m 192.168.1.2 -x C:\Program Files (x86)\ossec-agent\sslagent.cert -k C:\Program Files (x86)\ossec-agent\sslagent.key
 
 **Agent verification (with host validation)**
 
@@ -249,7 +249,7 @@ This is an alternative method to the previous one. In this case, we will bind th
   .. code-block:: console
 
     # cp sslagent.cert sslagent.key C:\Program Files (x86)\ossec-agent
-    # C:\Program Files (x86)\ossec-agent\agent-auth.exe -m 192.168.1.2 -x C:\Program Files (x86)\ossec-agent\sslagent.cert -k C:\Program Files (x86)\ossec-agent\sslagent.key
+    # "C:\Program Files (x86)"\ossec-agent\agent-auth.exe -m 192.168.1.2 -x C:\Program Files (x86)\ossec-agent\sslagent.cert -k C:\Program Files (x86)\ossec-agent\sslagent.key
 
 Additional configurations
 -------------------------

--- a/source/user-manual/registering/use-registration-service.rst
+++ b/source/user-manual/registering/use-registration-service.rst
@@ -70,7 +70,7 @@ This is the easiest method to register agents. It doesn't require any kind of au
 
   .. code-block:: none
 
-    # "C:\Program Files (x86)"\ossec-agent\agent-auth.exe -m <MANAGER_IP_ADDRESS>
+    # "C:\Program Files (x86)\ossec-agent\agent-auth.exe" -m <MANAGER_IP_ADDRESS>
 
 Password authorization
 ----------------------
@@ -114,7 +114,7 @@ To enable the password authorization, use the ``-P`` flag when running the regis
     .. code-block:: console
 
       # echo abcd1234 > C:\Program Files (x86)\ossec-agent\authd.pass
-      # "C:\Program Files (x86)"\ossec-agent\agent-auth.exe -m <MANAGER_IP_ADDRESS>
+      # "C:\Program Files (x86)\ossec-agent\agent-auth.exe" -m <MANAGER_IP_ADDRESS>
 
   * Run the program with the ``-P`` flag, and insert the password:
 
@@ -128,7 +128,7 @@ To enable the password authorization, use the ``-P`` flag when running the regis
 
     .. code-block:: none
 
-      # "C:\Program Files (x86)"\ossec-agent\agent-auth.exe -m <MANAGER_IP_ADDRESS> -P "abcd1234"
+      # "C:\Program Files (x86)\ossec-agent\agent-auth.exe" -m <MANAGER_IP_ADDRESS> -P "abcd1234"
 
 .. _verify-hosts:
 
@@ -178,7 +178,7 @@ Manager verification using SSL
   .. code-block:: console
 
     # cp rootCA.pem C:\Program Files (x86)\ossec-agent
-    # "C:\Program Files (x86)"\ossec-agent\agent-auth.exe -m 192.168.1.2 -v C:\Program Files (x86)\ossec-agent\rootCA.pem
+    # "C:\Program Files (x86)\ossec-agent\agent-auth.exe" -m 192.168.1.2 -v C:\Program Files (x86)\ossec-agent\rootCA.pem
 
 Agent verification using SSL
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -215,7 +215,7 @@ In this example, we are going to create a certificate for agents without specify
   .. code-block:: console
 
     # cp sslagent.cert sslagent.key C:\Program Files (x86)\ossec-agent
-    # "C:\Program Files (x86)"\ossec-agent\agent-auth.exe -m 192.168.1.2 -x C:\Program Files (x86)\ossec-agent\sslagent.cert -k C:\Program Files (x86)\ossec-agent\sslagent.key
+    # "C:\Program Files (x86)\ossec-agent\agent-auth.exe" -m 192.168.1.2 -x C:\Program Files (x86)\ossec-agent\sslagent.cert -k C:\Program Files (x86)\ossec-agent\sslagent.key
 
 **Agent verification (with host validation)**
 
@@ -249,7 +249,7 @@ This is an alternative method to the previous one. In this case, we will bind th
   .. code-block:: console
 
     # cp sslagent.cert sslagent.key C:\Program Files (x86)\ossec-agent
-    # "C:\Program Files (x86)"\ossec-agent\agent-auth.exe -m 192.168.1.2 -x C:\Program Files (x86)\ossec-agent\sslagent.cert -k C:\Program Files (x86)\ossec-agent\sslagent.key
+    # "C:\Program Files (x86)\ossec-agent\agent-auth.exe" -m 192.168.1.2 -x C:\Program Files (x86)\ossec-agent\sslagent.cert -k C:\Program Files (x86)\ossec-agent\sslagent.key
 
 Additional configurations
 -------------------------


### PR DESCRIPTION
Hi team,
After testing different orders in a Windows machine, I've seen that effectively, if we try to execute an executable using the full path instead of using `start` if the path contains a blank space it will return an error.

So, I've added " " to every "C:\Program Files (x86)" reference.

Related issue: #1069. 

Best regards.