### PR TITLE
3.10 cdb-list edit

### DIFF
--- a/source/user-manual/ruleset/cdb-list.rst
+++ b/source/user-manual/ruleset/cdb-list.rst
@@ -5,7 +5,7 @@
 Using CDB lists
 ===============
 
-Wazuh is able to check if a field extracted during the decoding phase is in a CDB list (constant database). The main use case of this feature is to create a white/black list of users, IPs or domain names.
+Wazuh is able to check if a field extracted during the decoding phase is in a CDB list (constant database). The main use case of this feature is to create a white/black list of users, file hashes, IPs or domain names.
 
 Creating a CDB list
 -------------------
@@ -18,7 +18,9 @@ The list file is a plain text file where each line has the following format::
     key1:value1
     key2:value2
 
-Each key must be unique and is terminated with a colon ``:``.
+Each key must be unique, followed by a colon ``:`` and it can have an optional value. The value can be identical to others but the key must remain unique.
+
+With a key we can determine the presence or absence of a field in a given list. By adding a value we can use it as criteria in rules. For example, if we have account names (key) with a department name (value) associated it would be possible to create alerts when a user not from the finance department logs into the finance server.
 
 For IP addresses the dot notation is used for subnet matches:
 
@@ -76,19 +78,19 @@ A rule would use the following syntax to look up a key within a CDB list.
 Positive key match
 ^^^^^^^^^^^^^^^^^^
 
-This example is a search for the key stored in the field attribute and will match if it **IS** present in the database:
+This example is a search for the key stored in the field attribute and will match if it is present in the database:
 
 .. code-block:: xml
 
      <list field="user" lookup="match_key">etc/lists/list-user</list>
 
-The ``lookup="match_key"`` is the default and can be left out as in this example:
+The ``lookup="match_key"`` is the default and can be omitted as in this example:
 
 .. code-block:: xml
 
      <list field="user">etc/lists/list-user</list>
 
-In case the field is an IP address, you must to use *address_match_key*:
+In case the field is an IP address, you must use ``address_match_key``:
 
 .. code-block:: xml
 
@@ -97,13 +99,13 @@ In case the field is an IP address, you must to use *address_match_key*:
 Negative key match
 ^^^^^^^^^^^^^^^^^^
 
-This example is a search for the key stored in the field attribute and will match if it *IS NOT* present in the database:
+This example is a search for the key stored in the field attribute and will match if it is not present in the database:
 
 .. code-block:: xml
 
     <list field="user" lookup="not_match_key">etc/lists/list-user</list>
 
-In case the field is an IP address, you must use *not_address_match_key*:
+In case the field is an IP address, you must use ``not_address_match_key``:
 
 .. code-block:: xml
 
@@ -112,13 +114,13 @@ In case the field is an IP address, you must use *not_address_match_key*:
 Key and value match
 ^^^^^^^^^^^^^^^^^^^
 
-This example is a search for the key stored in the field attribute, and on a positive match the returned value of the key will be processed using the regex in the check_value attribute:
+This example is a search for the key stored in the field attribute, and on a positive match the returned value of the key will be processed using the regex in the *check_value* attribute:
 
 .. code-block:: xml
 
      <list field="user" lookup="match_key_value" check_value="^block">etc/lists/list-user</list>
 
-In case the field is an IP address, you must use *not_address_match_key*:
+In case the field is an IP address, you must use ``not_address_match_key``:
 
 .. code-block:: xml
 
@@ -153,4 +155,4 @@ CDB lists examples
     <group>list1,list2,</group>
   </rule>
 
-In this example, the described rules check if an IP is in the *list-one*, in the *list-two*, or in both.
+In this example, the described rules check if an IP is in the *List-one*, in the *List-two* or in both.

--- a/source/user-manual/ruleset/cdb-list.rst
+++ b/source/user-manual/ruleset/cdb-list.rst
@@ -20,7 +20,7 @@ The list file is a plain text file where each line has the following format::
 
 Each key must be unique, followed by a colon ``:`` and it can have an optional value. The value can be identical to others but the key must remain unique.
 
-With a key we can determine the presence or absence of a field in a given list. By adding a value we can use it as criteria in rules. For example, if we have account names (key) with a department name (value) associated it would be possible to create an alert that triggers when a user not from the finance department logs into the finance server.
+With a key we can determine the presence or absence of a field in a given list. By adding a value we can use it as criteria in rules. For example, if we have account names (key) with a department name (value) associated, it would be possible to create an alert that triggers when a user not from the finance department logs into the finance server.
 
 For IP addresses the dot notation is used for subnet matches:
 

--- a/source/user-manual/ruleset/cdb-list.rst
+++ b/source/user-manual/ruleset/cdb-list.rst
@@ -20,7 +20,7 @@ The list file is a plain text file where each line has the following format::
 
 Each key must be unique, followed by a colon ``:`` and it can have an optional value. The value can be identical to others but the key must remain unique.
 
-With a key we can determine the presence or absence of a field in a given list. By adding a value we can use it as criteria in rules. For example, if we have account names (key) with a department name (value) associated it would be possible to create alerts when a user not from the finance department logs into the finance server.
+With a key we can determine the presence or absence of a field in a given list. By adding a value we can use it as criteria in rules. For example, if we have account names (key) with a department name (value) associated it would be possible to create an alert that triggers when a user not from the finance department logs into the finance server.
 
 For IP addresses the dot notation is used for subnet matches:
 


### PR DESCRIPTION
Reviewed _CDB-list_ section in an attempt to improve it: 

* Added a main case of use: File hashes. 
* Edited the description of how to create a CDB List. Including the optional value. 
* Added an explanation of how keys and values can be used, giving a description and a simple example
* Changed some formatting. Took out upper cases and words in bold. Changed some fields from _cursive_ to `highlighted`. Others were referring to an existing file as list-one instead of List-one which was the actual name. 
* Changed some wrong expressions and other for better sounding ones. 