### PR TITLE
X pack settings

### DIFF
--- a/source/installation-guide/installing-elastic-stack/protect-installation/xpack.rst
+++ b/source/installation-guide/installing-elastic-stack/protect-installation/xpack.rst
@@ -82,14 +82,12 @@ This section describes how to secure the communications between the involved com
 
 .. code-block:: yaml
 
-    # Transport layer
     xpack.security.transport.ssl.enabled: true
     xpack.security.transport.ssl.verification_mode: certificate
     xpack.security.transport.ssl.key: /etc/elasticsearch/certs/elasticsearch.key
     xpack.security.transport.ssl.certificate: /etc/elasticsearch/certs/elasticsearch.crt
     xpack.security.transport.ssl.certificate_authorities: [ "/etc/elasticsearch/certs/ca/ca.crt" ]
 
-    # HTTP layer
     xpack.security.http.ssl.enabled: true
     xpack.security.http.ssl.verification_mode: certificate
     xpack.security.http.ssl.key: /etc/elasticsearch/certs/elasticsearch.key
@@ -151,13 +149,11 @@ This section describes how to secure the communications between the involved com
 
 .. code-block:: yaml
 
-    # Elasticsearch from/to Kibana
     elasticsearch.hosts: ["https://10.0.0.3:9200"]
     elasticsearch.ssl.certificateAuthorities: ["/etc/kibana/certs/ca/ca.crt"]
     elasticsearch.ssl.certificate: "/etc/kibana/certs/kibana.crt"
     elasticsearch.ssl.key: "/etc/kibana/certs/kibana.key"
 
-    # Browser from/to Kibana
     server.ssl.enabled: true
     server.ssl.certificate: "/etc/kibana/certs/kibana.crt"
     server.ssl.key: "/etc/kibana/certs/kibana.key"


### PR DESCRIPTION
Hello team,

The new button that copies the commands to your clipboard:

![button](https://user-images.githubusercontent.com/47329460/67001697-9d0e2f00-f0da-11e9-9d93-ddba847932ff.png)

Doesn't copy the `#` character, it makes you copy this:

```
Transport layer
xpack.security.transport.ssl.enabled: true
xpack.security.transport.ssl.verification_mode: certificate
...
```

Instead of:

```
# Transport layer
xpack.security.transport.ssl.enabled: true
xpack.security.transport.ssl.verification_mode: certificate
...
```

To `/etc/elasticsearch/elasticsearch.yml`

In this case, that character is necessary because it indicates it is a commentary, without the character ElasticSearch won't start properly. Same for the rest of the configurations.

I've removed the commentary in this PR, it would be great to improve the button functionality to determine whether it's copying a command or a configuration.