### PR TITLE
Add new functionality to node name in cluster.

### DIFF
--- a/source/user-manual/reference/ossec-conf/cluster.rst
+++ b/source/user-manual/reference/ossec-conf/cluster.rst
@@ -56,6 +56,15 @@ Specifies the name of the current node of the cluster.
 | **Allowed values** | Any name      |
 +--------------------+---------------+
 
+.. versionadded:: 3.11
+
+The name of the node can be the environment variable ``hostname``.
+
+.. code-block:: xml
+
+  <node_name>$HOSTNAME</node_name>
+
+
 .. _cluster_node_type:
 
 node_type


### PR DESCRIPTION
|Related issue|
|--------|
|[#3057](https://github.com/wazuh/wazuh/issues/3057)|

Hi team

With the changes in the `issue-3026`, now is possible to get the system hostname, and put that as the node name of the cluster. This PR adds this new functionality to the docu. 

Regards