### PR TITLE
Fix bugs in code blocks

### DIFF
--- a/source/user-manual/capabilities/system-calls-monitoring/audit-configuration.rst
+++ b/source/user-manual/capabilities/system-calls-monitoring/audit-configuration.rst
@@ -164,11 +164,13 @@ Let's see what happens when we execute the following commands:
 New File
   Command:
 
- .. code-block:: console
+  .. code-block:: console
 
-      # touch /home/malware.py
+    # touch /home/malware.py
 
-  Alert::
+  Alert:
+
+  .. code-block:: default
 
     ** Alert 1487891161.28457: - audit,audit_watch_write,audit_watch_create,
     2017 Feb 23 15:06:01 localhost->/var/log/audit/audit.log
@@ -216,9 +218,11 @@ Write Access
 
   .. code-block:: console
 
-      # nano /home/malware.py
+    # nano /home/malware.py
 
-  Alert::
+  Alert:
+
+  .. code-block:: default
 
     ** Alert 1487891353.48010: - audit,audit_watch_write,
     2017 Feb 23 15:09:13 localhost->/var/log/audit/audit.log
@@ -264,11 +268,13 @@ Write Access
 Change Permissions
   Command:
 
- .. code-block:: console
+  .. code-block:: console
 
-      # chmod u+x /home/malware.py
+    # chmod u+x /home/malware.py
 
-  Alert::
+  Alert:
+
+  .. code-block:: default
 
     ** Alert 1487891409.49498: - audit,audit_watch_attribute,
     2017 Feb 23 15:10:09 localhost->/var/log/audit/audit.log
@@ -312,9 +318,11 @@ Read access
 
   .. code-block:: console
 
-      # /home/malware.py
+    # /home/malware.py
 
-  Alert::
+  Alert:
+
+  .. code-block:: default
 
     ** Alert 1487891459.53222: - audit,audit_watch_read,
     2017 Feb 23 15:10:59 localhost->/var/log/audit/audit.log
@@ -335,7 +343,7 @@ Read access
     audit.pid: 60821
     audit.auid: 1000
     audit.uid: 0
-    audit.gid: 0
+    audit.gid: 0q
     audit.euid: 0
     audit.suid: 0
     audit.fsuid: 0
@@ -357,9 +365,11 @@ Delete file
 
   .. code-block:: console
 
-      # rm /home/malware.py
+    # rm /home/malware.py
 
-  Alert::
+  Alert:
+
+  .. code-block:: default
 
     ** Alert 1487891497.54463: - audit,audit_watch_write,audit_watch_delete,
     2017 Feb 23 15:11:37 localhost->/var/log/audit/audit.log

--- a/source/user-manual/ruleset/ruleset-xml-syntax/decoders.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/decoders.rst
@@ -44,11 +44,11 @@ Example:
 
 Set name and type of decoder to *ossec*:
 
-  .. code-block:: xml
+.. code-block:: xml
 
-    <decoder name="ossec" type ="ossec">
-      ...
-    </decoder>
+  <decoder name="ossec" type ="ossec">
+    ...
+  </decoder>
 
 parent
 ^^^^^^
@@ -65,12 +65,12 @@ Example:
 
 Assign the decoder which father it belongs:
 
-  .. code-block:: xml
-    
-    <decoder name="decoder_junior">
-      <parent>decoder_father</parent>
-      ...
-    </decoder>
+.. code-block:: xml
+  
+  <decoder name="decoder_junior">
+    <parent>decoder_father</parent>
+    ...
+  </decoder>
 
 accumulate
 ^^^^^^^^^^^
@@ -100,12 +100,12 @@ Example:
 
 Define that the decoder is related with the ``syslogd`` process:
 
-  .. code-block:: xml
+.. code-block:: xml
 
-    <decoder name="syslogd_decoder">
-      <program_name>syslogd</program_name>
-      ...
-    </decoder>
+  <decoder name="syslogd_decoder">
+    <program_name>syslogd</program_name>
+    ...
+  </decoder>
 
 prematch
 ^^^^^^^^^
@@ -134,8 +134,9 @@ Decoders use them to find words or other patterns into the rules.
 
 An example is this regex that matches any numeral:
 
-  ..code-block:: xml
-    <regex> [+-]?(\d+(\.\d+)?|\.\d+)([eE][+-]?\d+)? </regex>
+.. code-block:: xml
+
+  <regex> [+-]?(\d+(\.\d+)?|\.\d+)([eE][+-]?\d+)? </regex>
 
 
 +--------------------+--------------------------------------------------------------------+
@@ -249,12 +250,12 @@ Example:
 
 The following decoder will extract the user who generated the alert and the location from where it comes:
 
-  .. code-block:: xml
-  
-    </decoder>
-      <fts>srcuser, location</fts>
-      ...
-    </decoder>
+.. code-block:: xml
+
+  </decoder>
+    <fts>srcuser, location</fts>
+    ...
+  </decoder>
 
 ftscomment
 ^^^^^^^^^^^
@@ -339,17 +340,17 @@ Example:
 
 .. code-block:: xml
 
-    <var name="header">myprog</var>
-    <var name="offset">after_parent</var>
-    <var name="type">syscall</var>
+  <var name="header">myprog</var>
+  <var name="offset">after_parent</var>
+  <var name="type">syscall</var>
 
-    <decoder name="syscall">
-      <prematch>^$header</prematch>
-    </decoder>
+  <decoder name="syscall">
+    <prematch>^$header</prematch>
+  </decoder>
 
-    <decoder name="syscall-child">
-      <parent>syscall</parent>
-      <prematch offset="$offset">^: $type </prematch>
-      <regex offset="after_prematch">(\S+)</regex>
-      <order>syscall</order>
-    </decoder>
+  <decoder name="syscall-child">
+    <parent>syscall</parent>
+    <prematch offset="$offset">^: $type </prematch>
+    <regex offset="after_prematch">(\S+)</regex>
+    <order>syscall</order>
+  </decoder>


### PR DESCRIPTION
In [this page](https://documentation.wazuh.com/current/user-manual/capabilities/system-calls-monitoring/audit-configuration.html) the code blocks looked like this:

![003](https://user-images.githubusercontent.com/37677237/60281498-4e5b4000-9905-11e9-87e7-62a7e8d6cf04.png)

Now they are fixed:

![004](https://user-images.githubusercontent.com/37677237/60281500-4e5b4000-9905-11e9-8602-2fe386fdc261.png)

