### PR TITLE
Added a correct way to execute certutil

### DIFF
--- a/source/installation-guide/installing-elastic-stack/protect-installation/xpack.rst
+++ b/source/installation-guide/installing-elastic-stack/protect-installation/xpack.rst
@@ -27,7 +27,7 @@ This section describes how to secure the communications between the involved com
           ip:
             - "10.0.0.4"
 
-2. Create the certificates using the `elasticsearch-certutil <https://www.elastic.co/guide/en/elasticsearch/reference/current/certutil.html>`_ tool. The ``--keep-ca-key`` modifier may be used in order to keep the CA's certificate and key files, in the case of future expansions these files may be use to sign certificates for new servers, otherwise they will be deleted in any future. Certificates will require a new CA, in consequence the previous certificates will no longer be valid and will need to be redistributed. It is important that the ``ca.key`` file be properly secured.
+2. Create the certificates using the `elasticsearch-certutil <https://www.elastic.co/guide/en/elasticsearch/reference/current/certutil.html>`_ tool. The ``--keep-ca-key`` modifier may be used in order to keep the CA's certificate and key files, in the case of future expansions these files may be used to sign certificates for new servers. If this modifier is not used, these files will be deleted and any future certificates will require a new CA, in consequence the previous certificates will no longer be valid and will need to be redistributed. It is important that the ``ca.key`` file be properly secured.
 
 .. code-block:: console
 

--- a/source/installation-guide/installing-elastic-stack/protect-installation/xpack.rst
+++ b/source/installation-guide/installing-elastic-stack/protect-installation/xpack.rst
@@ -27,11 +27,11 @@ This section describes how to secure the communications between the involved com
           ip:
             - "10.0.0.4"
 
-2. Create the certificates using the `elasticsearch-certutil <https://www.elastic.co/guide/en/elasticsearch/reference/current/certutil.html>`_ tool. Add the ``--keep-ca-key`` parameter in order to keep the CA's certificate and key for future enlargements, otherwise it will be deleted and new ones should be distributed. In this way, keeping the ``ca.key`` safe is strongly recommended.
+2. Create the certificates using the `elasticsearch-certutil <https://www.elastic.co/guide/en/elasticsearch/reference/current/certutil.html>`_ tool. The ``--keep-ca-key`` modifier may be used in order to keep the CA's certificate and key files, in the case of future expansions these files may be use to sign certificates for new servers, otherwise they will be deleted in any future. Certificates will require a new CA, in consequence the previous certificates will no longer be valid and will need to be redistributed. It is important that the ``ca.key`` file be properly secured.
 
 .. code-block:: console
 
-    # /usr/share/elasticsearch/bin/elasticsearch-certutil cert --pem --in /usr/share/elasticsearch/instances.yml --out certs.zip --keep-ca-key
+    # /usr/share/elasticsearch/bin/elasticsearch-certutil cert --pem --in instances.yml --out certs.zip --keep-ca-key
 
 .. code-block:: console
 

--- a/source/installation-guide/installing-elastic-stack/protect-installation/xpack.rst
+++ b/source/installation-guide/installing-elastic-stack/protect-installation/xpack.rst
@@ -27,17 +27,18 @@ This section describes how to secure the communications between the involved com
           ip:
             - "10.0.0.4"
 
-2. Create the certificates using the `elasticsearch-certutil <https://www.elastic.co/guide/en/elasticsearch/reference/current/certutil.html>`_ tool.
+2. Create the certificates using the `elasticsearch-certutil <https://www.elastic.co/guide/en/elasticsearch/reference/current/certutil.html>`_ tool. Add the ``--keep-ca-key`` parameter in order to keep the CA's certificate and key for future enlargements, otherwise it will be deleted and new ones should be distributed. In this way, keeping the ``ca.key`` safe is strongly recommended.
 
 .. code-block:: console
 
-    # /usr/share/elasticsearch/bin/elasticsearch-certutil cert ca --pem --in instances.yml --out certs.zip
+    # /usr/share/elasticsearch/bin/elasticsearch-certutil cert --pem --in /usr/share/elasticsearch/instances.yml --out certs.zip --keep-ca-key
 
 .. code-block:: console
 
     certs.zip
     |-- ca
     |   |-- ca.crt
+        |-- ca.key
     |-- wazuh-manager
     |   |-- wazuh-manager.crt
     |   |-- wazuh-manager.key
@@ -166,6 +167,8 @@ This section describes how to secure the communications between the involved com
 .. code-block:: console
 
     # systemctl restart kibana
+
+In order to establish HTTPS communication between the browser and Kibana, go to the browser's settings and import the ``ca.crt`` extracted from the .zip file.
 
 
 Adding authentication for Elasticsearch


### PR DESCRIPTION
Hi, Team!

A new way to execute 'certutil' has been added because the actual one is quite not correct as mentioned in Elastic Stack's documentation (ca and cert methods are not compatible): https://www.elastic.co/guide/en/elasticsearch/reference/current/certutil.html#_parameters_7

This may be quite useful in case of future expansions are foreseen so new certificates and keys have to be created by using the `ca.key`. Otherwise, creating and distributing new certificates and keys again for all the nodes, including the previously configured ones will be necessary.

Additionally, the step of importing the ca.crt into the browser's configuration is now mentioned.

Regards,
Pablo Rodríguez