### PR TITLE
Downgrade Wazuh docker deployment until is released

### DIFF
--- a/source/docker/wazuh-container.rst
+++ b/source/docker/wazuh-container.rst
@@ -93,11 +93,11 @@ Usage
 
   a) Only the file::
 
-      $ curl -so docker-compose.yml https://raw.githubusercontent.com/wazuh/wazuh-docker/3.9.3_7.2.0/docker-compose.yml
+      $ curl -so docker-compose.yml https://raw.githubusercontent.com/wazuh/wazuh-docker/3.9.2_7.1.1/docker-compose.yml
 
   b) Get the Wazuh repository::
 
-      $ git clone https://github.com/wazuh/wazuh-docker.git -b 3.9.3_7.2.0 --single-branch
+      $ git clone https://github.com/wazuh/wazuh-docker.git -b 3.9.2_7.1.1 --single-branch
 
 #. Start Wazuh, Elastic Stack and Nginx using `docker-compose`. From the directory where you have the ``docker-compose.yml`` file:
 


### PR DESCRIPTION
Hello team,

Closes #1351 
This PR changes the Wazuh docker deployment documentation to use 3.9.2-7.1.1 until 3.9.3-7.2.0 is released on wazuh-docker repository.

Regards.