### PR TITLE
Fix typo

### DIFF
--- a/source/docker-monitor/monitoring_containers_activity.rst
+++ b/source/docker-monitor/monitoring_containers_activity.rst
@@ -16,7 +16,7 @@ The following dependencies are required by the wodle:
 - Linux system.
 - Python 2.7 or newer.
 - `Python Docker library <https://pypi.org/project/docker/>`_: It can be installed with ``pip install docker`` command.
- - Starting with Wazuh v3.9.0 this requirement is met by default by the Wazuh manager and must only be installed in 
+- Starting with Wazuh v3.9.0 this requirement is met by default by the Wazuh manager and must only be installed in previous versions or Wazuh agents.
 
 
 Configuration

--- a/source/gdpr/gdpr-IV.rst
+++ b/source/gdpr/gdpr-IV.rst
@@ -132,7 +132,7 @@ Wazuh will generate an alert like this.
 	title: SSH Hardening - 9: Wrong Maximum number of authentication attempts
 	file: /etc/ssh/sshd_config
 
-We can also see the event stored in our log file ``archives.log``, as long as the ``log_all`` option is activated.
+We can also see the event stored in our log file ``archives.log``, as long as the ``logall`` option is activated.
 
 .. code-block:: console
 

--- a/source/user-manual/capabilities/log-data-collection/how-it-works.rst
+++ b/source/user-manual/capabilities/log-data-collection/how-it-works.rst
@@ -163,7 +163,7 @@ Once a rule is matched, the manager will create an alert as below::
   User: rromero
   Feb 14 12:19:04 localhost sshd[25474]: Accepted password for rromero from 192.168.1.133 port 49765 ssh2
 
-By default, alerts will be generated on events that are important or of security relevance. To store all events even if they do not match a rule, enable the ``<log_all>`` option.
+By default, alerts will be generated on events that are important or of security relevance. To store all events even if they do not match a rule, enable the ``<logall>`` option.
 
 Alerts will be stored at ``/var/ossec/logs/alerts/alerts.(json|log)`` and events at ``/var/ossec/logs/archives/archives.(json|log)``. Logs are rotated and an individual directory is created for each month and year.
 


### PR DESCRIPTION
Changes:

- https://github.com/wazuh/wazuh-documentation/commit/ebff8808d2192ec1f670a5233ad42cd08f0f5fac the phrase was not properly closed.
- https://github.com/wazuh/wazuh-documentation/commit/d9f6fb9999d39c8591fb31d00ee7baeed14e1030 replaces "log_all" with "logall", it was wrong.