### PR TITLE
Added warning about minimum recommendations

### DIFF
--- a/source/docker/docker-installation.rst
+++ b/source/docker/docker-installation.rst
@@ -13,6 +13,9 @@ The first thing you need to do is install Docker and Docker compose if you don't
 Docker engine
 -------------
 
+.. warning::
+  Remember that your docker host should have the minimum requirements for the installation of Wazuh + ELK.
+
 Docker requires a 64-bit operating system running kernel version 3.10 or higher.
 
 1. Check your current kernel version. Open a terminal and use ``uname -r`` to display your kernel version:


### PR DESCRIPTION
Hi team,

this PR adds a warning to remember users to don't install the docker host in a machine that does not meet the minimum specifications for installing Wazuh+ELK

Related issue: #1109.

Best regards.