### PR TITLE
Delete `wazuh-api must be restarted after deleting agents`

### DIFF
--- a/source/user-manual/api/reference.rst
+++ b/source/user-manual/api/reference.rst
@@ -557,7 +557,7 @@ Removes a list of groups.
 
 Delete agents
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Removes agents, using a list of them or a criterion based on the status or time of the last connection. The Wazuh API must be restarted after removing an agent.
+Removes agents, using a list of them or a criterion based on the status or time of the last connection.
 
 **Request**:
 


### PR DESCRIPTION
This PR aims to delete  `The Wazuh API must be restarted after removing an agent` in the following documentation page: https://documentation.wazuh.com/current/user-manual/api/reference.html#delete-agents. 

Actually, it is not necessary to restart the API after removing an agent.

Regards,
Sergio.