### PR TITLE
[3.8] Fixed responsivity for smartphone/tablet sizes

### DIFF
--- a/source/_static/css/style.css
+++ b/source/_static/css/style.css
@@ -1392,6 +1392,10 @@ footer a:focus,
   border: none;
 }
 
+#main-content {
+  width: 100%;
+}
+
 main li.toctree-l1 a {
   color: #0094ce;
 }
@@ -3136,7 +3140,7 @@ div.highlight pre {
 			}
 
 			#main-content {
-        width: calc(100% - 350px);
+        width: calc(100% - 360px);
         min-height: 100vh;
         margin-top: 90px;
         margin-left: 360px;


### PR DESCRIPTION
Fixes the bug in responsivity for screen width smaller than 992px. Also fixed the right margin of the main content area.

Related issue: https://github.com/wazuh/wazuh-website/issues/840