### PR TITLE
[AWS-S3 wodle] Correct typo

### DIFF
--- a/source/user-manual/reference/ossec-conf/wodle-s3.rst
+++ b/source/user-manual/reference/ossec-conf/wodle-s3.rst
@@ -55,7 +55,7 @@ Options
 disabled
 ^^^^^^^^
 
-Disables the CloudTrail wodle.
+Disables the AWS-S3 wodle.
 
 +--------------------+-----------------------------+
 | **Default value**  | no                          |


### PR DESCRIPTION
Hi,
This PR aims to correct a typo in the AWS-S3 wodle documentation: https://documentation.wazuh.com/3.11/user-manual/reference/ossec-conf/wodle-s3.html?#disabled

The `disabled` option says that it `Disables the CloudTrail` wodle, when actually it's the `AWS-S3` wodle. This typo can lead to confusions so I think it would be a good idea to correct it.

Regards,
Sergio.