### PR TITLE
Minor fixes to the Docker installation documentation.

### DIFF
--- a/source/docker/docker-installation.rst
+++ b/source/docker/docker-installation.rst
@@ -28,6 +28,16 @@ Docker requires a 64-bit operating system running kernel version 3.10 or higher.
 
       # curl -sSL https://get.docker.com/ | sh
 
+3. Start the Docker service:
+
+  a) For Systemd::
+
+      $ systemctl start docker
+      
+  b) For SysV Init::
+  
+      $ service docker start
+
 .. note::
   If you would like to use Docker as a non-root user, you should now consider adding your user to the ``docker`` group with something like the following command (remember that you'll have to log out and log back in for this to take effect):
 

--- a/source/docker/wazuh-container.rst
+++ b/source/docker/wazuh-container.rst
@@ -91,7 +91,7 @@ In Docker for OSX, there is a default memory limit of 2GB, so in order to run `d
 Usage
 -----
 
-#. Get the ``docker-compose.yml`` file to your system:
+1. Get the ``docker-compose.yml`` file to your system:
 
   a) Only the file::
 
@@ -101,7 +101,7 @@ Usage
 
       $ git clone https://github.com/wazuh/wazuh-docker.git -b 3.9.5_7.2.1 --single-branch
 
-#. Start Wazuh, Elastic Stack and Nginx using `docker-compose`. From the directory where you have the ``docker-compose.yml`` file:
+2. Start Wazuh, Elastic Stack and Nginx using `docker-compose`. From the directory where you have the ``docker-compose.yml`` file:
 
   a) Foreground::
 


### PR DESCRIPTION
Hi team,

I've added a new step to the Docker installation guide. 
It suggests starting docker before it is used because it comes inactive when you install it.
Also, I've manually set each step's number because it was showing "1" everywhere.

Regards.