### PR TITLE
Replaced ossec-docs links with Wazuh links

### DIFF
--- a/source/pci-dss/file-integrity-monitoring.rst
+++ b/source/pci-dss/file-integrity-monitoring.rst
@@ -9,7 +9,7 @@ File integrity monitoring (Syscheck) is performed by comparing the cryptographic
 
 First, the Wazuh agent scans the system at an interval you specify, and it sends the checksums of the monitored files and registry keys (for Windows systems) to the Wazuh server. Then, the server stores the checksums and looks for modifications by comparing the newly received checksums against the historical checksum values for those files and/or registry keys. An alert is sent if the checksum (or another file attribute) changes.  Wazuh also supports near real-time file integrity checking where this is desired.
 
-`Syscheck <http://ossec-docs.readthedocs.org/en/latest/manual/syscheck/index.html>`_  can be used to meet PCI DSS requirement 11.5:
+`Syscheck <https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html>`_  can be used to meet PCI DSS requirement 11.5:
 
 | **11.5** Deploy a change-detection mechanism (for example, file-integrity monitoring tools) to alert personnel to unauthorized modification (including changes, additions, and deletions) of critical system files, configuration files, or content files; and configure the software to perform critical file comparisons at least weekly.
 |

--- a/source/pci-dss/rootkit-detection.rst
+++ b/source/pci-dss/rootkit-detection.rst
@@ -14,7 +14,7 @@ Rootkit and trojan detection is performed using two files: ``rootkit_files.txt``
         <rootkit_trojans>/var/ossec/etc/shared/rootkit_trojans.txt</rootkit_trojans>
     </rootcheck>
 
-These are the options available for the `rootcheck component <http://ossec-docs.readthedocs.org/en/latest/syntax/head_ossec_config.rootcheck.html>`_:
+These are the options available for the `rootcheck component <https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/rootcheck.html>`_:
 
 + **rootkit_files**: Contains the Unix-based application level rootkit signatures.
 

--- a/source/user-manual/reference/ossec-conf/integration.rst
+++ b/source/user-manual/reference/ossec-conf/integration.rst
@@ -101,7 +101,7 @@ event_location
 
 This filters alerts by where the event originated. Follows the `OS_Regex Syntax`_.
 
-.. _`OS_Regex Syntax`: http://ossec-docs.readthedocs.org/en/latest/syntax/regex.html
+.. _`OS_Regex Syntax`: https://documentation.wazuh.com/current/user-manual/ruleset/ruleset-xml-syntax/regex.html
 
 +--------------------+-----------------------------------------------------------+
 | **Default value**  | n/a                                                       |


### PR DESCRIPTION
Hi team, this PR changes old ossec-docs references in certain pages of the documentation.

Now, they point to our equivalent sections.

Related issue: #1074.

Best regards.