### PR TITLE
Agents Centralized configuration typo

### DIFF
--- a/source/user-manual/reference/centralized-configuration.rst
+++ b/source/user-manual/reference/centralized-configuration.rst
@@ -186,7 +186,7 @@ The following is an example of how a centralized configuration can be done.
 
 3. Push the configuration to the agents:
 
-    Each time an agent checks-in with the manager (10 minute default), it looks to see if a new version of ``agent.conf`` is available from the manager.  When a new version is available, it automatically pulls the new file. However, the new ``agent.conf`` is not used by the agent until the next time the agent is restarted, as in step 5.
+    With every agent keepalive (10 seconds default), the manager looks to see if a new version of ``agent.conf`` is available. When a new version is available, it automatically pulls the new file. However, the new ``agent.conf`` is not used by the agent until the next time the agent is restarted, as in step 5. However, the new ``agent.conf`` is not used by the agent until the next time the agent is restarted, as in step 5.
 
     .. note:: Restarting the manager will make the new ``agent.conf`` file available to the agents more quickly.
 

--- a/source/user-manual/reference/centralized-configuration.rst
+++ b/source/user-manual/reference/centralized-configuration.rst
@@ -186,7 +186,7 @@ The following is an example of how a centralized configuration can be done.
 
 3. Push the configuration to the agents:
 
-    With every agent keepalive (10 seconds default), the manager looks to see if a new version of ``agent.conf`` is available. When a new version is available, it automatically pulls the new file. However, the new ``agent.conf`` is not used by the agent until the next time the agent is restarted, as in step 5. However, the new ``agent.conf`` is not used by the agent until the next time the agent is restarted, as in step 5.
+    With every agent keepalive (10 seconds default), the manager looks to see if a new version of ``agent.conf`` is available. When a new version is available, it automatically pulls the new file. However, the new ``agent.conf`` is not used by the agent until the next time the agent is restarted, as in step 5.
 
     .. note:: Restarting the manager will make the new ``agent.conf`` file available to the agents more quickly.
 


### PR DESCRIPTION
Hello team,

The centralized configuration documentation suggests that the agents check-in with the manager happens every 10 minutes by default. This is a typo as the agents [check-in with the manager every 10 seconds](https://documentation.wazuh.com/3.10/user-manual/reference/ossec-conf/client.html#notify-time). 

This PR fixes the typo.

Regards