### PR TITLE
Bump Puppet to 3.11.2_7.5.1

### DIFF
--- a/source/deploying-with-puppet/wazuh-puppet-module/index.rst
+++ b/source/deploying-with-puppet/wazuh-puppet-module/index.rst
@@ -14,7 +14,7 @@ Download and install the Wazuh module from Puppet Forge:
 
   .. code-block:: console
 
-    # puppet module install wazuh-wazuh --version 3.11.1
+    # puppet module install wazuh-wazuh --version 3.11.2
 
   .. code-block:: bash
   
@@ -22,7 +22,7 @@ Download and install the Wazuh module from Puppet Forge:
     Notice: Downloading from https://forgeapi.puppetlabs.com ...
     Notice: Installing -- do not interrupt ...
     /etc/puppet/modules
-    └─┬ wazuh-wazuh (v3.11.1)
+    └─┬ wazuh-wazuh (v3.11.2)
       ├── puppet-nodejs (v7.0.0)
       ├── puppet-selinux (v1.6.1)
       ├── puppetlabs-apt (v6.3.0)


### PR DESCRIPTION
Hi all!

This PR updates the version of `wazuh` to _3.11.2_7.5.1_ for Puppet corresponding documentation.

Kr,

Rshad