### PR TITLE
Info for operating systems that do not have default policy files

### DIFF
--- a/source/user-manual/capabilities/policy-monitoring/openscap/how-it-works.rst
+++ b/source/user-manual/capabilities/policy-monitoring/openscap/how-it-works.rst
@@ -72,6 +72,8 @@ These are the Security Policy includes by default on Wazuh:
 
 Each agent must have its policies in ``/var/ossec/wodles/oscap/content``.
 
+.. note:: If ``/var/ossec/wodles/oscap/content`` is empty after installation, none of the policies included by default on Wazuh is compatible with the operating system. In this case it is necessary to manually find and add the appropriate policy file.
+
 Wodle flow
 ------------
 

--- a/source/user-manual/capabilities/policy-monitoring/openscap/oscap-faq.rst
+++ b/source/user-manual/capabilities/policy-monitoring/openscap/oscap-faq.rst
@@ -39,3 +39,5 @@ Where are the policies?
 -----------------------
 
 Each agent must have its policies in ``/var/ossec/wodles/oscap/content``.
+
+.. note:: If ``/var/ossec/wodles/oscap/content`` is empty after installation, none of the policies included by default on Wazuh is compatible with the operating system. In this case it is necessary to manually find and add the appropriate policy file.


### PR DESCRIPTION
Hi team,

The possibility that none of the policies included by default in Wazuh for OpenScap is compatible with the operating system and what to do is now covered in the Oscap Wodle documentation.

Greetings!