### PR TITLE
Fix some documentation grammatical errors

### DIFF
--- a/source/user-manual/capabilities/antiflooding.rst
+++ b/source/user-manual/capabilities/antiflooding.rst
@@ -19,7 +19,7 @@ Why an anti-flooding mechanism is needed
 
 In the Wazuh architecture, Wazuh agents collect information from log files, command outputs, different kinds of scans, etc. They then send all the collected information to their manager, separated into individual events. Without any congestion control, an agent could potentially send events at a rate as high as the system is physically capable of transmitting, which could be hundreds or thousands of events per second.
 
-Due to this fact, a incorrect configuration in an agent may generate enough events to saturate a network or its manager. Here are some misconfiguration scenarios that could lead to this problem:
+Due to this fact, an incorrect configuration in an agent may generate enough events to saturate a network or its manager. Here are some misconfiguration scenarios that could lead to this problem:
 
 - Realtime FIM (Syscheck) of a directory with files that keep changing:
 

--- a/source/user-manual/kibana-app/reference/elasticsearch.rst
+++ b/source/user-manual/kibana-app/reference/elasticsearch.rst
@@ -42,7 +42,7 @@ The next document example shows you how we store a Wazuh API entry. This index c
 The ``.wazuh-version`` index
 ----------------------------
 
-This index has only one document and it includes useful information and it's being used by internal Wazuh app purposes. It includes information such your current version or your installation date. The next example shows you how we store that information.
+This index has only one document and it includes useful information and it's being used by internal Wazuh app purposes. It includes information such as your current version or your installation date. The next example shows you how we store that information.
 
 .. code-block:: console
 


### PR DESCRIPTION
Hi,

With this PR I'm aiming to fix the following sentences:

`It includes information such your current version or your installation date → It includes information such as your current version or your installation date`
https://documentation.wazuh.com/current/user-manual/kibana-app/reference/elasticsearch.html#the-wazuh-version-index

`Due to this fact, a incorrect configuration → Due to this fact, an incorrect configuration`
https://documentation.wazuh.com/current/user-manual/capabilities/antiflooding.html

Regards!