### PR TITLE
Restore the Download the alerts template for Elasticsearch step

### DIFF
--- a/source/upgrade-guide/upgrading-elastic-stack/elastic_server_minor_upgrade.rst
+++ b/source/upgrade-guide/upgrading-elastic-stack/elastic_server_minor_upgrade.rst
@@ -143,10 +143,10 @@ Upgrade Filebeat
 
 #. Download the alerts template for Elasticsearch:
 
-  .. code-block:: console
+    .. code-block:: console
 
-    # curl -so /etc/filebeat/wazuh-template.json https://raw.githubusercontent.com/wazuh/wazuh/v3.11.1/extensions/elasticsearch/7.x/wazuh-template.json
-    # chmod go+r /etc/filebeat/wazuh-template.json
+      # curl -so /etc/filebeat/wazuh-template.json https://raw.githubusercontent.com/wazuh/wazuh/v3.11.1/extensions/elasticsearch/7.x/wazuh-template.json
+      # chmod go+r /etc/filebeat/wazuh-template.json
 
 #. Download the Wazuh module for Filebeat:
 

--- a/source/upgrade-guide/upgrading-elastic-stack/elastic_server_minor_upgrade.rst
+++ b/source/upgrade-guide/upgrading-elastic-stack/elastic_server_minor_upgrade.rst
@@ -141,6 +141,13 @@ Upgrade Filebeat
       # curl -so /etc/filebeat/filebeat.yml https://raw.githubusercontent.com/wazuh/wazuh/v3.11.1/extensions/filebeat/7.x/filebeat.yml
       # chmod go+r /etc/filebeat/filebeat.yml
 
+#. Download the alerts template for Elasticsearch:
+
+  .. code-block:: console
+
+    # curl -so /etc/filebeat/wazuh-template.json https://raw.githubusercontent.com/wazuh/wazuh/v3.11.1/extensions/elasticsearch/7.x/wazuh-template.json
+    # chmod go+r /etc/filebeat/wazuh-template.json
+
 #. Download the Wazuh module for Filebeat:
 
     .. code-block:: console

--- a/source/upgrade-guide/upgrading-elastic-stack/elastic_server_rolling_upgrade.rst
+++ b/source/upgrade-guide/upgrading-elastic-stack/elastic_server_rolling_upgrade.rst
@@ -183,6 +183,13 @@ Upgrade Filebeat
       # curl -so /etc/filebeat/filebeat.yml https://raw.githubusercontent.com/wazuh/wazuh/v3.11.1/extensions/filebeat/7.x/filebeat.yml
       # chmod go+r /etc/filebeat/filebeat.yml
 
+#. Download the alerts template for Elasticsearch:
+
+  .. code-block:: console
+
+    # curl -so /etc/filebeat/wazuh-template.json https://raw.githubusercontent.com/wazuh/wazuh/v3.11.1/extensions/elasticsearch/7.x/wazuh-template.json
+    # chmod go+r /etc/filebeat/wazuh-template.json
+    
 #. Download the Wazuh module for Filebeat:
 
     .. code-block:: console

--- a/source/upgrade-guide/upgrading-elastic-stack/elastic_server_rolling_upgrade.rst
+++ b/source/upgrade-guide/upgrading-elastic-stack/elastic_server_rolling_upgrade.rst
@@ -185,11 +185,11 @@ Upgrade Filebeat
 
 #. Download the alerts template for Elasticsearch:
 
-  .. code-block:: console
+    .. code-block:: console
 
-    # curl -so /etc/filebeat/wazuh-template.json https://raw.githubusercontent.com/wazuh/wazuh/v3.11.1/extensions/elasticsearch/7.x/wazuh-template.json
-    # chmod go+r /etc/filebeat/wazuh-template.json
-    
+      # curl -so /etc/filebeat/wazuh-template.json https://raw.githubusercontent.com/wazuh/wazuh/v3.11.1/extensions/elasticsearch/7.x/wazuh-template.json
+      # chmod go+r /etc/filebeat/wazuh-template.json
+
 #. Download the Wazuh module for Filebeat:
 
     .. code-block:: console


### PR DESCRIPTION
Hi team,

This PR restores the missing step "Download the alert template for Elasticsearch" required in Elastic's server updates.

Regards.