### PR TITLE
Authd: Do not enforce source IP checking by default

### DIFF
--- a/source/deploying-with-ansible/reference.rst
+++ b/source/deploying-with-ansible/reference.rst
@@ -264,7 +264,7 @@ Wazuh Manager
       authd:
         enable: true
         port: 1515
-        use_source_ip: 'yes'
+        use_source_ip: 'no'
         force_insert: 'yes'
         force_time: 0
         purge: 'no'

--- a/source/user-manual/configuring-cluster/advanced-settings.rst
+++ b/source/user-manual/configuring-cluster/advanced-settings.rst
@@ -44,22 +44,8 @@ Pointing agents to the cluster with a load balancer
 
           # service wazuh-agent restart
 
-    3. Disable the option :ref:`use_source_ip <auth_use_source_ip>`:
 
-        - When using a LB, the cluster nodes will only see the LB's IP and no the agents'. This will make the agents unable to connect to the cluster. To change this, we need to change ``use_source_ip`` in the master's ``ossec.conf`` to no, this way agents can register with any IP.
-
-
-        .. code-block:: xml
-
-            <auth>
-                <disabled>no</disabled>
-                <port>1515</port>
-                <use_source_ip>no</use_source_ip>
-                ...
-            </auth>
-
-
-    4. Include in the ``Load Balancer`` the IP of every instance of the cluster we want to deliver events.
+    3. Include in the ``Load Balancer`` the IP of every instance of the cluster we want to deliver events.
 
         - This configuration will depend of the load balancer service chosen.
 

--- a/source/user-manual/reference/ossec-conf/auth.rst
+++ b/source/user-manual/reference/ossec-conf/auth.rst
@@ -65,7 +65,7 @@ use_source_ip
 Toggles the use of the client's source IP address or the use of "any" to add an agent.
 
 +--------------------+---------------------+
-| **Default value**  | yes                 |
+| **Default value**  | no                  |
 +--------------------+---------------------+
 | **Allowed values** | yes, no             |
 +--------------------+---------------------+
@@ -216,7 +216,7 @@ Default configuration
   <auth>
     <disabled>no</disabled>
     <port>1515</port>
-    <use_source_ip>yes</use_source_ip>
+    <use_source_ip>no</use_source_ip>
     <force_insert>yes</force_insert>
     <force_time>0</force_time>
     <purge>yes</purge>


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/3269|

## Description

As explained in the related issue, I have seen how this setting makes several users complain about an agent not able to report a few days after the registration. Dynamics environment (boot up and shut down instances) and load balancers make the agent unable to report.

My proposal is to disable use_source_ip by default. I think it will make easier the agent deployment (registering via LB) and connection durability.

## Changes

- Default values on settings configuration reference
- Cluster set up: No need for the extra step "Disabled use_source_ip"