### PR TITLE
Fix typo and remove parentheses

### DIFF
--- a/source/user-manual/capabilities/sec-config-assessment/how_it_works.rst
+++ b/source/user-manual/capabilities/sec-config-assessment/how_it_works.rst
@@ -12,7 +12,7 @@ change, only the scan ``summary`` event will be sent, thus avoiding unnecessary 
 the manager up to date. The manager will then use those updates to issue alerts that will be shown in the
 Kibana App.
 
-An the integrity (more on this later) and alerting flow is depicted in the
+Integrity and alerting flow is depicted in the
 :ref:`sequence diagram <sca_sequence_diagram>` below.
 
 .. figure:: ../../../images/sca/sca_sequence_diagram.svg


### PR DESCRIPTION
This PR aims to fix a typo here: https://documentation.wazuh.com/3.10/user-manual/capabilities/sec-config-assessment/how_it_works.html?highlight=sca

`An the integrity (more on this later) and alerting flow is depicted in the sequence diagram below.` →  `Integrity and alerting flow is depicted in the sequence diagram below.`

I also removed the parentheses because for me it looks better without it.
Regards,
Sergio.