### PR TITLE
[3.5] Hidden menu elements excluded from browser's search tool

### DIFF
--- a/source/_static/js/style.js
+++ b/source/_static/js/style.js
@@ -161,12 +161,6 @@ $(function() {
   scrollNavbar();
   headerSticky();
 
-  setTimeout(function() {
-    if ($('#page').hasClass('no-latest-docs')) {
-      noticeHeight = parseInt($('.no-latest-notice').outerHeight());
-    }
-  }, 500);
-
   $('#navbar').on('mousemove', function(e) {
     pageHover = 'nav';
   });
@@ -223,9 +217,6 @@ $(function() {
     documentScroll = $(window).scrollTop();
     containerNavHeight = parseInt($('#navbar-globaltoc').outerHeight());
     navHeight = parseInt($('#globaltoc').outerHeight());
-    if ($('#page').hasClass('no-latest-docs')) {
-      noticeHeight = parseInt($('.no-latest-notice').outerHeight());
-    }
     /* Update height of navbar */
     heightNavbar();
     /* If the coursor isn't in the navbar */

--- a/source/_static/js/style.js
+++ b/source/_static/js/style.js
@@ -145,6 +145,7 @@ $(function() {
   if ($('#page').hasClass('no-latest-docs')) {
     noticeHeight = parseInt($('.no-latest-notice').outerHeight());
   }
+
   let delay = navbarTop + 200;
   let windowHeight = window.innerHeight;
   let documentHeight = $(document).outerHeight();
@@ -159,6 +160,12 @@ $(function() {
   heightNavbar();
   scrollNavbar();
   headerSticky();
+
+  setTimeout(function() {
+    if ($('#page').hasClass('no-latest-docs')) {
+      noticeHeight = parseInt($('.no-latest-notice').outerHeight());
+    }
+  }, 500);
 
   $('#navbar').on('mousemove', function(e) {
     pageHover = 'nav';
@@ -216,7 +223,9 @@ $(function() {
     documentScroll = $(window).scrollTop();
     containerNavHeight = parseInt($('#navbar-globaltoc').outerHeight());
     navHeight = parseInt($('#globaltoc').outerHeight());
-
+    if ($('#page').hasClass('no-latest-docs')) {
+      noticeHeight = parseInt($('.no-latest-notice').outerHeight());
+    }
     /* Update height of navbar */
     heightNavbar();
     /* If the coursor isn't in the navbar */
@@ -322,6 +331,7 @@ $(function() {
     }
 
     $('.globaltoc li.initial').removeClass('initial');
+    completelyHideMenuItems();
     return false;
   });
 
@@ -343,6 +353,20 @@ $(function() {
       $(this).addClass('initial').addClass('show');
     });
     $('#navbar-globaltoc').removeClass('hidden');
+    completelyHideMenuItems();
+  }
+
+  /**
+   * Completely hides the visually hidden elements
+   */
+  function completelyHideMenuItems() {
+    $('#navbar-globaltoc li ul').each(function() {
+      if ( $(this).closest('li').hasClass('show') ) {
+        this.hidden = false;
+      } else {
+        this.hidden = true;
+      }
+    });
   }
 
   /**


### PR DESCRIPTION
This PR solves the issue described in https://github.com/wazuh/wazuh-website/issues/845, by `completely` hiding the elements of the sidebar that are visually hidden.
After this fix, the browser's search tool will no longer match the text that is hidden in the navigation sidebar.
