### PR TITLE
Forced min-width for sidebar buttons

### DIFF
--- a/source/_static/css/style.css
+++ b/source/_static/css/style.css
@@ -3107,6 +3107,7 @@ div.highlight pre {
         border: none;
         background: #ffb600;
         color: #ffffff;
+        min-width: 235px;
       }
 
       aside.help .btn-help:hover,


### PR DESCRIPTION
Hi team,

This PR fixes this issue: https://github.com/wazuh/wazuh-website/issues/909

The documentation buttons didn't have the same width before and they looked a little bit irregular.
I think they look much better now with this little fix:

![Screenshot 2019-10-16 at 08 31 03](https://user-images.githubusercontent.com/16825724/66893877-5abbf380-efef-11e9-98e7-71a6ff5cdaa0.png)


Thanks @alberpilot for suggesting this.