### PR TITLE
broken link of docker-compose.yml file

### DIFF
--- a/source/docker/wazuh-container.rst
+++ b/source/docker/wazuh-container.rst
@@ -95,7 +95,7 @@ Usage
 
   a) Only the file::
 
-      $ curl -so docker-compose.yml https://raw.githubusercontent.com/wazuh/wazuh-docker/3.11.1_7.5.1/docker-compose.yml
+      $ curl -so docker-compose.yml https://raw.githubusercontent.com/wazuh/wazuh-docker/v3.11.1_7.5.1/docker-compose.yml
 
   b) Get the Wazuh repository::
 


### PR DESCRIPTION
broken link of docker-compose.yml file, missing 'v' in front of version
https://raw.githubusercontent.com/wazuh/wazuh-docker/3.11.1_7.5.1/docker-compose.yml
VS
https://raw.githubusercontent.com/wazuh/wazuh-docker/v3.11.1_7.5.1/docker-compose.yml