### PR TITLE
[3.11] Fixed puppet section broken links

### DIFF
--- a/source/deploying-with-puppet/setup-puppet/index.rst
+++ b/source/deploying-with-puppet/setup-puppet/index.rst
@@ -5,7 +5,7 @@
 Set up Puppet
 =============
 
-In this section, we are going to give a short explanation of how to install the different instances of Puppet. For a more detailed guide, go to the `official Puppet documentation. <https://puppet.com/docs/puppet/5.1/index.html>`_
+In this section, we are going to give a short explanation of how to install the different instances of Puppet. For a more detailed guide, go to the `official Puppet documentation. <https://puppet.com/docs/puppet/latest/puppet_index.html>`_
 
 Before we get started with Puppet, confirm that the following network requirements are met:
 
@@ -13,7 +13,7 @@ Before we get started with Puppet, confirm that the following network requiremen
 - **Firewall open ports**: The Puppet master must be reachable on TCP port 8140.
 
 .. note::
-    This guide has been made using Puppet version 5.1. 
+    This guide has been made using Puppet version 5.1.
     Although, Wazuh supports Puppet versions from 5.0 to 6.0.
 
 .. topic:: Contents

--- a/source/deploying-with-puppet/setup-puppet/install-puppet-master.rst
+++ b/source/deploying-with-puppet/setup-puppet/install-puppet-master.rst
@@ -5,7 +5,7 @@
 Installing Puppet master
 ========================
 
-In this section it is explained how to install *puppet-master*. Follow this link to check the `official installation guide <https://puppet.com/docs/puppetserver/5.1/install_from_packages.html>`_.
+In this section it is explained how to install *puppet-master*. Follow this link to check the `official installation guide <https://puppet.com/docs/puppetserver/latest/install_from_packages.html>`_.
 
 Installation on CentOS/RHEL/Fedora
 ----------------------------------
@@ -48,7 +48,7 @@ Get the appropriate Puppet apt repository, and then the "puppetserver" package. 
 Create a symbolic link between the installed binary file and your default binary file:
 
   .. code-block:: bash
-    
+
     # ln -s /opt/puppetlabs/bin/puppet /bin
 
 Memory Allocation
@@ -64,7 +64,7 @@ Replace 2g with the amount of memory you want to allocate to Puppet Server. For 
 Configuration
 -------------
 
-Edit the ``/etc/puppetlabs/puppet/puppet.conf`` file, adding this line to the ``[main]`` section (create the section if it does not exist), and replacing ``puppet.example.com`` with your own FQDN: 
+Edit the ``/etc/puppetlabs/puppet/puppet.conf`` file, adding this line to the ``[main]`` section (create the section if it does not exist), and replacing ``puppet.example.com`` with your own FQDN:
 
   ::
 


### PR DESCRIPTION
Hi team, 

I found two broken links in the Puppet section in our documentation:

![Screenshot 2019-10-11 at 08 48 18](https://user-images.githubusercontent.com/16825724/66630837-4ea5ef80-ec05-11e9-8bbc-490d1e5f395c.png)


This happened because they changed the URLs in Puppet and now they no longer use that version, so I changed both URLs to `latest`. One of the URLs changed completely even the file link.

These are now fixed.

Best regards,

S Moran.