### PR TITLE
Add missing systemctl command in deploying-with-ansible/install-wazuh-manager.rst

### DIFF
--- a/source/deploying-with-ansible/guide/install-wazuh-manager.rst
+++ b/source/deploying-with-ansible/guide/install-wazuh-manager.rst
@@ -226,6 +226,7 @@ We can check the status of our new services in our Wazuh server.
 
 .. code-block:: console
 
+	[root@localhost centos]# systemctl status filebeat
 	● filebeat.service - Filebeat sends log files to Elasticsearch.
 	   Loaded: loaded (/usr/lib/systemd/system/filebeat.service; enabled; vendor preset: disabled)
 	   Active: active (running) since jue 2018-09-13 12:36:55 CEST; 37min ago


### PR DESCRIPTION
`[root@localhost centos]# systemctl status filebeat` 

Above line was missing to be just like the two other Wazuh server services status check.

NOTE: This file has different name in previous versions.