### PR TITLE
Keep the search when changing the version (3.5)

### DIFF
--- a/source/_static/js/version-selector.js
+++ b/source/_static/js/version-selector.js
@@ -46,13 +46,14 @@ jQuery(function($) {
     }
 
     page = document.location.pathname.split('/'+path)[1];
+    search = document.location.search;
 
     if (path == 'current' || path == '3.x' ) {
       path = currentVersion;
     }
 
     for (let i = 0; i < versions.length; i++) {
-      ele += '<li><a href="' + versions[i].url + page + '">'+versions[i].name+'</a></li>';
+      ele += '<li><a href="' + versions[i].url + page + search + '">'+versions[i].name+'</a></li>';
       if ( versions[i].url == '/' + path ) {
         selected = i;
       }


### PR DESCRIPTION
Issue [#814](https://github.com/wazuh/wazuh-website/issues/814)

---

Now, when a user searches on the documentation and selects another version on the same page, it will show the search results for that branch:

![search](https://user-images.githubusercontent.com/37677237/63684965-7c260d80-c7fe-11e9-91fd-2ae482f820a1.gif)