### PR TITLE
[3.11] Changed Wazuh logo link 

### DIFF
--- a/source/_static/css/style.css
+++ b/source/_static/css/style.css
@@ -273,7 +273,11 @@ dt {
   text-decoration: none;
 }
 
-a .docs-link {
+#links-to-home a.docs-link {
+  vertical-align: middle;
+}
+
+a.docs-link {
   color: #ffffff;
   vertical-align: text-top;
   display: inline-block;
@@ -281,8 +285,8 @@ a .docs-link {
   font-size: 1.2rem;
 }
 
-a .docs-link:hover,
-a .docs-link:active {
+a.docs-link:hover,
+a.docs-link:active {
   color: #ffffff;
 }
 
@@ -2894,6 +2898,10 @@ div.highlight pre {
 
       #header {
         position: relative;
+      }
+
+      #links-to-home a.docs-link {
+        vertical-align: bottom;
       }
 
       #header-sticky .navbar-open {

--- a/source/_themes/wazuh_doc_theme/header.html
+++ b/source/_themes/wazuh_doc_theme/header.html
@@ -33,10 +33,10 @@
         </div>
 
         <div class="branding col-3">
-          <a class="wazuh-logo-link" href="{{ pathto(master_doc) }}" title="Wazuh">
-            <img class="img-responsive" src={{ pathto('_static/img/wazuh_logo_w.png', 1) }} alt="Wazuh" />
-            <span class="docs-link">Docs</span>
+          <a class="wazuh-logo-link" href="{{ theme_wazuh_web_url }}" title="Wazuh">
+            <img class="img-responsive" src={{ pathto('_static/img/wazuh_logo_w.png', 1) }} alt="Wazuh">
           </a>
+          <a class="docs-link"  href="{{ pathto(master_doc) }}">Docs</a>
         </div>
 
         <div class="middle col-6">
@@ -63,10 +63,10 @@
         <nav id="main-navbar" class="col-3">
           <div class="navbar-brand d-flex justify-content-between" id="logo-title">
             <div id="links-to-home">
-              <a class="wazuh-logo-link" href="{{ pathto(master_doc) }}" title="Wazuh">
+              <a class="wazuh-logo-link" href="{{ theme_wazuh_web_url }}" title="Wazuh">
                 <img class="img-responsive" src={{ pathto('_static/img/wazuh_logo_w.png', 1) }} alt="Wazuh" />
-                <span class="docs-link">Docs</span>
               </a>
+              <a class="docs-link"  href="{{ pathto(master_doc) }}">Docs</a>
             </div>
           </div> <!-- // #logo-title -->
         </nav>


### PR DESCRIPTION
Hi
This PR separates the header's logo link into two different links, so now, in order to improve the user experience:
- The Wazuh logo links back to [Wazuh website](https://wazuh.com) as it is usually expected.
- The word `Docs` is a link to the documentation's home page of the release that the user is visiting.