### PR TITLE
Improve wording when referring to time

### DIFF
--- a/source/development/wazuh-cluster.rst
+++ b/source/development/wazuh-cluster.rst
@@ -117,7 +117,7 @@ Agent info
 
 This thread is in charge of synchronizing the agent's last keepalives and OS information with the master. The communication here is also started by the worker and it has the following stages:
 
-1. The worker sends the master a file containing all agent-info files merged in a single one. Only files whose modification date is less than half an hour will be sent.
+1. The worker sends the master a file containing all agent-info files merged in a single one. Only files whose modification date is less than 30 minutes will be sent.
 2. The master decompresses the merged file and updates agent statuses. During the update process, the master compares the modification dates of its local file and the remote file. In case the master has a more recent file, the remote one is discarded.
 
 If there is an error during this process the worker is NOT notified about it.

--- a/source/user-manual/agents/agent-life-cycle.rst
+++ b/source/user-manual/agents/agent-life-cycle.rst
@@ -25,7 +25,7 @@ Agent status
 - **Never connected:** The agent has been registered but has not yet connected to the manager.
 - **Pending.** The authentication process is pending: The manager has received a request for connection from the agent but has not received anything else. This may indicate a firewall issue. The agent will be in this state one time in its life cycle.
 - **Active:** The agent has successfully connected and can now communicate with the manager.
-- **Disconnected:** The manager will consider the agent disconnected if it does not receive any ``keep alive`` messages from the agent within a half an hour.
+- **Disconnected:** The manager will consider the agent disconnected if it does not receive any ``keep alive`` messages from the agent within 30 minutes.
 
 Removed agent
 -------------


### PR DESCRIPTION
In formal/technical English it is preferred to use `30 minutes` than `half an hour`.

Also fixed the typo: `a half an hour`