### PR TITLE
Correct typo in decoders syntax documentation

### DIFF
--- a/source/user-manual/ruleset/ruleset-xml-syntax/decoders.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/decoders.rst
@@ -11,7 +11,7 @@ When an event is received, the decoders separate the information in blocks to pr
 Options
 -------
 
-There is many options to configure the decoders:
+There are many options to configure the decoders:
 
 - `decoder`_
 - `parent`_


### PR DESCRIPTION
Hi team,
Just correcting this typo in https://documentation.wazuh.com/3.9/user-manual/ruleset/ruleset-xml-syntax/decoders.html#options:
`there is many options` → `there are many options`

Regards,
Sergio.