### PR TITLE
[3.3] Added the option to include/exclude GA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
+	@echo "  html-prod  to make standalone HTML files, including GA code (production only)"
 	@echo "  html       to make standalone HTML files"
 	@echo "  dirhtml    to make HTML files named index.html in directories"
 	@echo "  singlehtml to make a single large HTML file"
@@ -50,6 +51,11 @@ help:
 
 clean:
 	rm -rf $(BUILDDIR)/*
+
+html-prod:
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html -t production
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
-	@echo "  html-prod  to make standalone HTML files, including GA code (production only)"
+	@echo "  html-prod  to make standalone HTML files, including GA code. Production only"
 	@echo "  html       to make standalone HTML files"
 	@echo "  dirhtml    to make HTML files named index.html in directories"
 	@echo "  singlehtml to make a single large HTML file"

--- a/make.bat
+++ b/make.bat
@@ -18,6 +18,7 @@ if "%1" == "" goto help
 if "%1" == "help" (
 	:help
 	echo.Please use `make ^<target^>` where ^<target^> is one of
+	echo.  html-prod  to make standalone HTML files, including GA code (production only)
 	echo.  html       to make standalone HTML files
 	echo.  dirhtml    to make HTML files named index.html in directories
 	echo.  singlehtml to make a single large HTML file
@@ -71,6 +72,13 @@ if errorlevel 9009 (
 
 :sphinx_ok
 
+if "%1" == "html-prod" (
+	%SPHINXBUILD% -b html %ALLSPHINXOPTS% %BUILDDIR%/html -t production
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.Build finished. The HTML pages are in %BUILDDIR%/html.
+	goto end
+)
 
 if "%1" == "html" (
 	%SPHINXBUILD% -b html %ALLSPHINXOPTS% %BUILDDIR%/html

--- a/make.bat
+++ b/make.bat
@@ -18,7 +18,7 @@ if "%1" == "" goto help
 if "%1" == "help" (
 	:help
 	echo.Please use `make ^<target^>` where ^<target^> is one of
-	echo.  html-prod  to make standalone HTML files, including GA code (production only)
+	echo.  html-prod  to make standalone HTML files, including GA code. Production only
 	echo.  html       to make standalone HTML files
 	echo.  dirhtml    to make HTML files named index.html in directories
 	echo.  singlehtml to make a single large HTML file

--- a/source/_themes/wazuh_doc_theme/layout.html
+++ b/source/_themes/wazuh_doc_theme/layout.html
@@ -94,6 +94,7 @@
 
   {# Google Analytics #}
 
+  {% if production %}
   <script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -103,6 +104,8 @@
     ga('create', 'UA-65317123-3', 'auto');
     ga('send', 'pageview');
   </script>
+  {% endif %}
+  
 </head>
 {%- endblock head %}
 <body>

--- a/source/conf.py
+++ b/source/conf.py
@@ -419,10 +419,17 @@ exclude_patterns = [
 ]
 
 # -- Additional configuration ------------------------------------------------
+
+if (tags.has("production")):
+    production = True
+else:
+    production = False
+
 html_context = {
     "display_github": True,
     "github_user": "wazuh",
     "github_repo": "wazuh-documentation",
     "conf_py_path": "/source/",
-    "github_version": version
+    "github_version": version,
+    "production": production
 }


### PR DESCRIPTION
Until now, every compilation of our documentation included Google Analytics code. With this PR, the GA code will no longer be included in the compiled HTML files unless it is specifically indicated using a sphinx tag for production.

Related issue: https://github.com/wazuh/wazuh-website/issues/887