### PR TITLE
Restart Kibana after setting elastic user

### DIFF
--- a/source/installation-guide/installing-elastic-stack/protect-installation/xpack.rst
+++ b/source/installation-guide/installing-elastic-stack/protect-installation/xpack.rst
@@ -43,13 +43,19 @@ Adding authentication for Elasticsearch
 
     # systemctl restart filebeat
 
-6. Setting up credentials for Kibana. Add the next lines to ``/etc/kibana/kibana.yml``.
+7. Setting up credentials for Kibana. Add the next lines to ``/etc/kibana/kibana.yml``.
 
 .. code-block:: yaml
 
     xpack.security.enabled: true
     elasticsearch.username: "elastic"
     elasticsearch.password: "elastic_password"
+
+8. Restart Kibana.
+
+.. code-block:: console
+
+    # systemctl restart kibana
 
 Configure Elastic Stack to use encrypted connections 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
It has been fixed an index number and added the step to restart Kibana after adding the user and password to use to access the elasticsearch host.