### PR TITLE
Cluster documentation fixes

### DIFF
--- a/source/user-manual/configuring-cluster/index.rst
+++ b/source/user-manual/configuring-cluster/index.rst
@@ -92,8 +92,12 @@ Deploying a Wazuh cluster
 
         .. code-block:: console
 
-            # /var/ossec/bin/cluster-control -l
+            # /var/ossec/bin/cluster_control -l
 
+    The output should be similar to:
+
+        .. code-block:: console
+        
             NAME           TYPE    VERSION  ADDRESS
             master-node    master  3.10.2   wazuh-master
             worker01-node  worker  3.10.2   172.22.0.3


### PR DESCRIPTION
Hello team.

I've seen the tool used to verify the Wazuh cluster had a bad name in our documentation.
I've moved the output of the command to a new window to avoid the new feature of copying the command to copy the output too.

Regards.