### PR TITLE
Fixed integration 'groups' option [3.8]

### DIFF
--- a/source/user-manual/reference/ossec-conf/integration.rst
+++ b/source/user-manual/reference/ossec-conf/integration.rst
@@ -88,13 +88,13 @@ This filters alerts by rule ID.
 group
 ^^^^^
 
-This filters alerts by rule group. For the VirusTotal integration, only rules from the `syscheck` group are available. Follows the `OS_Regex Syntax`_.
+This filters alerts by rule group. For the VirusTotal integration, only rules from the `syscheck` group are available.
 
-+--------------------+---------------------------------------------------------------------------------------------+
-| **Default value**  | n/a                                                                                         |
-+--------------------+---------------------------------------------------------------------------------------------+
-| **Allowed values** | Any rule group is allowed. Multiple groups should be separated with a pipe character (“|”). |
-+--------------------+---------------------------------------------------------------------------------------------+
++--------------------+-------------------------------------------------+
+| **Default value**  | n/a                                             |
++--------------------+-------------------------------------------------+
+| **Allowed values** | Any rule group or comma-separated rule groups.  |
++--------------------+-------------------------------------------------+
 
 event_location
 ^^^^^^^^^^^^^^


### PR DESCRIPTION
Hi team,

this PR fixes an error in integration 'group' option.

Related issue: #1075.

Best regards.