### PR TITLE
Updated the version of the documentation corresponding to this release

### DIFF
--- a/source/_static/js/version-selector.js
+++ b/source/_static/js/version-selector.js
@@ -5,9 +5,10 @@ jQuery(function($) {
   */
 
 
-  const currentVersion = '3.11';
+  const currentVersion = '3.12';
   const versions = [
-    {name: '3.11 (current)', url: '/'+currentVersion},
+    {name: '3.12 (current)', url: '/'+currentVersion},
+    {name: '3.11', url: '/3.11'},
     {name: '3.10', url: '/3.10'},
     {name: '3.9', url: '/3.9'},
     {name: '3.8', url: '/3.8'},

--- a/source/conf.py
+++ b/source/conf.py
@@ -30,7 +30,7 @@ author = u'Wazuh, Inc.'
 copyright = u'&copy; ' + str(datetime.datetime.now().year) + u' &middot; Wazuh Inc.'
 
 # The short X.Y version
-version = '3.11'
+version = '3.12'
 # The full version, including alpha/beta/rc tags
 release = version
 


### PR DESCRIPTION
Hi,

The value of `version` was outdated in this branch. This PR updates the version to 3.12, and modifies the data in the version selector to include this release as `current`.