### PR TITLE
Add the fields protocol, system name and data

### DIFF
--- a/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
@@ -43,6 +43,7 @@ Available options
 - `same_user`_
 - `same_field`_
 - `not_same_field`_
+- `global_frequency`_
 - `different_url`_
 - `different_srcgeoip`_
 - `description`_
@@ -574,6 +575,16 @@ As an example of this option, check this rule:
 .. note::
 
   Rule 100002 will trigger when the last three events do not have the same `netinfo.iface.mac` address.
+
+global_frequency
+^^^^^^^^^^^^^^
+
+Specifies that the decoded id do not have to be the same.
+This option is used in conjunction with frequency and timeframe.
+
++--------------------+----------------------+
+| **Example of use** | <global_frequency /> |
++--------------------+----------------------+
 
 different_url
 ^^^^^^^^^^^^^

--- a/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
@@ -18,9 +18,12 @@ Available options
 - `field`_
 - `srcip`_
 - `dstip`_
+- `data`_
 - `extra_data`_
 - `user`_
+- `system_name`_
 - `program_name`_
+- `protocol`_
 - `hostname`_
 - `time`_
 - `weekday`_
@@ -201,6 +204,17 @@ Any IP address or CIDR block to be compared to an IP decoded as dstip. Use "!" t
 | **Allowed values** | Any dstip |
 +--------------------+-----------+
 
+data
+^^^^^^^^^^
+
+Any string that is decoded into the data field.
+
++--------------------+-------------+
+| **Default Value**  | n/a         |
++--------------------+-------------+
+| **Allowed values** | Any string. |
++--------------------+-------------+
+
 extra_data
 ^^^^^^^^^^
 
@@ -223,10 +237,32 @@ Any username (decoded as the username).
 | **Allowed values** | Any `sregex expression <regex.html#os-match-or-sregex-syntax>`_  |
 +--------------------+------------------------------------------------------------------+
 
+system_name
+^^^^^^^^^^^^
+
+system_name name is decoded from syslog process name.
+
++--------------------+------------------------------------------------------------------+
+| **Default Value**  | n/a                                                              |
++--------------------+------------------------------------------------------------------+
+| **Allowed values** | Any `sregex expression <regex.html#os-match-or-sregex-syntax>`_  |
++--------------------+------------------------------------------------------------------+
+
 program_name
 ^^^^^^^^^^^^
 
 Program name is decoded from syslog process name.
+
++--------------------+------------------------------------------------------------------+
+| **Default Value**  | n/a                                                              |
++--------------------+------------------------------------------------------------------+
+| **Allowed values** | Any `sregex expression <regex.html#os-match-or-sregex-syntax>`_  |
++--------------------+------------------------------------------------------------------+
+
+protocol
+^^^^^^^^
+
+Any protocol.
 
 +--------------------+------------------------------------------------------------------+
 | **Default Value**  | n/a                                                              |


### PR DESCRIPTION
|Related issue|
|---|
[3407](https://github.com/wazuh/wazuh/issues/3407)
[3865](https://github.com/wazuh/wazuh/issues/3865)

Hi team:

This PR adds the fields `protocol`, `system_name` and  `data`. This fields are implemented in the `issue-3407`. While the field `global_frequency` is implemented in the `issue-3865`. In addition, we include a definition of these fields and the value that can have. 

Regards.