### PR TITLE
[3.3] Removed extension intersphinx and added requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Sphinx==1.8.5
+sphinxcontrib-images==0.8.0
+sphinxprettysearchresults==0.3.5

--- a/source/conf.py
+++ b/source/conf.py
@@ -44,7 +44,6 @@ release = version
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
-    'sphinx.ext.intersphinx',
     'sphinxcontrib.images',
     'sphinxprettysearchresults',
 ]
@@ -336,7 +335,7 @@ images_config = {
 # -- Options for intersphinx extension ---------------------------------------
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+# intersphinx_mapping = {'https://docs.python.org/': None}
 
 # -- Options for todo extension ----------------------------------------------
 


### PR DESCRIPTION
Hi,

As we are not using `intersphinx`, this extension has been removed from file `conf.py`. In addition, the requirements have been added, including the máximum version of every package that can be used in our documentation.

Related issues: https://github.com/wazuh/wazuh-website/issues/907, https://github.com/wazuh/wazuh-website/issues/863
