### PR TITLE
Corrected bug in navbar (2.1)

### DIFF
--- a/source/_static/css/style.css
+++ b/source/_static/css/style.css
@@ -760,6 +760,16 @@ li.toctree-l5 > a {
   position: relative;
 }
 
+.central-page-area:before {
+  content: '';
+  width: 360px;
+  height: 100vh;
+  margin-left: -15px;
+  top: 0;
+  position: fixed;
+  background-color: #EAEAEA;
+}
+
 #navbar {
   z-index: 3;
   visibility: hidden;
@@ -768,6 +778,12 @@ li.toctree-l5 > a {
   width: 100%;
   height: 100vh;
   padding-top: 100px;
+  transition: opacity 0.3s ease;
+}
+
+#navbar.hidden {
+  visibility: hidden;
+  opacity: 0;
 }
 
 #navbar-globaltoc {
@@ -787,12 +803,6 @@ li.toctree-l5 > a {
 .no-latest-docs #navbar-globaltoc {
   padding-top: 132px;
 }
-
-#navbar-globaltoc.hidden {
-  visibility: hidden;
-  opacity: 0;
-}
-
 #navbar-globaltoc.show, #navbar-globaltoc.collapsing {
   right: 0;
   left: 0;

--- a/source/_static/js/style.js
+++ b/source/_static/js/style.js
@@ -59,8 +59,9 @@ $(function() {
 
   /* Show the hidden menu */
   setTimeout(function() {
-    $('#navbar-globaltoc').removeClass('hidden');
-  }, 500);
+    $('#navbar').removeClass('hidden');
+    $('.central-page-area:before').css({'content': 'none'});
+  }, 100);
 
   $(window).on('hashchange', function() {
     updateFromHash();

--- a/source/_themes/wazuh_doc_theme/layout.html
+++ b/source/_themes/wazuh_doc_theme/layout.html
@@ -124,13 +124,13 @@
     <section  class="container-fluid central-page-area">
       <div class="row">
 
-        <div id="navbar" class="full-toctree-nav navbar-expand-lg navbar-light order-0">
+        <div id="navbar" class="full-toctree-nav navbar-expand-lg navbar-light order-0 hidden">
 
           <div id="search-lg" class="title-bar-right col-lg-12 collapsed">
             {% include "searchbar.html" %}
           </div> <!-- // #search-lg -->
 
-          <div id="navbar-globaltoc" class="side-scroll collapse navbar-collapse hidden">
+          <div id="navbar-globaltoc" class="side-scroll collapse navbar-collapse">
             <div id="globaltoc" class="globaltoc" role="navigation" aria-label="main navigation">
 
               <nav>


### PR DESCRIPTION
Issue [#853](https://github.com/wazuh/wazuh-website/issues/853)

---

I've corrected a flicking effect in the navbar when the loads the page. This was more noticeable in the links that have a hash `#`, for example:
- https://documentation.wazuh.com/current/installation-guide/installing-wazuh-manager/sources_installation.html#sources-installation

Now, the navbar has a smooth transition:

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/37677237/64116604-1522ce80-cd93-11e9-8e11-35e7cd19d68d.gif)