### PR TITLE
Added documentation for the installation of the agent via sources in Solaris 11

### DIFF
--- a/source/installation-guide/installing-wazuh-agent/wazuh_agent_sources.rst
+++ b/source/installation-guide/installing-wazuh-agent/wazuh_agent_sources.rst
@@ -14,6 +14,8 @@ The Wazuh Agent can be installed via source files on the following operating sys
 +--------------------------------------------------------+--------------------------------------------------+
 | :doc:`Windows sources <wazuh_agent_sources_windows>`   | Install Wazuh agents on Windows.                 |
 +--------------------------------------------------------+--------------------------------------------------+
+| :doc:`Solaris sources <wazuh_agent_sources_solaris>`   | Install Wazuh agents on Solaris.                 |
++--------------------------------------------------------+--------------------------------------------------+
 
 .. toctree::
     :hidden:
@@ -21,3 +23,4 @@ The Wazuh Agent can be installed via source files on the following operating sys
 
     wazuh_agent_sources_linux
     wazuh_agent_sources_windows
+    wazuh_agent_sources_solaris

--- a/source/installation-guide/installing-wazuh-agent/wazuh_agent_sources_solaris.rst
+++ b/source/installation-guide/installing-wazuh-agent/wazuh_agent_sources_solaris.rst
@@ -1,0 +1,91 @@
+.. Copyright (C) 2019 Wazuh, Inc.
+
+.. _wazuh_agent_sources_solaris:
+
+Install Wazuh Agent on Solaris
+==============================
+
+This section describes how to download and build the Wazuh HIDS Solaris Agent from sources for the following versions:
+
+- For Solaris 11 i386
+- For Solaris 11 SPARC
+
+Installing Wazuh Agent
+----------------------
+
+1. Install development tools and compilers.
+
+  1.1 Install pkgutil an update it.
+
+     .. code-block:: console
+
+        # pkgadd -d http://get.opencsw.org/now
+        # /opt/csw/bin/pkgutil -y -U
+
+  1.2  Install python 2.7
+
+     .. code-block:: console
+
+        # /opt/csw/bin/pkgutil -y -i python27
+        # ln -sf /opt/csw/bin/python2.7 /usr/bin/python
+
+  1.3  Install the following tools:
+
+     .. code-block:: console
+
+        # /opt/csw/bin/pkgutil -y -i git gmake gcc5core
+
+2. Download the latest version.
+
+     .. code-block:: console
+
+        # git clone -b v3.9.5 https://github.com/wazuh/wazuh.git
+
+3. Compile the sources files.
+
+    * For Solaris 11 i386:
+
+        .. code-block:: console
+
+            # cd wazuh*/src
+            # gmake deps
+            # gmake -j 4 TARGET=agent PREFIX=/var/ossec USE_SELINUX=no
+            # gmake -j 4 TARGET=agent
+
+    * For Solaris 11 SPARC:
+
+        .. code-block:: console
+
+            # mv wazuh*/src/Makefile wazuh*/src/Makefile.tmp
+            # sed -n '/OSSEC_LDFLAGS+=-z relax=secadj/!p' wazuh*/src/Makefile.tmp > wazuh*/src/Makefile
+            # cd wazuh*/src
+            # gmake deps
+            # gmake -j 4 TARGET=agent PREFIX=/var/ossec USE_SELINUX=no USE_BIG_ENDIAN=yes
+            # gmake -j 4 TARGET=agent
+
+4. Run the ``install.sh`` script. This will run a wizard that will guide you through the installation process using the Wazuh sources:
+
+     .. code-block:: console
+
+        # cd ../
+        # ./install.sh
+
+    If you have previously compiled for another platform, you must clean the build using the Makefile in ``src``:
+
+      .. code-block:: console
+
+        # make -C src clean
+        # make -C src clean-deps
+
+   .. note::
+     During the installation, users can decide the installation path. Execute the ``./install.sh`` and select the language, set the installation mode to ``agent``, then set the installation path (``Choose where to install Wazuh [/var/ossec]``). The default path of installation is ``/var/ossec``. A commonly used custom path might be ``/opt``. When choosing a different path than the default, if the directory already exist the installer will ask if delete the directory or if installing Wazuh inside. You can also run an :ref:`unattended installation <unattended-installation>`.
+
+   .. note:: Since Wazuh 3.5 it is necessary to have internet connection when following this step.
+
+4. The script will ask about what kind of installation you want. Type ``agent`` in order to install a Wazuh Agent:
+
+ .. code-block:: none
+
+    1- What kind of installation do you want (manager, agent, local, hybrid or help)? agent
+
+Now that the Agent is installed, the next step is to register and configure it to communicate with the manager. For more information about this process, please visit the document: :doc:`user manual<../../user-manual/registering/index>`.


### PR DESCRIPTION
Hello team,

In this PR I have added the followings changes in the documentation:

- [x] Added documentation for the installation of the agent via sources in Solaris 11

I have successfully tested this documentation on the following operating systems:

- [x] Solaris 11 Intel.
