### PR TITLE
Correct sentences in Splunk documentation

### DIFF
--- a/source/installing-splunk/splunk-app.rst
+++ b/source/installing-splunk/splunk-app.rst
@@ -15,13 +15,13 @@ Wazuh app for Splunk offers a UI to visualize Wazuh alerts and Wazuh API data. W
 Installation
 ------------
 
-1. Download the latest Splunk app for Wazuh:
+1. Download the latest Wazuh app for Splunk:
 
   .. code-block:: console
 
     # curl -o SplunkAppForWazuh.tar.gz https://packages.wazuh.com/3.x/splunkapp/v3.9.2_7.3.0.tar.gz
 
-2. Install the Splunk app for Wazuh:
+2. Install the Wazuh app for Splunk:
 
   a. CLI mode:
 
@@ -67,7 +67,7 @@ Installation
     :align: center
     :width: 100%
 
-Now that you've finished installing Splunk app for Wazuh, you can install and setup Splunk forwarders on the :ref:`Splunk forwarder section <splunk_forwarder>`.
+Now that you've finished installing Wazuh app for Splunk, you can install and setup Splunk forwarders on the :ref:`Splunk forwarder section <splunk_forwarder>`.
 
 Installing the Wazuh App in a Splunk cluster
 --------------------------------------------


### PR DESCRIPTION
Hi team,

In this PR I'm changing every `Splunk app for Wazuh` to `Wazuh app for Splunk` in the following page:  https://documentation.wazuh.com/current/installing-splunk/splunk-app.html

Regards!
