### PR TITLE
Changing X-Pack documentation

### DIFF
--- a/source/installation-guide/installing-elastic-stack/protect-installation/xpack.rst
+++ b/source/installation-guide/installing-elastic-stack/protect-installation/xpack.rst
@@ -7,56 +7,6 @@ X-Pack
 
 Elastic Stack security features give the right access to the right people. IT, operations, and application teams rely on them to manage well-intentioned users and keep malicious actors at bay, while executives and customers can rest easy knowing data stored in the Elastic Stack is safe and secure.
 
-Adding authentication for Elasticsearch
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-1. Add the next lines to ``/etc/elasticsearch/elasticsearch.yml``.
-
-.. code-block:: yaml
-
-    xpack.security.enabled: true
-    xpack.security.transport.ssl.enabled: true
-
-2. Restart Elasticsearch.
-
-.. code-block:: console
-
-    # systemctl restart elasticsearch
-
-3. Generate credentials for all the Elastic Stack pre-built roles and users.
-
-.. code-block:: console
-
-    # /usr/share/elasticsearch/bin/elasticsearch-setup-passwords auto
-
-4. Note down at least the password for the ``elastic`` user.
-5. Setting up credentials for Filebeat. Add the next two lines to ``/etc/filebeat/filebeat.yml``.
-
-.. code-block:: yaml
-
-    output.elasticsearch.username: "elastic"
-    output.elasticsearch.password: "elastic_password"
-
-6. Restart Filebeat.
-
-.. code-block:: console
-
-    # systemctl restart filebeat
-
-7. Setting up credentials for Kibana. Add the next lines to ``/etc/kibana/kibana.yml``.
-
-.. code-block:: yaml
-
-    xpack.security.enabled: true
-    elasticsearch.username: "elastic"
-    elasticsearch.password: "elastic_password"
-
-8. Restart Kibana.
-
-.. code-block:: console
-
-    # systemctl restart kibana
-
 Configure Elastic Stack to use encrypted connections 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -202,6 +152,44 @@ This section describes how to secure the communications between the involved com
     server.ssl.key: "/etc/kibana/certs/kibana.key"
 
 3. Restart the service:
+
+.. code-block:: console
+
+    # systemctl restart kibana
+    
+Adding authentication for Elasticsearch
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+1. Generate credentials for all the Elastic Stack pre-built roles and users.
+
+.. code-block:: console
+
+    # /usr/share/elasticsearch/bin/elasticsearch-setup-passwords auto
+
+2. Copy the output of the previous command to a safe place. Specially the password for the ``elastic`` user.
+
+3. Setting up credentials for Filebeat. Add the next two lines to ``/etc/filebeat/filebeat.yml``.
+
+.. code-block:: yaml
+
+    output.elasticsearch.username: "elastic"
+    output.elasticsearch.password: "elastic_password"
+
+4. Restart Filebeat.
+
+.. code-block:: console
+
+    # systemctl restart filebeat
+
+5. Setting up credentials for Kibana. Add the next lines to ``/etc/kibana/kibana.yml``.
+
+.. code-block:: yaml
+
+    xpack.security.enabled: true
+    elasticsearch.username: "elastic"
+    elasticsearch.password: "elastic_password"
+
+6. Restart Kibana.
 
 .. code-block:: console
 


### PR DESCRIPTION
Hi team.
This PR update the documentation related to this issue: https://github.com/wazuh/wazuh-documentation/issues/1246

The solution consists in:
- Generate credentials for all the Elastic Stack pre-built roles and users the roles and user at the end of the guide.
- Remove code not needed.

