### PR TITLE
[3.6] Sidebar functionality compatible with IE11

### DIFF
--- a/source/_static/js/style.js
+++ b/source/_static/js/style.js
@@ -29,7 +29,9 @@ $(function() {
   const hideSubtreeNodes = [
     'Install Wazuh manager on Linux',
     'Install Wazuh agent on Linux',
-  ].map((item) => item.toLowerCase());
+  ].map(function(item) {
+    return item.toLowerCase();
+  });
 
   markTocNodesWithClass(emptyTocNodes, 'empty-toc-node');
   checkScroll();


### PR DESCRIPTION
The method `map` used in our script `style.js` has been changed to make the code compatible with the older version of javascript, ES5, which is the one supported by IE11. 

Related issue: https://github.com/wazuh/wazuh-website/issues/820