### PR TITLE
[3.4] Fixed some broken links in rst files

### DIFF
--- a/source/installation-guide/optional-configurations/elastic-tuning.rst
+++ b/source/installation-guide/optional-configurations/elastic-tuning.rst
@@ -249,4 +249,4 @@ Note that we are assuming your target index pattern is **"wazuh-alerts-*"**, how
 
 Reference:
 
-  - `Shards & Replicas <https://www.elastic.co/guide/en/elasticsearch/reference/current/_basic_concepts.html#getting-started-shards-and-replicas>`_.
+  - `Shards & Replicas <https://www.elastic.co/guide/en/elasticsearch/reference/6.2/_basic_concepts.html#getting-started-shards-and-replicas>`_.

--- a/source/installation-guide/upgrading/different_major.rst
+++ b/source/installation-guide/upgrading/different_major.rst
@@ -316,7 +316,7 @@ Upgrade Kibana
 
   The .kibana index (which holds Kibana's configuration) has drastically changed. To migrate it, follow the official documentation:
 
-  - `Migrating Kibana .index to 6.0 <https://www.elastic.co/guide/en/kibana/current/migrating-6.0-index.html>`_
+  - `Migrating Kibana .index to 6.0 <https://www.elastic.co/guide/en/kibana/6.x/migrating-6.0-index.html>`_
 
 
 4. Upgrade the Wazuh Kibana App:

--- a/source/installation-guide/virtual-machine.rst
+++ b/source/installation-guide/virtual-machine.rst
@@ -39,4 +39,4 @@ Wazuh provides a pre-built virtual machine image (OVA) that you can directly imp
     # systemctl start logstash
     # systemctl status kibana
 
-5. In order to connect to the Kibana web user interface, login with http://OVA_IP_ADRESS:5601 (where ``OVA_IP_ADDRESS`` is your system IP).
+5. In order to connect to the Kibana web user interface, login with ``http://OVA_IP_ADRESS:5601`` (where ``OVA_IP_ADDRESS`` is your system IP).

--- a/source/user-manual/reference/ossec-conf/agentless.rst
+++ b/source/user-manual/reference/ossec-conf/agentless.rst
@@ -62,7 +62,7 @@ Defines the username and the name of the agentless host.
 +--------------------+--------------------------------------------------------+
 | **Default value**  | n/a                                                    |
 +--------------------+--------------------------------------------------------+
-| **Allowed values** | Any username and host (username@hostname)              |
+| **Allowed values** | Any username and host (``username@hostname``)          |
 +--------------------+--------------------------------------------------------+
 
 state

--- a/source/user-manual/reference/tools/util.sh.rst
+++ b/source/user-manual/reference/tools/util.sh.rst
@@ -21,7 +21,7 @@ A `blogpost <http://dcid.me/blog/2011/10/3woo-alerting-on-dns-ip-address-changes
 |                                   |                                                                                                                                   |
 |                                   | A rule can be written to monitor this output for changes.                                                                         |
 |                                   |                                                                                                                                   |
-|                                   | Requires `lynx <http://lynx.isc.org/current/>`_                                                                                   |
+|                                   | Requires `lynx <https://lynx.invisible-island.net/current/index.html>`_                                                                                   |
 +-----------------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
 | **adddns <domain>**               | Monitor the nameserver of a domain for changes.                                                                                   |
 |                                   |                                                                                                                                   |

--- a/source/user-manual/ruleset/getting-started.rst
+++ b/source/user-manual/ruleset/getting-started.rst
@@ -23,7 +23,7 @@ In the ruleset repository you will find:
 Resources
 ^^^^^^^^^
 * Visit our repository to view the rules in detail at `Github Wazuh Ruleset <https://github.com/wazuh/wazuh-ruleset>`_
-* Find a complete description of the available rules at `Wazuh Ruleset Summary <http://www.wazuh.com/resources/OSSEC_Ruleset.pdf>`_
+* Find a complete description of the available rules at `Wazuh Ruleset Summary <http://www.wazuh.com/resources/Wazuh_Ruleset.pdf>`_
 
 
 Rule and Rootcheck example


### PR DESCRIPTION
Broken links in 3.4
===========

- https://documentation.wazuh.com/3.4/installation-guide/optional-configurations/elastic-tuning.html
  Replaced https://www.elastic.co/guide/en/elasticsearch/reference/current/_basic_concepts.html with https://www.elastic.co/guide/en/elasticsearch/reference/6.2/_basic_concepts.html
	
- https://documentation.wazuh.com/3.4/installation-guide/upgrading/different_major.html
  Replaced https://www.elastic.co/guide/en/kibana/current/migrating-6.0-index.html with https://www.elastic.co/guide/en/kibana/6.x/migrating-6.0-index.html
	
- https://documentation.wazuh.com/3.4/installation-guide/virtual-machine.html
  Replaced http://ova_ip_adress:5601 with ``http://ova_ip_adress:5601``

- https://documentation.wazuh.com/3.4/user-manual/ruleset/getting-started.html
  Replaced http://www.wazuh.com/resources/OSSEC_Ruleset.pdf with http://www.wazuh.com/resources/Wazuh_Ruleset.pdf
	
- https://documentation.wazuh.com/3.4/user-manual/reference/ossec-conf/agentless.html
  Replaced line: | **Allowed values** | Any username and host (username@hostname)              |
  with:		| **Allowed values** | Any username and host (``username@hostname``)          |
	
- https://documentation.wazuh.com/3.4/user-manual/reference/tools/util.sh.html
  Replaced http://lynx.isc.org/current/ with https://lynx.invisible-island.net/current/index.html