### PR TITLE
Add database option to syscheck

### DIFF
--- a/source/user-manual/reference/ossec-conf/syscheck.rst
+++ b/source/user-manual/reference/ossec-conf/syscheck.rst
@@ -41,6 +41,7 @@ Options
 - `process_priority`_
 - `synchronization`_
 - `max_eps`_
+- `database`_
 
 .. _reference_ossec_syscheck_directories:
 
@@ -593,6 +594,20 @@ Set the maximum output throughput.
 | **Default value**  | 200                                   |
 +--------------------+---------------------------------------+
 | **Allowed values** | Integer number between 1 and 1000000. |
++--------------------+---------------------------------------+
+
+
+database
+^^^^^^^^
+
+.. versionadded:: 3.12.0
+
+Specify where is the database going to be stored.
+
++--------------------+---------------------------------------+
+| **Default value**  | disk                                  |
++--------------------+---------------------------------------+
+| **Allowed values** | disk, memory                          |
 +--------------------+---------------------------------------+
 
 


### PR DESCRIPTION
Add database option so syscheck. This option specifies where to store the database: memory or disk.

## Example
```XML
<syscheck>
    ...
    <database>disk</database>
    ...
</syscheck>
```