### PR TITLE
Bump Kubernetes references to 3.11.3_7.5.2

### DIFF
--- a/source/deploying-with-kubernetes/kubernetes-conf.rst
+++ b/source/deploying-with-kubernetes/kubernetes-conf.rst
@@ -49,7 +49,7 @@ This pod contains the master node of the Wazuh cluster. The master node centrali
 +--------------------------+-------------+
 | Image                    | Controller  |
 +==========================+=============+
-| wazuh/wazuh:3.11.2_7.5.1 | StatefulSet |
+| wazuh/wazuh:3.11.3_7.5.2 | StatefulSet |
 +--------------------------+-------------+
 
 **Wazuh worker 0 / 1**
@@ -59,7 +59,7 @@ These pods contain a worker node of the Wazuh cluster. They will receive the age
 +--------------------------+-------------+
 | Image                    | Controller  |
 +==========================+=============+
-| wazuh/wazuh:3.11.2_7.5.1 | StatefulSet |
+| wazuh/wazuh:3.11.3_7.5.2 | StatefulSet |
 +--------------------------+-------------+
 
 **Elasticsearch**
@@ -69,7 +69,7 @@ Elasticsearch pod, it ingests events received from Logstash.
 +----------------------------------------+-------------+
 | Image                                  | Controller  |
 +========================================+=============+
-| wazuh/wazuh-elasticsearch:3.11.2_7.5.1 | StatefulSet |
+| wazuh/wazuh-elasticsearch:3.11.3_7.5.2 | StatefulSet |
 +----------------------------------------+-------------+
 
 **Logstash**
@@ -79,7 +79,7 @@ Logstash pod, it's listening to events from the Filebeat instances that are inst
 +-----------------------------------+-------------+
 | Image                             | Controller  |
 +===================================+=============+
-| wazuh/wazuh-logstash:3.11.2_7.5.1 | Deployment  |
+| wazuh/wazuh-logstash:3.11.3_7.5.2 | Deployment  |
 +-----------------------------------+-------------+
 
 **Kibana**
@@ -89,7 +89,7 @@ Kibana pod, the frontend for Elasticsearch, it also includes the Wazuh app.
 +---------------------------------+-------------+
 | Image                           | Controller  |
 +=================================+=============+
-| wazuh/wazuh-kibana:3.11.2_7.5.1 | Deployment  |
+| wazuh/wazuh-kibana:3.11.3_7.5.2 | Deployment  |
 +---------------------------------+-------------+
 
 **Nginx**
@@ -99,7 +99,7 @@ Nginx service used as a reverse proxy for Kibana.
 +---------------------------------+-------------+
 | Image                           | Controller  |
 +=================================+=============+
-| wazuh/wazuh-nginx:3.11.2_7.5.1  | Deployment  |
+| wazuh/wazuh-nginx:3.11.3_7.5.2  | Deployment  |
 +---------------------------------+-------------+
 
 Services

--- a/source/deploying-with-kubernetes/kubernetes-upgrade.rst
+++ b/source/deploying-with-kubernetes/kubernetes-upgrade.rst
@@ -45,7 +45,7 @@ For example:
 
     containers:
     - name: wazuh-manager
-      image: 'wazuh/wazuh:3.11.2_7.5.1'
+      image: 'wazuh/wazuh:3.11.3_7.5.2'
 
 
 Apply the new configuration


### PR DESCRIPTION
Hi all,

This PR bumps Kubernetes references to 3.11.3_7.5.2

Best regards

Jose