### PR TITLE
Restore toctree in branch 2.1 and fixed links

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -278,14 +278,14 @@ Wazuh is a free and open source platform for threat detection, security monitori
    getting-started/index
    installation-guide/index
    user-manual/index
-   development/index
-   containers
-   deployment
-   compliance
-   monitoring
-   installing-splunk/index
+   docker/index
+   deploying-with-puppet/index
+   deploying-with-ansible/index
+   pci-dss/index
+   amazon/index
    migrating-from-ossec/index
    release-notes/index
+   development/index
 
 .. raw:: html
 

--- a/source/installation-guide/optional-configurations/elastic-tuning.rst
+++ b/source/installation-guide/optional-configurations/elastic-tuning.rst
@@ -203,4 +203,4 @@ In a cluster with 1 node, the number of replicas should be 0::
 
 Reference:
 
-  - `Shards & Replicas <https://www.elastic.co/guide/en/elasticsearch/reference/current/getting-started-concepts.html#getting-started-shards-and-replicas>`_.
+  - `Shards & Replicas <https://www.elastic.co/guide/en/elasticsearch/reference/6.7/getting-started-concepts.html#getting-started-shards-and-replicas>`_.

--- a/source/user-manual/ruleset/getting-started.rst
+++ b/source/user-manual/ruleset/getting-started.rst
@@ -21,7 +21,7 @@ In the ruleset repository you will find:
 Resources
 ^^^^^^^^^
 * Visit our repository to view the rules in detail at `Github Wazuh Ruleset <https://github.com/wazuh/wazuh-ruleset>`_
-* Find a complete description of the available rules at `Wazuh Ruleset Summary <http://www.wazuh.com/resources/OSSEC_Ruleset.pdf>`_
+* Find a complete description of the available rules at `Wazuh Ruleset Summary <http://www.wazuh.com/resources/Wazuh_Ruleset.pdf>`_
 
 
 Rule and Rootcheck example


### PR DESCRIPTION
- Toctree restored in branch 2.1
- Fixed link to PDF in user-manual/ruleset/getting-started.rst
- Fixed link to Elastic's documentation
