### PR TITLE
Added gnupg to the list of dependencies

### DIFF
--- a/source/installation-guide/installing-wazuh-agent/wazuh_agent_linux_deb.rst
+++ b/source/installation-guide/installing-wazuh-agent/wazuh_agent_linux_deb.rst
@@ -16,7 +16,7 @@ Adding the Wazuh repository
 
   .. code-block:: console
 
-    # apt-get install curl apt-transport-https lsb-release
+    # apt-get install curl apt-transport-https lsb-release gnupg2
 
 2. Install the Wazuh repository GPG key:
 

--- a/source/installation-guide/installing-wazuh-server/wazuh_server_deb.rst
+++ b/source/installation-guide/installing-wazuh-server/wazuh_server_deb.rst
@@ -19,7 +19,7 @@ The first step to setting up Wazuh is to add the Wazuh repository to your server
   .. code-block:: console
 
     # apt-get update
-    # apt-get install curl apt-transport-https lsb-release
+    # apt-get install curl apt-transport-https lsb-release gnupg2
 
 2. Install the GPG key:
 


### PR DESCRIPTION
Hi team,

Closes #1288 

On this PR we have added `gnupg2` dependency to the installation tutorial, only on Debian based hosts.

Regards.