### PR TITLE
CSS and JS files minified (3.6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ node_modules
 .eslintrc
 package-lock.json
 package.json
+source/_static/css/style.min.css
+source/_static/css/wazuh-icons.min.css
+source/_static/js/style.min.js
+source/_static/js/version-selector.min.js

--- a/source/_static/js/version-selector.js
+++ b/source/_static/js/version-selector.js
@@ -76,7 +76,7 @@ jQuery(function($) {
       pageID.classList.add('no-latest-docs');
     }
 
-    // Updates link to the latest version with the correct path (documentation's home)
+    /* Updates link to the latest version with the correct path (documentation's home) */
     page = document.location.pathname.split('/'+thisVersion)[1];
     const link = document.querySelector('.link-latest');
     link.setAttribute('href', 'https://' + window.location.hostname + '/' + latestVersion + page);

--- a/source/_themes/wazuh_doc_theme/layout.html
+++ b/source/_themes/wazuh_doc_theme/layout.html
@@ -207,8 +207,6 @@
       </script>
       {{- js() }}
     {% endif %}
-    <script type="text/javascript" src="{{ pathto('_static/js/version-selector.js', 1) }}"></script>
-    <script type="text/javascript" src="{{ pathto('_static/js/style.js', 1) }}"></script>
   {% endif %}
   {%- endblock footer_js %}
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -349,8 +349,8 @@ actual_path = os.path.dirname(os.path.realpath(__file__))
 files = [
     ['css/style','css'],
     ['css/wazuh-icons','css'],
-    ['js/style','js'],
     ['js/version-selector','js'],
+    ['js/style','js'],
 ]
 
 for file in files:
@@ -392,16 +392,16 @@ def setup(app):
     app.add_stylesheet("css/style.min.css?ver=%s" % os.stat(
         os.path.join(actual_path, "_static/css/style.css")).st_mtime)
 
-    app.add_javascript("js/style.min.js?ver=%s" % os.stat(
-        os.path.join(actual_path, "_static/js/style.js")).st_mtime)
     app.add_javascript("js/version-selector.min.js?ver=%s" % os.stat(
         os.path.join(actual_path, "_static/js/version-selector.js")).st_mtime)
+    app.add_javascript("js/style.min.js?ver=%s" % os.stat(
+        os.path.join(actual_path, "_static/js/style.js")).st_mtime)
 
 exclude_patterns = [
     "css/wazuh-icons.css",
     "css/style.css",
-    "js/style.js",
     "js/version-selector.js"
+    "js/style.js",
 ]
 
 # -- Additional configuration ------------------------------------------------


### PR DESCRIPTION
Issue [#817](https://github.com/wazuh/wazuh-website/issues/817)

---

The `CSS` and `JS` files are now minified:

![002](https://user-images.githubusercontent.com/37677237/63763504-210b1e00-c8c5-11e9-9c1b-ee6bd51fa9d3.png)

Also, the url of the `JS` files have now a fix to avoid the browser cache:

![001](https://user-images.githubusercontent.com/37677237/63763503-210b1e00-c8c5-11e9-851f-7a4707a3c6b6.png)
