### PR TITLE
Specifies when same_field and not_same_field were added

### DIFF
--- a/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
@@ -477,6 +477,8 @@ This option is used in conjunction with frequency and timeframe.
 same_field
 ^^^^^^^^^^
 
+.. versionadded:: 3.9.0
+
 Specifies that the decoded field must be the same as the previous one.
 This option is used in conjunction with frequency and timeframe.
 
@@ -506,6 +508,8 @@ As an example of this option, check this rule:
 
 not_same_field
 ^^^^^^^^^^^^^^
+
+.. versionadded:: 3.9.0
 
 Specifies that the decoded field must be different than the previous one.
 This option is used in conjunction with frequency and timeframe.


### PR DESCRIPTION
Looking at the documentation, users may think that these options can be used in versions prior to 3.9.0. You can see when they were introduced by checking the changelog.

![imagen](https://user-images.githubusercontent.com/20266121/60024843-d38ded00-9698-11e9-95c6-1c80b6586d6c.png)
