### PR TITLE
Delete option email_log_source from email_alerts.

### DIFF
--- a/source/user-manual/reference/ossec-conf/email_alerts.rst
+++ b/source/user-manual/reference/ossec-conf/email_alerts.rst
@@ -28,7 +28,6 @@ Options
 - `rule_id`_
 - `do_not_delay`_
 - `do_not_group`_
-- `email_log_source`_
 
 
 email_to
@@ -139,19 +138,6 @@ This disables grouping of multiple alerts into the same email.
 | **Allowed values** | XML tag with no value |
 +--------------------+-----------------------+
 
-
-email_log_source
-^^^^^^^^^^^^^^^^
-
-.. versionadded:: 3.8.0
-
-This selects the alert file to be read from.
-
-+--------------------+---------------------------+
-| **Default value**  | alerts.json               |
-+--------------------+---------------------------+
-| **Allowed values** | alerts.log or alerts.json |
-+--------------------+---------------------------+
 
 .. warning::
 	Notice that **do_not_delay** and **do_not_group** are special empty-element XML tags, so they stand alone, not having a starting and ending version of the tag.  This is indicated by the tag name containing "/" at the end of the name.


### PR DESCRIPTION

## Description

In the actual documentation the option `email_log_source` appear in `email_alerts`. It isn't available in the `email_alerts`. This option should only appear in `global`. For this reason, I'm deleting the option `email_log_source` in the documentation of `emal_alerts`. 

Regards