### PR TITLE
Remote agent upgrade mention within the Wazuh upgrade section.

### DIFF
--- a/source/upgrade-guide/upgrading/latest_wazuh3_minor.rst
+++ b/source/upgrade-guide/upgrading/latest_wazuh3_minor.rst
@@ -60,6 +60,12 @@ c) OpenSUSE:
 Upgrade the Wazuh agent
 -----------------------
 
+Since the Wazuh 3.x version it is possible to upgrade the agents from the manager or locally.
+
+Upgrading the agents remotely from the manager is possible thanks to the agent_upgrade tools and the Wazuh API. You may check it in the  :ref:`Upgrading agent<upgrading-agent>` section.
+
+To perform the upgrade locally you have to follow the next steps:
+
 a) CentOS/RHEL/Fedora:
 
   .. code-block:: console


### PR DESCRIPTION
Hello team,

I've mentioned the remote upgrading options inside the [Upgrading Wazuh from 3.x to 3.y](https://documentation.wazuh.com/3.10/upgrade-guide/upgrading/latest_wazuh3_minor.html) section.

This could help people with several agents environments to perform upgrades faster.

Regards.