### PR TITLE
Add dequeued_after_close to remoted state file

### DIFF
--- a/source/user-manual/reference/statistics-files/ossec-remoted-state.rst
+++ b/source/user-manual/reference/statistics-files/ossec-remoted-state.rst
@@ -42,5 +42,5 @@ Below there is an example of the content of the file:
     # Total number of bytes received
     recv_bytes='435879'
 
-    # Messages dequeued after close socket
+    # Messages dequeued after the agent closes the connection
     dequeued_after_close='487'

--- a/source/user-manual/reference/statistics-files/ossec-remoted-state.rst
+++ b/source/user-manual/reference/statistics-files/ossec-remoted-state.rst
@@ -7,7 +7,7 @@ ossec-remoted.state
 
 The statistical file for **ossec-remoted** is located at ``/var/ossec/var/run/ossec-remoted.state``.
 
-This file provides information about the remote daemon as the queue size, discarded messages, number of remote connections and other useful information. 
+This file provides information about the remote daemon as the queue size, discarded messages, number of remote connections and other useful information.
 
 By default, this file is updated every 5 seconds. This interval can be changed by modifying the ``remoted.state_interval`` value from the :ref:`internal configuration <reference_internal_options>` file.
 
@@ -41,3 +41,6 @@ Below there is an example of the content of the file:
 
     # Total number of bytes received
     recv_bytes='435879'
+
+    # Messages dequeued after close socket
+    dequeued_after_close='487'


### PR DESCRIPTION
This PR adds the new field `dequeued_after_close` to the example of the file `ossec-remoted.state`.

<img width="476" alt="Screen Shot 2019-07-02 at 12 04 23 PM" src="https://user-images.githubusercontent.com/14975138/60504306-a4433580-9cc1-11e9-977f-ce38029109e6.png">
