### PR TITLE
Correct typo in "command" wodle documentation

### DIFF
--- a/source/user-manual/reference/ossec-conf/wodle-command.rst
+++ b/source/user-manual/reference/ossec-conf/wodle-command.rst
@@ -129,7 +129,7 @@ timeout
 .. versionadded:: 3.2.2
 
 Timeout for each command to wait for the end of the execution. Whether this parameter is set to 0, it will wait indefinitely for the end of the process.
-However, if the timeout is other than 0, the execution will finished if it expires.
+However, if the timeout is other than 0, the execution will finish if it expires.
 
 +--------------------+-----------------------------+
 | **Default value**  | n/a                         |


### PR DESCRIPTION
Hi,

This PR aims to correct the following typo here: https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/wodle-command.html#timeout

`the execution will finished` → `the execution will finish`

Regards,
Sergio.