### PR TITLE
Next steps indication after Wazuh upgrade.

### DIFF
--- a/source/upgrade-guide/upgrading/latest_wazuh3_minor.rst
+++ b/source/upgrade-guide/upgrading/latest_wazuh3_minor.rst
@@ -126,3 +126,10 @@ c) OpenSUSE:
   .. code-block:: console
 
     # sed -i "s/^enabled=1/enabled=0/" /etc/zypp/repos.d/wazuh.repo
+
+Next steps
+----------
+
+Once you have updated the Wazuh manager and API you are ready to :ref:`upgrade the Elastic Stack<upgrading-elastic-stack>`.
+
+You might also want to check our :ref:`compatibility matrix <compatibility-matrix>` in order to look at the Elastic stack version you need to use.


### PR DESCRIPTION
Hello team,

It has been added to the `Next Steps` section after the explanations about how to upgrade the Wazuh manager and API.

This section guides you to the `Upgrading Elastic Stack` section and also, it remembers to look at the `Compatibility matrix` to use a compatible Wazuh and ELK version.

Regards.