### PR TITLE
[3.10] Removed duplicated link 'SMTP server with authentication'

### DIFF
--- a/source/user-manual/manager/index.rst
+++ b/source/user-manual/manager/index.rst
@@ -22,5 +22,3 @@ The Wazuh manager is the system that analyzes the data received from all registe
         manual-database-output
         automatic-reports
         manual-email-report/index
-        manual-email-report/smtp_authentication
-


### PR DESCRIPTION
Hi, 

The link 'SMTP server with authentication' was duplicated in the navigation sidebar. The paths were: 
A) User manual > Wazuh server administration > Configuring email alerts > SMTP server with authentication
B) User manual > Wazuh server administration > SMTP server with authentication

The location `A` is the correct one, therefore the path `B` has been removed.

Related issue: https://github.com/wazuh/wazuh-website/issues/864
