### PR TITLE
Adjusting deployment variables to correct version on Wazuh v3.10

### DIFF
--- a/source/installation-guide/installing-wazuh-agent/windows/wazuh_agent_package_windows.rst
+++ b/source/installation-guide/installing-wazuh-agent/windows/wazuh_agent_package_windows.rst
@@ -30,11 +30,11 @@ The first step to installing the Wazuh agent on a Windows machine is to download
 
 	* Using CMD: ::
 
-            wazuh-agent-3.10.2-1.msi /q ADDRESS="10.0.0.2" AUTHD_SERVER="10.0.0.2"
+            wazuh-agent-3.10.2-1.msi /q WAZUH_MANAGER="10.0.0.2" WAZUH_REGISTRATION_SERVER="10.0.0.2"
 
 	* Using PowerShell: ::
 
-	    .\wazuh-agent-3.10.2-1.msi /q ADDRESS="10.0.0.2" AUTHD_SERVER="10.0.0.2"
+	    .\wazuh-agent-3.10.2-1.msi /q WAZUH_MANAGER="10.0.0.2" WAZUH_REGISTRATION_SERVER="10.0.0.2"
 
         See the following document for additional automated deployment options: :ref:`deployment variables for Windows <deployment_variables_windows>`.
 


### PR DESCRIPTION
Hi team,

|Related issue|
|-|
|https://github.com/wazuh/wazuh-documentation/issues/2099|

On the Wazuh v3.10 documentation, the Windows deployment variables are mentioned using the v3.10 syntax. This PR replaces the variables to the correct ones.

Greetings, JP Sáez