### PR TITLE
Azure deprecated json file

### DIFF
--- a/source/azure/monitoring activity.rst
+++ b/source/azure/monitoring activity.rst
@@ -304,9 +304,9 @@ Select the option to export to a storage account, establish the subscription we 
     :align: center
     :width: 50%
 
-In this case, the integration will be executed with an ``interval`` of one day, the credentials will be taken from a file and we will proceed to search in the container ``insights-operational-logs``, all the blobs that have the extension ``.json`` in the last ``24 hours``. We also indicate the type of content that have the blobs that we are going to recover, in this case ``json_file``:
+In this case, the integration will be executed with an ``interval`` of one day, the credentials will be taken from a file and we will proceed to search in the container ``insights-operational-logs``, all the blobs that have the extension ``.json`` in the last ``24 hours``. We also indicate the type of content that have the blobs that we are going to recover, in this case ``json_inline``:
 
-.. note:: As of November 1st 2018, the format of logs stored in Azure accounts will become inline JSON (``json_inline`` in Wazuh) and the previous format will be obsolete (``json_file`` in Wazuh).
+.. note:: As of November 1st 2018, the format of logs stored in Azure accounts became inline JSON (``json_inline`` in Wazuh) and the previous format became obsolete (``json_file`` in Wazuh).
 
 .. code-block:: xml
 
@@ -323,7 +323,7 @@ In this case, the integration will be executed with an ``interval`` of one day, 
 
                 <container name="insights-operational-logs">
                     <blobs>.json</blobs>
-                    <content_type>json_file</content_type>
+                    <content_type>json_inline</content_type>
                     <time_offset>24h</time_offset>
                 </container>
 

--- a/source/user-manual/reference/ossec-conf/wodle-azure-logs.rst
+++ b/source/user-manual/reference/ossec-conf/wodle-azure-logs.rst
@@ -702,11 +702,11 @@ storage\\container\\content_type
 Specifies the content of the blobs.
 
 - **text**. Plain text. Each line is a log.
-- **json_file**. The blob contain records of logs in standard json format. **Note:**
+- **json_file**. The blob contain records of logs in standard json format.
 - **json_inline**. Each line is a log in json format.
 
 .. note::
-	As of November 1st 2018, the format of logs stored in Azure accounts became inline JSON.
+	As of November 1st 2018, the format of logs stored in Azure accounts became **inline JSON** instead of **JSON file**.
 	
 .. note::
 

--- a/source/user-manual/reference/ossec-conf/wodle-azure-logs.rst
+++ b/source/user-manual/reference/ossec-conf/wodle-azure-logs.rst
@@ -702,9 +702,12 @@ storage\\container\\content_type
 Specifies the content of the blobs.
 
 - **text**. Plain text. Each line is a log.
-- **json_file**. The blob contain records of logs in standard json format.
+- **json_file**. The blob contain records of logs in standard json format. **Note:**
 - **json_inline**. Each line is a log in json format.
 
+.. note::
+	As of November 1st 2018, the format of logs stored in Azure accounts became inline JSON.
+	
 .. note::
 
 	When the ``day`` option is set, the interval value must be a multiple of months. By default, the interval is set to a month.
@@ -756,7 +759,7 @@ Example of storage configuration
 
             <container name="insights-operational-logs">
                 <blobs>.json</blobs>
-                <content_type>json_file</content_type>
+                <content_type>json_inline</content_type>
                 <time_offset>24h</time_offset>
             </container>
 
@@ -813,7 +816,7 @@ Example of all integration
 
             <container name="insights-operational-logs">
                 <blobs>.json</blobs>
-                <content_type>json_file</content_type>
+                <content_type>json_inline</content_type>
                 <time_offset>24h</time_offset>
             </container>
 


### PR DESCRIPTION
Updated json_file to json_inline for azureAs of November 2018 Azure's format is `json_inline` instead of `json_file`. 
To avoid confusion I'm changing these examples.

Also updated the language to reflect this time is in the past now.