### PR TITLE
Specify macOS versions compatibilty for Wazuh Agent

### DIFF
--- a/source/installation-guide/compatibility_matrix/index.rst
+++ b/source/installation-guide/compatibility_matrix/index.rst
@@ -72,7 +72,7 @@ In this table, you can check our supported OS list where the Wazuh agent can be 
 +------------------------------------+-------------------------+
 |   HP-UX 11.31                      |   ✓                     |
 +------------------------------------+-------------------------+
-|   Mac OS X                         |   ✓                     |
+|   macOS *                          |   ✓                     |
 +------------------------------------+-------------------------+
 |   OpenSUSE 42, 15, Tumbleweed      |   ✓                     |
 +------------------------------------+-------------------------+
@@ -91,7 +91,7 @@ In this table, you can check our supported OS list where the Wazuh agent can be 
 |   Windows Server 2003 or newer     |   ✓                     |
 +------------------------------------+-------------------------+
 
-
+*(\*) Since Wazuh v3.11.0, the macOS agent installer is only compatible with macOS Mojave or newer. If you need to install the agent in previous versions of macOS, you can use the v3.10.2 agent.*
 
 
 

--- a/source/installation-guide/installing-wazuh-agent/macos/wazuh_agent_package_macos.rst
+++ b/source/installation-guide/installing-wazuh-agent/macos/wazuh_agent_package_macos.rst
@@ -37,6 +37,9 @@ By default, all agent files can be found at the following location: ``/Library/O
 
 Now that the agent is installed, if you didn't use the deployment method, you will now have to register and configure the agent to communicate with the manager. For more information about this process, please visit :ref:`user manual<register_agents>`.
 
+.. note::
+  Since v3.11.0, the macOS agent installer is only compatible with macOS Mojave or newer. With the release of macOS Catalina (10.15) it is mandatory to notarize the macOS installer and to achieve this, we had to drop the support for older versions of macOS. If you need to install the agent in older versions, you can install the v3.10.2 macOS agent which is compatible with older macOS versions.
+
 Uninstall
 ---------
 


### PR DESCRIPTION
Hi team, 

Since the notarization of the macOS packages is mandatory in Catalina and optional in Mojave, we have changed our build scripts in https://github.com/wazuh/wazuh-packages/issues/316. This forced us to drop the support of macOS High Sierra and older versions of macOS for v3.11.0 and newer Wazuh packages.

Older versions of macOS are yet supported by Wazuh but you will need to install the v3.10.2 package or older.

Regards.