### PR TITLE
Inserting references to blog on documentation

### DIFF
--- a/source/getting-started/architecture.rst
+++ b/source/getting-started/architecture.rst
@@ -46,7 +46,7 @@ Wazuh agents use the OSSEC message protocol to send collected events to the Wazu
 
 .. note:: Alerts will be duplicated if you use both of these files. Also, note that both files receive fully decoded event data.
 
-The Wazuh message protocol uses a 192-bit Blowfish encryption with a full 16-round implementation, or AES encryption with 128 bits per block and 256-bit keys.
+The Wazuh message protocol uses a 192-bit Blowfish encryption with a full 16-round implementation, or AES encryption with 128 bits per block and 256-bit keys. Read the `Benefits of using AES in Wazuh communications <https://wazuh.com/blog/benefits-of-using-aes-in-our-communications//>`_ document for more information.
 
 Wazuh-Elastic communication
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/getting-started/architecture.rst
+++ b/source/getting-started/architecture.rst
@@ -46,7 +46,9 @@ Wazuh agents use the OSSEC message protocol to send collected events to the Wazu
 
 .. note:: Alerts will be duplicated if you use both of these files. Also, note that both files receive fully decoded event data.
 
-The Wazuh message protocol uses a 192-bit Blowfish encryption with a full 16-round implementation, or AES encryption with 128 bits per block and 256-bit keys. Read the `Benefits of using AES in Wazuh communications <https://wazuh.com/blog/benefits-of-using-aes-in-our-communications//>`_ document for more information.
+The Wazuh message protocol uses a 192-bit Blowfish encryption with a full 16-round implementation, or AES encryption with 128 bits per block and 256-bit keys.
+
+.. note:: Read the `Benefits of using AES in Wazuh communications <https://wazuh.com/blog/benefits-of-using-aes-in-our-communications//>`_ document for more information.
 
 Wazuh-Elastic communication
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/user-manual/agents/agent-life-cycle.rst
+++ b/source/user-manual/agents/agent-life-cycle.rst
@@ -30,4 +30,6 @@ Agent status
 Removed agent
 -------------
 
-The life cycle comes to an end when the agent is removed from the manager. This can be done through the :doc:`Wazuh API<./remove-agents/restful-api-remove>`, :doc:`command line<./remove-agents/remove>`, or Authd (if the force option is enabled).
+The life cycle comes to an end when the agent is removed from the manager. This can be done through the :doc:`Wazuh API<./remove-agents/restful-api-remove>`, :doc:`command line<./remove-agents/remove>`, or Authd (if the force option is enabled). 
+
+Sometimes the agents are permanently disconnected (i.e: terminated instances) or never connected (i.e: firewall issues). Read the `How to purge non-active agents <https://wazuh.com/blog/how-to-purge-non-active-agents//>`_ document for more information.

--- a/source/user-manual/agents/agent-life-cycle.rst
+++ b/source/user-manual/agents/agent-life-cycle.rst
@@ -30,6 +30,4 @@ Agent status
 Removed agent
 -------------
 
-The life cycle comes to an end when the agent is removed from the manager. This can be done through the :doc:`Wazuh API<./remove-agents/restful-api-remove>`, :doc:`command line<./remove-agents/remove>`, or Authd (if the force option is enabled). 
-
-Sometimes the agents are permanently disconnected (i.e: terminated instances) or never connected (i.e: firewall issues). Read the `How to purge non-active agents <https://wazuh.com/blog/how-to-purge-non-active-agents//>`_ document for more information.
+The life cycle comes to an end when the agent is removed from the manager. This can be done through the :doc:`Wazuh API<./remove-agents/restful-api-remove>`, :doc:`command line<./remove-agents/remove>`, or Authd (if the force option is enabled).

--- a/source/user-manual/agents/grouping-agents.rst
+++ b/source/user-manual/agents/grouping-agents.rst
@@ -8,7 +8,7 @@ Grouping agents
 .. versionadded:: 3.0.0
 
 There are two methods for configuring registered agents. They can either be configured locally with the :doc:`ossec.conf <../reference/ossec-conf/index>` file or remotely using
-the :doc:`centralized configuration <../reference/centralized-configuration>`. If the centralized configuration is used, agents may be assigned to groups with each group possessing a unique configuration.  This greatly simplifies the overall configuration process.
+the :doc:`centralized configuration <../reference/centralized-configuration>`. If the centralized configuration is used, agents may be assigned to groups with each group possessing a unique configuration.  This greatly simplifies the overall configuration process. Read the `Agent groups and centralized configuration <https://wazuh.com/blog/agent-groups-and-centralized-configuration//>`_ document for more information.
 
 Unless otherwise assigned, all new agents automatically belong to the **'default'** group. This group is created during the installation process with the configuration files placed in the ``/var/ossec/etc/shared/default/`` folder. These files will be pushed from the manager to all agents belonging to this group.
 

--- a/source/user-manual/agents/grouping-agents.rst
+++ b/source/user-manual/agents/grouping-agents.rst
@@ -8,7 +8,9 @@ Grouping agents
 .. versionadded:: 3.0.0
 
 There are two methods for configuring registered agents. They can either be configured locally with the :doc:`ossec.conf <../reference/ossec-conf/index>` file or remotely using
-the :doc:`centralized configuration <../reference/centralized-configuration>`. If the centralized configuration is used, agents may be assigned to groups with each group possessing a unique configuration.  This greatly simplifies the overall configuration process. Read the `Agent groups and centralized configuration <https://wazuh.com/blog/agent-groups-and-centralized-configuration//>`_ document for more information.
+the :doc:`centralized configuration <../reference/centralized-configuration>`. If the centralized configuration is used, agents may be assigned to groups with each group possessing a unique configuration.  This greatly simplifies the overall configuration process.
+
+.. note:: Read the `Agent groups and centralized configuration <https://wazuh.com/blog/agent-groups-and-centralized-configuration//>`_ document for more information.
 
 Unless otherwise assigned, all new agents automatically belong to the **'default'** group. This group is created during the installation process with the configuration files placed in the ``/var/ossec/etc/shared/default/`` folder. These files will be pushed from the manager to all agents belonging to this group.
 

--- a/source/user-manual/capabilities/command-monitoring/how-it-works.rst
+++ b/source/user-manual/capabilities/command-monitoring/how-it-works.rst
@@ -34,4 +34,4 @@ Example::
 Process the output
 ------------------
 
-After configuring the system to monitor the command's output as if it were log data, custom rules can be created, like for :ref:`Log analysis <manual_log_analysis>` for instance, in order to process the output and trigger an alert when alert criteria are met.
+After configuring the system to monitor the command's output as if it were log data, custom rules can be created, like for :ref:`Log analysis <manual_log_analysis>` for instance, in order to process the output and trigger an alert when alert criteria are met. Read the `Scheduling remote commands for Wazuh agents <https://wazuh.com/blog/scheduling-remote-commands-for-wazuh-agents//>`_ document for more information and remote command use cases.

--- a/source/user-manual/capabilities/command-monitoring/how-it-works.rst
+++ b/source/user-manual/capabilities/command-monitoring/how-it-works.rst
@@ -34,4 +34,6 @@ Example::
 Process the output
 ------------------
 
-After configuring the system to monitor the command's output as if it were log data, custom rules can be created, like for :ref:`Log analysis <manual_log_analysis>` for instance, in order to process the output and trigger an alert when alert criteria are met. Read the `Scheduling remote commands for Wazuh agents <https://wazuh.com/blog/scheduling-remote-commands-for-wazuh-agents//>`_ document for more information and remote command use cases.
+After configuring the system to monitor the command's output as if it were log data, custom rules can be created, like for :ref:`Log analysis <manual_log_analysis>` for instance, in order to process the output and trigger an alert when alert criteria are met.
+
+.. note:: Read the `Scheduling remote commands for Wazuh agents <https://wazuh.com/blog/scheduling-remote-commands-for-wazuh-agents//>`_ document for more information and remote command use cases.

--- a/source/user-manual/capabilities/log-data-collection/how-to-collect-wlogs.rst
+++ b/source/user-manual/capabilities/log-data-collection/how-to-collect-wlogs.rst
@@ -51,7 +51,7 @@ These logs are obtained through Windows API calls and sent to the manager where 
 Monitor the Windows Event Channel with Wazuh
 --------------------------------------------
 
-Windows event channels can be monitored by placing their name at the location field from the localfile block and "eventchannel" as the log format.
+Windows event channels can be monitored by placing their name at the location field from the localfile block and "eventchannel" as the log format.  Read the `How to collect Windows events with Wazuh <https://wazuh.com/blog/how-to-collect-windows-events-with-wazuh//>`_ document for more information.
 
 .. note::
 

--- a/source/user-manual/capabilities/log-data-collection/how-to-collect-wlogs.rst
+++ b/source/user-manual/capabilities/log-data-collection/how-to-collect-wlogs.rst
@@ -51,7 +51,9 @@ These logs are obtained through Windows API calls and sent to the manager where 
 Monitor the Windows Event Channel with Wazuh
 --------------------------------------------
 
-Windows event channels can be monitored by placing their name at the location field from the localfile block and "eventchannel" as the log format.  Read the `How to collect Windows events with Wazuh <https://wazuh.com/blog/how-to-collect-windows-events-with-wazuh//>`_ document for more information.
+Windows event channels can be monitored by placing their name at the location field from the localfile block and "eventchannel" as the log format.
+
+.. note:: Read the `How to collect Windows events with Wazuh <https://wazuh.com/blog/how-to-collect-windows-events-with-wazuh//>`_ document for more information.
 
 .. note::
 

--- a/source/user-manual/kibana-app/index.rst
+++ b/source/user-manual/kibana-app/index.rst
@@ -8,7 +8,7 @@ Kibana app
 .. meta::
   :description: Find information about the Wazuh Kibana app, its different features, configuration reference and how to troubleshoot some of the most common problems.
 
-The Wazuh app for Kibana lets you visualize and analyze Wazuh alerts stored in Elasticsearch. You can obtain statistics per agent, search alerts and filter using different visualizations. It integrates with the Wazuh API to retrieve information about manager and agents configuration, logs, ruleset, groups and much more.
+The Wazuh app for Kibana lets you visualize and analyze Wazuh alerts stored in Elasticsearch. You can obtain statistics per agent, search alerts and filter using different visualizations. It integrates with the Wazuh API to retrieve information about manager and agents configuration, logs, ruleset, groups and much more. Read our `Searching for alerts using the Wazuh app for Kibana <https://wazuh.com/blog/searching-for-alerts-using-the-wazuh-app-for-kibana//>`_ document for more information.
 
 To install the app, you can follow our Elastic Stack installation guides (for :ref:`RPM <install_kibana_app_rpm>` or :ref:`Debian <install_kibana_app_deb>` systems).
 

--- a/source/user-manual/kibana-app/index.rst
+++ b/source/user-manual/kibana-app/index.rst
@@ -8,7 +8,9 @@ Kibana app
 .. meta::
   :description: Find information about the Wazuh Kibana app, its different features, configuration reference and how to troubleshoot some of the most common problems.
 
-The Wazuh app for Kibana lets you visualize and analyze Wazuh alerts stored in Elasticsearch. You can obtain statistics per agent, search alerts and filter using different visualizations. It integrates with the Wazuh API to retrieve information about manager and agents configuration, logs, ruleset, groups and much more. Read our `Searching for alerts using the Wazuh app for Kibana <https://wazuh.com/blog/searching-for-alerts-using-the-wazuh-app-for-kibana//>`_ document for more information.
+The Wazuh app for Kibana lets you visualize and analyze Wazuh alerts stored in Elasticsearch. You can obtain statistics per agent, search alerts and filter using different visualizations. It integrates with the Wazuh API to retrieve information about manager and agents configuration, logs, ruleset, groups and much more.
+
+.. note:: Read our `Searching for alerts using the Wazuh app for Kibana <https://wazuh.com/blog/searching-for-alerts-using-the-wazuh-app-for-kibana//>`_ document for more information.
 
 To install the app, you can follow our Elastic Stack installation guides (for :ref:`RPM <install_kibana_app_rpm>` or :ref:`Debian <install_kibana_app_deb>` systems).
 


### PR DESCRIPTION
The next articles have been referenced and linked on documentation:

- Benefits of using AES in Wazuh communications -> https://wazuh.com/blog/benefits-of-using-aes-in-our-communications/
- How to purge non-active agents -> https://wazuh.com/blog/how-to-purge-non-active-agents/
- Read the Agent groups and centralized configuration -> https://wazuh.com/blog/agent-groups-and-centralized-configuration/
- Read the How to collect Windows events with Wazuh -> https://wazuh.com/blog/how-to-collect-windows-events-with-wazuh/
- Searching for alerts using the Wazuh app for Kibana -> https://wazuh.com/blog/searching-for-alerts-using-the-wazuh-app-for-kibana/