### PR TITLE
Eventchannel queries syntax fix

### DIFF
--- a/source/user-manual/capabilities/log-data-collection/how-to-collect-wlogs.rst
+++ b/source/user-manual/capabilities/log-data-collection/how-to-collect-wlogs.rst
@@ -284,11 +284,11 @@ Users can filter events with different severity levels.
         <location>System</location>
         <log_format>eventchannel</log_format>
         <query>
-            \<QueryList\>
-                \<Query Id="0" Path="System"\>
-                    \<Select Path="System"\>*[System[(Level&lt;=3)]]\</Select\>
-                \</Query\>
-            \</QueryList\>
+            \<QueryList>
+                \<Query Id="0" Path="System">
+                    \<Select Path="System">*[System[(Level&lt;=3)]]\</Select>
+                \</Query>
+            \</QueryList>
         </query>
     </localfile>
 

--- a/source/user-manual/capabilities/log-data-collection/how-to-collect-wlogs.rst
+++ b/source/user-manual/capabilities/log-data-collection/how-to-collect-wlogs.rst
@@ -266,7 +266,7 @@ Some events from different channels are shown below with the associated provider
 Filtering events from Windows Event Channel with queries
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Events from the Windows Event channel can be filtered as below.
+Events from the Windows Event channel can be filtered as below. In this example, only events which levels are less or equal to "3" are checked.
 
 .. code-block:: xml
 
@@ -284,12 +284,13 @@ Users can filter events with different severity levels.
         <location>System</location>
         <log_format>eventchannel</log_format>
         <query>
-            <QueryList>
-                <Query Id="0" Path="System">
-                    <Select Path="System">*[System[(Level&lt;=3)]]</Select>
-                </Query>
-            </QueryList>
+            \<QueryList\>
+                \<Query Id="0" Path="System"\>
+                    \<Select Path="System"\>*[System[(Level&lt;=3)]]\</Select\>
+                \</Query\>
+            \</QueryList\>
         </query>
     </localfile>
 
-In this example, only events which levels are less or equal to "3" are checked.
+.. note::
+  The ``<QueryList>`` syntax requires escaping the XML labels inside the query as above. 

--- a/source/user-manual/capabilities/log-data-collection/how-to-collect-wlogs.rst
+++ b/source/user-manual/capabilities/log-data-collection/how-to-collect-wlogs.rst
@@ -279,6 +279,7 @@ Events from the Windows Event channel can be filtered as below. In this example,
 Users can filter events with different severity levels.
 
 .. code-block:: xml
+    :class: escaped-tag-signs
 
     <localfile>
         <location>System</location>


### PR DESCRIPTION
|Related Issue|
|---|
|https://github.com/wazuh/wazuh-documentation/issues/2156| 


Hi team,



This PR displays the correct syntax for the Eventchannel advanced XML queries. On XML labels under `<query> </query>` tags, the  `<` characters s should escaped. 

This syntax allows the content under the `<query> </query>` tags to be properly interpreted as text.

Greetings, JP Sáez