### PR TITLE
Remove 'display' in param required options

### DIFF
--- a/source/user-manual/reference/tools/agent-auth.rst
+++ b/source/user-manual/reference/tools/agent-auth.rst
@@ -39,7 +39,7 @@ The ``agent-auth`` program is the client application used along with :ref:`ossec
 +---------------------+-------------------------------------------------------------------------------+
 | **-h**              | Display the help message                                                      |
 +---------------------+-------------------------------------------------------------------------------+
-| **-k <path>**       | Display the full path to the agent key.                                       |
+| **-k <path>**       | Full path to the agent key.                                                   |
 +---------------------+-------------------------------------------------------------------------------+
 | **-m <manager_ip>** | IP address of the manager.                                                    |
 +---------------------+-------------------------------------------------------------------------------+
@@ -57,9 +57,9 @@ The ``agent-auth`` program is the client application used along with :ref:`ossec
 +---------------------+-------------------------------------------------------------------------------+
 | **-V**              | Display version and license information.                                      |
 +---------------------+-------------------------------------------------------------------------------+
-| **-v <path>**       | Display the full path to the CA certificate used to verify the server.        |
+| **-v <path>**       | Full path to the CA certificate used to verify the server.                    |
 +---------------------+-------------------------------------------------------------------------------+
-| **-x <path>**       | Display the full path to the agent certificate.                               |
+| **-x <path>**       | Full path to the agent certificate.                                           |
 +---------------------+-------------------------------------------------------------------------------+
 
 .. _`SSL ciphers`: https://www.openssl.org/docs/man1.1.0/apps/ciphers.html


### PR DESCRIPTION
The 'Display' word has been removed in the parameters which need a value and don't display any information.

https://github.com/wazuh/wazuh/blob/ee0943daae73677c3ff886b9ac892711fdf4ceeb/src/os_auth/main-client.c#L55-L56