### PR TITLE
Exclude search results from release notes

### DIFF
--- a/source/_static/css/style.css
+++ b/source/_static/css/style.css
@@ -34,8 +34,7 @@ table.docutils col {
 }
 
 th, td {
-  padding: 7px;
-  padding-left: 12px;
+  padding: 7px 18px;
   border-color: #e1e4e5;
   vertical-align: middle;
 }

--- a/source/_static/css/style.css
+++ b/source/_static/css/style.css
@@ -35,8 +35,9 @@ table.docutils col {
 
 th, td {
   padding: 7px 18px;
-  border-color: #e1e4e5;
+  border: 1px solid #e1e4e5;
   vertical-align: middle;
+	border-spacing: 0;
 }
 
 table tr:nth-child(2n+1){

--- a/source/_static/css/style.css
+++ b/source/_static/css/style.css
@@ -1118,6 +1118,10 @@ footer a:focus,
   line-height: 1.2;
 }
 
+#search-results li.excluded-search-result.hidden-result {
+	display: none!important;
+}
+
 .search_main .form-control:focus {
   box-shadow: none;
   border: none;
@@ -1996,7 +2000,7 @@ a:focus {
   border-color: transparent;
 }
 
-#main-content .navigation-buttons a:hover, 
+#main-content .navigation-buttons a:hover,
 #main-content .navigation-buttons a:focus {
   border-color: transparent;
 }
@@ -2012,7 +2016,7 @@ a:focus {
   transition: .2s all ease;
 }
 
-#main-content .navigation-buttons a:hover::after, 
+#main-content .navigation-buttons a:hover::after,
 #main-content .navigation-buttons a:focus::after {
   opacity: 1;
 }
@@ -2708,7 +2712,7 @@ div.highlight pre {
 			#globaltoc .toc-toggle-btn {
 				display: none;
 			}
-      
+
 			#globaltoc .toc-toggle > a:hover > .toc-toggle-btn,
 			#globaltoc .toc-toggle > a:focus > .toc-toggle-btn {
 				display: flex;

--- a/source/_static/js/style.js
+++ b/source/_static/js/style.js
@@ -30,6 +30,8 @@ $(function(){
 		'development/index',
 		'docker-monitor/index',
 		'installation-guide/upgrading/legacy/index',
+    'installation-guide/packages-list/linux/linux-index',
+    'installation-guide/packages-list/solaris/solaris-index',
 		'monitoring',
 		'release-notes/index',
 		'user-manual/index',
@@ -406,6 +408,6 @@ $(function(){
 				});
 			});
     });
-    
+
   }
 });

--- a/source/_static/js/style.js
+++ b/source/_static/js/style.js
@@ -343,7 +343,6 @@ $(function(){
     var ulSearch = $('ul.search');
     var lastResult = null;
     var splitURL;
-    var n_excludedResults;
 
     /* Detects every result that is added to the list */
     ulSearch.on('DOMSubtreeModified', function(){
@@ -354,7 +353,7 @@ $(function(){
       $.each(excludedSearchFolders, function(index, value){
         if ( $.inArray(value, splitURL) !== -1 ) {
           lastResult.addClass('excluded-search-result'); /* Marks initially excluded result */
-          lastResult.addClass('hidden-result'); /* Hides the excluded result */
+					lastResult.addClass('hidden-result'); /* Hides the excluded result */
           return false; // breaks the $.each loop
         }
       });
@@ -364,7 +363,49 @@ $(function(){
     $('#search-results > p:first').one('DOMSubtreeModified', function(){
       var totalResults = $('ul.search li').length;
       var excludedResults = $('ul.search li.excluded-search-result').length;
-      $(this).text( "Showing " + (totalResults-excludedResults) + " page(s) matching the search query.");
+      var resultText = '';
+      if ( excludedResults > 0 ) {
+        resultText = 'Search finished. Found <span id="n-results">' + (totalResults-excludedResults) + '</span> page(s) matching the search query. <a id="toggle-results" class="include" href="#">Include Release Notes results</a>';
+      } else {
+        resultText = 'Search finished. Found <span id="n-results">' + totalResults + '</span> page(s) matching the search query.';
+      }
+      $(this).html(resultText);
     });
+
+    /* Click that allows showing excluded results */
+    $(document).delegate('#search-results #toggle-results.include', 'click', function(){
+			var toggleButton = $(this);
+			var excludedResults = $('ul.search li.excluded-search-result');
+
+      toggleButton.text(toggleButton.text().replace('Include', 'Exclude'));
+      toggleButton.removeClass('include').addClass('exclude');
+			$('#search-results #n-results').text($('ul.search li').length);
+
+			excludedResults.each(function(e){
+				currResult = $(this);
+				currResult.hide(0, function(){
+					$(this).removeClass('hidden-result');
+				})
+				currResult.show('fast');
+			});
+    });
+
+    /* Click that allows hiding excluded results */
+    $(document).delegate('#search-results #toggle-results.exclude', 'click', function(){
+			var toggleButton = $(this);
+			var excludedResults = $('ul.search li.excluded-search-result');
+
+      toggleButton.text(toggleButton.text().replace('Exclude', 'Include'));
+      toggleButton.removeClass('exclude').addClass('include');
+			$('#search-results #n-results').text($('ul.search li').length - excludedResults.length);
+
+			excludedResults.each(function(e){
+				currResult = $(this);
+				currResult.hide('fast', function(){
+					$(this).addClass('hidden-result');
+				});
+			});
+    });
+    
   }
 });

--- a/source/_static/js/style.js
+++ b/source/_static/js/style.js
@@ -366,12 +366,14 @@ $(function(){
       var totalResults = $('ul.search li').length;
       var excludedResults = $('ul.search li.excluded-search-result').length;
       var resultText = '';
-      if ( excludedResults > 0 ) {
-        resultText = 'Search finished. Found <span id="n-results">' + (totalResults-excludedResults) + '</span> page(s) matching the search query. <a id="toggle-results" class="include" href="#">Include Release Notes results</a>';
-      } else {
-        resultText = 'Search finished. Found <span id="n-results">' + totalResults + '</span> page(s) matching the search query.';
+      if ( totalResults > 0 ){
+        if ( excludedResults > 0 ) {
+          resultText = 'Search finished. Found <span id="n-results">' + (totalResults-excludedResults) + '</span> page(s) matching the search query. <a id="toggle-results" class="include" href="#">Include Release Notes results</a>';
+        } else {
+          resultText = 'Search finished. Found <span id="n-results">' + totalResults + '</span> page(s) matching the search query.';
+        }
+        $(this).html(resultText);
       }
-      $(this).html(resultText);
     });
 
     /* Click that allows showing excluded results */

--- a/source/_static/js/style.js
+++ b/source/_static/js/style.js
@@ -19,6 +19,7 @@ $(function(){
       gTocSpaceTop = $('#search-lg').height();
   var breakpoint = 992,
 			spaceBeforeAnchor = 60;
+	var excludedSearchFolders = ['release-notes']; // List of folders that will be excluded from search
 
 	// List of empty nodes, containing only a toctree
 	var empty_toc_nodes = [
@@ -336,4 +337,34 @@ $(function(){
     }, 10);
 	}
 
+  /* Search results --------------------------------------------------------------------------------------------------*/
+
+  if ( $('#search-results').length > 0 ) {
+    var ulSearch = $('ul.search');
+    var lastResult = null;
+    var splitURL;
+    var n_excludedResults;
+
+    /* Detects every result that is added to the list */
+    ulSearch.on('DOMSubtreeModified', function(){
+      lastResult = $('ul.search li:last-child');
+      splitURL = lastResult.children('a').prop('href').split('/');
+
+      /* Checks the URL to mark the results found in excludedSearchFolders */
+      $.each(excludedSearchFolders, function(index, value){
+        if ( $.inArray(value, splitURL) !== -1 ) {
+          lastResult.addClass('excluded-search-result'); /* Marks initially excluded result */
+          lastResult.addClass('hidden-result'); /* Hides the excluded result */
+          return false; // breaks the $.each loop
+        }
+      });
+    });
+
+    /* Replaces the result message */
+    $('#search-results > p:first').one('DOMSubtreeModified', function(){
+      var totalResults = $('ul.search li').length;
+      var excludedResults = $('ul.search li.excluded-search-result').length;
+      $(this).text( "Showing " + (totalResults-excludedResults) + " page(s) matching the search query.");
+    });
+  }
 });

--- a/source/index.rst
+++ b/source/index.rst
@@ -63,9 +63,14 @@ Wazuh helps you to gain deeper security visibility into your infrastructure by m
    Wazuh provides some of the necessary security controls to become compliant with industry standards and regulations. These features, combined with its scalability and multi-platform support help organizations meet technical compliance requirements.
 
 .. topic:: Cloud Security Monitoring
-   :class: cloud col-md-12
+   :class: cloud col-md-6
 
    Wazuh helps monitoring cloud infrastructure at an API level, using integration modules that are able to pull security data from well known cloud providers, such as Amazon AWS, Azure or Google Cloud. In addition, Wazuh provides rules to assess the configuration of your cloud environment, easily spotting weaknesses.
+
+.. topic:: Docker Security Monitoring
+   :class: docker col-md-6
+
+   Wazuh provides security visibility into your Docker hosts and containers, monitoring their behavior and detecting threats, vulnerabilities and anomalies. The Wazuh agent has native integration with the Docker engine allowing users to monitor images, volumes, network settings, and running containers. Wazuh continuously collects and analyzes detailed runtime information. For example, alerting for containers running in privileged mode, vulnerable applications, a shell running in a container, changes to persistent volumes or images, and other possible threats.
 
 .. raw:: html
 


### PR DESCRIPTION
This PR include various changes from https://github.com/wazuh/wazuh-website/issues/678, some of then unrelated. Specífically, the ones contained in https://github.com/wazuh/wazuh-website/issues/678#issuecomment-507536243 and https://github.com/wazuh/wazuh-website/issues/678#issuecomment-507590533:

- Added content of the new capacity (Docker monitoring) to the index page (no style)
- Implemented javascript code that excludes some results from the search. These results are specified as the name of the container folder in the array `excludedSearchFolders`, and can be shown by pressing the link at the top of the result page.
- Style fixes: increased padding in table cells and fixed table style the keep the same cross-browser appearance.

In addition, the array `empty_toc_nodes` has been updated with the latest changes.
