### PR TITLE
[3.10] Fixed the position of the lightbox in releases other than the latest

### DIFF
--- a/source/_static/js/style.js
+++ b/source/_static/js/style.js
@@ -181,6 +181,7 @@ $(function() {
     }
 
     heightNavbar();
+    adjustLightboxHeight();
   });
 
   const mousewheelevt = (/Firefox/i.test(navigator.userAgent))? 'DOMMouseScroll' : 'wheel';
@@ -676,13 +677,22 @@ $(function() {
   $('#lightboxOverlay, #lightbox, #lightbox .lb-close').on('click', function(e) {
     $('html, body').css('overflow', '');
     $('.side-scroll').removeAttr('style');
-    menuHeight();
   });
 
   $('#lightbox .lb-details span, #lightbox .lb-dataContainer :not(.lb-close)').on('click', function(e) {
     e.stopPropagation();
     $('html, body').css('overflow', 'hidden');
   });
+  adjustLightboxHeight();
+
+  /**
+   * Checks the real height of .no-latest-notice in order to add the appropriate top margin to the lightbox element.
+   * If .no-latest-notice is not visible, the margin is zero
+   */
+  function adjustLightboxHeight() {
+    noLatestHeight = document.querySelector('.no-latest-notice').offsetHeight;
+    $('#lightbox').css('margin-top', noLatestHeight );
+  }
 
   /* Restore overflow when pressing key 'Esc' */
   $(document).on('keydown', function(e) {


### PR DESCRIPTION
Hi, 
This PR fixes the problem with the `#lightbotx` element (zoomed image) being overlapped by the 'no-latest-notice` in small devices when visiting a page in any release other than the latest (marked as current). 

**Before**
![imagen](https://user-images.githubusercontent.com/13232723/73457031-48ce4880-4373-11ea-806c-f7e05dfd34f7.png)

**After**
With this change, the position of the lightbox will always be correct, whether the `.no-latest-notice` is visible or not:

  - No latest
    ![imagen](https://user-images.githubusercontent.com/13232723/73525704-0575e780-4410-11ea-8d85-0e91280375a8.png)

  - Latest
    ![imagen](https://user-images.githubusercontent.com/13232723/73525621-dceded80-440f-11ea-97f7-038d40d33c03.png)

Related issue: https://github.com/wazuh/wazuh-website/issues/1087