### PR TITLE
The 'Release notes' index page is now accessible from sidebar (3.9)

### DIFF
--- a/source/_static/js/style.js
+++ b/source/_static/js/style.js
@@ -16,7 +16,6 @@ $(function() {
     'installation-guide/packages-list/linux/linux-index',
     'installation-guide/packages-list/solaris/solaris-index',
     'monitoring',
-    'release-notes/index',
     'user-manual/index',
     'user-manual/agents/index',
     'user-manual/agents/remove-agents/index',
@@ -73,7 +72,6 @@ $(function() {
    */
   function updateFromHash() {
     loc = location.hash;
-    $('.globaltoc .leaf, .globaltoc a.current').removeClass('current');
     selectLeaf(loc);
   }
 


### PR DESCRIPTION
Issue [#830](https://github.com/wazuh/wazuh-website/issues/830)

---

Now, is possible access to the 'release' index from the sidebar:

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/37677237/63925975-52adf180-ca4b-11e9-9556-2cc4f3b16e89.gif)