### PR TITLE
Add description for <fts> option in rules syntax

### DIFF
--- a/source/user-manual/ruleset/ruleset-xml-syntax/decoders.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/decoders.rst
@@ -256,6 +256,8 @@ The following decoder will extract the user who generated the alert and the loca
       ...
     </decoder>
 
+The decoder will consider this option when it triggers a rule that uses `if_fts <rules.html#if-fts>`_.
+
 ftscomment
 ^^^^^^^^^^^
 

--- a/source/user-manual/ruleset/ruleset-xml-syntax/decoders.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/decoders.rst
@@ -256,7 +256,7 @@ The following decoder will extract the user who generated the alert and the loca
       ...
     </decoder>
 
-The decoder will consider this option when it triggers a rule that uses `if_fts <rules.html#if-fts>`_.
+The decoder will consider this option if the decoded event triggers a rule that uses `if_fts <rules.html#if-fts>`_.
 
 ftscomment
 ^^^^^^^^^^^

--- a/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
@@ -417,7 +417,7 @@ This option is used in conjunction with frequency and timeframe.
 if_fts
 ^^^^^^
 
-Means "if first time seen". Some decoders look for first time seen information by using the option <fts>
+Means "if first time seen". Some decoders look for first time seen information by using the option <fts>.
 
 If the rule has <if_fts />, it takes the <fts> line into consideration.
 

--- a/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
@@ -417,7 +417,7 @@ This option is used in conjunction with frequency and timeframe.
 if_fts
 ^^^^^^
 
-Makes the decoder that processed the event to take the <fts> line into consideration.
+Makes the decoder that processed the event to take the `fts <decoders.html#fts>`_ line into consideration.
 
 +--------------------+--------------------+
 | **Example of use** | <if_fts />         |

--- a/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
@@ -32,6 +32,7 @@ Available options
 - `if_level`_
 - `if_matched_sid`_
 - `if_matched_group`_
+- `if_fts`_
 - `same_id`_
 - `same_source_ip`_
 - `same_src_port`_
@@ -413,6 +414,16 @@ This option is used in conjunction with frequency and timeframe.
 | **Allowed values** | Any Group |
 +--------------------+-----------+
 
+if_fts
+^^^^^^
+
+Means "if first time seen". Some decoders look for first time seen information by using the option <fts>
+
+If the rule has <if_fts />, it takes the <fts> line into consideration.
+
++--------------------+--------------------+
+| **Example of use** | <if_fts />         |
++--------------------+--------------------+
 
 same_id
 ^^^^^^^

--- a/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
@@ -417,9 +417,7 @@ This option is used in conjunction with frequency and timeframe.
 if_fts
 ^^^^^^
 
-Means "if first time seen". Some decoders look for first time seen information by using the option <fts>.
-
-If the rule has <if_fts />, it takes the <fts> line into consideration.
+Makes the decoder that processed the event to take the <fts> line into consideration.
 
 +--------------------+--------------------+
 | **Example of use** | <if_fts />         |


### PR DESCRIPTION
Hi team,

I noticed that we don't have a description for `<fts>` option in rules syntax, so I added it.

• Rules syntax: https://documentation.wazuh.com/current/user-manual/ruleset/ruleset-xml-syntax/rules.html?highlight=rules%20syntax
• Reference: https://groups.google.com/forum/#!topic/ossec-list/TXvCs8B7L_8

Regards!