### PR TITLE
Link "Windows package" to the windows package download link

### DIFF
--- a/source/installation-guide/installing-wazuh-agent/windows/wazuh_agent_package_windows.rst
+++ b/source/installation-guide/installing-wazuh-agent/windows/wazuh_agent_package_windows.rst
@@ -7,7 +7,7 @@ Windows from package
 
 .. note:: You will need administrator privileges to perform this installation.
 
-The first step to installing the Wazuh agent on a Windows machine is to download the :ref:`Windows installer<https://packages.wazuh.com/3.x/windows/wazuh-agent-3.10.2-1.msi>` from the :ref:`packages list<packages>`. Once this is downloaded, you can install it by using the command line or following the GUI steps:
+The first step to installing the Wazuh agent on a Windows machine is to download the `Windows installer <https://packages.wazuh.com/3.x/windows/wazuh-agent-3.10.2-1.msi>`_ from the :ref:`packages list<packages>`. Once this is downloaded, you can install it by using the command line or following the GUI steps:
 
   a) Using the command line, you can choose installation or deployment:
 

--- a/source/installation-guide/installing-wazuh-agent/windows/wazuh_agent_package_windows.rst
+++ b/source/installation-guide/installing-wazuh-agent/windows/wazuh_agent_package_windows.rst
@@ -7,7 +7,7 @@ Windows from package
 
 .. note:: You will need administrator privileges to perform this installation.
 
-The first step to installing the Wazuh agent on a Windows machine is to download the `Windows installer <https://packages.wazuh.com/3.x/windows/wazuh-agent-3.11.3-1.msi>`_ from the :ref:`packages list<packages>`. Once this is downloaded, you can install it by using the command line or following the GUI steps:
+The first step to install the Wazuh agent on a Windows machine is to download the `Windows installer <https://packages.wazuh.com/3.x/windows/wazuh-agent-3.11.3-1.msi>`_ from the :ref:`packages list<packages>`. Once this is downloaded, you can install it using the command line or following the GUI steps:
 
   a) Using the command line, you can choose installation or deployment:
 

--- a/source/installation-guide/installing-wazuh-agent/windows/wazuh_agent_package_windows.rst
+++ b/source/installation-guide/installing-wazuh-agent/windows/wazuh_agent_package_windows.rst
@@ -7,7 +7,7 @@ Windows from package
 
 .. note:: You will need administrator privileges to perform this installation.
 
-The first step to installing the Wazuh agent on a Windows machine is to download the `Windows installer <https://packages.wazuh.com/3.x/windows/wazuh-agent-3.10.2-1.msi>`_ from the :ref:`packages list<packages>`. Once this is downloaded, you can install it by using the command line or following the GUI steps:
+The first step to installing the Wazuh agent on a Windows machine is to download the `Windows installer <https://packages.wazuh.com/3.x/windows/wazuh-agent-3.11.3-1.msi>`_ from the :ref:`packages list<packages>`. Once this is downloaded, you can install it by using the command line or following the GUI steps:
 
   a) Using the command line, you can choose installation or deployment:
 

--- a/source/installation-guide/installing-wazuh-agent/windows/wazuh_agent_package_windows.rst
+++ b/source/installation-guide/installing-wazuh-agent/windows/wazuh_agent_package_windows.rst
@@ -7,7 +7,7 @@ Windows from package
 
 .. note:: You will need administrator privileges to perform this installation.
 
-The first step to installing the Wazuh agent on a Windows machine is to download the Windows installer from the :ref:`packages list<packages>`. Once this is downloaded, you can install it by using the command line or following the GUI steps:
+The first step to installing the Wazuh agent on a Windows machine is to download the :ref:`Windows installer<https://packages.wazuh.com/3.x/windows/wazuh-agent-3.10.2-1.msi>` from the :ref:`packages list<packages>`. Once this is downloaded, you can install it by using the command line or following the GUI steps:
 
   a) Using the command line, you can choose installation or deployment:
 


### PR DESCRIPTION
Hi team,
In order to reduce the number of clicks needed to download the Windows package and to avoid redirecting the user to a page he's not interested in seeing, I think it would be a good idea to link `Windows package` text to the windows package download link in this documentation page: https://documentation.wazuh.com/3.11/installation-guide/installing-wazuh-agent/windows/wazuh_agent_package_windows.html.