### PR TITLE
Clearer description for the <white_list> tag

### DIFF
--- a/source/user-manual/reference/ossec-conf/global.rst
+++ b/source/user-manual/reference/ossec-conf/global.rst
@@ -254,7 +254,7 @@ This sets the memory size for the event correlation engine.
 white_list
 ^^^^^^^^^^
 
-This designates IP addresses that should never be blocked with an active response and, though only one IP address can be included in this section, you may repeat this as many times as needed to include additional IP addresses.
+This specifies an IP for which Active Responses will not be triggered. Only one IP may be specified for each ``<while_list>`` tag, but several IPs may be used by including multiple ``<white_list>`` tags.
 
 +--------------------+----------------------------+
 | **Default value**  | n/a                        |


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/4422|


Hello team,

The `<white_list>` description now clarifies that alerts containing IP's under this tag do not trigger active responses. 


Greetings, JP Sáez