### PR TITLE
Corrected bug in navbar (3.11)

### DIFF
--- a/source/_static/css/style.css
+++ b/source/_static/css/style.css
@@ -760,6 +760,16 @@ li.toctree-l5 > a {
   position: relative;
 }
 
+.central-page-area:before {
+  content: '';
+  width: 360px;
+  height: 100vh;
+  margin-left: -15px;
+  top: 0;
+  position: fixed;
+  background-color: #EAEAEA;
+}
+
 #navbar {
   z-index: 3;
   visibility: hidden;
@@ -768,6 +778,12 @@ li.toctree-l5 > a {
   width: 100%;
   height: 100vh;
   padding-top: 100px;
+  transition: opacity 0.3s ease;
+}
+
+#navbar.hidden {
+  visibility: hidden;
+  opacity: 0;
 }
 
 #navbar-globaltoc {
@@ -787,12 +803,6 @@ li.toctree-l5 > a {
 .no-latest-docs #navbar-globaltoc {
   padding-top: 132px;
 }
-
-#navbar-globaltoc.hidden {
-  visibility: hidden;
-  opacity: 0;
-}
-
 #navbar-globaltoc.show, #navbar-globaltoc.collapsing {
   right: 0;
   left: 0;

--- a/source/_static/css/style.css
+++ b/source/_static/css/style.css
@@ -1722,10 +1722,21 @@ select, option {
   transition: .1s all ease;
   color: #00a9e5;
   text-align: left;
- }
+}
 
 #select-version .dropdown-menu li:hover a {
   color: #fff;
+}
+
+#select-version .dropdown-menu li a.disable {
+  cursor: default;
+  color: #999;
+  background-color: #f5f5f5;
+}
+
+#select-version .dropdown-menu li:hover a.disable {
+  color: #fff;
+  background-color: #00a9e5;
 }
 
 .version::after {
@@ -2525,6 +2536,31 @@ div.highlight pre {
 .linenos {
   padding: 0 0.5em 0 1em !important;
   border-right: 1px solid #00a9e5;
+}
+
+.tooltip > .tooltip-inner {
+  max-width: 300px !important;
+  padding: 7px !important;
+  font-size: 11px !important;
+  color: #fff !important;
+  background-color: #888 !important;
+}
+
+.bs-tooltip-auto[x-placement^=top] .arrow::before,
+.bs-tooltip-top .arrow::before {
+  display: none;
+}
+.bs-tooltip-auto[x-placement^=right] .arrow::before,
+.bs-tooltip-right .arrow::before {
+  display: none;
+}
+.bs-tooltip-auto[x-placement^=bottom] .arrow::before,
+.bs-tooltip-bottom .arrow::before {
+  display: none;
+}
+.bs-tooltip-auto[x-placement^=left] .arrow::before,
+.bs-tooltip-left .arrow::before {
+  display: none;
 }
 
 @media (min-width:576px){

--- a/source/_static/js/style.js
+++ b/source/_static/js/style.js
@@ -609,4 +609,12 @@ $(function() {
       $('html, body').css('overflow', '');
     }
   });
+
+  /* Enable all tooltips in the documentation */
+  $('[data-toggle="tooltip"]').tooltip();
+
+  /* Enable links that have the '.disable' class */
+  $('#select-version .dropdown-menu').on('click keypress', 'li a.disable', function(e) {
+    return false;
+  });
 });

--- a/source/_static/js/style.js
+++ b/source/_static/js/style.js
@@ -59,8 +59,9 @@ $(function() {
 
   /* Show the hidden menu */
   setTimeout(function() {
-    $('#navbar-globaltoc').removeClass('hidden');
-  }, 500);
+    $('#navbar').removeClass('hidden');
+    $('.central-page-area:before').css({'content': 'none'});
+  }, 100);
 
   $(window).on('hashchange', function() {
     updateFromHash();

--- a/source/_static/js/version-selector.js
+++ b/source/_static/js/version-selector.js
@@ -54,8 +54,30 @@ jQuery(function($) {
       path = currentVersion;
     }
 
+    const actualVersion = $('.no-latest-notice').attr('data-version');
+    url = window.location.href.split(actualVersion)[1];
     for (let i = 0; i < versions.length; i++) {
-      ele += '<li><a href="' + versions[i].url + page + search + '">'+versions[i].name+'</a></li>';
+      let pageExists = false;
+      let tooltip = '';
+      const ver = versions[i].name.split(' (current)')[0];
+      $.ajax({
+        url: '/'+ver+url,
+        success: function() {
+          pageExists = true;
+        },
+        error: function() {
+          pageExists = false;
+        },
+        async: false,
+      });
+
+      if (!pageExists) {
+        tooltip = 'class="disable" data-toggle="tooltip" data-placement="left" title="This page is not available in version ' + versions[i].name +'"';
+      } else {
+        tooltip = '';
+      }
+
+      ele += '<li><a href="' + versions[i].url + page + search + '" '+ tooltip +'>'+versions[i].name+'</a></li>';
       if ( versions[i].url == '/' + path ) {
         selected = i;
       }

--- a/source/_themes/wazuh_doc_theme/layout.html
+++ b/source/_themes/wazuh_doc_theme/layout.html
@@ -124,13 +124,13 @@
     <section  class="container-fluid central-page-area">
       <div class="row">
 
-        <div id="navbar" class="full-toctree-nav navbar-expand-lg navbar-light order-0">
+        <div id="navbar" class="full-toctree-nav navbar-expand-lg navbar-light order-0 hidden">
 
           <div id="search-lg" class="title-bar-right col-lg-12 collapsed">
             {% include "searchbar.html" %}
           </div> <!-- // #search-lg -->
 
-          <div id="navbar-globaltoc" class="side-scroll collapse navbar-collapse hidden">
+          <div id="navbar-globaltoc" class="side-scroll collapse navbar-collapse">
             <div id="globaltoc" class="globaltoc" role="navigation" aria-label="main navigation">
 
               <nav>


### PR DESCRIPTION
Issue [#853](https://github.com/wazuh/wazuh-website/issues/853)

---

I've corrected a flicking effect in the navbar when the loads the page. This was more noticeable in the links that have a hash `#`, for example:
- https://documentation.wazuh.com/current/installation-guide/installing-wazuh-manager/sources_installation.html#sources-installation

Now, the navbar has a smooth transition:

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/37677237/64116604-1522ce80-cd93-11e9-8e11-35e7cd19d68d.gif)