### PR TITLE
Correcting some typos in upgrading ELK documentation

### DIFF
--- a/source/installation-guide/upgrading-elastic-stack/elastic_server_rolling_upgrade.rst
+++ b/source/installation-guide/upgrading-elastic-stack/elastic_server_rolling_upgrade.rst
@@ -135,7 +135,7 @@ Due to this change, previous alerts won't be visible in Wazuh indices, an update
 
 Run below request for each Wazuh index created before Elastic 7.x upgrade. It will add the *timestamp* field for all the index documents.
 
-Here is an example of how run the request using the index *wazuh-alerts-3.x-2019.05.16*. 
+Here is an example of how to run the request using the index *wazuh-alerts-3.x-2019.05.16*. 
 
 .. code-block:: bash
 

--- a/source/installation-guide/upgrading-elastic-stack/elastic_server_rolling_upgrade.rst
+++ b/source/installation-guide/upgrading-elastic-stack/elastic_server_rolling_upgrade.rst
@@ -131,7 +131,7 @@ Field migration: From @timestamp to timestamp
 
 In previous Elastic search versions, the Elastic documents were indexed using the field *@timestamp* as the reference field for time-based indices. Starting in Elastic 7.x, this field has become a reserved field and it is no longer manipulable. Wazuh time-based indices now make use of field *timestamp* instead.
 
-Due to this change, previous alerts won't be visible in Wazuh indices, an update must be perform to all previous indices in order to complete the upgrade.
+Due to this change, previous alerts won't be visible in Wazuh indices, an update must be performed to all previous indices in order to complete the upgrade.
 
 Run below request for each Wazuh index created before Elastic 7.x upgrade. It will add the *timestamp* field for all the index documents.
 


### PR DESCRIPTION
Hi team,

Just correcting some typos I found:

`must be perform → must be performed`
`how run → how to run`

I found them in this documentation page: https://documentation.wazuh.com/current/installation-guide/upgrading-elastic-stack/elastic_server_rolling_upgrade.html

Regards,
Sergio.