### PR TITLE
Add note in CDB lists

### DIFF
--- a/source/user-manual/capabilities/system-calls-monitoring/audit-configuration.rst
+++ b/source/user-manual/capabilities/system-calls-monitoring/audit-configuration.rst
@@ -49,7 +49,7 @@ You can add your own key with its value to the list like this:
 
     # echo "my_key_write_type:write" >> /var/ossec/etc/lists/audit-keys
 
-Each time you modify a CDB list, you must compile it:
+Each time you modify a CDB list, the manager has to be restarted to apply the new changes.
 
 Agent
 ^^^^^^^

--- a/source/user-manual/ruleset/cdb-list.rst
+++ b/source/user-manual/ruleset/cdb-list.rst
@@ -40,6 +40,9 @@ Example of IP address list file::
 
 We recommend to store the lists on ``/var/ossec/etc/lists``.
 
+.. note::
+  Until version 3.11, ``ossec-makelist`` compiled the CDB list. Now, the CBD list will be compiled at the start of wazuh or running ``ossec-logtest``  
+
 Adding the list to ossec.conf
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/source/user-manual/ruleset/cdb-list.rst
+++ b/source/user-manual/ruleset/cdb-list.rst
@@ -41,7 +41,7 @@ Example of IP address list file::
 We recommend to store the lists on ``/var/ossec/etc/lists``.
 
 .. note::
-  Until version 3.11, ``ossec-makelist`` compiled the CDB list. Now, the CBD list will be compiled at the start of wazuh or running ``ossec-logtest``  
+  Since version 3.11 the CBD list will be compiled at the start of ``ossec-analysisd`` and wazuh. 
 
 Adding the list to ossec.conf
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/user-manual/ruleset/cdb-list.rst
+++ b/source/user-manual/ruleset/cdb-list.rst
@@ -40,8 +40,9 @@ Example of IP address list file::
 
 We recommend to store the lists on ``/var/ossec/etc/lists``.
 
-.. note::
-  Since version 3.11 the CBD list will be compiled at the start of ``ossec-analysisd`` and wazuh. 
+.. versionadded:: 3.11.0
+
+Since Wazuh v3.11.0, CDB lists are built and loaded automatically when the analysis engine is started. Therefore, when adding or modifying CDB lists, it is no longer needed to run ``ossec-makelists``, just restart the manager.
 
 Adding the list to ossec.conf
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
|Related issue|
|--------|
|[#3026](https://github.com/wazuh/wazuh/issues/3026)|

Hi team.

This PR adds a new note in the CBD list page. This note informs of new functionality in the compilation of the CBD list. Now the CBD list will be compiled at the start of wazuh, start of `ossec-analysisd` or at the start of `ossec-logtest`. 

Regards