### PR TITLE
[3.9] Fixed some broken links in rst files

### DIFF
--- a/source/deploying-with-kubernetes/kubernetes-conf.rst
+++ b/source/deploying-with-kubernetes/kubernetes-conf.rst
@@ -146,7 +146,7 @@ Deploy
 2. Create domains to access the services
 
     We recommend creating domains and certificates to access the services. Examples:
-    
+
     - wazuh-master.your-domain.com: Wazuh API and authd registration service.
     - wazuh-manager.your-domain.com: Reporting service.
     - wazuh.your-domain.com: Kibana and Wazuh app.
@@ -198,7 +198,7 @@ Deploy
 
             $ kubectl apply -f elastic_stack/logstash/logstash-svc.yaml
             $ kubectl apply -f elastic_stack/logstash/logstash-deploy.yaml
-        
+
 4. Deploy Wazuh
 
     .. code-block:: console
@@ -277,9 +277,9 @@ Verifying the deployment
 
 **Accesing Kibana**
 
-    In case you created domain names for the services, you should be able to access Kibana using the proposed domain name: https://wazuh.your-domain.com.
+    In case you created domain names for the services, you should be able to access Kibana using the proposed domain name: ``https://wazuh.your-domain.com``.
 
-    Also, you can access using the DNS (Eg: https://internal-xxx-yyy.us-east-1.elb.amazonaws.com):
+    Also, you can access using the DNS (Eg: ``https://internal-xxx-yyy.us-east-1.elb.amazonaws.com``):
 
     .. code-block:: console
 

--- a/source/installation-guide/installing-elastic-stack/elastic_tuning.rst
+++ b/source/installation-guide/installing-elastic-stack/elastic_tuning.rst
@@ -250,4 +250,4 @@ In a cluster with one node, the number of replicas should be set to zero:
 
 Reference:
 
-  - `Shards & Replicas <https://www.elastic.co/guide/en/elasticsearch/reference/current/getting-started-concepts.html#getting-started-shards-and-replicas>`_.
+  - `Shards & Replicas <https://www.elastic.co/guide/en/elasticsearch/reference/6.x/getting-started-concepts.html#getting-started-shards-and-replicas>`_.

--- a/source/installation-guide/virtual-machine.rst
+++ b/source/installation-guide/virtual-machine.rst
@@ -43,7 +43,7 @@ Wazuh provides a pre-built virtual machine image (OVA) that you can directly imp
       # systemctl start filebeat
       # systemctl status kibana
 
-5. In order to connect to the Kibana web user interface, login with https://OVA_IP_ADDRESS (where ``OVA_IP_ADDRESS`` is your system IP).
+5. In order to connect to the Kibana web user interface, login with ``https://OVA_IP_ADDRESS`` (where ``OVA_IP_ADDRESS`` is your system IP).
 
     .. note::
 

--- a/source/user-manual/kibana-app/reference/elasticsearch.rst
+++ b/source/user-manual/kibana-app/reference/elasticsearch.rst
@@ -74,4 +74,4 @@ They are auto-generated and they store the Wazuh agents statuses periodically. T
 More information
 ----------------
 
-- `Elasticsearch documentation - Exploring Your Cluster <https://www.elastic.co/guide/en/elasticsearch/reference/current/getting-started-explore.html>`_
+- `Elasticsearch documentation - Exploring Your Cluster <https://www.elastic.co/guide/en/elasticsearch/reference/6.x/getting-started-explore.html>`_

--- a/source/user-manual/reference/ossec-conf/agentless.rst
+++ b/source/user-manual/reference/ossec-conf/agentless.rst
@@ -62,7 +62,7 @@ Defines the username and the name of the agentless host.
 +--------------------+--------------------------------------------------------+
 | **Default value**  | n/a                                                    |
 +--------------------+--------------------------------------------------------+
-| **Allowed values** | Any username and host (username@hostname)              |
+| **Allowed values** | Any username and host (``username@hostname``)          |
 +--------------------+--------------------------------------------------------+
 
 state


### PR DESCRIPTION
Links fixed:

- https://documentation.wazuh.com/3.9/installation-guide/virtual-machine.html
  Replaced https://OVA_IP_ADDRESS with ``https://OVA_IP_ADDRESS``
	
- https://documentation.wazuh.com/3.9/installation-guide/installing-elastic-stack/elastic_tuning.html
  Replaced https://www.elastic.co/guide/en/elasticsearch/reference/current/getting-started-concepts.html with https://www.elastic.co/guide/en/elasticsearch/reference/6.x/getting-started-concepts.html
	
- https://documentation.wazuh.com/3.9/user-manual/kibana-app/reference/elasticsearch.html	
  Replaced https://www.elastic.co/guide/en/elasticsearch/reference/current/getting-started-explore.html with https://www.elastic.co/guide/en/elasticsearch/reference/6.x/getting-started-explore.html
	
- https://documentation.wazuh.com/3.9/user-manual/reference/ossec-conf/agentless.html
  Replaced line: | **Allowed values** | Any username and host (username@hostname)              |
  with:		| **Allowed values** | Any username and host (``username@hostname``)          |
	
- https://documentation.wazuh.com/3.9/deploying-with-kubernetes/kubernetes-conf.html
  Replaced https://wazuh.your-domain.com with ``https://wazuh.your-domain.com``
  Replace https://internal-xxx-yyy.us-east-1.elb.amazonaws.com with ``https://internal-xxx-yyy.us-east-1.elb.amazonaws.com``