### PR TITLE
[3.10] Added reminded to cdb lists

### DIFF
--- a/source/user-manual/ruleset/cdb-list.rst
+++ b/source/user-manual/ruleset/cdb-list.rst
@@ -55,7 +55,7 @@ Each list must be defined in the ``ossec.conf`` file using the following syntax:
   The ``<list>`` setting uses a relative path to the Wazuh installation folder (``/var/ossec/``) so make sure to indicate the directory accordingly.
   
 .. warning::
-  It is necessary to compile the lists every time they are modified. You may compile them manually by using the ``/var/ossec/bin/ossec-makelists`` tool. Any change to a list won't take effect until the Wazuh manager is restarted.
+  It is necessary to compile the lists every time they are modified. You may compile them manually by using the ``/var/ossec/bin/ossec-makelists`` tool. 
   
 
 Restart Wazuh to apply the changes:

--- a/source/user-manual/ruleset/cdb-list.rst
+++ b/source/user-manual/ruleset/cdb-list.rst
@@ -55,7 +55,7 @@ Each list must be defined in the ``ossec.conf`` file using the following syntax:
   The ``<list>`` setting uses a relative path to the Wazuh installation folder (``/var/ossec/``) so make sure to indicate the directory accordingly.
   
 .. warning::
-  It is necessary to compile the lists every time they are modified. You may compile them manually by using the ossec-makelists tool ( /var/ossec/bin/ossec-makelists ). Any change to a list won't take effect until the Wazuh manager is restarted.
+  It is necessary to compile the lists every time they are modified. You may compile them manually by using the ``/var/ossec/bin/ossec-makelists`` tool. Any change to a list won't take effect until the Wazuh manager is restarted.
   
 
 Restart Wazuh to apply the changes:

--- a/source/user-manual/ruleset/cdb-list.rst
+++ b/source/user-manual/ruleset/cdb-list.rst
@@ -53,6 +53,10 @@ Each list must be defined in the ``ossec.conf`` file using the following syntax:
 
 .. warning::
   The ``<list>`` setting uses a relative path to the Wazuh installation folder (``/var/ossec/``) so make sure to indicate the directory accordingly.
+  
+.. warning::
+  It is necessary to compile the lists every time they are modified. You may compile them manually by using the ossec-makelists tool ( /var/ossec/bin/ossec-makelists ). Any change to a list won't take effect until the Wazuh manager is restarted.
+  
 
 Restart Wazuh to apply the changes:
 


### PR DESCRIPTION
Hello team,

Our documentation doesn't remember the users to compile the lists after either adds them or modify them.
I've explained they need to restart the manager after they compile a list to allow the manager to get the new values.

Regards.