### PR TITLE
Made steps order X-pack security cluster compatible

### DIFF
--- a/source/installation-guide/installing-elastic-stack/protect-installation/xpack.rst
+++ b/source/installation-guide/installing-elastic-stack/protect-installation/xpack.rst
@@ -163,11 +163,6 @@ This section describes how to secure the communications between the involved com
 
     # systemctl restart kibana
 
-.. thumbnail:: ../../../images/protect-elastic-stack/xpack-login.png
-  :align: center
-  :width: 100%
-
-
 
 Adding authentication for Elasticsearch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -178,11 +173,12 @@ Adding authentication for Elasticsearch
 
     xpack.security.enabled: true
 
-2. Restart Elasticsearch.
+2. Restart Elasticsearch and wait for the service to be ready.
 
 .. code-block:: console
 
     # systemctl restart elasticsearch
+
 
 3. Generate credentials for all the Elastic Stack pre-built roles and users.
 
@@ -217,3 +213,8 @@ Adding authentication for Elasticsearch
 .. code-block:: console
 
     # systemctl restart kibana
+
+You may now login to your Kibana web interface and use the elastic user credentials to login:
+.. thumbnail:: ../../../images/protect-elastic-stack/xpack-login.png
+  :align: center
+  :width: 100%

--- a/source/installation-guide/installing-elastic-stack/protect-installation/xpack.rst
+++ b/source/installation-guide/installing-elastic-stack/protect-installation/xpack.rst
@@ -104,9 +104,9 @@ This section describes how to secure the communications between the involved com
 .. code-block:: console
 
     # mkdir /etc/filebeat/certs/ca -p
-    # cp certs/ca/ca.crt /etc/filebeat/certs/ca
-    # cp certs/wazuh-manager/wazuh-manager.crt /etc/filebeat/certs
-    # cp certs/wazuh-manager/wazuh-manager.key /etc/filebeat/certs
+    # cp ca/ca.crt /etc/filebeat/certs/ca
+    # cp wazuh-manager/wazuh-manager.crt /etc/filebeat/certs
+    # cp wazuh-manager/wazuh-manager.key /etc/filebeat/certs
     # chmod 770 -R /etc/filebeat/certs
 
 2. Add the proper settings in ``/etc/filebeat/filebeat.yml``.
@@ -136,9 +136,9 @@ This section describes how to secure the communications between the involved com
 .. code-block:: console
 
     # mkdir /etc/kibana/certs/ca -p
-    # cp certs/ca/ca.crt /etc/kibana/certs/ca
-    # cp certs/kibana/kibana.crt /etc/kibana/certs
-    # cp certs/kibana/kibana.key /etc/kibana/certs
+    # cp ca/ca.crt /etc/kibana/certs/ca
+    # cp kibana/kibana.crt /etc/kibana/certs
+    # cp kibana/kibana.key /etc/kibana/certs
     # chown -R kibana: /etc/kibana/certs
     # chmod -R 770 /etc/kibana/certs
 

--- a/source/installation-guide/installing-elastic-stack/protect-installation/xpack.rst
+++ b/source/installation-guide/installing-elastic-stack/protect-installation/xpack.rst
@@ -192,7 +192,7 @@ Adding authentication for Elasticsearch
 .. code-block:: yaml
 
     output.elasticsearch.username: "elastic"
-    output.elasticsearch.password: "elastic_password"
+    output.elasticsearch.password: "password_generated_for_elastic"
 
 6. Restart Filebeat.
 
@@ -206,7 +206,7 @@ Adding authentication for Elasticsearch
 
     xpack.security.enabled: true
     elasticsearch.username: "elastic"
-    elasticsearch.password: "elastic_password"
+    elasticsearch.password: "password_generated_for_elastic"
 
 8. Restart Kibana.
 

--- a/source/installation-guide/installing-elastic-stack/protect-installation/xpack.rst
+++ b/source/installation-guide/installing-elastic-stack/protect-installation/xpack.rst
@@ -67,9 +67,9 @@ This section describes how to secure the communications between the involved com
 .. code-block:: console
 
     # mkdir /etc/elasticsearch/certs/ca -p
-    # cp certs/ca/ca.crt /etc/elasticsearch/certs/ca
-    # cp certs/elasticsearch/elasticsearch.crt /etc/elasticsearch/certs
-    # cp certs/elasticsearch/elasticsearch.key /etc/elasticsearch/certs
+    # cp ca/ca.crt /etc/elasticsearch/certs/ca
+    # cp elasticsearch/elasticsearch.crt /etc/elasticsearch/certs
+    # cp elasticsearch/elasticsearch.key /etc/elasticsearch/certs
     # chown -R elasticsearch: /etc/elasticsearch/certs
     # chmod -R 770 /etc/elasticsearch/certs
 

--- a/source/installation-guide/installing-elastic-stack/protect-installation/xpack.rst
+++ b/source/installation-guide/installing-elastic-stack/protect-installation/xpack.rst
@@ -7,56 +7,6 @@ X-Pack
 
 Elastic Stack security features give the right access to the right people. IT, operations, and application teams rely on them to manage well-intentioned users and keep malicious actors at bay, while executives and customers can rest easy knowing data stored in the Elastic Stack is safe and secure.
 
-Adding authentication for Elasticsearch
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-1. Add the next lines to ``/etc/elasticsearch/elasticsearch.yml``.
-
-.. code-block:: yaml
-
-    xpack.security.enabled: true
-    xpack.security.transport.ssl.enabled: true
-
-2. Restart Elasticsearch.
-
-.. code-block:: console
-
-    # systemctl restart elasticsearch
-
-3. Generate credentials for all the Elastic Stack pre-built roles and users.
-
-.. code-block:: console
-
-    # /usr/share/elasticsearch/bin/elasticsearch-setup-passwords auto
-
-4. Note down at least the password for the ``elastic`` user.
-5. Setting up credentials for Filebeat. Add the next two lines to ``/etc/filebeat/filebeat.yml``.
-
-.. code-block:: yaml
-
-    output.elasticsearch.username: "elastic"
-    output.elasticsearch.password: "elastic_password"
-
-6. Restart Filebeat.
-
-.. code-block:: console
-
-    # systemctl restart filebeat
-
-7. Setting up credentials for Kibana. Add the next lines to ``/etc/kibana/kibana.yml``.
-
-.. code-block:: yaml
-
-    xpack.security.enabled: true
-    elasticsearch.username: "elastic"
-    elasticsearch.password: "elastic_password"
-
-8. Restart Kibana.
-
-.. code-block:: console
-
-    # systemctl restart kibana
-
 Configure Elastic Stack to use encrypted connections 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -106,7 +56,13 @@ This section describes how to secure the communications between the involved com
 
 **Configure the Elasticsearch instance**
 
+
 1. Create the directory ``/etc/elasticsearch/certs``, then copy the certificate authorities, the certificate and the key there.
+
+.. note::
+
+    The following commands are assuming a single-host installation, if the components are distributed each file should be distributed to its components (via scp or other available means).
+
 
 .. code-block:: console
 
@@ -210,3 +166,54 @@ This section describes how to secure the communications between the involved com
 .. thumbnail:: ../../../images/protect-elastic-stack/xpack-login.png
   :align: center
   :width: 100%
+
+
+
+Adding authentication for Elasticsearch
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+1. Add the next line to ``/etc/elasticsearch/elasticsearch.yml``.
+
+.. code-block:: yaml
+
+    xpack.security.enabled: true
+
+2. Restart Elasticsearch.
+
+.. code-block:: console
+
+    # systemctl restart elasticsearch
+
+3. Generate credentials for all the Elastic Stack pre-built roles and users.
+
+.. code-block:: console
+
+    # /usr/share/elasticsearch/bin/elasticsearch-setup-passwords auto
+
+4. Note down at least the password for the ``elastic`` user.
+5. Setting up credentials for Filebeat. Add the next two lines to ``/etc/filebeat/filebeat.yml``.
+
+.. code-block:: yaml
+
+    output.elasticsearch.username: "elastic"
+    output.elasticsearch.password: "elastic_password"
+
+6. Restart Filebeat.
+
+.. code-block:: console
+
+    # systemctl restart filebeat
+
+7. Setting up credentials for Kibana. Add the next lines to ``/etc/kibana/kibana.yml``.
+
+.. code-block:: yaml
+
+    xpack.security.enabled: true
+    elasticsearch.username: "elastic"
+    elasticsearch.password: "elastic_password"
+
+8. Restart Kibana.
+
+.. code-block:: console
+
+    # systemctl restart kibana


### PR DESCRIPTION
Although not an issue for single-node elasticsearch installation, if doing an installation with more than one Elasticsearch node it is necessary to first run the SSL configuration before configuring credentials.
This PR changes the order of the steps so it will work in both cases.

Also, the variable `xpack.security.transport.ssl.enabled` was duplicated before this PR.