### PR TITLE
[3.2] Fixed some broken links

### DIFF
--- a/source/docker/wazuh-container.rst
+++ b/source/docker/wazuh-container.rst
@@ -89,7 +89,7 @@ Usage
 
         $ docker-compose up -d
 
-    Then access the Kibana UI by hitting `http://localhost:5601 <http://localhost:5601>`_ with a web browser.
+    Then access the Kibana UI by hitting ``http://localhost:5601`` with a web browser.
 
 
 By default, the stack exposes the following ports:

--- a/source/pci-dss/file-integrity-monitoring.rst
+++ b/source/pci-dss/file-integrity-monitoring.rst
@@ -9,7 +9,7 @@ File integrity monitoring (Syscheck) is performed by comparing the cryptographic
 
 First, the Wazuh agent scans the system at an interval you specify, and it sends the checksums of the monitored files and registry keys (for Windows systems) to the Wazuh server. Then, the server stores the checksums and looks for modifications by comparing the newly received checksums against the historical checksum values for those files and/or registry keys. An alert is sent if the checksum (or another file attribute) changes.  Wazuh also supports near real-time file integrity checking where this is desired.
 
-`Syscheck <http://ossec-docs.readthedocs.org/en/latest/manual/syscheck/index.html>`_  can be used to meet PCI DSS requirement 11.5:
+:doc:`Syscheck <../user-manual/reference/ossec-conf/syscheck>` can be used to meet PCI DSS requirement 11.5:
 
 | **11.5** Deploy a change-detection mechanism (for example, file-integrity monitoring tools) to alert personnel to unauthorized modification (including changes, additions, and deletions) of critical system files, configuration files, or content files; and configure the software to perform critical file comparisons at least weekly.
 |

--- a/source/pci-dss/rootkit-detection.rst
+++ b/source/pci-dss/rootkit-detection.rst
@@ -14,7 +14,7 @@ Rootkit and trojan detection is performed using two files: ``rootkit_files.txt``
         <rootkit_trojans>/var/ossec/etc/shared/rootkit_trojans.txt</rootkit_trojans>
     </rootcheck>
 
-These are the options available for the `rootcheck component <http://ossec-docs.readthedocs.org/en/latest/syntax/head_ossec_config.rootcheck.html>`_:
+These are the options available for the :doc:`rootcheck component<../user-manual/reference/ossec-conf/rootcheck>`:
 
 + **rootkit_files**: Contains the Unix-based application level rootkit signatures.
 

--- a/source/user-manual/reference/ossec-conf/integration.rst
+++ b/source/user-manual/reference/ossec-conf/integration.rst
@@ -101,10 +101,7 @@ This filters alerts by rule group. For the VirusTotal integration, only rules fr
 event_location
 ^^^^^^^^^^^^^^
 
-This filters alerts by where the event originated. `OS_Regex Syntax`_
-
-.. _`OS_Regex Syntax`: http://ossec-docs.readthedocs.org/en/latest/syntax/regex.html
-
+This filters alerts by where the event originated. Follows the :ref:`OS_Regex Syntax<os_regex_syntax>`.
 
 +--------------------+-----------------------------------------------------------+
 | **Default value**  | n/a                                                       |

--- a/source/user-manual/ruleset/ruleset-xml-syntax/regex.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/regex.rst
@@ -7,6 +7,8 @@ Regular Expression Syntax
 
 There are two types of regular expressions: regex (*OS_Regex*) and sregex (*OS_Match*).
 
+.. _os_regex_syntax:
+
 Regex (OS_Regex) syntax
 --------------------------------
 


### PR DESCRIPTION
Hi,

This PR fixes some broken links we have detected during recent analysis:

<table>
<tr>
<th>
 Broken link
</th>
<th>
Location
</th>
<th>
Fix
</th>
</tr>

<tr>
<td>
http://localhost:5601
</td>
<td>
https://documentation.wazuh.com/3.2/docker/wazuh-container.html
</td>
<td>
Removed (`http://localhost:5601` appears as highlighted text)
</td>
</tr>

<tr>
<td>
http://ossec-docs.readthedocs.org/en/latest/syntax/regex.html
</td>
<td>
https://documentation.wazuh.com/3.2/user-manual/reference/ossec-conf/integration.html
</td>
<td>
Replaced with https://documentation.wazuh.com/3.2/user-manual/ruleset/ruleset-xml-syntax/regex.html
</td>
</tr>

<tr>
<td>
http://ossec-docs.readthedocs.org/en/latest/syntax/head_ossec_config.rootcheck.html
</td>
<td>
https://documentation.wazuh.com/3.2/pci-dss/rootkit-detection.html
</td>
<td>
 https://documentation.wazuh.com/3.2/user-manual/reference/ossec-conf/rootcheck.html 
</td>
</tr>

<tr>
<td>
http://ossec-docs.readthedocs.org/en/latest/manual/syscheck/index.html
</td>
<td>
https://documentation.wazuh.com/3.2/pci-dss/file-integrity-monitoring.html
</td>
<td>
https://documentation.wazuh.com/3.2/user-manual/reference/ossec-conf/syscheck.html
</td>
</tr>

</table>

Related issue: https://github.com/wazuh/wazuh-website/issues/1025
