### PR TITLE
Fix typo in XML tag in Fluentd forwarder module

### DIFF
--- a/source/user-manual/capabilities/fluent-forwarder.rst
+++ b/source/user-manual/capabilities/fluent-forwarder.rst
@@ -5,9 +5,9 @@
 Fluentd forwarder
 =================
 
-.. versionadded:: 4.0.0
+.. versionadded:: 3.9.0
 
-This module allows Wazuh to forward messages to a Fluentd server. Fluentd it's an open source data collector logger that comes along 
+This module allows Wazuh to forward messages to a Fluentd server. Fluentd it's an open source data collector logger that comes along
 with great plugins to build your own logging layer. Check it out at https://www.fluentd.org/
 
 - `How it works`_

--- a/source/user-manual/reference/ossec-conf/fluent-forward.rst
+++ b/source/user-manual/reference/ossec-conf/fluent-forward.rst
@@ -5,6 +5,8 @@
 fluent-forward
 ==============
 
+.. versionadded:: 3.9.0
+
 .. topic:: XML section name
 
 	.. code-block:: xml

--- a/source/user-manual/reference/ossec-conf/fluent-forward.rst
+++ b/source/user-manual/reference/ossec-conf/fluent-forward.rst
@@ -9,8 +9,8 @@ fluent-forward
 
 	.. code-block:: xml
 
-		<fluent_forward>
-		</fluent_forward>
+		<fluent-forward>
+		</fluent-forward>
 
 This configuration section is used to configure the Fluentd forwarder module.
 
@@ -172,15 +172,15 @@ Linux configuration:
 .. code-block:: xml
 
     <!-- Simple usage without using TLS -->
-    <fluent_forward>
+    <fluent-forward>
       <enabled>yes</enabled>
       <socket_path>/var/run/fluent.sock</socket_path>
       <address>localhost</address>
       <port>24224</port>
-    </fluent_forward>
+    </fluent-forward>
 
     <!-- Simple usage using TLS -->
-    <fluent_forward>
+    <fluent-forward>
       <enabled>yes</enabled>
       <socket_path>/var/run/fluent.sock</socket_path>
       <address>localhost</address>
@@ -189,4 +189,4 @@ Linux configuration:
       <ca_file>/root/certs/fluent.crt</ca_file>
       <user>foo</user>
       <password>bar</password>
-    </fluent_forward>
+    </fluent-forward>


### PR DESCRIPTION
The correct tag for this module should be `<fluent-forward>` instead of `<fluent_forward>`.

https://github.com/wazuh/wazuh/blob/6f47eb206f65ecef6053ff77921639161e1a8db6/src/wazuh_modules/wmodules.h#L40