### PR TITLE
A bug of the navbar background on the 3.10 fixed on the mobile version

### DIFF
--- a/source/_static/css/style.css
+++ b/source/_static/css/style.css
@@ -760,8 +760,9 @@ li.toctree-l5 > a {
   position: relative;
 }
 
-.central-page-area:before {
+.central-page-area::before {
   content: '';
+  display: none;
   width: 360px;
   height: 100vh;
   margin-left: -15px;
@@ -2896,6 +2897,10 @@ div.highlight pre {
       #navbar {
         visibility: visible;
         width: 360px;
+      }
+
+      .central-page-area::before {
+        display: block;
       }
 
       #navbar-globaltoc {

--- a/source/_static/js/style.js
+++ b/source/_static/js/style.js
@@ -59,7 +59,6 @@ $(function() {
   /* Show the hidden menu */
   setTimeout(function() {
     $('#navbar').removeClass('hidden');
-    $('.central-page-area:before').css({'content': 'none'});
   }, 100);
 
   $(window).on('hashchange', function() {


### PR DESCRIPTION
Issue [#874](https://github.com/wazuh/wazuh-website/issues/874)

---

I've fixed a bug on the version mobile of the 3.10 release. The background was grey and it covered some elements. Now everything looks good:

![006](https://user-images.githubusercontent.com/37677237/65328813-7fbb7300-dbb7-11e9-9c49-dc0cdb91c6c3.png)
