### PR TITLE
Fixes in the style after the revision of the new design

### DIFF
--- a/source/_static/css/style.css
+++ b/source/_static/css/style.css
@@ -411,7 +411,7 @@ blockquote {
   background-color: #fff;
   margin-bottom: 1rem;
   overflow: auto;
-  padding-left: 1.7rem;
+  padding-left: 0.7rem;
 }
 
 blockquote ul,
@@ -1548,7 +1548,7 @@ a[data-lightbox] img {
   margin-bottom: 2em;
 }
 
-a-lightbox] img {
+[data-lightbox] img {
   border: 1px solid #eee;
 }
 
@@ -1874,7 +1874,9 @@ label {
 }
 
 .admonition ul, .admonition ol {
-  padding: 1em 1em 0;
+  padding-top: 1rem;
+  padding-right: 1rem;
+  padding-bottom: 0;
 }
 
 p.admonition-title {
@@ -2224,9 +2226,9 @@ blockquote blockquote {
   padding-left: 0;
 }
 
-.line-block {
-  border-left: 2px solid #ddd;
-  padding-left: 10px;
+.line-block {
+  border-left: 2px solid #dddddd;
+  padding-left: 10px;
 }
 
 table.highlighttable {
@@ -2274,6 +2276,10 @@ div.highlight pre {
 		top: 107px;
 		height: calc(100vh - 107px);
 	}
+
+  blockquote {
+    padding-left: 1.7rem;
+  }
 
   ul#breadcrumbs {
     max-width: 80%;

--- a/source/_static/css/style.css
+++ b/source/_static/css/style.css
@@ -500,7 +500,7 @@ main ul > li::before {
 
 ol ol, ol ul, ul ol, ul ul {
   margin-bottom: 1rem;
-  padding-left: 1.3rem;
+  padding-left: 1rem;
   list-style-type: disc;
 }
 
@@ -1375,7 +1375,7 @@ select, option {
 #select-version .dropdown-toggle {
   cursor: pointer;
   position: relative;
-  min-width: 130px;
+  min-width: 120px;
   padding: 2px 8px;
   color: #fff;
   font-size: 0.85rem;
@@ -1867,8 +1867,8 @@ label {
 }
 
 .admonition p,
-.admonition.note [class*="highlight-"],
-.admonition.warning [class*="highlight-"] {
+.admonition.note > [class*="highlight-"],
+.admonition.warning > [class*="highlight-"] {
   padding: 1rem;
   margin: 0;
 }
@@ -2214,7 +2214,7 @@ blockquote [class*="highlight-"],
 blockquote ul,
 blockquote blockquote {
   margin-bottom: 1em;
-  margin-left: 1.7rem; /*padding-left: 1.7rem;*/
+  margin-left: 0.7rem;
 }
 
 blockquote ul li > div[class^='highlight'] {
@@ -2227,7 +2227,6 @@ blockquote blockquote {
 }
 
 .line-block {
-  border-left: 2px solid #dddddd;
   padding-left: 10px;
 }
 
@@ -2254,7 +2253,7 @@ div.highlight pre {
 
 	.no-latest-notice {
 		height: 60px;
-	}
+  }
 
 	.no-latest-docs .menu-sub,
 	.no-latest-docs header	{
@@ -2275,6 +2274,19 @@ div.highlight pre {
 	.scrolled .no-latest-docs #navbar-globaltoc.collapsing {
 		top: 107px;
 		height: calc(100vh - 107px);
+  }
+
+  .edit-repo-wrapper {
+    position: absolute;
+    right: 0;
+    background: #cbcbcb;
+    border-radius: 0 0 0 10px;
+    color: #ffffff;
+    z-index: 1;
+  }
+
+  .edit-repo-wrapper a{
+    color: #ffffff;
 	}
 
   blockquote {
@@ -2917,19 +2929,7 @@ div.highlight pre {
 				height: 40px;
       }
 
-      .edit-repo-wrapper {
-        position: absolute;
-        right: 0;
-        background: #cbcbcb;
-        border-radius: 0 0 0 10px;
-        color: #ffffff;
-        z-index: 1;
-      }
-      .edit-repo-wrapper a{
-        color: #ffffff;
-      }
-
-			.breadcrumbs-wrapper {
+      .breadcrumbs-wrapper {
         display: inline-block;
         width: calc(100% - 60px);
       }

--- a/source/_static/css/style.css
+++ b/source/_static/css/style.css
@@ -50,6 +50,10 @@ th {
   border-bottom: solid 2px #e1e4e5;
 }
 
+dt {
+  padding-bottom: 10px;
+}
+
 .no-bullets li::before {
   content: none !important;
 }
@@ -410,10 +414,10 @@ blockquote {
   padding-left: 1.7rem;
 }
 
-/*blockquote ul,
+blockquote ul,
 blockquote dl {
 	padding-left: 0;
-}*/
+}
 
 ol blockquote {
 	padding-left: 0;
@@ -1544,6 +1548,10 @@ a[data-lightbox] img {
   margin-bottom: 2em;
 }
 
+a-lightbox] img {
+  border: 1px solid #eee;
+}
+
 .central-page-area #main-content {
   margin-bottom: 1.5rem;
 	transition: max-width 0.3s, flex 0.3s;
@@ -1793,7 +1801,8 @@ pre {
 }
 
 code {
-  display: inline-flex;
+  display: inline-block;
+  vertical-align: middle;
   white-space: nowrap;
   max-width: 100%;
   background: #fff;
@@ -1857,9 +1866,15 @@ label {
   border-radius: 4px;
 }
 
-.admonition p {
+.admonition p,
+.admonition.note [class*="highlight-"],
+.admonition.warning [class*="highlight-"] {
   padding: 1rem;
   margin: 0;
+}
+
+.admonition ul, .admonition ol {
+  padding: 1em 1em 0;
 }
 
 p.admonition-title {
@@ -1996,7 +2011,7 @@ a:focus {
   border-color: transparent;
 }
 
-#main-content .navigation-buttons a:hover, 
+#main-content .navigation-buttons a:hover,
 #main-content .navigation-buttons a:focus {
   border-color: transparent;
 }
@@ -2012,7 +2027,7 @@ a:focus {
   transition: .2s all ease;
 }
 
-#main-content .navigation-buttons a:hover::after, 
+#main-content .navigation-buttons a:hover::after,
 #main-content .navigation-buttons a:focus::after {
   opacity: 1;
 }
@@ -2206,6 +2221,12 @@ blockquote ul li > div[class^='highlight'] {
 
 blockquote blockquote {
   margin-bottom: 0;
+  padding-left: 0;
+}
+
+.line-block {
+  border-left: 2px solid #ddd;
+  padding-left: 10px;
 }
 
 table.highlighttable {
@@ -2708,7 +2729,7 @@ div.highlight pre {
 			#globaltoc .toc-toggle-btn {
 				display: none;
 			}
-      
+
 			#globaltoc .toc-toggle > a:hover > .toc-toggle-btn,
 			#globaltoc .toc-toggle > a:focus > .toc-toggle-btn {
 				display: flex;

--- a/source/compliance/pci-dss/rootkit-detection.rst
+++ b/source/compliance/pci-dss/rootkit-detection.rst
@@ -36,8 +36,8 @@ These are the options available for the `rootcheck component <https://documentat
 
 Rootcheck helps you to meet PCI DSS requirement 11.4 related to intrusions, trojans, and malware in general:
 
-| **11.4**: Use intrusion-detection and/or intrusion-prevention techniques to detect and/or prevent intrusions into the network. Keep all intrusion-detection and prevention engines, baselines, and signatures up to date. Intrusion detection and/or intrusion prevention techniques (such as IDS/IPS) compare the traffic coming into the network with known “signatures” and/or behaviors of thousands of compromise types (hacker tools, Trojans, and other malware), and send alerts and/or stop the attempt as it happens.
-|
+  | **11.4**: Use intrusion-detection and/or intrusion-prevention techniques to detect and/or prevent intrusions into the network. Keep all intrusion-detection and prevention engines, baselines, and signatures up to date. Intrusion detection and/or intrusion prevention techniques (such as IDS/IPS) compare the traffic coming into the network with known “signatures” and/or behaviors of thousands of compromise types (hacker tools, Trojans, and other malware), and send alerts and/or stop the attempt as it happens.
+  |
 
 Use cases
 ---------

--- a/source/containers/docker/docker-installation.rst
+++ b/source/containers/docker/docker-installation.rst
@@ -52,14 +52,14 @@ Docker Compose 1.6 or newer is required. Follow these steps to install it:
 
       # chmod +x /usr/local/bin/docker-compose
 
-    .. note:: 
+    .. note::
       If the command *docker-compose* fails after installation, check your path. You can also create a symbolic link to /usr/bin or any other directory in your path.
-      
+
     For example:
 
-      .. code-block:: bash
-        
-        sudo ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
+    .. code-block:: bash
+
+      sudo ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
 
 3. Test the installation to ensure everything went properly:
 

--- a/source/deployment/deploying-with-puppet/setup-puppet/install-puppet-agent.rst
+++ b/source/deployment/deploying-with-puppet/setup-puppet/install-puppet-agent.rst
@@ -49,7 +49,7 @@ Get the appropriate Puppet apt repository, and then the "puppet-agent" package. 
 Create a symbolic link between the installed binary file and your default binary file:
 
   .. code-block:: bash
-    
+
     # ln -s /opt/puppetlabs/bin/puppet /bin
 
 Installation on Windows
@@ -63,17 +63,17 @@ Installation on Windows
       This is the package for a Puppet 5.1 version agent. If another package is needed, go to the `official directory <https://downloads.puppetlabs.com/windows/puppet5>`_ where all packages are available for download.
 
 2. Install Puppet.
-  
+
     a. Using command line:
 
       .. code-block:: bash
-        
+
         msiexec /qn /norestart /i puppet-agent-<VERSION>-x64.msi
 
       Optionally, you can specify ``/l*v install.txt`` to log the installation’s progress to a file.
 
       You can also set several MSI properties to pre-configure Puppet as you install it. For example:
-          
+
       .. code-block:: bash
 
         msiexec /qn /norestart /i puppet-agent-<VERSION>-x64.msi PUPPET_MASTER_SERVER=puppet.example.com
@@ -85,7 +85,7 @@ Installation on Windows
       - During installation, Puppet asks you for the hostname of your Puppet master server.
 
       - For standalone Puppet nodes that won’t connect to a master, use the default hostname (*puppet*). You might also want to install on the command line and set the agent startup mode to *Disabled*.
-      
+
       - Once the installer finishes, Puppet will be installed and running.
 
 Configuration
@@ -98,6 +98,6 @@ Add the server value to the ``[main]`` section of the node’s ``/etc/puppetlabs
 
 Restart the Puppet service:
 
-  .. code-block:: console
+.. code-block:: console
 
     # puppet resource service puppet ensure=running enable=true

--- a/source/deployment/deploying-with-puppet/setup-puppet/install-puppet-agent.rst
+++ b/source/deployment/deploying-with-puppet/setup-puppet/install-puppet-agent.rst
@@ -14,7 +14,7 @@ Installation on CentOS/RHEL/Fedora
 
 Install the Puppet yum repository and then the "puppet-agent" package. See this `index <https://yum.puppetlabs.com/>`_ to find the correct rpm file needed to install the puppet repo for your Linux distribution. For example, to install Puppet 5 for CentOS 7 or RHEL 7, do the following:
 
-  .. code-block:: console
+.. code-block:: console
 
     # rpm -ivh https://yum.puppetlabs.com/puppet5/puppet5-release-el-7.noarch.rpm
     # yum -y install puppet-agent
@@ -32,14 +32,14 @@ Installation on Debian/Ubuntu
 
 Install ``curl``, ``apt-transport-https`` and ``lsb-release``:
 
-  .. code-block:: console
+.. code-block:: console
 
     # apt-get update
     # apt-get install curl apt-transport-https lsb-release
 
 Get the appropriate Puppet apt repository, and then the "puppet-agent" package. See https://apt.puppetlabs.com to find the correct deb file to install the puppet repo for your Linux distribution.
 
-  .. code-block:: console
+.. code-block:: console
 
     # wget https://apt.puppetlabs.com/puppet5-release-xenial.deb
     # dpkg -i puppet5-release-xenial.deb
@@ -48,7 +48,7 @@ Get the appropriate Puppet apt repository, and then the "puppet-agent" package. 
 
 Create a symbolic link between the installed binary file and your default binary file:
 
-  .. code-block:: bash
+.. code-block:: bash
 
     # ln -s /opt/puppetlabs/bin/puppet /bin
 

--- a/source/installing-splunk/splunk-distributed.rst
+++ b/source/installing-splunk/splunk-distributed.rst
@@ -120,9 +120,9 @@ Now, restart the Splunk Service:
 
   Check the state of the cluster executing:
 
-    .. code-block:: console
+  .. code-block:: console
 
-      # /opt/splunk/bin/splunk show cluster-bundle-status
+    # /opt/splunk/bin/splunk show cluster-bundle-status
 
 
 Next step is installing the :ref:`Wazuh App <splunk_app>` into the search heads instances to start using the services.

--- a/source/migrating-from-ossec/index.rst
+++ b/source/migrating-from-ossec/index.rst
@@ -112,6 +112,7 @@ The migration of Elastic stack, in the case that you already have it installed, 
 
 .. toctree::
    :maxdepth: 2
+   :hidden:
 
    ossec-server
    ossec-agent


### PR DESCRIPTION
Changes in the style resulting from the last deep revision of the new design. Most of the modifications happen in the stylesheet file but minor editions have been done to 5 of the RST (mainly indentation changes).
See below the detailed list of the errors found during the style revision and their corresponding solutions:

---
# /development/client-keys.html

## 1. Datalist titles 
### Problem
There was too little space between titles such as `UNIX systems` and the next paragraph.
![imagen](https://user-images.githubusercontent.com/13232723/60351408-07814f00-99c6-11e9-989c-696c01bd6612.png)

### Solution
Added
`dt {padding-bottom: 10px;} `
![imagen](https://user-images.githubusercontent.com/13232723/60351587-62b34180-99c6-11e9-9d29-6b1e5a949ea0.png)

--- 
# /containers/docker/docker-installation.html 
## 2. Code highlight within admonition (Note and Warning)
### Problem
![imagen](https://user-images.githubusercontent.com/13232723/60351949-20d6cb00-99c7-11e9-873c-79d30fc73a16.png)

### Solution
Replaced `.admonition p { padding: 1rem; margin: 0; }` with `.admonition p, .admonition.note [class*="highlight-"], .admonition.warning [class*="highlight-"]  { padding: 1rem; margin: 0; }`
![imagen](https://user-images.githubusercontent.com/13232723/60352089-6d220b00-99c7-11e9-93a9-9cbd8a0c098c.png)

---
## 3. Code block not aligned
### Problem
![imagen](https://user-images.githubusercontent.com/13232723/60352103-76ab7300-99c7-11e9-9f69-9fd4bab46dbe.png)

### Solution
Replaced `blockquote blockquote {margin-bottom: 0;}` with `blockquote blockquote {margin-bottom: 0; padding-left: 0;}`
![imagen](https://user-images.githubusercontent.com/13232723/60352127-7f9c4480-99c7-11e9-8816-5437d4f69470.png)

---
# /containers/docker/wazuh-container.html 
## 4. RST
### Problem
![imagen](https://user-images.githubusercontent.com/13232723/60352277-c427e000-99c7-11e9-9299-20a8eb9fdf5e.png)
![imagen](https://user-images.githubusercontent.com/13232723/60352283-c5f1a380-99c7-11e9-8097-d8929175fca6.png)

### Solved
![imagen](https://user-images.githubusercontent.com/13232723/60352293-cb4eee00-99c7-11e9-9be6-10a918e1abc6.png)

---
## 5. List within admonition
### Problem
![imagen](https://user-images.githubusercontent.com/13232723/60352315-d99d0a00-99c7-11e9-9466-0bea2f8b6edc.png)

### Solution 
Added `.admonition ul, admonition ol { padding-top: 1rem; padding-right: 1rem; padding-bottom: 0; }`
![imagen](https://user-images.githubusercontent.com/13232723/60352323-de61be00-99c7-11e9-861b-4f0dd7adcc5e.png)

---
# /deployment/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-server-class.html 
## 6. Code block titles 
### Problem
![imagen](https://user-images.githubusercontent.com/13232723/60352329-e4f03580-99c7-11e9-8987-daa7fbcd8718.png)

### Solution 
Replaced  `display: inline-flex;`  with  `display: inline-block;` in `code` and add `vertical-align: middle;`
![imagen](https://user-images.githubusercontent.com/13232723/60435150-16a40f00-9c09-11e9-880b-f03d5c9dca7b.png)

---
# /compliance/pci-dss/log-analysis.html 
## 7. Style for line blocks 
### Problem
When these special blocks are not in a blockquote the look like any other paragraph.
![imagen](https://user-images.githubusercontent.com/13232723/60352349-f0dbf780-99c7-11e9-8cb4-994a3cb9b3e0.png)
![imagen](https://user-images.githubusercontent.com/13232723/60435319-8c0fdf80-9c09-11e9-8d2e-a6dc4220e1e3.png)

### Solution 
Added left padding `.line-block {padding-left: 10px;}`
![imagen](https://user-images.githubusercontent.com/13232723/60434768-3a1a8a00-9c08-11e9-835c-d9115d5de7ba.png)

---
## 8. Thumbnails limit
### Problem
It was difficult to separate some images from the background of the page.
![imagen](https://user-images.githubusercontent.com/13232723/60352377-018c6d80-99c8-11e9-9c12-5643a7df630a.png)

### Solution 
Added  `[data-lightbox] img {border: 1px solid #eee;}`
![imagen](https://user-images.githubusercontent.com/13232723/60352430-1c5ee200-99c8-11e9-89ed-a37bb490865b.png)

---
# /deployment/deploying-with-puppet/setup-puppet/install-puppet-agent.html 
## 9. Incorrect indentation in RST:
### Problem
![imagen](https://user-images.githubusercontent.com/13232723/60352440-2254c300-99c8-11e9-8268-82430f91c07b.png)
![imagen](https://user-images.githubusercontent.com/13232723/60352442-24b71d00-99c8-11e9-877d-f3785cee3967.png)

### Solution 
![imagen](https://user-images.githubusercontent.com/13232723/60352452-284aa400-99c8-11e9-923c-ffec9bab7d09.png)

---
# In general
## 10. Link `Edit on GitHub`
### Problem
This link should only be visible in screen wider than 576px and with a consistent style. Right now, the style for 576px to 991px is: 
![imagen](https://user-images.githubusercontent.com/13232723/60421001-39263000-9be9-11e9-9924-93c591e7bcd3.png)
and for screens wider than 991px it looks like this: 
![imagen](https://user-images.githubusercontent.com/13232723/60421175-9326f580-9be9-11e9-8a76-4bfb75c66dcc.png)

### Solution
Move the style of the link from `@media (min-width: 992px)` to `@media (min-width: 576px)`.
![imagen](https://user-images.githubusercontent.com/13232723/60422733-e77fa480-9bec-11e9-874f-9eff629a6d1b.png)

---
## 11. Version selector for the smallest width
### Problem
![imagen](https://user-images.githubusercontent.com/13232723/60422871-362d3e80-9bed-11e9-87aa-123777f8d96d.png)

### Solution
Replace `min-width: 130px;` with `min-width: 120px;` in `#select-version .dropdown-toggle`.
![imagen](https://user-images.githubusercontent.com/13232723/60423265-1f3b1c00-9bee-11e9-9301-0bb650c50a15.png)

---
## 12. Nested lists
### Problem
Nested lists take too much space: 
![imagen](https://user-images.githubusercontent.com/13232723/60426183-6d531e00-9bf4-11e9-818f-807a61b559ea.png)

### Solution
Decreased their left padding from `padding-left: 1.3rem;` to `padding-left: 1rem;` in `ol ol, ol ul, ul ol, ul ul`. And also decreased margin-left from `1.7rem;` to `0.7rem;` in `blockquote [class*="highlight-"], blockquote ul, blockquote blockquotel`. 
![imagen](https://user-images.githubusercontent.com/13232723/60427613-5530ce00-9bf7-11e9-8331-81d3f8619c48.png)

---
# /installing-splunk/splunk-distributed.html

## 13. Bad RST indentation
### Problem
The extra indentation in `installing-splunk/splunk-distributed.rst` is causing a code block within a paragraph instead of the code block alone, thus its adding padding to the code block:
![imagen](https://user-images.githubusercontent.com/13232723/60429100-9ecee800-9bfa-11e9-918b-98e267be1ad1.png)
![imagen](https://user-images.githubusercontent.com/13232723/60429292-113fc800-9bfb-11e9-93cc-16a17627f7c9.png)

### Solution
Removed the extra indentation
![imagen](https://user-images.githubusercontent.com/13232723/60429367-37656800-9bfb-11e9-823f-7ae6d3a74a9a.png)
![imagen](https://user-images.githubusercontent.com/13232723/60429492-74c9f580-9bfb-11e9-8249-882c407ce0d2.png)
Also restricted the CSS rule by replacing `.admonition p, .admonition.note [class*="highlight-"], .admonition.warning [class*="highlight-"]` with `.admonition p, .admonition.note > [class*="highlight-"],
.admonition.warning > [class*="highlight-"]`.

---
# /migrating-from-ossec/index.html

## 14. Non hidden TOC at the bottom of the page
### Problem
This TOC should no be in shown in the page:
![imagen](https://user-images.githubusercontent.com/13232723/60431124-46e6b000-9bff-11e9-86bc-177925898c2c.png)

### Solution
Added the option `:hidden:` to the directive `toctree` in the RST file:
![imagen](https://user-images.githubusercontent.com/13232723/60431341-d8eeb880-9bff-11e9-98de-4e9ba1d7225f.png)
