### PR TITLE
Option allow prefilter cmd

### DIFF
--- a/source/user-manual/reference/ossec-conf/syscheck.rst
+++ b/source/user-manual/reference/ossec-conf/syscheck.rst
@@ -371,7 +371,7 @@ allow_prefilter_cmd
 
 .. versionadded:: 3.11.0
 
-Allows to activate _prefilter_cmd_ option.
+Allows to activate the ``prefilter_cmd`` option.
 
 +--------------------+--------------------------------+
 | **Default value**  | no                             |
@@ -388,7 +388,7 @@ Example:
 
 .. note::
 
-   This option only can be activate from agent side, in the ossec.conf.
+   This option only can be activate from the agent side, in its own ``ossec.conf``.
 
 prefilter_cmd
 ^^^^^^^^^^^^^^
@@ -411,7 +411,10 @@ Example:
 .. note::
 
    This option may negatively impact performance as the configured command will be run for each file checked.
-   To use it need activate `allow_prefilter_cmd` in _ossec.conf_ before.
+
+.. note::
+
+   It is needed to enable the ``allow_prefilter_cmd`` option before use it.
 
 skip_nfs
 ^^^^^^^^

--- a/source/user-manual/reference/ossec-conf/syscheck.rst
+++ b/source/user-manual/reference/ossec-conf/syscheck.rst
@@ -369,6 +369,8 @@ Attributes:
 allow_prefilter_cmd
 ^^^^^^^^^^^^^^^^^^^^
 
+.. versionadded:: 3.11.0
+
 Allows to activate _prefilter_cmd_ option.
 
 +--------------------+--------------------------------+

--- a/source/user-manual/reference/ossec-conf/syscheck.rst
+++ b/source/user-manual/reference/ossec-conf/syscheck.rst
@@ -29,6 +29,7 @@ Options
 - `scan_on_start`_
 - `windows_registry`_
 - `registry_ignore`_
+- `allow_prefilter_cmd`_
 - `prefilter_cmd`_
 - `skip_nfs`_
 - `remove_old_diff`_
@@ -365,6 +366,28 @@ Attributes:
 |          | Allowed values   |  sregex                                                     |
 +----------+------------------+-------------------------------------------------------------+
 
+allow_prefilter_cmd
+^^^^^^^^^^^^^^^^^^^^
+
+Allows to activate _prefilter_cmd_ option.
+
++--------------------+--------------------------------+
+| **Default value**  | no                             |
++--------------------+--------------------------------+
+| **Allowed values** | yes, no                        |
++--------------------+--------------------------------+
+
+Example:
+
+.. code-block:: xml
+
+  <allow_prefilter_cmd>yes</allow_prefilter_cmd>
+
+
+.. note::
+
+   This option only can be activate from agent side, in the ossec.conf.
+
 prefilter_cmd
 ^^^^^^^^^^^^^^
 
@@ -386,6 +409,7 @@ Example:
 .. note::
 
    This option may negatively impact performance as the configured command will be run for each file checked.
+   To use it need activate `allow_prefilter_cmd` in _ossec.conf_ before.
 
 skip_nfs
 ^^^^^^^^


### PR DESCRIPTION
Includes documentation for using the _allow_prefilter_cmd_ option described in the following https://github.com/wazuh/wazuh/pull/4178

### Example 
```xml
<syscheck>
    ...
    <allow_prefilter_cmd>yes</allow_prefilter_cmd>
    <prefilter_cmd>/usr/bin/prefilter -y</prefilter_cmd>
</syscheck>
```
This option can be enable in _ossec.conf_ in agent side.