### PR TITLE
Minor command fix

### DIFF
--- a/source/user-manual/configuring-cluster/index.rst
+++ b/source/user-manual/configuring-cluster/index.rst
@@ -92,7 +92,7 @@ Deploying a Wazuh cluster
 
         .. code-block:: console
 
-            # /var/ossec/bin/cluster-control -l
+            # /var/ossec/bin/cluster_control -l
 
             NAME           TYPE    VERSION  ADDRESS
             master-node    master  3.10.2   wazuh-master


### PR DESCRIPTION
In the `Deploying a Wazuh cluster` section, the command shown to list the worker nodes is this one: 
```
/var/ossec/bin/cluster-control -l
```
When it should be this one:
```
/var/ossec/bin/cluster_control -l
```