### PR TITLE
[3.11] Added special management for code blocks with escaped tag signs

### DIFF
--- a/source/_static/js/style.js
+++ b/source/_static/js/style.js
@@ -691,16 +691,42 @@ $(function() {
     }
   });
 
-  /* Copy to clipboard ----------------------------------------------------------------------------------*/
+  /* Special code blocks --------------------------------------------------------------------------------*/
   $('.highlight').each(function() {
     const blockCode = $(this).parent();
+
+    /* Output */
     if ( !blockCode.hasClass('output') ) {
       blockCode.prepend('<button type="button" class="copy-to-clipboard" title="Copy to clipboard"><span>Copied to clipboard</span><i class="far fa-copy" aria-hidden="true"></i></button>');
     } else {
       blockCode.prepend('<div class="admonition admonition-output"><p class="first admonition-title">Output</p></div>');
     }
+
+    /* Escaped tag signs */
+    if ( blockCode.hasClass('escaped-tag-signs') ) {
+      let data = $(this).html();
+      const datafragments = data.split(/\\</);
+      data = '';
+      datafragments.forEach(function( ltFragment, i) {
+        /* The first fragment occurs just before the opening tag, so it doesn't need to be processed */
+        if ( i != 0 ) {
+          gtFragments = ltFragment.split(/&gt;/);
+          ltFragment = gtFragments.shift();
+          if ( gtFragments.length ) {
+            ltFragment += '\\>' + gtFragments.join('>');
+          }
+        }
+        if ( i != datafragments.length-1 ) {
+          data += ltFragment+'\\<';
+        } else {
+          data += ltFragment;
+        }
+      });
+      $(this).html(data);
+    }
   });
 
+  /* Copy to clipboard ----------------------------------------------------------------------------------*/
   $('.copy-to-clipboard').click(function() {
     const ele = $(this);
     let data = $(ele).parent().find('.highlight').text();


### PR DESCRIPTION
Hi, 
We need to insert escaped tag signs in some XML code-blocks, so, instead of `<tag>Content</tag>` the code block would show `\<tag\>Content\</tag\>`. However, Sphinx's syntax highlighter doesn't work with these scaped tags, in particular, with the escaped closing part of the tag (`\>`).

To solve the problem, the code-blocks requiring this format will be written using only the escaped opening sign `\>` where required. Later, on page load, the escaped closing signs `\>` will be added to the code-block thanks to the code included in this PR. For this to work, the code-block that requires this change must have the class `escaped-tag-signs`, as shown in the image below:

![imagen](https://user-images.githubusercontent.com/13232723/73542150-5d264a00-4434-11ea-8d83-6301e457118c.png)

Related issue: https://github.com/wazuh/wazuh-website/issues/1089