### PR TITLE
[Design] Fixed style of highlighted string (3.0)

### DIFF
--- a/source/_static/css/style.css
+++ b/source/_static/css/style.css
@@ -1977,7 +1977,7 @@ h4, h5, h6 {
   padding-left: 5px;
 }
 
-#search-results .highlighted {
+main .highlighted {
   background-color: #fff200;
 }
 


### PR DESCRIPTION
The terms used during a search are now highlighted when the page is opened from the search results page.

Issue: #1430