### PR TITLE
Rootcheck - Modify readall definition

### DIFF
--- a/source/user-manual/reference/ossec-conf/rootcheck.rst
+++ b/source/user-manual/reference/ossec-conf/rootcheck.rst
@@ -166,7 +166,8 @@ Tells rootcheck to scan the entire system.  This option may lead to some false p
 readall
 ^^^^^^^^^^^^^^^
 
-Tells rootcheck to scan recursively in each of the selected system directories
+Allow Rootcheck read all system files and compare the bytes read with files size.
+With ``readall`` set to no, only these folders are checked: ``/bin``, ``/sbin``, ``/usr/bin``, ``/usr/sbin``, ``/dev``, ``/etc``, ``/boot``
 
 +--------------------+---------+
 | **Default value**  | no      |


### PR DESCRIPTION
[Issue relative](https://github.com/wazuh/wazuh/issues/4492)


I have modified `readall` definition according to the previous issue.

![imagen](https://user-images.githubusercontent.com/17710550/73336748-f0178680-4272-11ea-86b3-e057635def15.png)

