### PR TITLE
Deprecate option -D in Agentd

### DIFF
--- a/source/user-manual/reference/daemons/ossec-agentd.rst
+++ b/source/user-manual/reference/daemons/ossec-agentd.rst
@@ -5,14 +5,14 @@
 ossec-agentd
 ============
 
-The ossec-agentd program is the client-side daemon that communicates with the server. It runs as ``ossec`` and is chrooted to ``/var/ossec``.
+The ossec-agentd program is the client-side daemon that communicates with the server. It runs as user ``ossec``.
 
 +-----------------+-------------------------------------------------------------------------------------------------+
 | **-c <config>** | Run using <config> as the configuration file.                                                   |
 +                 +-------------------------------------------+-----------------------------------------------------+
 |                 | Default value                             | /var/ossec/etc/ossec.conf                           |
 +-----------------+-------------------------------------------+-----------------------------------------------------+
-| **-D <dir>**    | Chroot to <dir>                                                                                 |
+| **-D <dir>**    | Chroot to <dir>. **Deprecated since v3.12.0.**                                                  |
 +                 +-------------------------------------------+-----------------------------------------------------+
 |                 | Default value                             | /var/ossec                                          |
 +-----------------+-------------------------------------------+-----------------------------------------------------+


### PR DESCRIPTION
This PR aims to note that option `-D` does not apply in Agnentd anymore.

## Screenshot
![image](https://user-images.githubusercontent.com/10536251/73260536-5f856b80-41ca-11ea-82c6-2d3e79dfae6f.png)
