### PR TITLE
Fix visual bug

### DIFF
--- a/source/installing-splunk/splunk-app.rst
+++ b/source/installing-splunk/splunk-app.rst
@@ -19,7 +19,7 @@ Installation
 
     .. code-block:: console
 
-    # curl -o SplunkAppForWazuh.tar.gz https://packages.wazuh.com/3.x/splunkapp/v3.9.5_7.3.0.tar.gz
+      # curl -o SplunkAppForWazuh.tar.gz https://packages.wazuh.com/3.x/splunkapp/v3.9.5_7.3.0.tar.gz
 
 2. Install the Wazuh app for Splunk:
 

--- a/source/installing-splunk/splunk-forwarder.rst
+++ b/source/installing-splunk/splunk-forwarder.rst
@@ -52,7 +52,7 @@ Configuring props
 
     .. code-block:: console
 
-    # curl -so /opt/splunkforwarder/etc/system/local/props.conf https://raw.githubusercontent.com/wazuh/wazuh/v3.9.5/extensions/splunk/props.conf
+      # curl -so /opt/splunkforwarder/etc/system/local/props.conf https://raw.githubusercontent.com/wazuh/wazuh/v3.9.5/extensions/splunk/props.conf
 
 Configuring inputs
 ++++++++++++++++++
@@ -61,7 +61,7 @@ Configuring inputs
 
     .. code-block:: console
 
-    # curl -so /opt/splunkforwarder/etc/system/local/inputs.conf https://raw.githubusercontent.com/wazuh/wazuh/v3.9.5/extensions/splunk/inputs.conf
+      # curl -so /opt/splunkforwarder/etc/system/local/inputs.conf https://raw.githubusercontent.com/wazuh/wazuh/v3.9.5/extensions/splunk/inputs.conf
 
 2. Set the Wazuh manager hostname:
 


### PR DESCRIPTION
Hi team,

Some commands in the Splunk installation guide are not being shown correctly due to a wrong indentation, this PR fixes it.

Regards,