### PR TITLE
Add poll_interval and keepalive options to Fluent Forward module

### DIFF
--- a/source/user-manual/reference/ossec-conf/fluent-forward.rst
+++ b/source/user-manual/reference/ossec-conf/fluent-forward.rst
@@ -29,6 +29,8 @@ Options
 - `user`_
 - `password`_
 - `timeout`_
+- `poll_interval`_
+- `keepalive`_
 
 enabled
 ^^^^^^^
@@ -164,6 +166,52 @@ For example ``<timeout>10</timeout>``.
 
 .. note::
   The default value 0 means no timeout.
+
+
+poll_interval
+^^^^^^^^^^^^^
+.. versionadded:: 3.11.0
+
+Defines the connection health check interval (in seconds). If the module keeps idle during the defined time, it will poll the connection. If the connection is broken, the module will reconnect to the Fluent server.
+
++--------------------+--------------------------------+
+| **Default value**  | 60                             |
++--------------------+--------------------------------+
+| **Allowed values** | 1 to 7200                      |
++--------------------+--------------------------------+
+
+For instance: ``<poll_interval>60</poll_interval>``
+
+
+keepalive
+^^^^^^^^^
+.. versionadded:: 3.11.0
+
+Enables TCP keepalive on the connection with the Fluent server. With the default configuration, the agent will wait undefinitely for the server to confirm a delivery. If ``<timeout>`` is disabled, or no data is available to send, the agent is unable to detect a broken connection.
+
+This option allows enabling TCP keepalive and tune its options. When the connection becomes idle during ``<idle>`` seconds, the agent will start delivering one keepalive probe every ``<interval>`` seconds. If no response is received after ``<count>`` attempts, the agent will reset the connection.
+
+Attributes
+~~~~~~~~~~
+
++-------------+-------------------+--------------------+-----------------------+
+| **Option**  | **Default value** | **Allowed values** | **Description**       |
++-------------+-------------------+--------------------+-----------------------+
+| **enabled** | yes               | ``yes`` or ``no``  | Enable TCP keepalive. |
++-------------+-------------------+--------------------+-----------------------+
+
+Keepalive options
+~~~~~~~~~~~~~~~~~
+
++--------------+-------------------+--------------------+--------------------------------------------------------------+
+| **Option**   | **Default value** | **Allowed values** | **Description**                                              |
++--------------+-------------------+--------------------+--------------------------------------------------------------+
+| **count**    | Defined by the OS | 1 to 32767         | Maximum number of probes before closing the connection.      |
++--------------+-------------------+--------------------+--------------------------------------------------------------+
+| **idle**     | Defined by the OS | 1 to 32767         | Idle time: number of seconds before starting to send probes. |
++--------------+-------------------+--------------------+--------------------------------------------------------------+
+| **interval** | Defined by the OS | 1 to 32767         | Interval (in seconds) between probes.                        |
++--------------+-------------------+--------------------+--------------------------------------------------------------+
 
 
 Configuration examples


### PR DESCRIPTION
|Related issue|Related PR|Target version|
|---|---|---|
|https://github.com/wazuh/wazuh/issues/4197|https://github.com/wazuh/wazuh/pull/4274|3.11.0|

This PR aims to add the options introduced in the mentioned issue to the reference documentation for Fluent Forwarder.

## Screenshot

![image](https://user-images.githubusercontent.com/10536251/69592367-89dc6200-0faa-11ea-88ba-c43df5388acd.png)
