### PR TITLE
Fix Splunk-Forwarder code-block

### DIFF
--- a/source/installation-guide/installing-splunk/splunk-forwarder.rst
+++ b/source/installation-guide/installing-splunk/splunk-forwarder.rst
@@ -122,7 +122,7 @@ Starting with **inputs.conf**, create it and fill it with the next block:
   index = wazuh
   sourcetype = wazuh
 
-  Now, following with the **outputs.conf**:
+Now, following with the **outputs.conf**:
 
 .. code-block:: console
 


### PR DESCRIPTION
Hi team,

This PR fixes this issue:
![image](https://user-images.githubusercontent.com/37381070/64348603-c1fc8600-cff5-11e9-8963-e27d6db057ff.png)

Seems like one of the lines wasn't properly indented so it was showing as part of the code-block.

Best regards,
Miguel