### PR TITLE
3.10 typos below.

### DIFF
--- a/source/user-manual/api/getting-started.rst
+++ b/source/user-manual/api/getting-started.rst
@@ -132,7 +132,7 @@ Often when an alert fires, it is helpful to know details about the rule itself. 
     }
 
 
-It can also be helpful to know what rules are available that match a specific criteria. For example, all the rules with a group of **web**, a PCI tag of **10.6.1**, and containing the word **failures** can be showed using the command bellow:
+It can also be helpful to know what rules are available that match a specific criteria. For example, all the rules with a group of **web**, a PCI tag of **10.6.1**, and containing the word **failures** can be showed using the command below:
 
 .. code-block:: console
 
@@ -337,7 +337,7 @@ Some information about the manager can be retrieved using the API. Configuration
     }
 
 
-You can even dump the manager's current configuration with the request bellow (response shortened for brevity):
+You can even dump the manager's current configuration with the request below (response shortened for brevity):
 
 .. code-block:: console
 

--- a/source/user-manual/capabilities/agent-key-polling.rst
+++ b/source/user-manual/capabilities/agent-key-polling.rst
@@ -208,7 +208,7 @@ Suppose you have a table named ``agent`` in your database with the following str
 .. note::
   If your executable is a script that does not include shebang, you must include its interpreter in the `sexec_path` parameter of the configuration.
 
-The python script bellow shows an example of an agent key retrieval from the database (MySQL).
+The python script below shows an example of an agent key retrieval from the database (MySQL).
 
 .. code-block:: python
 
@@ -254,7 +254,7 @@ The python script bellow shows an example of an agent key retrieval from the dat
   if __name__ == '__main__':
       main()
 
-The php script bellow shows an example of an agent key retrieval from the database (MySQL).
+The php script below shows an example of an agent key retrieval from the database (MySQL).
 
 .. code-block:: php
 

--- a/source/user-manual/kibana-app/features/query-configuration.rst
+++ b/source/user-manual/kibana-app/features/query-configuration.rst
@@ -11,7 +11,7 @@ The actual configuration of an agent, or the manager can be queried on demand by
   :align: center
   :width: 100%
 
-The image bellow shows that the agent configuration is synchronized:
+The image below shows that the agent configuration is synchronized:
 
 .. thumbnail:: ../../../images/kibana-app/features/query-configuration/is-sync.png
   :align: center


### PR DESCRIPTION
Discovered the word `bellow` was being used incorrectly some places. 

**bellow**: to shout in a loud voice, or (of a cow or large animal) to make a loud, deep sound.
**below**: in a lower position (than), under.