### PR TITLE
Add a way to unzip certs.zip

### DIFF
--- a/source/installation-guide/installing-elastic-stack/protect-installation/xpack.rst
+++ b/source/installation-guide/installing-elastic-stack/protect-installation/xpack.rst
@@ -83,8 +83,6 @@ This section describes how to secure the communications between the involved com
 
     # /usr/share/elasticsearch/bin/elasticsearch-certutil cert ca --pem --in instances.yml --out certs.zip
 
-3. Extract the generated ``/usr/share/elasticsearch/certs.zip`` file from the previous step.
-
 .. code-block:: console
 
     certs.zip
@@ -99,6 +97,12 @@ This section describes how to secure the communications between the involved com
     |-- kibana
         |-- kibana.crt
         |-- kibana.key
+
+3. Extract the generated ``/usr/share/elasticsearch/certs.zip`` file from the previous step. You can use ``unzip``:
+
+.. code-block:: console
+
+    # unzip /usr/share/elasticsearch/certs.zip -d /usr/share/elasticsearch/
 
 .. note::
 


### PR DESCRIPTION
Hi,

This PR adds a line saying how to unzip `certs.zip` after creating it. Unzip isn't usually installed by default, I didn't add a `how to install it` commit due to the difference between OS, but the user should know how to install a package in his OS. We can add it if you see that convenient.

The PR targets the following page: https://documentation.wazuh.com/current/installation-guide/installing-elastic-stack/protect-installation/xpack.html

Regards,
Sergio.