### PR TITLE
Removed Python reference in Manager

### DIFF
--- a/source/installation-guide/installing-wazuh-server/wazuh_server_deb.rst
+++ b/source/installation-guide/installing-wazuh-server/wazuh_server_deb.rst
@@ -21,12 +21,6 @@ The first step to setting up Wazuh is to add the Wazuh repository to your server
     # apt-get update
     # apt-get install curl apt-transport-https lsb-release
 
-  If the ``/usr/bin/python`` file doesn't exist (like in **Ubuntu 16.04 LTS or later**), create a symlink to Python (2.7 or newer) with the following command:
-
-  .. code-block:: console
-
-    # if [ ! -f /usr/bin/python ]; then ln -s /usr/bin/python3 /usr/bin/python; fi
-
 2. Install the GPG key:
 
   .. code-block:: console


### PR DESCRIPTION
Hello team

  I removed an unnecessary part of the documentation about python dependency in the Wazuh Manager. 

Best regards, 
Alberto R.