### PR TITLE
Prepare warning old branch (3.9)

### DIFF
--- a/source/_static/js/style.js
+++ b/source/_static/js/style.js
@@ -143,6 +143,7 @@ $(function() {
   if ($('#page').hasClass('no-latest-docs')) {
     noticeHeight = parseInt($('.no-latest-notice').outerHeight());
   }
+
   let delay = navbarTop + 200;
   let windowHeight = window.innerHeight;
   let documentHeight = $(document).outerHeight();
@@ -157,6 +158,12 @@ $(function() {
   heightNavbar();
   scrollNavbar();
   headerSticky();
+
+  setTimeout(function() {
+    if ($('#page').hasClass('no-latest-docs')) {
+      noticeHeight = parseInt($('.no-latest-notice').outerHeight());
+    }
+  }, 500);
 
   $('#navbar').on('mousemove', function(e) {
     pageHover = 'nav';
@@ -214,7 +221,9 @@ $(function() {
     documentScroll = $(window).scrollTop();
     containerNavHeight = parseInt($('#navbar-globaltoc').outerHeight());
     navHeight = parseInt($('#globaltoc').outerHeight());
-
+    if ($('#page').hasClass('no-latest-docs')) {
+      noticeHeight = parseInt($('.no-latest-notice').outerHeight());
+    }
     /* Update height of navbar */
     heightNavbar();
     /* If the coursor isn't in the navbar */

--- a/source/_themes/wazuh_doc_theme/layout.html
+++ b/source/_themes/wazuh_doc_theme/layout.html
@@ -10,7 +10,6 @@
 {%- set url_root = pathto('', 1) %}
 {% set script_files = script_files + ["_static/js/popper.min.js"] %}
 {% set script_files = script_files + ["_static/js/bootstrap.min.js"] %}
-{% set script_files = script_files + ["_static/js/style.js"] %}
 {%- if url_root == '#' %}{% set url_root = '' %}{% endif %}
 {%- if not embedded and docstitle %}
   {%- set titlesuffix = " &middot; "|safe + docstitle|e %}
@@ -209,6 +208,7 @@
       {{- js() }}
     {% endif %}
     <script type="text/javascript" src="{{ pathto('_static/js/version-selector.js', 1) }}"></script>
+    <script type="text/javascript" src="{{ pathto('_static/js/style.js', 1) }}"></script>
   {% endif %}
   {%- endblock footer_js %}
 


### PR DESCRIPTION
We need to prepare the branch `3.9` for the near future when the branch `3.10` released. When the `3.9` isn't the current branch anymore, this warning will appear on the top.

![004](https://user-images.githubusercontent.com/37677237/63581715-f6088d80-c597-11e9-8c1b-beb8235a9d90.png)

This PR contains also some fixes to the warning work fine.