### PR TITLE
Sticky menu fixed (3.0)

### DIFF
--- a/source/_static/css/style.css
+++ b/source/_static/css/style.css
@@ -340,7 +340,7 @@ header .menuweb-bar .menu-item a {
           animation: showMenuStickyMobile 0.2s cubic-bezier(0.250, 0.460, 0.450, 0.940) 0ms both;
 }
 
-.no-latest-docs #header-sticky {
+.scrolled .no-latest-docs #header-sticky {
   -webkit-animation: showMenuStickyMobile_noLatestDocs 0.2s cubic-bezier(0.250, 0.460, 0.450, 0.940) 0ms both;
           animation: showMenuStickyMobile_noLatestDocs 0.2s cubic-bezier(0.250, 0.460, 0.450, 0.940) 0ms both;
 }
@@ -1652,6 +1652,7 @@ select, option {
   cursor: pointer;
   position: relative;
   min-width: 120px;
+  height: 26px;
   padding: 2px 8px;
   color: #fff;
   font-size: 0.85rem;
@@ -2840,7 +2841,7 @@ div.highlight pre {
                 animation: showMenuSticky 0.2s cubic-bezier(0.250, 0.460, 0.450, 0.940) 0ms both;
       }
 
-      .no-latest-docs #header-sticky {
+      .scrolled .no-latest-docs #header-sticky {
         -webkit-animation: showMenuSticky_noLatestDocs 0.2s cubic-bezier(0.250, 0.460, 0.450, 0.940) 0ms both;
                 animation: showMenuSticky_noLatestDocs 0.2s cubic-bezier(0.250, 0.460, 0.450, 0.940) 0ms both;
       }


### PR DESCRIPTION
Issue [#783](https://github.com/wazuh/wazuh-website/issues/783)

---

It was only necessary to add the `.scrolled` class to the class of the sticky menu. These images are the changes to the left and the original to the right.

![001](https://user-images.githubusercontent.com/37677237/63410038-a9378200-c3f2-11e9-9baf-7003dc1a2f84.png)
![002](https://user-images.githubusercontent.com/37677237/63410021-a177dd80-c3f2-11e9-847a-7f1a2a23507e.png)

Also, I've taken advantage of giving `height` to the version selector. It was necessary to avoid an unwanted jump when the content appears on the selector.

![000](https://user-images.githubusercontent.com/37677237/63410019-a0df4700-c3f2-11e9-9094-34f3c4e43344.png)
