### PR TITLE
Typo found

### DIFF
--- a/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
@@ -119,7 +119,7 @@ Example:
   .. code-block:: xml
 
     <rule id="100001" maxsize="300" level="3">
-      <if_sid>100020</if_sid>
+      <if_sid>100200</if_sid>
       <match>Queue flood!</match>
       <description> Flooded events queue.</description>
     </rule>


### PR DESCRIPTION
The rule said 100020 and the explanation said 100200. 