### PR TITLE
[3.8] Fixed some broken links in rst files

### DIFF
--- a/source/installation-guide/installing-elastic-stack/elastic_tuning.rst
+++ b/source/installation-guide/installing-elastic-stack/elastic_tuning.rst
@@ -249,4 +249,4 @@ Note that we are assuming your target index pattern is **"wazuh-alerts-*"**, how
 
 Reference:
 
-  - `Shards & Replicas <https://www.elastic.co/guide/en/elasticsearch/reference/current/getting-started-concepts.html#getting-started-shards-and-replicas>`_.
+  - `Shards & Replicas <https://www.elastic.co/guide/en/elasticsearch/reference/6.x/getting-started-concepts.html#getting-started-shards-and-replicas>`_.

--- a/source/installation-guide/upgrading/different_major.rst
+++ b/source/installation-guide/upgrading/different_major.rst
@@ -340,7 +340,7 @@ Upgrade Kibana
 
   The .kibana index (which holds Kibana's configuration) has drastically changed. To migrate it, follow the official documentation:
 
-  - `Migrating Kibana .index to 6.0 <https://www.elastic.co/guide/en/kibana/current/migrating-6.0-index.html>`_
+  - `Migrating Kibana .index to 6.0 <https://www.elastic.co/guide/en/kibana/6.x/migrating-6.0-index.html>`_
 
 4. Upgrade the Wazuh Kibana App:
 

--- a/source/installation-guide/virtual-machine.rst
+++ b/source/installation-guide/virtual-machine.rst
@@ -39,7 +39,7 @@ Wazuh provides a pre-built virtual machine image (OVA) that you can directly imp
     # systemctl start logstash
     # systemctl status kibana
 
-5. In order to connect to the Kibana web user interface, login with https://OVA_IP_ADDRESS (where ``OVA_IP_ADDRESS`` is your system IP).
+5. In order to connect to the Kibana web user interface, login with ``https://OVA_IP_ADDRESS`` (where ``OVA_IP_ADDRESS`` is your system IP).
 
 
 .. note:: If you need to update your OVA virtual machine, you can check out :ref:`this article <upgrading_latest_minor>`. We also recommend updating the repositories using the ``yum update`` command.

--- a/source/user-manual/kibana-app/reference/elasticsearch.rst
+++ b/source/user-manual/kibana-app/reference/elasticsearch.rst
@@ -74,4 +74,4 @@ They are auto-generated and they store the Wazuh agents statuses periodically. T
 More information
 ----------------
 
-- `Elasticsearch documentation - Exploring Your Cluster <https://www.elastic.co/guide/en/elasticsearch/reference/current/getting-started-explore.html>`_
+- `Elasticsearch documentation - Exploring Your Cluster <https://www.elastic.co/guide/en/elasticsearch/reference/6.x/getting-started-explore.html>`_

--- a/source/user-manual/reference/ossec-conf/agentless.rst
+++ b/source/user-manual/reference/ossec-conf/agentless.rst
@@ -62,7 +62,7 @@ Defines the username and the name of the agentless host.
 +--------------------+--------------------------------------------------------+
 | **Default value**  | n/a                                                    |
 +--------------------+--------------------------------------------------------+
-| **Allowed values** | Any username and host (username@hostname)              |
+| **Allowed values** | Any username and host (``username@hostname``)          |
 +--------------------+--------------------------------------------------------+
 
 state


### PR DESCRIPTION
## 3.8

- https://documentation.wazuh.com/3.8/installation-guide/virtual-machine.html
  Replaced https://OVA_IP_ADDRESS with ``https://OVA_IP_ADDRESS``

- https://documentation.wazuh.com/3.8/installation-guide/installing-elastic-stack/elastic_tuning.html
  Replaced https://www.elastic.co/guide/en/elasticsearch/reference/current/getting-started-concepts.html with https://www.elastic.co/guide/en/elasticsearch/reference/6.x/getting-started-concepts.html

- https://documentation.wazuh.com/3.8/installation-guide/upgrading/different_major.html
  Replaced https://www.elastic.co/guide/en/kibana/current/migrating-6.0-index.html with https://www.elastic.co/guide/en/kibana/6.x/migrating-6.0-index.html
	
- https://documentation.wazuh.com/3.8/user-manual/kibana-app/reference/elasticsearch.html	
  Replaced https://www.elastic.co/guide/en/elasticsearch/reference/current/getting-started-explore.html with https://www.elastic.co/guide/en/elasticsearch/reference/6.x/getting-started-explore.html
	
- https://documentation.wazuh.com/3.8/user-manual/reference/ossec-conf/agentless.html
  Replaced line: | **Allowed values** | Any username and host (username@hostname)              |
  with:		| **Allowed values** | Any username and host (``username@hostname``)          |