### PR TITLE
[2.1] Fixed some broken links in rst files

### DIFF
--- a/source/installation-guide/virtual-machine.rst
+++ b/source/installation-guide/virtual-machine.rst
@@ -36,4 +36,4 @@ We provide a pre-built virtual machine image (OVA), you can directly import usin
     $ systemctl start logstash
     $ systemctl status kibana
 
-5. In order to connect to Kibana web user interface, you can login with http://OVA_IP_ADRESS:5601 (where ``OVA_IP_ADDRESS`` is your system IP).
+5. In order to connect to Kibana web user interface, you can login with ``http://OVA_IP_ADRESS:5601`` (where ``OVA_IP_ADDRESS`` is your system IP).

--- a/source/user-manual/capabilities/agentless-monitoring/how-it-works.rst
+++ b/source/user-manual/capabilities/agentless-monitoring/how-it-works.rst
@@ -82,7 +82,7 @@ A set of commands can also be configured to run on a remote device. Wazuh will a
 
 .. note::
 
-  To use ``su`` in a command as an argument, ``use_su`` must be set before the hostname. In the previous example, this would appear as: <host>use_su root@example_address.com</host>
+  To use ``su`` in a command as an argument, ``use_su`` must be set before the hostname. In the previous example, this would appear as: ``<host>use_su root@example_address.com</host>``
 
 
 Pix config

--- a/source/user-manual/reference/ossec-conf/agentless.rst
+++ b/source/user-manual/reference/ossec-conf/agentless.rst
@@ -60,7 +60,7 @@ This defines the username and the name of the agentless host.
 +--------------------+--------------------------------------------------------+
 | **Default value**  | n/a                                                    |
 +--------------------+--------------------------------------------------------+
-| **Allowed values** | Any username and host (user@hostname)                  |
+| **Allowed values** | Any username and host (``username@hostname``)          |
 +--------------------+--------------------------------------------------------+
 
 state

--- a/source/user-manual/reference/tools/util.sh.rst
+++ b/source/user-manual/reference/tools/util.sh.rst
@@ -20,7 +20,7 @@ A `blogpost <http://dcid.me/blog/2011/10/3woo-alerting-on-dns-ip-address-changes
 |                                   |                                                                                                                                   |
 |                                   | A rule can be written to monitor this output for changes.                                                                         |
 |                                   |                                                                                                                                   |
-|                                   | Requires `lynx <http://lynx.isc.org/current/>`_                                                                                   |
+|                                   | Requires `lynx <https://lynx.invisible-island.net/current/index.html>`_                                                           |
 +-----------------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
 | **adddns <domain>**               | Monitor the nameserver of a domain for changes.                                                                                   |
 |                                   |                                                                                                                                   |


### PR DESCRIPTION
Broken links in 2.1
===========

- https://documentation.wazuh.com/2.1/installation-guide/virtual-machine.html
  Replaced http://ova_ip_adress:5601 with ``http://ova_ip_adress:5601``
	
- https://documentation.wazuh.com/2.1/user-manual/capabilities/agentless-monitoring/how-it-works.html
  Replaced <host>use_su root@example_address.com</host> with ``<host>use_su root@example_address.com</host>``
	
- https://documentation.wazuh.com/2.1/user-manual/reference/ossec-conf/agentless.html
  Replaced line: | **Allowed values** | Any username and host (username@hostname)              |
  with:		| **Allowed values** | Any username and host (``username@hostname``)          |
	
- https://documentation.wazuh.com/2.1/user-manual/reference/tools/util.sh.html
  Replaced |                                   | Requires `lynx <http://lynx.isc.org/current/>`_                                                                                   | 
  with |                                   | Requires `lynx <https://lynx.invisible-island.net/current/index.html>`_                                                           |