### PR TITLE
Warn about SCA duplicated check IDs

### DIFF
--- a/source/user-manual/capabilities/sec-config-assessment/security-configuration-assessment.rst
+++ b/source/user-manual/capabilities/sec-config-assessment/security-configuration-assessment.rst
@@ -344,8 +344,7 @@ Each section has their own fields that can be mandatory as described below:
 It is recommended that new policy files be placed under the `ruleset/sca` directory.
 
 .. note::
-  - Remember that the **policy** id field must be unique, not existing in other policy files.
-  - Remember that the **checks** id field must be unique within the same policy.
+  - Remember that the value of the **policy** and **check** id fields must be unique, not existing in other policy files.
 
 
 Information about variables


### PR DESCRIPTION
Fixing the note in the SCA documentation to warn about duplicated check IDs (issue reported here: https://github.com/wazuh/wazuh/issues/3657)