### PR TITLE
[3.10] Fixed some bugs occurring only on Internet Explorer

### DIFF
--- a/source/_static/css/style.css
+++ b/source/_static/css/style.css
@@ -429,7 +429,7 @@ header .menuweb-bar .menu-item a {
   font-size: 1.1rem;
   font-weight: normal !important;
   transition: .2s all ease;
-	position: relative;
+  position: relative;
 }
 
 #capabilities .left .topic .topic-title::before {
@@ -2987,7 +2987,7 @@ div.highlight pre {
         height: calc(100vh - 165px); /* 40px search + 100px buttons + 25px padding = 165px */
         visibility: visible;
         overflow-y: hidden;
-				-ms-overflow-style: -ms-autohiding-scrollbar;
+        -ms-overflow-style: -ms-autohiding-scrollbar; /* Internet Explorer */
       }
 
       .scrolled #navbar-globaltoc {

--- a/source/_static/css/style.css
+++ b/source/_static/css/style.css
@@ -429,6 +429,7 @@ header .menuweb-bar .menu-item a {
   font-size: 1.1rem;
   font-weight: normal !important;
   transition: .2s all ease;
+	position: relative;
 }
 
 #capabilities .left .topic .topic-title::before {
@@ -2986,6 +2987,7 @@ div.highlight pre {
         height: calc(100vh - 165px); /* 40px search + 100px buttons + 25px padding = 165px */
         visibility: visible;
         overflow-y: hidden;
+				-ms-overflow-style: -ms-autohiding-scrollbar;
       }
 
       .scrolled #navbar-globaltoc {
@@ -3319,7 +3321,6 @@ div.highlight pre {
 				overflow: hidden;
 				height: 100%;
         flex-direction: column;
-        padding-right: 15px;
         width: 360px;
       }
 

--- a/source/_static/js/style.js
+++ b/source/_static/js/style.js
@@ -568,11 +568,12 @@ $(function() {
     let observerResults = null;
     let observerResultList = null;
     let observerResultText = null;
+		let i = 0;
 
     /* Detects every result that is added to the list */
     const addedResult = function(mutationsList, observer) {
-      for (const mutation of mutationsList) {
-        if (mutation.type === 'childList') {
+			for ( i = 0; i< mutationsList.length-1; i++) {
+			 if (mutationsList[i].type === 'childList') {
           lastResult = $('ul.search li:last-child');
           splitURL = lastResult.children('a').prop('href').split('/');
           /* Checks the URL to mark the results found in excludedSearchFolders */
@@ -589,8 +590,8 @@ $(function() {
 
     /* Checking that the list of search results exists */
     const existsResultList = function(mutationsList, observer) {
-      for (const mutation of mutationsList) {
-        if (mutation.type === 'childList' && $(mutation.addedNodes[0]).hasClass('search') ) {
+      for ( i = 0; i< mutationsList.length-1; i++) {
+        if (mutationsList[i].type === 'childList' && $(mutationsList[i].addedNodes[0]).hasClass('search') ) {
           const ulSearch = $('ul.search');
 
           observerResults.disconnect();
@@ -605,8 +606,8 @@ $(function() {
 
     /* Replaces the result message */
     const changeResultText = function(mutationsList, observer) {
-      for (const mutation of mutationsList) {
-        if (mutation.type === 'attributes') {
+      for ( i = 0; i< mutationsList.length-1; i++) {
+        if (mutationsList[i].type === 'attributes') {
           observerResultText.disconnect();
           const totalResults = $('ul.search li').length;
           const excludedResults = $('ul.search li.excluded-search-result').length;
@@ -740,7 +741,7 @@ $(function() {
     if (find != null) {
       const dataArray = data.split('\n');
       let content = '';
-      dataArray.forEach((line) => {
+      dataArray.forEach(function(line) {
         line = line.replace('<span class="gp">#</span> ', '<span class="gp no-select"># </span>');
         line = line.replace(/(?:\$\s)/g, '<span class="no-select">$ </span>') + '\n';
         content += line;

--- a/source/_static/js/style.js
+++ b/source/_static/js/style.js
@@ -568,12 +568,12 @@ $(function() {
     let observerResults = null;
     let observerResultList = null;
     let observerResultText = null;
-		let i = 0;
+    let i = 0;
 
     /* Detects every result that is added to the list */
     const addedResult = function(mutationsList, observer) {
-			for ( i = 0; i< mutationsList.length-1; i++) {
-			 if (mutationsList[i].type === 'childList') {
+      for ( i = 0; i< mutationsList.length-1; i++) {
+        if (mutationsList[i].type === 'childList') {
           lastResult = $('ul.search li:last-child');
           splitURL = lastResult.children('a').prop('href').split('/');
           /* Checks the URL to mark the results found in excludedSearchFolders */


### PR DESCRIPTION
Hi

During the last update, we included a code which uses the javascript statement `for ... of`, however, this statement is not compatible with Internet Explorer (IE), thus the browser completely ignores the whole JS file, braking the functionality in our documentation's web when visiting the site through IE. Therefore, the statement `for ... of` has been replaced with the classic `for`.

In addition, some bugs in the style which occur only on this browser, have been fixed.