### PR TITLE
Add ossec.conf path on Windows agents (ossec.conf docu)

### DIFF
--- a/source/user-manual/reference/ossec-conf/index.rst
+++ b/source/user-manual/reference/ossec-conf/index.rst
@@ -5,7 +5,7 @@
 Local configuration (ossec.conf)
 ================================
 
-The ``ossec.conf`` file is the main configuration file on the Wazuh manager and it also plays an important role on the agents. It is located at ``/var/ossec/etc/ossec.conf`` both in the manager and agent. It is recommended that you back up this file before making changes to it, as an error in the configuration can prevent Wazuh services from starting up.
+The ``ossec.conf`` file is the main configuration file on the Wazuh manager and it also plays an important role on the agents. It is located at ``/var/ossec/etc/ossec.conf`` both in the manager and agent on Linux machines. On Windows agents, we can find it at ``C:\Program Files (x86)\ossec-agent\ossec.conf``.  It is recommended that you back up this file before making changes to it, as an error in the configuration can prevent Wazuh services from starting up.
 
 The ``ossec.conf`` file is in XML format and all of its configuration options are nested in their appropriate section of the file.  In this file, the outermost XML tag is ``<ossec_config>``.  Here is an example of the proper location of the *alerts* configuration section:
 


### PR DESCRIPTION
Hi team,

Seems like the `ossec.conf` path is missing for Windows agents here: https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/index.html

I added it.

Regards,
Sergio.