### PR TITLE
[3.11] Fixed wrong path in one of the thumbnails

### DIFF
--- a/source/amazon/services/supported-services/config.rst
+++ b/source/amazon/services/supported-services/config.rst
@@ -23,7 +23,7 @@ Amazon configuration
 
 3. Select an existing S3 Bucket or :ref:`create a new one. <S3_bucket>`
 
-    .. thumbnail:: ../../images/aws/aws-create-config-1.png
+    .. thumbnail:: ../../../images/aws/aws-create-config-1.png
       :align: center
       :width: 100%
 


### PR DESCRIPTION
Hi,

I've found out that branch `3.11` could not be compiled due to an error in the path of one of the thumbnails. Said path has been corrected in this PR.