### PR TITLE
Remove $manage_epel_repo parameter from Puppet resources.

### DIFF
--- a/source/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-agent-class.rst
+++ b/source/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-agent-class.rst
@@ -101,11 +101,6 @@ $manage_repo
 
   `Default true`
 
-$manage_epel_repo
-  Install epel repo and inotify-tools
-
-  `Default true`
-
 $agent_package_name
   Define package name defined in params.pp
 

--- a/source/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-server-class.rst
+++ b/source/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-server-class.rst
@@ -135,11 +135,6 @@ $manage_repos
 
   `Default true`
 
-$manage_epel_repo
-  Install epel repo and inotify-tools
-
-  `Default true`
-
 $manage_client_keys
   Manage client keys option.
 


### PR DESCRIPTION
Hi team,

This PR closes #1303. 

Removes $manage_epel_repo from Puppet resources. It does no longer exists on Puppet code.

- [x] Compilation

Best Regards,

Jose
