### PR TITLE
Remove duplicated line in Elasticsearch upgrade documentation

### DIFF
--- a/source/upgrade-guide/upgrading-elastic-stack/elastic_server_hard_upgrade.rst
+++ b/source/upgrade-guide/upgrading-elastic-stack/elastic_server_hard_upgrade.rst
@@ -56,7 +56,6 @@ Upgrade Elasticsearch
     .. code-block:: console
 
       # apt-get install elasticsearch=6.8.6
-      # systemctl restart elasticsearch
 
 5. Restart the service.
 


### PR DESCRIPTION
Hi team,
In this documentation page: https://documentation.wazuh.com/3.11/upgrade-guide/upgrading-elastic-stack/elastic_server_hard_upgrade.html

The line that I remove in this PR is duplicated. The documentation suggests restarting Elasticsearch twice for DEB systems.

This PR fixes that.

Best regards,
Sergio.