### PR TITLE
Remove wrong <regex> option on <description> field example

### DIFF
--- a/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
@@ -589,12 +589,6 @@ Examples:
 
   .. code-block:: xml
 
-    <rule id="100009" level="1">
-      ...
-      <regex>^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$</regex>
-      <description> Rule to match IPs </description>
-    </rule>
-
     <rule id="100015" level="2">
       ...
       <description> A timeout occurred. </description>


### PR DESCRIPTION
Hi team,

Our documentation has an error in one of the `<description>` field examples:

```
    <rule id="100009" level="1">
      ...
      <regex>^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$</regex>
      <description> Rule to match IPs </description>
    </rule>
```

The `<regex>` field in the example above includes regex expressions out of [our syntax](https://documentation.wazuh.com/3.10/user-manual/ruleset/ruleset-xml-syntax/regex.html). I propose removing it to avoid confusion among users.

Greetings, Juan Pablo Sáez