### PR TITLE
[3.9] Fixed the style of the button 'Copy to clipboard'

### DIFF
--- a/source/_static/css/style.css
+++ b/source/_static/css/style.css
@@ -2299,8 +2299,7 @@ p.first.admonition-title::before,
   background-color: transparent;
 }
 
-.admonition div[class^='highlight'],
-.admonition div[class^='last highlight']{
+.admonition div[class*='highlight'] {
   margin-left: 1rem;
   margin-right: 1rem;
 }
@@ -2576,8 +2575,7 @@ blockquote blockquote {
   margin-left: 0.3rem;
 }
 
-blockquote ul li > div[class^='highlight'],
-blockquote ul li > div[class^='last highlight'] {
+blockquote ul li > div[class*='highlight'] {
   margin-bottom: 0.5rem;
 }
 
@@ -3462,37 +3460,30 @@ div.highlight pre {
 pre.literal-block,
 .rst-content .literal-block,
 .rst-content pre.literal-block,
-div[class^='highlight'],
-div[class^='last highlight'] {
+div[class*='highlight'] {
   border: 1px solid #e1e4e5;
   padding: 0px;
   margin: 1px 0 24px 0
 }
 
-div[class^='highlight'],
-div[class^='last highlight'] {
+div[class*='highlight'] {
   position: relative;
 }
 
-.codeblock div[class^='highlight'],
-pre.literal-block div[class^='highlight'],
-.rst-content .literal-block div[class^='highlight'],
-div[class^='highlight'] div[class^='highlight'],
-.codeblock div[class^='last highlight'],
-pre.literal-block div[class^='last highlight'],
-.rst-content .literal-block div[class^='last highlight'],
-div[class^='last highlight'] div[class^='last highlight'] {
+.codeblock div[class*='highlight'],
+pre.literal-block div[class*='highlight'],
+.rst-content .literal-block div[class*='highlight'],
+div[class*='highlight'] div[class*='highlight'] {
   border: none;
   background: none;
   margin: 0
 }
 
-.last div[class^='highlight'] {
+.last div[class*='highlight'] {
   margin: 0;
 }
 
-div[class^='highlight'] td.code,
-div[class^='last highlight'] td.code {
+div[class*='highlight'] td.code {
   width: 100%
 }
 
@@ -3500,8 +3491,7 @@ div[class^='last highlight'] td.code {
   line-height: 1.5;
 }
 
-div[class^='highlight'] pre,
-div[class^='last highlight'] pre {
+div[class*='highlight'] pre {
   white-space: pre;
   margin: 0;
   line-height: 1.5;
@@ -3509,8 +3499,7 @@ div[class^='last highlight'] pre {
   overflow: auto;
 }
 
-div[class^='highlight'] .copy-to-clipboard,
-div[class^='last highlight'] .copy-to-clipboard {
+div[class*='highlight'] .copy-to-clipboard {
   z-index: 1;
   cursor: pointer;
   opacity: 0;
@@ -3526,31 +3515,27 @@ div[class^='last highlight'] .copy-to-clipboard {
   transition: all 0.2s ease;
 }
 
-div[class^='highlight']:hover .copy-to-clipboard,
-div[class^='last highlight']:hover .copy-to-clipboard {
+div[class*='highlight']:hover .copy-to-clipboard {
   opacity: 1;
 }
 
-div[class^='highlight'] .copy-to-clipboard.copied,
-div[class^='last highlight'] .copy-to-clipboard.copied {
+div[class*='highlight'] .copy-to-clipboard.copied {
   opacity: 1;
   background-color: #333;
 }
 
-div[class^='highlight'] .copy-to-clipboard:hover,
-div[class^='last highlight'] .copy-to-clipboard:hover {
+div[class*='highlight'] .copy-to-clipboard:hover {
   background-color: #333;
 }
 
-div[class^='highlight'] .copy-to-clipboard span,
-div[class^='last highlight'] .copy-to-clipboard span {
+div[class*='highlight'] .copy-to-clipboard span {
   display: none;
   font-size: 0.9rem;
   font-family: 'Open Sans', sans-serif;
 }
 
 @media print {
-  .codeblock,pre.literal-block,.rst-content .literal-block,.rst-content pre.literal-block,div[class^='highlight'],div[class^='highlight'] pre {
+  .codeblock,pre.literal-block,.rst-content .literal-block,.rst-content pre.literal-block,div[class*='highlight'],div[class*='highlight'] pre {
     white-space: pre-wrap
   }
 }


### PR DESCRIPTION
Hi,

The style of the button 'Copy to clipboard' has been fixed, so it should now look correctly regardless of the location of the code block.

Related issue: https://github.com/wazuh/wazuh-website/issues/942