### PR TITLE
Fixed command to add new agents to the manager via API

### DIFF
--- a/source/user-manual/registering/api/api-register-linux-unix.rst
+++ b/source/user-manual/registering/api/api-register-linux-unix.rst
@@ -11,7 +11,7 @@ Open a session in your Linux/Unix agent host as root user. Then, follow these st
 
   .. code-block:: console
 
-    # curl -u foo:bar -k -X POST -d '{"name":"ubuntu-ag","ip":"10.0.0.8"}' -H 'Content-Type:application/json' "https://192.168.1.2:55000/agents?pretty"
+    # curl -u foo:bar -k -X POST -d '{"name":"ubuntu-ag","ip":"10.0.0.8"}' -H 'Content-Type:application/json' "http://192.168.1.2:55000/agents?pretty"
 
   .. code-block:: json
 


### PR DESCRIPTION
Fixed command to add new agents to the manager via API.

By default using https in the curl command would produce openssl related errors, switching to http instead worked fine.

Environment:

- Manager running with API on a CentOS7 VM
- Several Linux agents running on Ubuntu 16.04.6 LTS (Xenial Xerus), CentOS7 and Lavarel Homestead.

*All the virtual machines only had the essentials installed*

Problem:

Couldn't add agent using the command at the doc:

`curl -u foo:bar -k -X POST -d '{"name":"ubuntu-ag","ip":"10.0.0.8"}' -H 'Content-Type:application/json' "http://192.168.1.2:55000/agents?pretty"`

Error: 

`curl: (35) gnutls_handshake() failed: The TLS connection was non-properly terminated.` 

Instead these other commands worked:

`curl -s -u foo:bar -k -X POST -d 'name=<name> http://<manager_IP>:55000/agents`

`curl -u foo:bar -k -X POST -d '{"name":"ubuntu-ag","ip":"10.0.0.8"}' -H 'Content-Type:application/json' "http://192.168.1.2:55000 agents?pretty"`

*Note the s missing in **https→http***

*(Also note that the content in \<vars\> must be replaced with its proper value)*