### PR TITLE
Update documentation for installing Wazuh API on Fedora 30.

### DIFF
--- a/source/installation-guide/installing-wazuh-server/wazuh_server_rpm_fedora.rst
+++ b/source/installation-guide/installing-wazuh-server/wazuh_server_rpm_fedora.rst
@@ -59,11 +59,11 @@ Once the process is complete, you can check the service status with:
 Installing the Wazuh API
 ------------------------
 
-1. Install NodeJS:
+1. Install the Wazuh API:
 
   .. code-block:: console
 
-    # dnf install nodejs
+    # dnf install wazuh-api
 
 .. note::
   If you have Fedora v24 or lower, you need to add the official NodeJS repository previously. Download and install NodeJS by using these commands:
@@ -72,13 +72,7 @@ Installing the Wazuh API
 
    # curl --silent --location https://rpm.nodesource.com/setup_8.x | bash - && dnf install nodejs
 
-2. Install the Wazuh API:
-
-  .. code-block:: console
-
-    # dnf install wazuh-api
-
-3. Once the process is complete, you can check the service status with:
+2. Once the process is complete, you can check the service status with:
 
   * For Systemd:
 
@@ -95,7 +89,7 @@ Installing the Wazuh API
 .. note::
     Now that the Wazuh API is installed, check out the section :ref:`securing_api` to set up some additional settings.
 
-4. (Optional) Disable the Wazuh repository:
+3. (Optional) Disable the Wazuh repository:
 
   It is recommended that the Wazuh repository be disabled in order to prevent accidental upgrades. To do this, use the following command:
 

--- a/source/installation-guide/installing-wazuh-server/wazuh_server_rpm_fedora.rst
+++ b/source/installation-guide/installing-wazuh-server/wazuh_server_rpm_fedora.rst
@@ -97,7 +97,7 @@ Installing the Wazuh API
 .. note::
     Now that the Wazuh API is installed, check out the section :ref:`securing_api` to set up some additional settings.
 
-3. (Optional) Disable the Wazuh repository:
+4. (Optional) Disable the Wazuh repository:
 
   It is recommended that the Wazuh repository be disabled in order to prevent accidental upgrades. To do this, use the following command:
 

--- a/source/installation-guide/installing-wazuh-server/wazuh_server_rpm_fedora.rst
+++ b/source/installation-guide/installing-wazuh-server/wazuh_server_rpm_fedora.rst
@@ -59,20 +59,28 @@ Once the process is complete, you can check the service status with:
 Installing the Wazuh API
 ------------------------
 
-1. Install the Wazuh API:
+.. note::
+  
+  If you have Fedora v24 or lower, you need to add the official NodeJS repository previously: 
+
+
+    .. code-block:: console
+
+      # curl --silent --location https://rpm.nodesource.com/setup_8.x | bash - 
+
+1. Install NodeJS:
+
+  .. code-block:: console
+
+    # dnf install nodejs
+
+2. Install the Wazuh API:
 
   .. code-block:: console
 
     # dnf install wazuh-api
 
-.. note::
-  If you have Fedora v24 or lower, you need to add the official NodeJS repository previously. Download and install NodeJS by using these commands:
-
-  .. code-block:: console
-
-   # curl --silent --location https://rpm.nodesource.com/setup_8.x | bash - && dnf install nodejs
-
-2. Once the process is complete, you can check the service status with:
+3. Once the process is complete, you can check the service status with:
 
   * For Systemd:
 

--- a/source/installation-guide/installing-wazuh-server/wazuh_server_rpm_fedora.rst
+++ b/source/installation-guide/installing-wazuh-server/wazuh_server_rpm_fedora.rst
@@ -59,19 +59,20 @@ Once the process is complete, you can check the service status with:
 Installing the Wazuh API
 ------------------------
 
-1. NodeJS >= 4.6.1 is required in order to run the Wazuh API. If you do not have NodeJS installed or your version is older than 4.6.1, we recommend that you add the official NodeJS repository like this:
-
-  .. code-block:: console
-
-    # curl --silent --location https://rpm.nodesource.com/setup_8.x | bash -
-
-  and then, install NodeJS:
+1. Install NodeJS:
 
   .. code-block:: console
 
     # dnf install nodejs
 
-2. Install the Wazuh API. It will update NodeJS if it is required:
+.. note::
+  If you have Fedora v24 or lower, you need to add the official NodeJS repository previously. Download and install NodeJS by using these commands:
+
+  .. code-block:: console
+
+   # curl --silent --location https://rpm.nodesource.com/setup_8.x | bash - && dnf install nodejs
+
+2. Install the Wazuh API:
 
   .. code-block:: console
 


### PR DESCRIPTION
Hi team,

This PR updates installation guide from `Fedora`. From versions higher than `24`, Wazuh API works fine if `NodeJS` is installed from `Fedora` repository.

Best regards,

Demetrio.