### PR TITLE
[3.5] Avoid the unnecessary rebuilding of the minified files

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -356,35 +356,49 @@ files = [
 for file in files:
 
     path_end = actual_path+'/_static/'
+    min_file = os.path.join(path_end, file[0]+'.min.'+file[1])
 
-    with open(os.path.join(path_end, file[0]+'.'+file[1]), 'r') as f:
+    if os.path.isfile(min_file):
+        with open(min_file, 'r') as f_min:
+            min_file_content = f_min.read()
 
-        output = f.read()
+        with open(os.path.join(path_end, file[0]+'.'+file[1]), 'r') as f:
 
-        # remove comments - this will break a lot of hacks :-P
-        output = re.sub( r'\s*/\*\s*\*/', "$$HACK1$$", output ) # preserve IE<6 comment hack
-        output = re.sub( r'/\*[\s\S]*?\*/', "", output )
-        output = output.replace( "$$HACK1$$", '/**/' ) # preserve IE<6 comment hack
+            output = f.read()
 
-        # url() doesn't need quotes
-        output = re.sub( r'url\((["\'])([^)]*)\1\)', r'url(\2)', output )
+            # remove comments - this will break a lot of hacks :-P
+            output = re.sub( r'\s*/\*\s*\*/', "$$HACK1$$", output ) # preserve IE<6 comment hack
+            output = re.sub( r'/\*[\s\S]*?\*/', "", output )
+            output = output.replace( "$$HACK1$$", '/**/' ) # preserve IE<6 comment hack
 
-        # spaces may be safely collapsed as generated content will collapse them anyway
-        output = re.sub( r'\s+', ' ', output )
+            # url() doesn't need quotes
+            output = re.sub( r'url\((["\'])([^)]*)\1\)', r'url(\2)', output )
 
-        # shorten collapsable colors: #aabbcc to #abc
-        output = re.sub( r'#([0-9a-f])\1([0-9a-f])\2([0-9a-f])\3(\s|;)', r'#\1\2\3\4', output )
+            # spaces may be safely collapsed as generated content will collapse them anyway
+            output = re.sub( r'\s+', ' ', output )
 
-        # fragment values can loose zeros
-        output = re.sub( r':\s*0(\.\d+([cm]m|e[mx]|in|p[ctx]))\s*;', r':\1;', output )
+            # shorten collapsable colors: #aabbcc to #abc
+            output = re.sub( r'#([0-9a-f])\1([0-9a-f])\2([0-9a-f])\3(\s|;)', r'#\1\2\3\4', output )
 
-        with open(os.path.join(path_end, file[0]+'.min.'+file[1]), 'w') as f2:
+            # fragment values can loose zeros
+            output = re.sub( r':\s*0(\.\d+([cm]m|e[mx]|in|p[ctx]))\s*;', r':\1;', output )
+
+            if output == min_file_content:
+                minify = False
+            else:
+                minify = True
+    else:
+        minify = True
+
+
+    if minify:
+        with open(min_file, 'w') as f2:
             f2.write(output)
 
 # -- Setup -------------------------------------------------------------------
 
 def setup(app):
-    
+
     app.add_stylesheet("css/font-awesome.min.css?ver=%s" % os.stat(
         os.path.join(actual_path, "_static/css/font-awesome.min.css")).st_mtime)
     app.add_stylesheet("css/wazuh-icons.min.css?ver=%s" % os.stat(


### PR DESCRIPTION
Hi 

I modified the code in conf.py in order to avoid rewriting the minified files if their content has not changed. This allows the use of `sphinx-autobuild`, as described in #1802, without entering in an endless "compilation loop".

Related issue: #1802 

Note: In order to test this code without Docker (only Sphinx) run `sphinx-autobuild` like this:
`sphinx-autobuild -b html -d build/doctrees source build/html`