### PR TITLE
[3.9] Fix for wrong tabulation in a code-block

### DIFF
--- a/source/user-manual/kibana-app/reference/configure-indices.rst
+++ b/source/user-manual/kibana-app/reference/configure-indices.rst
@@ -49,7 +49,7 @@ Let's suppose that we want to add a new index pattern (``my-custom-alerts-*``) a
 
     .. code-block:: console
 
-    # curl -so template.json https://raw.githubusercontent.com/wazuh/wazuh/v3.9.5/extensions/elasticsearch/7.x/wazuh-template.json
+      # curl -so template.json https://raw.githubusercontent.com/wazuh/wazuh/v3.9.5/extensions/elasticsearch/7.x/wazuh-template.json
 
 3. Open the template file and locate this line:
 


### PR DESCRIPTION
Hi, 

This PR fixes the wrong tabulation of the content of a code-block in `User manual > Kibana app > Reference > Configure the name of Elasticsearch indices`:

![imagen](https://user-images.githubusercontent.com/13232723/64877159-1a183580-d651-11e9-8c55-8cb4f61b349f.png)

Related issue: https://github.com/wazuh/wazuh-website/issues/870