### PR TITLE
Change the Red Hat feed link in Vulnerability Detector

### DIFF
--- a/source/user-manual/capabilities/vulnerability-detection.rst
+++ b/source/user-manual/capabilities/vulnerability-detection.rst
@@ -21,7 +21,7 @@ To be able to detect vulnerabilities, now agents are able to natively collect a 
 The global vulnerabilities database is created automatically, currently pulling data from the following repositories:
 
 - `<https://people.canonical.com>`_: Used to pull CVEs for Ubuntu Linux distributions.
-- `<https://www.redhat.com>`_: Used to pull CVEs for Red Hat and CentOS Linux distributions.
+- `<https://access.redhat.com>`_: Used to pull CVEs for Red Hat and CentOS Linux distributions.
 - `<https://www.debian.com>`_: Used to pull CVEs for Debian Linux distributions.
 
 This database can be configured to be updated periodically, ensuring that the solution will check for the very latest CVEs.


### PR DESCRIPTION
This PR updates the reference to the Red Hat base URL used by Vulnerability Detector to fetch the vulnerability feed.

Adding the previous URL to a proxy or firewall is not valid at the time of the online update.

Use case: https://groups.google.com/forum/#!topic/wazuh/9H3JWdjRrHM.