### PR TITLE
Fix windows wildcards description on localfile

### DIFF
--- a/source/user-manual/reference/ossec-conf/localfile.rst
+++ b/source/user-manual/reference/ossec-conf/localfile.rst
@@ -36,9 +36,9 @@ location
 
 Option to get the location of a log or a group of logs. ``strftime`` format strings may be used for log file names.
 
-For instance, a log file named ``file.log-2019-07-30`` could be referenced with ``file.log-%Y-%m-%d`` (assuming today is Jul 30nd, 2019).
+For instance, a log file named ``file.log-2019-07-30`` can be referenced with ``file.log-%Y-%m-%d`` (assuming today is Jul 30th, 2019).
 
-Wildcards could be used on Linux and Windows systems, if the log file doesn't exist at ``ossec-logcollector`` start time, such log will be re-scanned after ``logcollector.vcheck_files`` seconds.
+Wildcards can be used on Linux and Windows systems, if the log file doesn't exist at ``ossec-logcollector`` start time, such log will be re-scanned after ``logcollector.vcheck_files`` seconds.
 
 The location field is also valid to filter by channel in case of using an ``eventchannel`` supporting Windows.
 
@@ -85,7 +85,7 @@ Below we have some Windows wildcard examples.
 .. note::
   * ``strftime`` format strings and wildcards cannot be used on the same entry.
 
-  * On Windows systems, only character ``*`` is supported as a wildcard. For instance ``*ANY_STRING*``, will match all files that have ``ANY_STRING`` inside its name, another example could be ``*.log`` this will match any log file.
+  * On Windows systems, only character ``*`` is supported as a wildcard. For instance ``*ANY_STRING*``, will match all files that have ``ANY_STRING`` inside its name, another example is ``*.log`` this will match any log file.
   * The maximum amount of files monitored at same time is limited to 200.
 
 command

--- a/source/user-manual/reference/ossec-conf/localfile.rst
+++ b/source/user-manual/reference/ossec-conf/localfile.rst
@@ -40,8 +40,6 @@ For instance, a log file named ``file.log-2019-07-30`` could be referenced with 
 
 Wildcards could be used on Linux and Windows systems, if the log file doesn't exist at ``ossec-logcollector`` start time, such log will be re-scanned after ``logcollector.vcheck_files`` seconds.
 
-Note that ``strftime`` format strings and wildcards cannot be used on the same entry.
-
 The location field is also valid to filter by channel in case of using an ``eventchannel`` supporting Windows.
 
 In the following example we can see two configurations showing a channel filtering for firewall and Sysmon events.
@@ -85,8 +83,10 @@ Below we have some Windows wildcard examples.
 +--------------------+--------------------------+
 
 .. note::
-  On Windows systems, only character ``*`` is supported as a wildcard. For instance ``*ANY_STRING*``, will match all files that have ``ANY_STRING`` inside its name, another example could be ``*.log`` this will match any log file.
-  The maximum amount of files monitored at same time is limited to 200.
+  * ``strftime`` format strings and wildcards cannot be used on the same entry.
+
+  * On Windows systems, only character ``*`` is supported as a wildcard. For instance ``*ANY_STRING*``, will match all files that have ``ANY_STRING`` inside its name, another example could be ``*.log`` this will match any log file.
+  * The maximum amount of files monitored at same time is limited to 200.
 
 command
 ^^^^^^^

--- a/source/user-manual/reference/ossec-conf/localfile.rst
+++ b/source/user-manual/reference/ossec-conf/localfile.rst
@@ -36,15 +36,15 @@ location
 
 Option to get the location of a log or a group of logs. ``strftime`` format strings may be used for log file names.
 
-For instance, a log file named ``file.log-2017-01-22`` could be referenced with ``file.log-%Y-%m-%d`` (assuming today is Jan 22nd, 2017).
+For instance, a log file named ``file.log-2019-07-30`` could be referenced with ``file.log-%Y-%m-%d`` (assuming today is Jul 30nd, 2019).
 
-Wildcards may be used on non-Windows systems, but if the log file doesn't exist at the time ``ossec-logcollector`` is started, it will be added after ``logcollector.vcheck_files`` seconds.
+Wildcards could be used on Linux and Windows systems, if the log file doesn't exist at ``ossec-logcollector`` start time, such log will be re-scanned after ``logcollector.vcheck_files`` seconds.
 
 Note that ``strftime`` format strings and wildcards cannot be used on the same entry.
 
-The location field is also valid to filter by channel in case of using an ``eventchannel`` supporting Windows. 
+The location field is also valid to filter by channel in case of using an ``eventchannel`` supporting Windows.
 
-As an example, these two configurations show a channel filtering for firewall and Sysmon events.
+In the following example we can see two configurations showing a channel filtering for firewall and Sysmon events.
 
 .. code-block:: xml
 
@@ -58,6 +58,26 @@ As an example, these two configurations show a channel filtering for firewall an
       <log_format>eventchannel</log_format>
   </localfile>
 
+
+Below we have some Windows wildcard examples.
+
+.. code-block:: xml
+
+  <localfile>
+      <location>C:\Users\wazuh\myapp\*</location>
+      <log_format>syslog</log_format>
+  </localfile>
+
+  <localfile>
+      <location>C:\xampp\apache\logs\*.log</location>
+      <log_format>syslog</log_format>
+  </localfile>
+
+  <localfile>
+      <location>C:\logs\file-%Y-%m-%d.log</location>
+      <log_format>syslog</log_format>
+  </localfile>
+
 +--------------------+--------------------------+
 | **Default value**  | n/a                      |
 +--------------------+--------------------------+
@@ -65,8 +85,8 @@ As an example, these two configurations show a channel filtering for firewall an
 +--------------------+--------------------------+
 
 .. note::
-  On Windows systems, only one wildcard character is supported. For instance ``*match*``, will match all files.
-  The maximum amount of files to monitor is limited to 200.
+  On Windows systems, only character ``*`` is supported as a wildcard. For instance ``*ANY_STRING*``, will match all files that have ``ANY_STRING`` inside its name, another example could be ``*.log`` this will match any log file.
+  The maximum amount of files monitored at same time is limited to 200.
 
 command
 ^^^^^^^
@@ -133,7 +153,7 @@ query
 
 Filter ``eventchannel`` events that Wazuh will process by using an *XPATH* query following the event schema.
 
-Example: 
+Example:
 
 .. code-block:: xml
 


### PR DESCRIPTION
Hello team,

Closes #1381 

We have improved the description of `location` tag inside `localfile`.
Now we explain better the use of wildcards on Windows with more examples.

Regards.