### PR TITLE
The contents section links are now blue (3.0)

### DIFF
--- a/source/_static/css/style.css
+++ b/source/_static/css/style.css
@@ -1392,8 +1392,8 @@ footer a:focus,
   border: none;
 }
 
-main li.toctree-l1 > a {
-  color: #333;
+main li.toctree-l1 a {
+  color: #0094ce;
 }
 
 main li.toctree-l1 > a:hover,


### PR DESCRIPTION
Issue [#787](https://github.com/wazuh/wazuh-website/issues/787)

---

The contents section links are now blue. The others links of the docu haven't been affected.

![000](https://user-images.githubusercontent.com/37677237/63494264-9f2e8580-c4bd-11e9-9db2-3b2d34d6df07.png)