### PR TITLE
[3.11] Fixed code that excludes 'Release notes' from search results

### DIFF
--- a/source/_static/js/style.js
+++ b/source/_static/js/style.js
@@ -558,40 +558,74 @@ $(function() {
 
   /* Search results --------------------------------------------------------------------------------------------------*/
 
-  if ( $('#search-results').length > 0 ) {
-    const ulSearch = $('ul.search');
+  const searchResults = $('#search-results');
+
+  if ( searchResults.length > 0 ) {
     let lastResult = null;
-    let splitURL;
+    let splitURL = null;
+    const configAdd = {childList: true};
+    const configAtt = {attributes: true, attributeOldValue: true};
+    let observerResults = null;
+    let observerResultList = null;
+    let observerResultText = null;
 
     /* Detects every result that is added to the list */
-    ulSearch.on('DOMSubtreeModified', function() {
-      lastResult = $('ul.search li:last-child');
-      splitURL = lastResult.children('a').prop('href').split('/');
-
-      /* Checks the URL to mark the results found in excludedSearchFolders */
-      $.each(excludedSearchFolders, function(index, value) {
-        if ( $.inArray(value, splitURL) !== -1 ) {
-          lastResult.addClass('excluded-search-result'); /* Marks initially excluded result */
-          lastResult.addClass('hidden-result'); /* Hides the excluded result */
-          return false; /* breaks the $.each loop */
+    const addedResult = function(mutationsList, observer) {
+      for (const mutation of mutationsList) {
+        if (mutation.type === 'childList') {
+          lastResult = $('ul.search li:last-child');
+          splitURL = lastResult.children('a').prop('href').split('/');
+          /* Checks the URL to mark the results found in excludedSearchFolders */
+          $.each(excludedSearchFolders, function(index, value) {
+            if ( $.inArray(value, splitURL) !== -1 ) {
+              lastResult.addClass('excluded-search-result'); /* Marks initially excluded result */
+              lastResult.addClass('hidden-result'); /* Hides the excluded result */
+              return false; /* breaks the $.each loop */
+            }
+          });
         }
-      });
-    });
+      }
+    };
+
+    /* Checking that the list of search results exists */
+    const existsResultList = function(mutationsList, observer) {
+      for (const mutation of mutationsList) {
+        if (mutation.type === 'childList' && $(mutation.addedNodes[0]).hasClass('search') ) {
+          const ulSearch = $('ul.search');
+
+          observerResults.disconnect();
+
+          observerResultList = new MutationObserver(addedResult);
+          observerResultList.observe(ulSearch[0], configAdd);
+          observerResultText = new MutationObserver(changeResultText);
+          observerResultText.observe($('#search-results > p')[0], configAtt);
+        }
+      }
+    };
 
     /* Replaces the result message */
-    $('#search-results > p:first').one('DOMSubtreeModified', function() {
-      const totalResults = $('ul.search li').length;
-      const excludedResults = $('ul.search li.excluded-search-result').length;
-      let resultText = '';
-      if ( totalResults > 0 ) {
-        if ( excludedResults > 0 ) {
-          resultText = 'Search finished. Found <span id="n-results">' + (totalResults-excludedResults) + '</span> page(s) matching the search query. <a id="toggle-results" class="include" href="#">Include Release Notes results</a>';
-        } else {
-          resultText = 'Search finished. Found <span id="n-results">' + totalResults + '</span> page(s) matching the search query.';
+    const changeResultText = function(mutationsList, observer) {
+      for (const mutation of mutationsList) {
+        if (mutation.type === 'attributes') {
+          observerResultText.disconnect();
+          const totalResults = $('ul.search li').length;
+          const excludedResults = $('ul.search li.excluded-search-result').length;
+          let resultText = '';
+          if ( totalResults > 0 ) {
+            if ( excludedResults > 0 ) {
+              resultText = 'Search finished. Found <span id="n-results">' + (totalResults-excludedResults) + '</span> page(s) matching the search query. <a id="toggle-results" class="include" href="#">Include Release Notes results</a>';
+            } else {
+              resultText = 'Search finished. Found <span id="n-results">' + totalResults + '</span> page(s) matching the search query.';
+            }
+            $('#search-results > p:first').html(resultText);
+          }
         }
-        $(this).html(resultText);
       }
-    });
+    };
+
+    observerResults = new MutationObserver(existsResultList);
+    observerResults.observe(searchResults[0], configAdd);
+
 
     /* Click that allows showing excluded results */
     $(document).delegate('#search-results #toggle-results.include', 'click', function() {


### PR DESCRIPTION
Hi,

The search functionality in our documentation should hide the results found within the 'Release notes' from search results by default, allowing the user to add them later. However, the event that was triggering the function in charge of excluding the 'Release notes' from search results was deprecated and stopped working. 
This PR adapts the code to use `Mutation Observer API` instead, which allows us to recover this feature in our search page.

Related issue: https://github.com/wazuh/wazuh-website/issues/949
