### PR TITLE
[3.9] Fixed some broken links

### DIFF
--- a/source/pci-dss/file-integrity-monitoring.rst
+++ b/source/pci-dss/file-integrity-monitoring.rst
@@ -9,7 +9,7 @@ File integrity monitoring (Syscheck) is performed by comparing the cryptographic
 
 First, the Wazuh agent scans the system at an interval you specify, and it sends the checksums of the monitored files and registry keys (for Windows systems) to the Wazuh server. Then, the server stores the checksums and looks for modifications by comparing the newly received checksums against the historical checksum values for those files and/or registry keys. An alert is sent if the checksum (or another file attribute) changes.  Wazuh also supports near real-time file integrity checking where this is desired.
 
-`Syscheck <https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html>`_  can be used to meet PCI DSS requirement 11.5:
+:doc:`Syscheck <../user-manual/reference/ossec-conf/syscheck>` can be used to meet PCI DSS requirement 11.5:
 
     | **11.5** Deploy a change-detection mechanism (for example, file-integrity monitoring tools) to alert personnel to unauthorized modification (including changes, additions, and deletions) of critical system files, configuration files, or content files; and configure the software to perform critical file comparisons at least weekly.
     |

--- a/source/pci-dss/rootkit-detection.rst
+++ b/source/pci-dss/rootkit-detection.rst
@@ -14,7 +14,7 @@ Rootkit and trojan detection is performed using two files: ``rootkit_files.txt``
         <rootkit_trojans>/var/ossec/etc/shared/rootkit_trojans.txt</rootkit_trojans>
     </rootcheck>
 
-These are the options available for the `rootcheck component <https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/rootcheck.html>`_:
+These are the options available for the :doc:`rootcheck component<../user-manual/reference/ossec-conf/rootcheck>`:
 
 + **rootkit_files**: Contains the Unix-based application level rootkit signatures.
 

--- a/source/user-manual/capabilities/osquery.rst
+++ b/source/user-manual/capabilities/osquery.rst
@@ -39,12 +39,12 @@ Check the processes that have a deleted executable.
 
     SELECT * FROM processes WHERE on_disk = 0;
 
-A complete list of all the available tables can be found `here <https://osquery.io/schema/>`_.
+A complete list of all the available tables can be found `here <https://osquery.io/schema/current/>`_.
 
 Configuration
 -------------
 
-You need a working Osquery installation in your system. See `downloads page <https://osquery.io/downloads/official/>`_ for details.
+You need a working Osquery installation in your system. See `downloads page <https://osquery.io/downloads/official/4.1.2>`_ for details.
 
 Red Hat, CentOS and Fedora:
 
@@ -116,14 +116,14 @@ After this enable and start the osquery Daemon:
 
   systemctl enable osqueryd
   systemctl start osqueryd
-    
+
 And the osquery module must be enabled for the agents where the osquery is running by adding:
 
 .. code-block:: xml
-  
+
   <wodle name="osquery"/>
 
-To their ``/var/ossec/etc/ossec.conf`` file or through :doc:`centralized configuration <../reference/centralized-configuration>` 
+To their ``/var/ossec/etc/ossec.conf`` file or through :doc:`centralized configuration <../reference/centralized-configuration>`
 
 .. note::
   More options may be specified as shown in the  :doc:`osquery configuration reference <../reference/ossec-conf/wodle-osquery>`

--- a/source/user-manual/reference/ossec-conf/integration.rst
+++ b/source/user-manual/reference/ossec-conf/integration.rst
@@ -102,9 +102,7 @@ This filters alerts by rule group. For the VirusTotal integration, only rules fr
 event_location
 ^^^^^^^^^^^^^^
 
-This filters alerts by where the event originated. Follows the `OS_Regex Syntax`_.
-
-.. _`OS_Regex Syntax`: https://documentation.wazuh.com/current/user-manual/ruleset/ruleset-xml-syntax/regex.html
+This filters alerts by where the event originated. Follows the :ref:`OS_Regex Syntax<os_regex_syntax>`.
 
 +--------------------+-----------------------------------------------------------+
 | **Default value**  | n/a                                                       |

--- a/source/user-manual/ruleset/ruleset-xml-syntax/regex.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/regex.rst
@@ -9,6 +9,8 @@ Regular Expression Syntax
 
 There are two types of regular expressions: regex (*OS_Regex*) and sregex (*OS_Match*).
 
+.. _os_regex_syntax:
+
 Regex (OS_Regex) syntax
 --------------------------------
 


### PR DESCRIPTION
Hi,

This PR fixes some broken links we have detected during recent analysis:


<table>
<tr>
<th>
Broken link
</th>
<th>
Location
</th>
<th>
Fix
</th>
</tr>

<tr>
<td>
https://osquery.io/schema/
</td>
<td>
https://documentation.wazuh.com/3.9/user-manual/capabilities/osquery.html
</td>
<td>
Replaced with https://osquery.io/schema/current/
</td>
</tr>

<tr>
<td>
https://osquery.io/downloads/official
</td>
<td>
https://documentation.wazuh.com/3.9/user-manual/capabilities/osquery.html
</td>
<td>
Replaced with https://osquery.io/downloads/official/4.1.2
</td>
</tr>

</table>

While fixing the broken links, I've noticed some internal links that work correctly but they are included via their absolute path instead of the relative one, which may result in future broken links. Using the relative path for internal references in Sphinx have an important advantage: it is possible to avoid the broken link as it will be notified as a warning on compilation time. 

This is the table of links that have been changed to use a relative path:

<table>
<tr>
<th>
Absolute path
</th>
<th>
Location
</th>
</tr>

<tr>
<td>
https://documentation.wazuh.com/current/user-manual/ruleset/ruleset-xml-syntax/regex.html
</td>
<td>
https://documentation.wazuh.com/3.9/user-manual/reference/ossec-conf/integration.html
</td>
</tr>

<tr>
<td>
https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/rootcheck.html
</td>
<td>
https://documentation.wazuh.com/3.9/pci-dss/rootkit-detection.html
</td>
</tr>

<tr>
<td>
https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html
</td>
<td>
https://documentation.wazuh.com/3.9/pci-dss/file-integrity-monitoring.html
</td>
</tr>

</table>

Related issue: https://github.com/wazuh/wazuh-website/issues/1025
