### PR TITLE
Add Syscheck configurations changes to documentation

### DIFF
--- a/source/user-manual/reference/ossec-conf/syscheck.rst
+++ b/source/user-manual/reference/ossec-conf/syscheck.rst
@@ -39,7 +39,7 @@ Options
 - `windows_audit_interval`_
 - `whodata`_
 - `process_priority`_
-- `inventory`_
+- `synchronization`_
 - `max_eps`_
 
 .. _reference_ossec_syscheck_directories:
@@ -596,7 +596,7 @@ Set the maximum output throughput.
 +--------------------+---------------------------------------+
 
 
-inventory
+synchronization
 ^^^^^^^^^
 
 .. versionadded:: 3.12.0
@@ -606,20 +606,33 @@ The database synchronization settings will be configured inside this tag.
 .. code-block:: xml
 
     <!-- Database synchronization settings -->
-    <inventory>
-      <sync_interval>5m</sync_interval>
-      <max_sync_interval>1h</max_sync_interval>
+    <synchronization>
+      <enabled>yes</enabled>
+      <interval>5m</interval>
+      <max_interval>1h</max_interval>
       <response_timeout>30</response_timeout>
       <sync_queue_size>16384</sync_queue_size>
-    </inventory>
+    </synchronization>
 
 
-**sync_interval**
+**enabled**
+
+.. versionadded:: 3.12.0
+
+Specifies whether there will be periodic inventory synchronizations or not.
+
++--------------------+---------------------------------------+
+| **Default value**  | yes                                   |
++--------------------+---------------------------------------+
+| **Allowed values** | yes/no                                |
++--------------------+---------------------------------------+
+
+**interval**
 
 .. versionadded:: 3.12.0
 
 Specifies the initial number of seconds between every inventory synchronization. If synchronization fails
-the value will be duplicated until it reaches the value of ``max_sync_interval``.
+the value will be duplicated until it reaches the value of ``max_interval``.
 
 +--------------------+---------------------------------------+
 | **Default value**  | 300                                   |
@@ -627,7 +640,7 @@ the value will be duplicated until it reaches the value of ``max_sync_interval``
 | **Allowed values** | Any number greater than or equal to 0.|
 +--------------------+---------------------------------------+
 
-**max_sync_interval**
+**max_interval**
 
 .. versionadded:: 3.12.0
 
@@ -636,7 +649,7 @@ Specifies the maximum number of seconds between every inventory synchronization.
 +--------------------+-----------------------------------------------------------+
 | **Default value**  | 3600                                                      |
 +--------------------+-----------------------------------------------------------+
-| **Allowed values** | Any number greater than or equal to max_sync_interval.    |
+| **Allowed values** | Any number greater than or equal to interval.             |
 +--------------------+-----------------------------------------------------------+
 
 **response_timeout**
@@ -653,7 +666,7 @@ may start a new synchronization session at the defined interval.
 | **Allowed values** | Any number greater than or equal to 0.|
 +--------------------+---------------------------------------+
 
-**sync_queue_size**
+**queue_size**
 
 .. versionadded:: 3.12.0
 
@@ -722,9 +735,8 @@ Default Unix configuration
     <max_eps>200</max_eps>
 
     <!-- Database synchronization settings -->
-    <inventory>
-      <sync_interval>5m</sync_interval>
-      <response_timeout>30</response_timeout>
-      <sync_queue_size>16384</sync_queue_size>
-    </inventory>
+    <synchronization>
+      <interval>5m</interval>
+      <max_interval>1h</max_interval>
+    </synchronization>
   </syscheck>

--- a/source/user-manual/reference/ossec-conf/syscheck.rst
+++ b/source/user-manual/reference/ossec-conf/syscheck.rst
@@ -597,7 +597,7 @@ Set the maximum output throughput.
 
 
 synchronization
-^^^^^^^^^
+^^^^^^^^^^^^^^^
 
 .. versionadded:: 3.12.0
 
@@ -634,11 +634,11 @@ Specifies whether there will be periodic inventory synchronizations or not.
 Specifies the initial number of seconds between every inventory synchronization. If synchronization fails
 the value will be duplicated until it reaches the value of ``max_interval``.
 
-+--------------------+---------------------------------------+
-| **Default value**  | 300                                   |
-+--------------------+---------------------------------------+
-| **Allowed values** | Any number greater than or equal to 0.|
-+--------------------+---------------------------------------+
++--------------------+----------------------------------------------------------------------+
+| **Default value**  | 300 s                                                                |
++--------------------+----------------------------------------------------------------------+
+| **Allowed values** | Any number greater than or equal to 0. Allowed sufixes (s, m, h, d). |
++--------------------+----------------------------------------------------------------------+
 
 **max_interval**
 
@@ -646,11 +646,11 @@ the value will be duplicated until it reaches the value of ``max_interval``.
 
 Specifies the maximum number of seconds between every inventory synchronization.
 
-+--------------------+-----------------------------------------------------------+
-| **Default value**  | 3600                                                      |
-+--------------------+-----------------------------------------------------------+
-| **Allowed values** | Any number greater than or equal to interval.             |
-+--------------------+-----------------------------------------------------------+
++--------------------+-----------------------------------------------------------------------------+
+| **Default value**  | 1 h                                                                         |
++--------------------+-----------------------------------------------------------------------------+
+| **Allowed values** | Any number greater than or equal to interval. Allowed sufixes (s, m, h, d). |
++--------------------+-----------------------------------------------------------------------------+
 
 **response_timeout**
 


### PR DESCRIPTION
|Related issue|
|---|
| [#4364](https://github.com/wazuh/wazuh/issues/4364)|


> **interval**
>
> * [x]  Change the values table for this setting in the documentation ([wazuh/wazuh-documentation#2027](https://github.com/wazuh/wazuh-documentation/pull/2027)) to add the allowed sufixes (s, m, h, d).
> 
> 
> **sync_queue_size**
>
> * [x]  Change its name from `sync_queue_size` to `queue_size`
> 
> **enabled**
> 
> * [x]  Add this option to the documentation
> 
> **max_sync_interval**
> 
> * [x]  Change its name from `max_sync_interval` to `max_interval`
> * [x]  Add this option to the documentation
> 
> **synchronization**
> 
> * [x]  Change the stanza title: from `inventory` to `synchronization`
> 
