### PR TITLE
Docker listener docu fixes

### DIFF
--- a/source/docker-monitor/monitoring_containers_activity.rst
+++ b/source/docker-monitor/monitoring_containers_activity.rst
@@ -16,6 +16,7 @@ The following dependencies are required by the wodle:
 - Linux system.
 - Python 2.7 or newer.
 - `Python Docker library <https://pypi.org/project/docker/>`_: It can be installed with ``pip install docker`` command.
+ - Starting with Wazuh v3.9.0 this requirement is met by default by the Wazuh manager and must only be installed in 
 
 
 Configuration
@@ -23,10 +24,10 @@ Configuration
 
 .. note::
 
-    In the following examples, the configuration is done in the manager instance (*Docker host*) that collects the events sent from the agents (*Docker containers*).
+    In the following examples, the configuration is done in the *Docker host* that collects the events sent from the *Docker containers*. This may be either a server with a Wazuh Agent or Manager installed.
 
 
-The configuration is pretty straightforward, it is only necessary to enable the ``wodle`` in the manager instance in the ``/var/ossec/etc/ossec.conf`` file. It will start a new thread to listen to Docker events.
+In order to use the Docker listener module it is only necessary to enable the ``wodle`` in the ``/var/ossec/etc/ossec.conf`` file of the server running docker, or this can also be done through :doc:`Centralized Configuration <../user-manual/reference/centralized-configuration>`. It will start a new thread to listen to Docker events.
 
 .. code-block:: xml
 
@@ -35,19 +36,8 @@ The configuration is pretty straightforward, it is only necessary to enable the 
     </wodle>
 
 
-Then, restart the service:
-
-    a. For Systemd:
-
-        .. code-block:: console
-
-            # systemctl restart wazuh-manager
-
-     b. For SysV Init:
-
-        .. code-block:: console
-
-            # service wazuh-manager restart
+Then, it is necessary to restart the Wazuh service (where the listener will be running).
+            
 
 Use cases
 ^^^^^^^^^

--- a/source/user-manual/reference/ossec-conf/index.rst
+++ b/source/user-manual/reference/ossec-conf/index.rst
@@ -86,7 +86,7 @@ Wazuh can be installed in two ways: as a manager by using the "server/manager" i
 +---------------------------------------------------------------------+------------------------+
 | :doc:`wodle name="osquery" <wodle-osquery>`                         | manager, agent         |
 +---------------------------------------------------------------------+------------------------+
-| :doc:`wodle name="docker-listener" <wodle-docker>`                  | agent                  |
+| :doc:`wodle name="docker-listener" <wodle-docker>`                  | manager, agent         |
 +---------------------------------------------------------------------+------------------------+
 | :doc:`wodle name="azure-logs" <wodle-azure-logs>`                   | manager                |
 +---------------------------------------------------------------------+------------------------+


### PR DESCRIPTION
The documentation implied that this configuration only works on the manager when in reality it can be configured on any agent that has a docker server and the docker python library installed.

Enabling it for the manager will not listen in the agents as this configuration seems to suggest.

Also in the configuration reference, the Supported installations table specified the docker-listener module was only supported for the agent installation where it can be configured for the manager as well.