### PR TITLE
Version on the conf.py changed to 3.1

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -29,7 +29,7 @@ author = u'Wazuh, Inc.'
 copyright = u'&copy; ' + str(datetime.datetime.now().year) + u' &middot; Wazuh Inc.'
 
 # The short X.Y version
-version = '2.1'
+version = '3.1'
 # The full version, including alpha/beta/rc tags
 release = version
 


### PR DESCRIPTION
Issue [#807 ](https://github.com/wazuh/wazuh-website/issues/807)

---

We have a problem with the version notice in these versions:

### 3.0
![Screenshot 2019-08-21 at 12 17 03](https://user-images.githubusercontent.com/16825724/63423980-b877f900-c40d-11e9-8e2c-002cc8ed3593.png)

### 3.1
![Screenshot 2019-08-21 at 12 16 49](https://user-images.githubusercontent.com/16825724/63424008-c88fd880-c40d-11e9-925f-d8093cc70dcb.png)

The problem was on `conf.py` file. It was defined how `2.1` version:

![010](https://user-images.githubusercontent.com/37677237/63425910-e7906980-c411-11e9-8fdf-8c773bd328e2.png)

I've put the correct version:

![011](https://user-images.githubusercontent.com/37677237/63425911-e7906980-c411-11e9-9c98-cd5184c3ccac.png)

Now, the notice bar has the correct version and the URL to the current version is linked correctly.

![image (2)](https://user-images.githubusercontent.com/37677237/63425912-e8290000-c411-11e9-8646-81932bc19d87.png)
