### PR TITLE
Dynamic paths for cache in conf.py (3.4)

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -345,9 +345,13 @@ todo_include_todos = False
 # -- Setup -------------------------------------------------------------------
 
 def setup(app):
-    app.add_stylesheet("css/font-awesome.min.css?ver=%s" % os.stat("source/_static/css/font-awesome.min.css").st_mtime)
-    app.add_stylesheet("css/wazuh-icons.css?ver=%s" % os.stat("source/_static/css/wazuh-icons.css").st_mtime)
-    app.add_stylesheet("css/style.css?ver=%s" % os.stat("source/_static/css/style.css").st_mtime)
+    actual_path = os.path.dirname(os.path.realpath(__file__))
+    app.add_stylesheet("css/font-awesome.min.css?ver=%s" % os.stat(
+        os.path.join(actual_path, "_static/css/font-awesome.min.css")).st_mtime)
+    app.add_stylesheet("css/wazuh-icons.css?ver=%s" % os.stat(
+        os.path.join(actual_path, "_static/css/wazuh-icons.css")).st_mtime)
+    app.add_stylesheet("css/style.css?ver=%s" % os.stat(
+        os.path.join(actual_path, "_static/css/style.css")).st_mtime)
 
 # -- Additional configuration ------------------------------------------------
 html_context = {


### PR DESCRIPTION
Issue [#816](https://github.com/wazuh/wazuh-website/issues/816)

---

The problem is the following:

- In windows, mac, etc. the path is `source/_static/css/font-awesome.min.css`
- In Debian (maybe others) it is `docs/_static/css/font-awesome.min.css`

That difference of `source` and `docs` is what generates the error in some and not in others, because the script was configured only for `source`.
The route is load dynamically now, so according to the OS it will have one route or another.

These were the original routes:

![008](https://user-images.githubusercontent.com/37677237/63513471-a453fa80-c4e6-11e9-8f14-e523ba7feadf.png)

And these are the new dynamics routes:

![009](https://user-images.githubusercontent.com/37677237/63513473-a453fa80-c4e6-11e9-992e-69abe63e6dbf.png)
