### PR TITLE
Manager verification note

### DIFF
--- a/source/user-manual/registering/manager-verification/agents/linux-unix-manager-verification.rst
+++ b/source/user-manual/registering/manager-verification/agents/linux-unix-manager-verification.rst
@@ -14,6 +14,8 @@ Open a session in your Linux/Unix agent host as root user. After that, you can r
       # cp rootCA.pem /var/ossec/etc
       # /var/ossec/bin/agent-auth -m 192.168.1.2 -v /var/ossec/etc/rootCA.pem
 
+    .. note:: Note that this method must include the -v option that indicates the location of the CA. If this option is not included, the manager will register following the simple registration service and will not verify with the CA.
+
 
 2. Edit the Wazuh agent configuration to add the Wazuh server IP address.
 

--- a/source/user-manual/registering/manager-verification/agents/linux-unix-manager-verification.rst
+++ b/source/user-manual/registering/manager-verification/agents/linux-unix-manager-verification.rst
@@ -9,12 +9,12 @@ Open a session in your Linux/Unix agent host as root user. After that, you can r
 
 1. Copy the CA (**.pem file**) to the ``/var/ossec/etc`` folder and run the ``agent-auth`` program:
 
-    .. code-block:: console
+  .. code-block:: console
 
-      # cp rootCA.pem /var/ossec/etc
-      # /var/ossec/bin/agent-auth -m 192.168.1.2 -v /var/ossec/etc/rootCA.pem
+    # cp rootCA.pem /var/ossec/etc
+    # /var/ossec/bin/agent-auth -m 192.168.1.2 -v /var/ossec/etc/rootCA.pem
 
-    .. note:: Note that this method must include the -v option that indicates the location of the CA. If this option is not included, the manager will register following the simple registration service and will not verify with the CA.
+  .. note:: Note that this method must include the -v option that indicates the location of the CA. If this option is not included, the manager will register following the simple registration service and will not verify with the CA.
 
 
 2. Edit the Wazuh agent configuration to add the Wazuh server IP address.

--- a/source/user-manual/registering/manager-verification/agents/linux-unix-manager-verification.rst
+++ b/source/user-manual/registering/manager-verification/agents/linux-unix-manager-verification.rst
@@ -14,7 +14,7 @@ Open a session in your Linux/Unix agent host as root user. After that, you can r
     # cp rootCA.pem /var/ossec/etc
     # /var/ossec/bin/agent-auth -m 192.168.1.2 -v /var/ossec/etc/rootCA.pem
 
-  .. note:: Note that this method must include the -v option that indicates the location of the CA. If this option is not included, the manager will register following the simple registration service and will not verify with the CA.
+  .. note:: Note that this method must include the -v option that indicates the location of the CA. If this option is not included, a warning message will be displayed and the connection will be established without verifying the manager.
 
 
 2. Edit the Wazuh agent configuration to add the Wazuh server IP address.

--- a/source/user-manual/registering/manager-verification/agents/macos-manager-verification.rst
+++ b/source/user-manual/registering/manager-verification/agents/macos-manager-verification.rst
@@ -14,6 +14,8 @@ Open a session in your MacOS X agent host as root user. After that, you can regi
     # cp rootCA.pem /Library/Ossec/etc
     # /Library/Ossec/bin/agent-auth -m 192.168.1.2 -v /Library/Ossec/etc/rootCA.pem
 
+  .. note:: Note that this method must include the -v option that indicates the location of the CA. If this option is not included, the manager will register following the simple registration service and will not verify with the CA.
+
 2. Edit the Wazuh agent configuration to add the Wazuh server IP address.
 
   In the file ``/Library/Ossec/etc/ossec.conf``, in the ``<client><server>`` section, change the *MANAGER_IP* value to the Wazuh server address:

--- a/source/user-manual/registering/manager-verification/agents/macos-manager-verification.rst
+++ b/source/user-manual/registering/manager-verification/agents/macos-manager-verification.rst
@@ -14,7 +14,7 @@ Open a session in your MacOS X agent host as root user. After that, you can regi
     # cp rootCA.pem /Library/Ossec/etc
     # /Library/Ossec/bin/agent-auth -m 192.168.1.2 -v /Library/Ossec/etc/rootCA.pem
 
-  .. note:: Note that this method must include the -v option that indicates the location of the CA. If this option is not included, the manager will register following the simple registration service and will not verify with the CA.
+  .. note:: Note that this method must include the -v option that indicates the location of the CA. If this option is not included, a warning message will be displayed and the connection will be established without verifying the manager.
 
 2. Edit the Wazuh agent configuration to add the Wazuh server IP address.
 

--- a/source/user-manual/registering/manager-verification/agents/windows-manager-verification.rst
+++ b/source/user-manual/registering/manager-verification/agents/windows-manager-verification.rst
@@ -21,6 +21,7 @@ After that, you can register the agent using ``agent-auth.exe``:
     # cp rootCA.pem C:\Program Files (x86)\ossec-agent
     # C:\Program Files (x86)\ossec-agent\agent-auth.exe -m 192.168.1.2 -v C:\Program Files (x86)\ossec-agent\rootCA.pem
 
+  .. note:: Note that this method must include the -v option that indicates the location of the CA. If this option is not included, the manager will register following the simple registration service and will not verify with the CA.
 
 2. Edit the Wazuh agent configuration to add the Wazuh server IP address.
 

--- a/source/user-manual/registering/manager-verification/agents/windows-manager-verification.rst
+++ b/source/user-manual/registering/manager-verification/agents/windows-manager-verification.rst
@@ -21,7 +21,7 @@ After that, you can register the agent using ``agent-auth.exe``:
     # cp rootCA.pem C:\Program Files (x86)\ossec-agent
     # C:\Program Files (x86)\ossec-agent\agent-auth.exe -m 192.168.1.2 -v C:\Program Files (x86)\ossec-agent\rootCA.pem
 
-  .. note:: Note that this method must include the -v option that indicates the location of the CA. If this option is not included, the manager will register following the simple registration service and will not verify with the CA.
+  .. note:: Note that this method must include the -v option that indicates the location of the CA. If this option is not included, a warning message will be displayed and the connection will be established without verifying the manager.
 
 2. Edit the Wazuh agent configuration to add the Wazuh server IP address.
 

--- a/source/user-manual/registering/manager-verification/manager-verification-registration.rst
+++ b/source/user-manual/registering/manager-verification/manager-verification-registration.rst
@@ -18,20 +18,41 @@ Wazuh manager
 
 Follow these steps in the Wazuh server:
 
-1. Issue and sign a certificate for the manager. You can enter the hostname or the IP address of the Wazuh server where the agents are going to be registerd. In this case, the Wazuh server IP is ``192.168.1.2``:
+1. Create a configuration file and name it ``req.conf``. You can enter the hostname or the IP address of the Wazuh server where the agents are going to be registered. In this case, the Wazuh server IP is ``192.168.1.2``. The content of the configuration file could be as follows:
 
   .. code-block:: console
 
-    # openssl req -new -nodes -newkey rsa:4096 -keyout sslmanager.key -out sslmanager.csr -subj '/C=US/CN=192.168.1.2'
-    # openssl x509 -req -days 365 -in sslmanager.csr -CA rootCA.pem -CAkey rootCA.key -out sslmanager.cert -CAcreateserial
+    [req]
+    distinguished_name = req_distinguished_name
+    req_extensions = req_ext
+    prompt = no
+    [req_distinguished_name]
+    C = US
+    CN = 192.168.1.2
+    [req_ext]
+    subjectAltName = @alt_names
+    [alt_names]
+    DNS.1 = wazuh
+    DNS.2 = wazuh.com
 
-2. Copy the newly created certificate and its key to the ``/var/ossec/etc`` folder:
+  .. note:: The ``subjectAltName`` extension is optional but necessary to allow the registration of Wazuh agents with a SAN certificate. In this case, the Wazuh server DNS are ``wazuh`` and ``wazuh.com``.
+
+2. Issue and sign a certificate for the manager:
+
+  .. code-block:: console
+
+    # openssl req -new -nodes -newkey rsa:4096 -keyout sslmanager.key -out sslmanager.csr -config req.conf
+    # openssl x509 -req -days 365 -in sslmanager.csr -CA rootCA.pem -CAkey rootCA.key -out sslmanager.cert -CAcreateserial -extfile req.conf -extensions req_ext
+
+  .. note:: The ``-extfile`` and ``-extensions`` options are required to copy the subject and the extensions from ``sslmanager.csr`` to ``sslmanager.cert``. This will allow the registration of Wazuh agents with a SAN certificate.
+
+3. Copy the newly created certificate and its key to the ``/var/ossec/etc`` folder:
 
   .. code-block:: console
 
     # cp sslmanager.cert sslmanager.key /var/ossec/etc
 
-3. Restart the Wazuh manager:
+4. Restart the Wazuh manager:
 
   a) For Systemd:
 


### PR DESCRIPTION
This PR updates the manager verification section.

- A note was added to indicate that the -v option must be included when executing the agent-auth process if we want to verify the CA. If this option is not included, the manager will register following the simple registration service (as expected).

- Added explanation to create manager certificates with alternative names. This allows the registration of Wazuh agents with a SAN certificate.