### PR TITLE
'Copy to clipboard' button added on the code blocks (3.3)

### DIFF
--- a/source/_static/css/style.css
+++ b/source/_static/css/style.css
@@ -2182,7 +2182,7 @@ label {
 
 .output[class*="highlight-"] .highlight {
 	margin: 0;
-	padding-top: 1.3rem;
+	padding-top: 0.3rem;
 	border: none;
 	background-color: #e8e8e8;
 }

--- a/source/_static/css/style.css
+++ b/source/_static/css/style.css
@@ -2527,6 +2527,13 @@ div.highlight pre {
   padding: 0.5em 1em;
 }
 
+.highlight .no-select {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -khtml-user-select: none;
+  -ms-user-select:none;
+}
+
 .note pre,
 .warning pre {
   background-color: #f4f4f4 !important;
@@ -3436,6 +3443,7 @@ div[class^='highlight']:hover .copy-to-clipboard {
 
 div[class^='highlight'] .copy-to-clipboard.copied {
   opacity: 1;
+  background-color: #333;
 }
 
 div[class^='highlight'] .copy-to-clipboard:hover {

--- a/source/_static/css/style.css
+++ b/source/_static/css/style.css
@@ -3381,6 +3381,10 @@ div[class^='highlight'] {
   margin: 1px 0 24px 0
 }
 
+div[class^='highlight'] {
+  position: relative;
+}
+
 .codeblock div[class^='highlight'],
 pre.literal-block div[class^='highlight'],
 .rst-content .literal-block div[class^='highlight'],
@@ -3408,6 +3412,40 @@ div[class^='highlight'] pre {
   line-height: 1.5;
   display: block;
   overflow: auto;
+}
+
+div[class^='highlight'] .copy-to-clipboard {
+  z-index: 1;
+  cursor: pointer;
+  opacity: 0;
+  position: absolute;
+  top: 7px;
+  right: 7px;
+  padding: 5px;
+  color: #fff;
+  font: normal normal normal 14px/1 FontAwesome;
+  background-color: #00a9e5;
+  border: 0;
+  border-radius: 3px;
+  transition: all 0.2s ease;
+}
+
+div[class^='highlight']:hover .copy-to-clipboard {
+  opacity: 1;
+}
+
+div[class^='highlight'] .copy-to-clipboard.copied {
+  opacity: 1;
+}
+
+div[class^='highlight'] .copy-to-clipboard:hover {
+  background-color: #333;
+}
+
+div[class^='highlight'] .copy-to-clipboard span {
+  display: none;
+  font-size: 0.9rem;
+  font-family: 'Open Sans', sans-serif;
 }
 
 @media print {

--- a/source/_static/js/style.js
+++ b/source/_static/js/style.js
@@ -627,7 +627,6 @@ $(function() {
   $('.copy-to-clipboard').click(function() {
     const ele = $(this);
     let data = $(ele).parent().find('.highlight').text();
-    data = data.replace(/(<([^>]+)>)/ig, '');
     data = String(data);
     data = data.replace(/(?:\$\s)/g, '');
     data = data.replace(/(?:\#\s)/g, '');

--- a/source/_static/js/style.js
+++ b/source/_static/js/style.js
@@ -625,6 +625,9 @@ $(function() {
     const ele = $(this);
     let data = $(ele).parent().find('.highlight').html();
     data = data.replace(/(<([^>]+)>)/ig, '');
+    data = String(data);
+    data = data.replace(/(?:\$\s)/g, '');
+    data = data.replace(/(?:\#\s)/g, '');
     copyToClipboard(data);
     $(ele).addClass('copied');
     $(ele).find('i').css({'display': 'none'}).find('span').css({'display': 'block'});
@@ -650,4 +653,21 @@ $(function() {
     document.execCommand('copy');
     document.body.removeChild(aux);
   }
+
+  /* Avoid select $ and # on the code blocks -----------------------------------------------------*/
+  $('.highlight').each(function() {
+    const ele = $(this);
+    const data = ele.html();
+    const find = data.match(/(?:\$\s|\#)/g);
+    if (find != null) {
+      const dataArray = data.split('\n');
+      let content = '';
+      dataArray.forEach((line) => {
+        line = line.replace('<span class="gp">#</span> ', '<span class="gp no-select"># </span>');
+        line = line.replace(/(?:\$\s)/g, '<span class="no-select">$ </span>') + '\n';
+        content += line;
+      });
+      ele.html(content);
+    }
+  });
 });

--- a/source/_static/js/style.js
+++ b/source/_static/js/style.js
@@ -614,4 +614,40 @@ $(function() {
       $('html, body').css('overflow', '');
     }
   });
+
+  /* Copy to clipboard ----------------------------------------------------------------------------------*/
+  $('.highlight').each(function() {
+    const blockCode = $(this).parent();
+    blockCode.prepend('<button type="button" class="copy-to-clipboard" title="Copy to clipboard"><span>Copied to clipboard</span><i class="fa fa-files-o" aria-hidden="true"></i></button>');
+  });
+
+  $('.copy-to-clipboard').click(function() {
+    const ele = $(this);
+    let data = $(ele).parent().find('.highlight').html();
+    data = data.replace(/(<([^>]+)>)/ig, '');
+    copyToClipboard(data);
+    $(ele).addClass('copied');
+    $(ele).find('i').css({'display': 'none'}).find('span').css({'display': 'block'});
+    $(ele).find('span').css({'display': 'block'});
+    setTimeout(function() {
+      $(ele).removeClass('copied');
+    }, 700);
+    setTimeout(function() {
+      $(ele).find('span').css({'display': 'none'});
+      $(ele).find('i').css({'display': 'block'});
+    }, 1000);
+  });
+
+  /**
+   * Copy the data to clipboard
+   * @param {string} data The string to copy
+   */
+  function copyToClipboard(data) {
+    const aux = document.createElement('textarea');
+    aux.value = data;
+    document.body.appendChild(aux);
+    aux.select();
+    document.execCommand('copy');
+    document.body.removeChild(aux);
+  }
 });


### PR DESCRIPTION
Issue [#770](https://github.com/wazuh/wazuh-website/issues/770)

---

I've implemented a simple button on the code blocks to copy their content to the clipboard. This is re result:

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/37677237/65322140-44fd0f00-dba6-11e9-9e8d-0eb93a7f71d3.gif)

A "Copy as cURL" button was also suggested in this issue [#841](https://github.com/wazuh/wazuh-website/issues/841). I need to research more about this. When I implement it I will add it to this PR.
