### PR TITLE
Typo fix on message-format.rst L206

### DIFF
--- a/source/development/message-format.rst
+++ b/source/development/message-format.rst
@@ -203,7 +203,7 @@ For agents with unrestricted address (address ``any`` or netmask different from 
 
     .. code-block:: console
 
-        "!" <ID> "!#AES:" Blowfish(<!-padding> Gzip(MD5(<Random> <Global> ":" <Local> ":" <Event>) <Random> <Global> ":" <Local> ":" <Event>))
+        "!" <ID> "!#Blowfish:" Blowfish(<!-padding> Gzip(MD5(<Random> <Global> ":" <Local> ":" <Event>) <Random> <Global> ":" <Local> ":" <Event>))
 
     b) AES encryption
 

--- a/source/development/message-format.rst
+++ b/source/development/message-format.rst
@@ -203,7 +203,7 @@ For agents with unrestricted address (address ``any`` or netmask different from 
 
     .. code-block:: console
 
-        "!" <ID> "!#Blowfish:" Blowfish(<!-padding> Gzip(MD5(<Random> <Global> ":" <Local> ":" <Event>) <Random> <Global> ":" <Local> ":" <Event>))
+        "!" <ID> "!:" Blowfish(<!-padding> Gzip(MD5(<Random> <Global> ":" <Local> ":" <Event>) <Random> <Global> ":" <Local> ":" <Event>))
 
     b) AES encryption
 


### PR DESCRIPTION
Hi team,

This PR fixes the further documentation typo from [Standard message format](https://documentation.wazuh.com/3.x/development/message-format.html#complete-encryption-formula) document:
<br></br>
**Blowfish example format has #AES inside:**
```
"!" <ID> "!#AES:" Blowfish(<!-padding> Gzip(MD5(<Random> <Global> ":" <Local> ":" <Event>) <Random> <Global> ":" <Local> ":" <Event>))
```

**Blowfish example format after fix:**
```
"!" <ID> "!#Blowfish:" Blowfish(<!-padding> Gzip(MD5(<Random> <Global> ":" <Local> ":" <Event>) <Random> <Global> ":" <Local> ":" <Event>))
```

Regards,

Juan Pablo Sáez