### PR TITLE
Fix invalid specification in field of rules

### DIFF
--- a/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
@@ -173,7 +173,7 @@ Selects in which rule decoding category the rule should be included: ids, syslog
 field
 ^^^^^
 
-Any ``sregex`` to be compared to a field extracted by the decoder.
+Any ``OS_Regex`` to be compared to a field extracted by the decoder.
 
 +----------+-----------------------------------------------------------+
 | **name** | Specifies the name of the field extracted by the decoder. |
@@ -560,7 +560,7 @@ Example:
   As an example to this last options, check this rule:
 
     .. code-block:: xml
-      
+
       <rule id=100005 level="0">
         <match> Could not open /home </match>
         <same_user />
@@ -607,7 +607,7 @@ Since Wazuh version 3.3 it is possible to include any decoded field (static or d
 Example:
 
   .. code-block:: xml
-  
+
     <rule id="100005" level="8">
       <match>illegal user|invalid user</match>
       <description>sshd: Attempt to login using a non-existent user from IP $(attempt_ip)</description>


### PR DESCRIPTION
The `field` option of the rules expects a string in `OS_Regex` format, not `sregex`.

This value is processed here: 

https://github.com/wazuh/wazuh/blob/18bac2de69f5a37e5c3c4e2dfbce5a0093042ea7/src/analysisd/analysisd.c#L1083

If it were `sregex`, the function used would be `OSMatch_Execute`.