### PR TITLE
Add report_ip option to ossec.conf reference

### DIFF
--- a/source/user-manual/reference/ossec-conf/client.rst
+++ b/source/user-manual/reference/ossec-conf/client.rst
@@ -241,6 +241,19 @@ Choose the encryption of the messages that the agent sends to the manager.
 | **Allowed values** | blowfish, aes       |
 +--------------------+---------------------+
 
+report_ip
+^^^^^^^^^
+
+.. versionadded:: 3.10.0
+
+Toggle on and off the module of the agent that extract the default IP and send it in the keep alive.
+
++--------------------+---------------------+
+| **Default value**  | yes                 |
++--------------------+---------------------+
+| **Allowed values** | yes, no             |
++--------------------+---------------------+
+
 Sample configuration
 --------------------
 


### PR DESCRIPTION
Due to the issue https://github.com/wazuh/wazuh/issues/3384 the agent will have an option to avoid get the default IP of the agent.

If the option doesn't exist on the ossec.conf the module will work normally. If the option is set to no the keep alive of the agent will not contain the agent IP.