### PR TITLE
Added link to remote methods in the upgrading guide

### DIFF
--- a/source/installation-guide/upgrading/latest_wazuh3_minor.rst
+++ b/source/installation-guide/upgrading/latest_wazuh3_minor.rst
@@ -85,7 +85,7 @@ Find every available option from agent_upgrade tool in :ref:`agent-upgrade <agen
 Installing the packets in the agent locally.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This section isn't neccesary if you have already used the agent-upgrade tool.
+You don't need to follow this section if you have already used the agent-upgrade tool.
 
 1. Upgrade the ``wazuh-agent`` package:
 

--- a/source/installation-guide/upgrading/latest_wazuh3_minor.rst
+++ b/source/installation-guide/upgrading/latest_wazuh3_minor.rst
@@ -70,7 +70,7 @@ It's possible to upgrade the Wazuh agents from the manager by using the agent_up
 Upgrading the agents from the manager
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To upgrade you agents from the manager follow the :ref:`Upgrading agent <upgrading-agent>` page.
+To upgrade you agents from the manager follow the :ref:`Upgrading agent <agent_upgrade>` page.
 
 Installing the packets in the agent locally.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/installation-guide/upgrading/latest_wazuh3_minor.rst
+++ b/source/installation-guide/upgrading/latest_wazuh3_minor.rst
@@ -65,7 +65,7 @@ Upgrade the Wazuh manager
 
 Upgrade the Wazuh agent
 ^^^^^^^^^^^^^^^^^^^^^^^
-It is possible to upgrade the Wazuh agents from the manager by using the agent_upgrade tool or the Wazuh api or locally by installing the packages in the agents.
+It is possible to upgrade the Wazuh agents from the manager by using the agent_upgrade tool or the Wazuh API or locally by installing the packages in the agents.
 
 Upgrading the agents from the manager
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/installation-guide/upgrading/latest_wazuh3_minor.rst
+++ b/source/installation-guide/upgrading/latest_wazuh3_minor.rst
@@ -69,6 +69,10 @@ It's possible to upgrade the Wazuh agents from the manager by using the agent_up
 
 Using the agent_upgrade tool
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. note::
+  The agent_upgrade tool is available since Wazuh version 3.0. It can only be used to upgrade agents with an actual version equal or greater than 3.0.
+  It isn't available fot Windows XP agents.
+
 1. List the agents to see its versions:
   .. code-block:: console
 

--- a/source/installation-guide/upgrading/latest_wazuh3_minor.rst
+++ b/source/installation-guide/upgrading/latest_wazuh3_minor.rst
@@ -65,26 +65,12 @@ Upgrade the Wazuh manager
 
 Upgrade the Wazuh agent
 ^^^^^^^^^^^^^^^^^^^^^^^
-It's possible to upgrade the Wazuh agents from the manager by using the agent_upgrade tool or installing the packages in the agent directly.
+It's possible to upgrade the Wazuh agents from the manager by using the agent_upgrade tool or the Wazuh api or locally by installing the packages in the agents.
 
-Using the agent_upgrade tool
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. note::
-  The agent_upgrade tool is available since Wazuh version 3.0. It can only be used to upgrade agents with an actual version equal or greater than 3.0.
-  It isn't available fot Windows XP agents.
+Upgrading the agents from the manager
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-1. List the agents to see its versions:
-  .. code-block:: console
-
-    # /var/ossec/bin/agent_upgrade -l
-
-2. Upgrade the agents:
-
-  .. code-block:: console
-
-    # /var/ossec/bin/agent-upgrade -a AGENTID
-
-Find every available option from agent_upgrade tool in :ref:`agent-upgrade <agent_upgrade>`.
+To upgrade you agents from the manager follow the :ref:`Upgrading agent <upgrading-agent>` page.
 
 Installing the packets in the agent locally.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/installation-guide/upgrading/latest_wazuh3_minor.rst
+++ b/source/installation-guide/upgrading/latest_wazuh3_minor.rst
@@ -80,7 +80,7 @@ Using the agent_upgrade tool
 
     # /var/ossec/bin/agent-upgrade -a AGENTID
 
-Find every available option from agent_upgrade tool in :ref:`agent-upgrade <user_manual>`.
+Find every available option from agent_upgrade tool in :ref:`agent-upgrade <agent_upgrade>`.
 
 Installing the packets in the agent locally.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/installation-guide/upgrading/latest_wazuh3_minor.rst
+++ b/source/installation-guide/upgrading/latest_wazuh3_minor.rst
@@ -65,7 +65,7 @@ Upgrade the Wazuh manager
 
 Upgrade the Wazuh agent
 ^^^^^^^^^^^^^^^^^^^^^^^
-It's possible to upgrade the Wazuh agents from the manager by using the agent_upgrade tool or the Wazuh api or locally by installing the packages in the agents.
+It is possible to upgrade the Wazuh agents from the manager by using the agent_upgrade tool or the Wazuh api or locally by installing the packages in the agents.
 
 Upgrading the agents from the manager
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/installation-guide/upgrading/latest_wazuh3_minor.rst
+++ b/source/installation-guide/upgrading/latest_wazuh3_minor.rst
@@ -75,7 +75,7 @@ To upgrade you agents from the manager follow the :ref:`Upgrading agent <agent_u
 Installing the packets in the agent locally.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You don't need to follow this section if you have already upgraded the agents from the manager.
+It is not neccesary to follow this section if the one of the previous methods has been used.
 
 1. Upgrade the ``wazuh-agent`` package:
 

--- a/source/installation-guide/upgrading/latest_wazuh3_minor.rst
+++ b/source/installation-guide/upgrading/latest_wazuh3_minor.rst
@@ -75,7 +75,7 @@ To upgrade you agents from the manager follow the :ref:`Upgrading agent <upgradi
 Installing the packets in the agent locally.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You don't need to follow this section if you have already used the agent-upgrade tool.
+You don't need to follow this section if you have already upgraded the agents from the manager.
 
 1. Upgrade the ``wazuh-agent`` package:
 

--- a/source/installation-guide/upgrading/latest_wazuh3_minor.rst
+++ b/source/installation-guide/upgrading/latest_wazuh3_minor.rst
@@ -65,6 +65,27 @@ Upgrade the Wazuh manager
 
 Upgrade the Wazuh agent
 ^^^^^^^^^^^^^^^^^^^^^^^
+It's possible to upgrade the Wazuh agents from the manager by using the agent_upgrade tool or installing the packages in the agent directly.
+
+Using the agent_upgrade tool
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+1. List the agents to see its versions:
+  .. code-block:: console
+
+    # /var/ossec/bin/agent_upgrade -l
+
+2. Upgrade the agents:
+
+  .. code-block:: console
+
+    # /var/ossec/bin/agent-upgrade -a AGENTID
+
+Find every available option from agent_upgrade tool in :ref:`agent-upgrade <user_manual>`.
+
+Installing the packets in the agent locally.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This section isn't neccesary if you have already used the agent-upgrade tool.
 
 1. Upgrade the ``wazuh-agent`` package:
 

--- a/source/user-manual/agents/remote-upgrading/upgrading-agent.rst
+++ b/source/user-manual/agents/remote-upgrading/upgrading-agent.rst
@@ -13,8 +13,8 @@ Using the command line
 ----------------------
 
 .. note::
-  The agent_upgrade tool is available since Wazuh version 3.0. It can only be used to upgrade agents with an actual version equal or greater than 3.0.
-  It isn't available fot Windows XP agents.
+  The agent_upgrade tool is available since Wazuh version 3.0. It can only be used to upgrade agents with an actual version equal to or greater than 3.0.
+  It is not available for Windows XP agents.
 
 To upgrade agents using the command line, use the :doc:`agent_upgrade <../../reference/tools/agent_upgrade>` tool as follows:
 

--- a/source/user-manual/agents/remote-upgrading/upgrading-agent.rst
+++ b/source/user-manual/agents/remote-upgrading/upgrading-agent.rst
@@ -14,7 +14,7 @@ Using the command line
 
 .. note::
   The agent_upgrade tool is available since Wazuh version 3.0. It can only be used to upgrade agents with an actual version equal to or greater than 3.0.
-  It is not available for Windows XP agents.
+  Remote upgrades are compatible with agents running on Windows 6.0 (Vista and Server 2008) and newer..
 
 To upgrade agents using the command line, use the :doc:`agent_upgrade <../../reference/tools/agent_upgrade>` tool as follows:
 

--- a/source/user-manual/agents/remote-upgrading/upgrading-agent.rst
+++ b/source/user-manual/agents/remote-upgrading/upgrading-agent.rst
@@ -12,6 +12,10 @@ Upgrading an agent remotely can be performed at the command line and through the
 Using the command line
 ----------------------
 
+.. note::
+  The agent_upgrade tool is available since Wazuh version 3.0. It can only be used to upgrade agents with an actual version equal or greater than 3.0.
+  It isn't available fot Windows XP agents.
+
 To upgrade agents using the command line, use the :doc:`agent_upgrade <../../reference/tools/agent_upgrade>` tool as follows:
 
 1. List all outdated agents using the *'-l'* parameter:


### PR DESCRIPTION
I've added a link to the [remote upgrading methods page](https://documentation.wazuh.com/current/user-manual/agents/remote-upgrading/upgrading-agent.html) in the [upgrading guide](https://documentation.wazuh.com/current/installation-guide/upgrading/latest_wazuh3_minor.html#upgrading-latest-minor).
I've added a note in the remote upgrading methods page to tell the users you need wazuh 3.0 or higher to use the agent-upgrade tools and it doesn't work on Windows XP agents.

This PR is related to the [issue 1174](https://github.com/wazuh/wazuh-documentation/issues/1174).