### PR TITLE
Fixed installation link for Puppet-agent

### DIFF
--- a/source/deploying-with-puppet/setup-puppet/install-puppet-agent.rst
+++ b/source/deploying-with-puppet/setup-puppet/install-puppet-agent.rst
@@ -5,9 +5,9 @@
 Installing Puppet agent
 =======================
 
-In this section it is explained how to install *puppet-agent*. Follow this link to check the `official installation guide <https://puppet.com/docs/puppet/5.1/install_linux.html>`_.
+In this section it is explained how to install *puppet-agent*. Follow this link to check the `official installation guide <https://puppet.com/docs/puppet/6.4/install_agents.html>`_.
 
-In this section we assume that you have already installed the ``apt`` or ``yum`` Puppet repository on your agent system in the same way that you did on your Puppet Server.
+We assume that you have already installed the ``apt`` or ``yum`` Puppet repository on your agent system in the same way that you did on your Puppet Server.
 
 Installation on CentOS/RHEL/Fedora
 ----------------------------------


### PR DESCRIPTION
Hi team,

Seems like the puppet team is changing their installation guide, and because of this, we're experiencing some broken links. 

I've replaced the broken link with a stable one (that's not using the `/latest/` version).
I've also corrected a redundancy in the text that seemed wrong.

Best regards.
