### PR TITLE
Increased email_maxperhour upper limit

### DIFF
--- a/source/user-manual/reference/ossec-conf/global.rst
+++ b/source/user-manual/reference/ossec-conf/global.rst
@@ -141,11 +141,11 @@ This sets the maximum number of email alerts that can be sent per hour. All emai
 
   At the end of the hour, the queued emails will be sent together in one email whether mail grouping is turned on or not.
 
-+--------------------+---------------------------+
-| **Default value**  | 12                        |
-+--------------------+---------------------------+
-| **Allowed values** | Any number from 1 to 9999 |
-+--------------------+---------------------------+
++--------------------+--------------------------------+
+| **Default value**  | 12                             |
++--------------------+--------------------------------+
+| **Allowed values** | Any number from 1 to 1000000   |
++--------------------+--------------------------------+
 
 email_idsname
 ^^^^^^^^^^^^^


### PR DESCRIPTION
This PR updates the documentation regarding the fix to the issue https://github.com/wazuh/wazuh/issues/3021. Now the upper limit of <email_maxperhour> is `1.000.000`. 
<br></br>
Best regards,

Juan Pablo Sáez