### PR TITLE
Cache problem solved (3.0)

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -345,9 +345,9 @@ todo_include_todos = False
 # -- Setup -------------------------------------------------------------------
 
 def setup(app):
-    app.add_stylesheet('css/font-awesome.min.css')
-    app.add_stylesheet('css/wazuh-icons.css')
-    app.add_stylesheet('css/style.css')
+    app.add_stylesheet("css/font-awesome.min.css?ver=%s" % os.stat("source/_static/css/font-awesome.min.css").st_mtime)
+    app.add_stylesheet("css/wazuh-icons.css?ver=%s" % os.stat("source/_static/css/wazuh-icons.css").st_mtime)
+    app.add_stylesheet("css/style.css?ver=%s" % os.stat("source/_static/css/style.css").st_mtime)
 
 # -- Additional configuration ------------------------------------------------
 html_context = {


### PR DESCRIPTION
Issue [#805](https://github.com/wazuh/wazuh-website/issues/805)

---

In the `conf.py` file the CSS urls are configured. Therefore, in this file I've added to the URLs the attribute `?ver=` and the UNIX date of the last change.

![005](https://user-images.githubusercontent.com/37677237/63420782-bad75480-c407-11e9-8251-89a8930609ef.png)

In this way, every time the CSS files changes and the docu is compiled, the number of `ver` change and the browser load these files without cache.

This is the result:

![007](https://user-images.githubusercontent.com/37677237/63421277-9a5bca00-c408-11e9-8710-3a1b737cd6a5.png)
