### PR TITLE
Fixed visual bug caused by wrong tabulation

### DIFF
--- a/source/user-manual/agents/remote-upgrading/create-custom-wpk.rst
+++ b/source/user-manual/agents/remote-upgrading/create-custom-wpk.rst
@@ -77,7 +77,7 @@ Canonical WPK package example
 
     .. code-block:: console
 
-    # curl -Ls https://github.com/wazuh/wazuh/archive/v3.9.5.tar.gz | tar zx
+        # curl -Ls https://github.com/wazuh/wazuh/archive/v3.9.5.tar.gz | tar zx
 
 3. Modify the ``wazuh-3.9.5/etc/preloaded-vars.conf`` file that was downloaded to deploy an :ref:`unattended update <unattended-installation>` in the agent by uncommenting the following lines:
 


### PR DESCRIPTION
Somehow old docu showed this properly, but now it will show this badly if it does not have the right indentation.

Old:
![imagen](https://user-images.githubusercontent.com/14235896/63030514-b9130b80-beb2-11e9-9738-542ed7f9ab62.png)

Fixed (added tabulation):
![imagen](https://user-images.githubusercontent.com/14235896/63030580-d647da00-beb2-11e9-85c6-d2c4eafbe639.png)
