### PR TITLE
[3.11] Replace Docker base image for python:3.7-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,11 @@
 # docker build -t sphinx-autobuild .
 # docker run -it -p 8000:8000 --rm -v "$(pwd)/source":/home/python/docs sphinx-autobuild
 
-FROM keimlink/sphinx-doc:1.7.1
+FROM python:3.7-alpine
 
 COPY --chown=1000:1000 requirements.txt ./
 
-RUN . .venv/bin/activate \
-    && python -m pip install --requirement requirements.txt && python -m pip install sphinx-autobuild==0.7.1
+RUN python -m pip install --requirement requirements.txt && python -m pip install sphinx-autobuild==0.7.1
 
 EXPOSE 8000
 


### PR DESCRIPTION
Hi,

Since the change in the requirements of our documentation, using Docker or Vagrant automation to compile our documentation was not possible due to problems with the version of Python. We noticed that the Docker image we were using for automation was outdated. 
Fortunately, @xr09 has found a Docker image that works correctly with the new requirements.

Related issue: https://github.com/wazuh/wazuh-automation/issues/167