### PR TITLE
Fix title of the SCA section

### DIFF
--- a/source/user-manual/reference/ossec-conf/sca.rst
+++ b/source/user-manual/reference/ossec-conf/sca.rst
@@ -2,8 +2,8 @@
 
 .. _reference_sec_config_assessment:
 
-Security Configuration Assessment configuration section
-========================================================
+sca
+===
 
 .. versionadded:: 3.9.0
 


### PR DESCRIPTION
The section that describes the options for each component in the `ossec.conf` file use the configuration name to refer them. However, SCA has an inconsistency with this in the title of its page.

![image](https://user-images.githubusercontent.com/20266121/66810169-f9cce680-ef2e-11e9-9be4-9ec3de7441fc.png)
