### PR TITLE
A small bug in the list style fixed (3.0)

### DIFF
--- a/source/_static/css/style.css
+++ b/source/_static/css/style.css
@@ -2492,7 +2492,7 @@ blockquote [class*="highlight-"],
 blockquote ul,
 blockquote blockquote {
   margin-bottom: 1em;
-  margin-left: 0.7rem;
+  margin-left: 0.3rem;
 }
 
 blockquote ul li > div[class^='highlight'] {


### PR DESCRIPTION
Issue [#821](https://github.com/wazuh/wazuh-website/issues/821)

---

I've made a small change in the lists style. Before, it looked different in some browsers. But now it's the same in every browser. 

- **Chrome**

  ![032](https://user-images.githubusercontent.com/37677237/64173798-54672300-ce58-11e9-9191-f578319a77eb.png)

- **Firefox**

  ![031](https://user-images.githubusercontent.com/37677237/64173797-54672300-ce58-11e9-8619-f18f9f606915.png)

- **Edge** (The circle is smaller because is their native style)

  ![030](https://user-images.githubusercontent.com/37677237/64173796-54672300-ce58-11e9-9033-f1564e1ca197.png)
