### PR TITLE
[3.5] Removed broken links and disabled genindex

### DIFF
--- a/source/_static/js/style.js
+++ b/source/_static/js/style.js
@@ -330,7 +330,7 @@ $(function() {
    */
   function showCurrentSubtree() {
     updateFromHash();
-    if ($('ul li.toctree-l1 a.current.reference.internal, ul li.toctree-l1 .current > .leaf').length == 0 && !$('#page').hasClass('index') && !$('#page').hasClass('page-404') ) {
+    if ($('ul li.toctree-l1 a.current.reference.internal, ul li.toctree-l1 .current > .leaf').length == 0 && !$('#page').hasClass('index') && !$('#page').hasClass('not-indexed') ) {
       $('.globaltoc :contains("'+ $('#breadcrumbs li:nth-last-child(2) a').text() +'")').addClass('show').addClass('current');
       return true;
     }

--- a/source/_themes/wazuh_doc_theme/layout.html
+++ b/source/_themes/wazuh_doc_theme/layout.html
@@ -114,7 +114,9 @@
   {% if pagename == 'index' %}
   <div id="page" class="index">
   {% elif pagename == 'not_found' %}
-  <div id="page" class="page-404">
+  <div id="page" class="page-404 not-indexed">
+  {% elif pagename == 'search' or pagename == 'genindex' %}
+  <div id="page" class="not-indexed">
   {% else %}
   <div id="page">
   {% endif %}
@@ -155,7 +157,7 @@
         <div id="main-content" class="order-1">
           <div id="rst-content">
 
-          {% if pagename != 'index' and pagename != 'not_found' %}
+          {% if pagename != 'index' and pagename != 'not_found' and pagename != 'search' and pagename != 'genindex' %}
           <div class="edit-repo-wrapper">
             {% include "editrepo.html" %}
           </div>

--- a/source/conf.py
+++ b/source/conf.py
@@ -177,7 +177,7 @@ html_static_path = ['_static']
 #html_domain_indices = True
 
 # If false, no index is generated.
-#html_use_index = True
+html_use_index = False
 
 # If true, the index is split into individual pages for each letter.
 #html_split_index = False

--- a/source/deploying-with-ansible/install-ansible-control.rst
+++ b/source/deploying-with-ansible/install-ansible-control.rst
@@ -8,7 +8,7 @@ Install Ansible
 OpenSSH Compatibility
 ------------------------------
 
-Ansible version 1.3 and later uses native OpenSSH for remote communication and, also, uses ControlPersist, a feature available for OpenSSH v5.6. This will increase performance by speeding up SSH Session Creation, which is very useful for Ansible. Otherwise, you will need to consider to setup Accelerated Mode on Ansible.
+Ansible version 1.3 and later uses native OpenSSH for remote communication and, also, uses ControlPersist, a feature available for OpenSSH v5.6. This will increase performance by speeding up SSH Session Creation, which is very useful for Ansible. Otherwise, you will need to consider to setup `Accelerated Mode <https://docs.ansible.com/ansible/2.3/playbooks_acceleration.html>`_ on Ansible.
 
 Windows hosts
 ------------------

--- a/source/deploying-with-ansible/install-ansible-control.rst
+++ b/source/deploying-with-ansible/install-ansible-control.rst
@@ -8,7 +8,7 @@ Install Ansible
 OpenSSH Compatibility
 ------------------------------
 
-Ansible version 1.3 and later uses native OpenSSH for remote communication and, also, uses ControlPersist, a feature available for OpenSSH v5.6. This will increase performance by speeding up SSH Session Creation, which is very useful for Ansible. Otherwise, you will need to consider to setup `Accelerated Mode <http://docs.ansible.com/ansible/playbooks_acceleration.html>`_ on Ansible.
+Ansible version 1.3 and later uses native OpenSSH for remote communication and, also, uses ControlPersist, a feature available for OpenSSH v5.6. This will increase performance by speeding up SSH Session Creation, which is very useful for Ansible. Otherwise, you will need to consider to setup Accelerated Mode on Ansible.
 
 Windows hosts
 ------------------

--- a/source/user-manual/capabilities/vulnerability-detection.rst
+++ b/source/user-manual/capabilities/vulnerability-detection.rst
@@ -20,9 +20,9 @@ To be able to detect vulnerabilities, now agents are able to natively collect a 
 
 The global vulnerabilities database is created automatically, currently pulling data from the following repositories:
 
-- `<https://people.canonical.com>`_: Used to pull CVEs for Ubuntu Linux distributions.
+- `<https://canonical.com>`_: Used to pull CVEs for Ubuntu Linux distributions.
 - `<https://www.redhat.com>`_: Used to pull CVEs for Red Hat and CentOS Linux distributions.
-- `<https://www.debian.com>`_: Used to pull CVEs for Debian Linux distributions.
+- `<https://www.debian.org>`_: Used to pull CVEs for Debian Linux distributions.
 
 This database can be configured to be updated periodically, ensuring that the solution will check for the very latest CVEs.
 


### PR DESCRIPTION
Hi,

This removes some broken links that I've found during the lastest link-check:
- The link `Edit on GitHub` in the page search.html, as this page is not editable on our repository.
- The link `Edit on GitHub` in the page genindex.html. In fact, the generation of this page has been disabled.
- The link to Ansible's documentation on Accelerated Mode.
- The links to CVE repositories for Ubuntu and Debian Linux distributions were wrong.

Related issue: https://github.com/wazuh/wazuh-website/issues/850
