### PR TITLE
Build clean notice between compilations on different platforms

### DIFF
--- a/source/installation-guide/installing-wazuh-agent/wazuh_agent_sources.rst
+++ b/source/installation-guide/installing-wazuh-agent/wazuh_agent_sources.rst
@@ -42,8 +42,13 @@ Installing Linux agent
     # cd wazuh-*
     # ./install.sh
 
-  .. note::
-  If you have previously compiled for another platform, you must clean the build using the command below: ``# make clean; make clean deps``
+  If you have previously compiled for another platform, you must clean the build using the Makefile in ``src``:
+
+  .. code-block:: console
+
+    # cd wazuh-*
+    # make -C src clean
+    # make -C src clean-deps
 
 .. note::
   During the installation, users can decide the installation path. Execute the ``./install.sh`` and select the language, set the installation mode to ``agent``, then set the installation path (``Choose where to install Wazuh [/var/ossec]``). The default path of installation is ``/var/ossec``. A commonly used custom path might be ``/opt``.

--- a/source/installation-guide/installing-wazuh-agent/wazuh_agent_sources.rst
+++ b/source/installation-guide/installing-wazuh-agent/wazuh_agent_sources.rst
@@ -42,6 +42,9 @@ Installing Linux agent
     # cd wazuh-*
     # ./install.sh
 
+  .. note::
+  If you have previously compiled for another platform, you must clean the build using the command below: ``# make clean; make clean deps``
+
 .. note::
   During the installation, users can decide the installation path. Execute the ``./install.sh`` and select the language, set the installation mode to ``agent``, then set the installation path (``Choose where to install Wazuh [/var/ossec]``). The default path of installation is ``/var/ossec``. A commonly used custom path might be ``/opt``.
 

--- a/source/installation-guide/installing-wazuh-server/sources_installation.rst
+++ b/source/installation-guide/installing-wazuh-server/sources_installation.rst
@@ -69,6 +69,9 @@ Installing Wazuh manager
     # cd wazuh-*
     # ./install.sh
 
+  .. note::
+    If you have previously compiled for another platform, you must clean the build using the command below: ``# make clean; make clean deps``
+
 4. When the script asks what kind of installation you want, type ``manager`` to install the Wazuh Manager:
 
   .. code-block:: none

--- a/source/installation-guide/installing-wazuh-server/sources_installation.rst
+++ b/source/installation-guide/installing-wazuh-server/sources_installation.rst
@@ -69,8 +69,13 @@ Installing Wazuh manager
     # cd wazuh-*
     # ./install.sh
 
-  .. note::
-    If you have previously compiled for another platform, you must clean the build using the command below: ``# make clean; make clean deps``
+  If you have previously compiled for another platform, you must clean the build using the Makefile in ``src``:
+
+  .. code-block:: console
+
+    # cd wazuh-*
+    # make -C src clean
+    # make -C src clean-deps
 
 4. When the script asks what kind of installation you want, type ``manager`` to install the Wazuh Manager:
 


### PR DESCRIPTION
This PR adds information requested on https://github.com/wazuh/wazuh/issues/66

Notes are added explaining that it is necessary to clean the project between compilations for different platforms.

Regards,

Juan Pablo Sáez