### PR TITLE
Modified the explanation about how to change api's username

### DIFF
--- a/source/installation-guide/installing-wazuh-server/securing_api.rst
+++ b/source/installation-guide/installing-wazuh-server/securing_api.rst
@@ -13,7 +13,7 @@ By default, the communications between the Wazuh Kibana App and the Wazuh API ar
 
     **Change the default credentials:**
 
-    The ``configure_api.sh`` script allows you to change the api user. If you did not use the script you can still change the api user as follows:
+    The ``configure_api.sh`` script allows you to change the api's user. If you did not use the script you can still change the api user as follows:
     
     .. code-block:: console
 

--- a/source/installation-guide/installing-wazuh-server/securing_api.rst
+++ b/source/installation-guide/installing-wazuh-server/securing_api.rst
@@ -12,7 +12,7 @@ By default, the communications between the Wazuh Kibana App and the Wazuh API ar
   In order to enable HTTPS, you can generate your own certificate or generate it automatically by using the script ``/var/ossec/api/scripts/configure_api.sh``.
   
   .. note::
-    This script allows you to change the port used by Kibana to communicate with the Wazuh's API. It is used the port 55000 by default.
+    This script allows you to change the port used by the Wazuh API to handle the incoming HTTP requests. The port 55000 is used by default.
 
     **Change the default credentials:**
 

--- a/source/installation-guide/installing-wazuh-server/securing_api.rst
+++ b/source/installation-guide/installing-wazuh-server/securing_api.rst
@@ -16,7 +16,7 @@ By default, the communications between the Wazuh Kibana App and the Wazuh API ar
 
     **Change the default credentials:**
 
-    The ``configure_api.sh`` script allows you to change the api's user. If you did not use the script you can still change the api user as follows:
+    The ``configure_api.sh`` script allows you to change the API's user. If you did not use the script you can still change it as follows:
     
     .. code-block:: console
 

--- a/source/installation-guide/installing-wazuh-server/securing_api.rst
+++ b/source/installation-guide/installing-wazuh-server/securing_api.rst
@@ -9,7 +9,10 @@ By default, the communications between the Wazuh Kibana App and the Wazuh API ar
 
 1. Enable HTTPS:
 
-  In order to enable HTTPS, you need to generate or provide a certificate. You can learn how to generate your own certificate or generate it automatically using the script ``/var/ossec/api/scripts/configure_api.sh``.
+  In order to enable HTTPS, you can generate your own certificate or generate it automatically using the script ``/var/ossec/api/scripts/configure_api.sh``.
+  
+  .. note::
+    This script will allow you to change the default port used by Kibana.
 
     **Change the default credentials:**
 

--- a/source/installation-guide/installing-wazuh-server/securing_api.rst
+++ b/source/installation-guide/installing-wazuh-server/securing_api.rst
@@ -7,20 +7,22 @@ Securing the Wazuh API
 
 By default, the communications between the Wazuh Kibana App and the Wazuh API are not encrypted. It is highly recommended that you secure the Wazuh API by following the steps below:
 
-1. Change the default credentials:
-
-  By default, you can access the Wazuh API by typing user "foo" and password "bar", however, you can create new credentials as follows:
-
-  .. code-block:: console
-
-    # cd /var/ossec/api/configuration/auth
-    # node htpasswd -c user myUserName
- 
-You will then need to restart the ``wazuh-api`` and ``wazuh-manager`` services for the change to take effect.
-
-2. Enable HTTPS:
+1. Enable HTTPS:
 
   In order to enable HTTPS, you need to generate or provide a certificate. You can learn how to generate your own certificate or generate it automatically using the script ``/var/ossec/api/scripts/configure_api.sh``.
+
+    **Change the default credentials:**
+
+    The ``configure_api.sh`` script allows you to change the api user. If you did not use the script you can still change the api user as follows:
+    
+    .. code-block:: console
+
+      # cd /var/ossec/api/configuration/auth
+      # node htpasswd -c user myUserName
+      
+    By default, you can access the Wazuh API by typing user "foo" and password "bar".
+ 
+You will then need to restart the ``wazuh-api`` and ``wazuh-manager`` services for the change to take effect.
 
 3. Bind to localhost:
 

--- a/source/installation-guide/installing-wazuh-server/securing_api.rst
+++ b/source/installation-guide/installing-wazuh-server/securing_api.rst
@@ -9,10 +9,10 @@ By default, the communications between the Wazuh Kibana App and the Wazuh API ar
 
 1. Enable HTTPS:
 
-  In order to enable HTTPS, you can generate your own certificate or generate it automatically using the script ``/var/ossec/api/scripts/configure_api.sh``.
+  In order to enable HTTPS, you can generate your own certificate or generate it automatically by using the script ``/var/ossec/api/scripts/configure_api.sh``.
   
   .. note::
-    This script will allow you to change the default port used by Kibana.
+    This script allows you to change the port used by Kibana to communicate with the Wazuh's API. It is used the port 55000 by default.
 
     **Change the default credentials:**
 


### PR DESCRIPTION
This PR is related to the issue [1172](https://github.com/wazuh/wazuh-documentation/issues/1172).

It changes the order explained to the user to change the api's user because the script used to generate the SSL certificate let you change the api's username and password.