### PR TITLE
adapted wazuh module version in wazuh deployment with puppet

### DIFF
--- a/source/deploying-with-puppet/wazuh-puppet-module/index.rst
+++ b/source/deploying-with-puppet/wazuh-puppet-module/index.rst
@@ -14,7 +14,7 @@ Download and install the Wazuh module from Puppet Forge:
 
   .. code-block:: console
 
-    # puppet module install wazuh-wazuh --version 3.9.0
+    # puppet module install wazuh-wazuh --version 3.9.2
 
   .. code-block:: bash
   
@@ -22,7 +22,7 @@ Download and install the Wazuh module from Puppet Forge:
     Notice: Downloading from https://forgeapi.puppetlabs.com ...
     Notice: Installing -- do not interrupt ...
     /etc/puppet/modules
-    └─┬ wazuh-wazuh (v3.9.0)
+    └─┬ wazuh-wazuh (v3.9.2)
       ├── puppet-nodejs (v7.0.0)
       ├── puppet-selinux (v1.6.1)
       ├── puppetlabs-apt (v6.3.0)


### PR DESCRIPTION
Hi team!

This PR has the goal to adapt Wazuh module version, allocated in [`Puppet Forge`](https://forge.puppet.com/wazuh/wazuh). In the actual documentation, it indicates to install the module `3.9.0` which does not exist in [`Puppet Forge`](https://forge.puppet.com/wazuh/wazuh).

* Actual docs:
```
# puppet module install wazuh-wazuh --version 3.9.0
```

* Changed docs:
```
# puppet module install wazuh-wazuh --version 3.9.2
```

Kr,

Rshad