### PR TITLE
Update documentation for auth parameters

### DIFF
--- a/source/user-manual/reference/ossec-conf/auth.rst
+++ b/source/user-manual/reference/ossec-conf/auth.rst
@@ -65,7 +65,7 @@ use_source_ip
 Toggles the use of the client's source IP address or the use of "any" to add an agent.
 
 +--------------------+---------------------+
-| **Default value**  | no                  |
+| **Default value**  | yes                 |
 +--------------------+---------------------+
 | **Allowed values** | yes, no             |
 +--------------------+---------------------+
@@ -76,7 +76,7 @@ force_insert
 Toggles whether or not to force the insertion of an agent if there is a duplicate name or IP address. This will remove the old agent with same name or IP address.
 
 +--------------------+---------------------+
-| **Default value**  | no                  |
+| **Default value**  | yes                 |
 +--------------------+---------------------+
 | **Allowed values** | yes, no             |
 +--------------------+---------------------+
@@ -101,7 +101,7 @@ purge
 Toggles the deletion of client keys on or off when agents are removed.
 
 +--------------------+---------------------+
-| **Default value**  | no                  |
+| **Default value**  | yes                 |
 +--------------------+---------------------+
 | **Allowed values** | yes, no             |
 +--------------------+---------------------+


### PR DESCRIPTION
Hi team,

I made a fix in order to update the default values of `auth` service in our documentation:

```XML
  <auth>
    <disabled>no</disabled>
    <port>1515</port>
    <use_source_ip>yes</use_source_ip>
    <force_insert>yes</force_insert>
    <force_time>0</force_time>
    <purge>yes</purge>
    <use_password>no</use_password>
    <limit_maxagents>yes</limit_maxagents>
    <ciphers>HIGH:!ADH:!EXP:!MD5:!RC4:!3DES:!CAMELLIA:@STRENGTH</ciphers>
    <!-- <ssl_agent_ca></ssl_agent_ca> -->
    <ssl_verify_host>no</ssl_verify_host>
    <ssl_manager_cert>/var/ossec/etc/sslmanager.cert</ssl_manager_cert>
    <ssl_manager_key>/var/ossec/etc/sslmanager.key</ssl_manager_key>
    <ssl_auto_negotiate>no</ssl_auto_negotiate>
  </auth>

```

Best regards,

Demetrio.