### PR TITLE
Update syscheck frequency option default value

### DIFF
--- a/source/user-manual/reference/ossec-conf/syscheck.rst
+++ b/source/user-manual/reference/ossec-conf/syscheck.rst
@@ -215,7 +215,7 @@ frequency
 Frequency that the syscheck will be run (in seconds).
 
 +--------------------+-------------------------------------+
-| **Default value**  | 21600                               |
+| **Default value**  | 43200                               |
 +--------------------+-------------------------------------+
 | **Allowed values** | A positive number, time in seconds. |
 +--------------------+-------------------------------------+


### PR DESCRIPTION
Hi team,
As I found, the default value for frequency option in syscheck section is not 6h as was documented, so I changed it to its actual default value which is 12h.

Related issue: #1099 
Best regards.