### PR TITLE
Fix explanation of AR location field

### DIFF
--- a/source/learning-wazuh/shellshock.rst
+++ b/source/learning-wazuh/shellshock.rst
@@ -201,31 +201,29 @@ Observe that elastic-server is no longer blocking the offending linux-agent, wit
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
 In the newly-added <active-response> section in ossec.conf on wazuh-server, change the <location> value from **local** to **all** so that
-all Linux Wazuh agents and the Wazuh manager will block the attacker even when only one of them is targeted.
+all Linux Wazuh agents will block the attacker even when only one of them is targeted.
 
-.. error::
-    There is a bug in Wazuh AR causing Wazuh managers themselves to not execute an AR commands when the AR <location> is
-    set to **all**, leaving only the agents running the command.  For now, work around this by changing the <location> of the existing
-    <active-response> section from **all** to **local** and then create a duplicate <active-response> section with a <location> of
-    **server**.  The resulting configuration should look like this:
+.. note::
+    The option **all** sends the active response to all agents. If we want it to also run in the manager,
+    we must duplicate the active-response block indicating **server** in the ``location`` field.
 
-    .. code-block:: xml
+.. code-block:: xml
 
-        <active-response>
-            <disabled>no</disabled>
-            <command>firewall-drop</command>
-            <location>local</location>
-            <rules_id>30412</rules_id>
-            <timeout>300</timeout>
-        </active-response>
+    <active-response>
+        <disabled>no</disabled>
+        <command>firewall-drop</command>
+        <location>all</location>
+        <rules_id>30412</rules_id>
+        <timeout>300</timeout>
+    </active-response>
 
-        <active-response>
-            <disabled>no</disabled>
-            <command>firewall-drop</command>
-            <location>server</location>
-            <rules_id>30412</rules_id>
-            <timeout>300</timeout>
-        </active-response>
+    <active-response>
+        <disabled>no</disabled>
+        <command>firewall-drop</command>
+        <location>server</location>
+        <rules_id>30412</rules_id>
+        <timeout>300</timeout>
+    </active-response>
 
 Run the same malicious curl probe from linux-agent as before, and then using the same iptables command as before, confirm
 on both elastic-server and wazuh-manager that both Linux systems are blocking the linux-agent attacker.


### PR DESCRIPTION
This PR fix the description given about the `location` option in the Shellshock attack guide. When `all` is specified, the behaviour is expected and known, it is not a bug.

![imagen](https://user-images.githubusercontent.com/20266121/56817317-a910e680-6845-11e9-85a3-ba97cb7dca84.png)

However, I have opened an issue (https://github.com/wazuh/wazuh/issues/3186) to add an option (or modify `all`) to allow execution in agents and manager at the same time.

### Current

![imagen](https://user-images.githubusercontent.com/20266121/56817832-9c40c280-6846-11e9-96ec-a53b0c9d3350.png)

### Change

![imagen](https://user-images.githubusercontent.com/20266121/56817862-b084bf80-6846-11e9-99c5-091679e8d81d.png)
