### PR TITLE
[3.11] Added empty nodes to toctree

### DIFF
--- a/source/_static/js/style.js
+++ b/source/_static/js/style.js
@@ -21,6 +21,9 @@ $(function() {
     'user-manual/agents/remove-agents/index',
     'user-manual/agents/listing/index',
     'user-manual/kibana-app/reference/index',
+    'user-manual/registering/simple-registration-method',
+    'user-manual/registering/password-authorization-registration-service',
+    'user-manual/registering/manager-verification/host-verification-registration',
     'user-manual/ruleset/ruleset-xml-syntax/index',
   ];
 

--- a/source/user-manual/registering/manager-verification/host-verification-registration.rst
+++ b/source/user-manual/registering/manager-verification/host-verification-registration.rst
@@ -2,32 +2,11 @@
 
 .. _host-verification-registration:
 
-Registering agents using registration service with host verification
---------------------------------------------------------------------
-
-Using verification with an SSL key certificate provides confidence that the connection between the right agent and the right manager is established.
-
-Creating a Certificate of Authority (CA)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-To use the registration service with SSL certification, you must create a **Certificate of Authority** that will be used to sign certificates for the manager and the agents. The hosts will receive a copy of this CA in order to verify the remote certificate.
-To generate the certificate execute the following command:
-
-.. code-block:: console
-
-  # openssl req -x509 -new -nodes -newkey rsa:4096 -keyout rootCA.key -out rootCA.pem -batch -subj "/C=US/ST=CA/O=Manager"
-
-.. warning::
-  The file ``rootCA.key`` that we have just created is the **private key** of the CA. It is needed to sign other certificates and it is critical to keep it secure. Note that we will **never copy this file to other hosts**.
-
-
-Available options to verify the hosts
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-After creating your ``CA``, you have these options to register the agents verifying the hosts:
+Using registration service with host verification
+=================================================
 
 .. toctree::
     :maxdepth: 1
 
-    manager-verification/manager-verification-registration
-    manager-verification/agent-verification-registration
+    Using manager verification<manager-verification-registration>
+    Using host verification<agent-verification-registration>

--- a/source/user-manual/registering/password-authorization-registration-service.rst
+++ b/source/user-manual/registering/password-authorization-registration-service.rst
@@ -3,66 +3,11 @@
 .. _password-authorization-registration-service:
 
 Registering agents using registration service with password authorization
--------------------------------------------------------------------------
-
-This registration method is similar to ``Simple registration service`` except that it allows additional protection of the manager from unauthorized registrations by using a password.
-
-To register the agent follow the instructions in the **Manager** section and then select the corresponding section for the agent's operating system.
-
-Manager
-^^^^^^^
-
-To enable password authorization, in ``/var/ossec/etc/ossec.conf`` file, in ``<auth><use_password>`` section, set the value to ``yes``.
-
-   .. code-block:: xml
-
-     <auth>
-       ...
-       <use_password>yes</use_password>
-       ...
-     </auth>
-
-You can choose your password or let the registration service generate one for you.
-
-.. note::
-  In this example, the custom password to register the Wazuh agent is ``TopSecret``.
-
-a) **Using a custom password**: create ``/var/ossec/etc/authd.pass`` file and save your custom password in it:
-
-   .. code-block:: console
-
-     # echo "TopSecret" > /var/ossec/etc/authd.pass
-
-b) **Using a random password**: if no password is specified in ``/var/ossec/etc/authd.pass``, the registration service will create a random password. You can find the password in ``/var/ossec/logs/ossec.log`` by exectuting the following command:
-
-   .. code-block:: console
-
-     # grep "Random password" /var/ossec/logs/ossec.log
-       2019/04/25 15:09:50 ossec-authd: INFO: Accepting connections on port 1515. Random password chosen for agent authentication: 3027022fa85bb4c697dc0ed8274a4554
-
-
-Restart the Wazuh manager for the changes to take effect:
-
-a) For Systemd:
-
-   .. code-block:: console
-
-     # systemctl start wazuh-manager
-
-b) For SysV Init:
-
-   .. code-block:: console
-
-     # service wazuh-manager start
-
-Agents
-^^^^^^
-
-Now, follow the instructions to register the agent depending on the OS of the host:
+=========================================================================
 
 .. toctree::
     :maxdepth: 1
 
-    password/linux-unix-password-registration
-    password/windows-password-registration
-    password/macos-password-registration
+    Linux<password/linux-unix-password-registration>
+    Windows<password/windows-password-registration>
+    MacOS<password/macos-password-registration>

--- a/source/user-manual/registering/registration-method.rst
+++ b/source/user-manual/registering/registration-method.rst
@@ -5,17 +5,117 @@
 Registering agents using registration service
 =============================================
 
-Below are presented three different scenarios of registering the agent using ``agent-auth`` program.
-
-.. include::
-  simple-registration-method.rst
-
-.. include::
-  password-authorization-registration-service.rst
-
-.. include::
-  manager-verification/host-verification-registration.rst
-
 .. toctree::
     :maxdepth: 2
     :hidden:
+
+    Using simple registration service<simple-registration-method>
+    Using password authorization<password-authorization-registration-service>
+    manager-verification/host-verification-registration
+
+Below are presented three different scenarios of registering the agent using ``agent-auth`` program.
+
+Registering agents using simple registration service
+----------------------------------------------------
+
+This is the easiest method to register agents. It doesn’t require any kind of authorization or host verification. If the ``OpenSSL`` package is installed before installing the manager, the package will create the certificate and key needed to run the authentication process called ``ossec-authd``. This certificate and key can be found on the manager in ``/var/ossec/etc/sslmanager.cert`` and
+``/var/ossec/etc/sslmanager.key``.
+
+The ``ossec-authd`` service is used to obtain a unique key, one per each agent, which allows to authenticate with the Wazuh communication service and to encrypt traffic. The communication is done over TLS protocol.
+The ``agent-auth`` program is the client application used along with ``ossec-authd`` to automatically add agent to the manager.
+
+Registering the Agents
+^^^^^^^^^^^^^^^^^^^^^^
+
+* :doc:`Simple registration service for Linux and Unix hosts<linux-unix-simple-registration>`
+* :doc:`Simple registration service for Windows hosts<windows-simple-registration>`
+* :doc:`Simple registration service for MacOS X hosts<macos-simple-registration>`
+
+Registering agents using registration service with password authorization
+-------------------------------------------------------------------------
+
+This registration method is similar to ``Simple registration service`` except that it allows additional protection of the manager from unauthorized registrations by using a password.
+
+To register the agent follow the instructions in the **Manager** section and then select the corresponding section for the agent's operating system.
+
+Manager
+^^^^^^^
+
+To enable password authorization, in ``/var/ossec/etc/ossec.conf`` file, in ``<auth><use_password>`` section, set the value to ``yes``.
+
+   .. code-block:: xml
+
+     <auth>
+       ...
+       <use_password>yes</use_password>
+       ...
+     </auth>
+
+You can choose your password or let the registration service generate one for you.
+
+.. note::
+  In this example, the custom password to register the Wazuh agent is ``TopSecret``.
+
+a) **Using a custom password**: create ``/var/ossec/etc/authd.pass`` file and save your custom password in it:
+
+   .. code-block:: console
+
+     # echo "TopSecret" > /var/ossec/etc/authd.pass
+
+b) **Using a random password**: if no password is specified in ``/var/ossec/etc/authd.pass``, the registration service will create a random password. You can find the password in ``/var/ossec/logs/ossec.log`` by exectuting the following command:
+
+   .. code-block:: console
+
+     # grep "Random password" /var/ossec/logs/ossec.log
+       2019/04/25 15:09:50 ossec-authd: INFO: Accepting connections on port 1515. Random password chosen for agent authentication: 3027022fa85bb4c697dc0ed8274a4554
+
+
+Restart the Wazuh manager for the changes to take effect:
+
+a) For Systemd:
+
+   .. code-block:: console
+
+     # systemctl start wazuh-manager
+
+b) For SysV Init:
+
+   .. code-block:: console
+
+     # service wazuh-manager start
+
+Agents
+^^^^^^
+
+Now, follow the instructions to register the agent depending on the OS of the host:
+
+* :doc:`Registration with password authorization for Linux and Unix hosts<password/linux-unix-password-registration>`
+* :doc:`Registration with password authorization for Windows hosts<password/windows-password-registration>`
+* :doc:`Registration with password authorization for MacOS X hosts<password/macos-password-registration>`
+
+Registering agents using registration service with host verification
+--------------------------------------------------------------------
+
+Using verification with an SSL key certificate provides confidence that the connection between the right agent and the right manager is established.
+
+Creating a Certificate of Authority (CA)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To use the registration service with SSL certification, you must create a **Certificate of Authority** that will be used to sign certificates for the manager and the agents. The hosts will receive a copy of this CA in order to verify the remote certificate.
+To generate the certificate execute the following command:
+
+.. code-block:: console
+
+  # openssl req -x509 -new -nodes -newkey rsa:4096 -keyout rootCA.key -out rootCA.pem -batch -subj "/C=US/ST=CA/O=Manager"
+
+.. warning::
+  The file ``rootCA.key`` that we have just created is the **private key** of the CA. It is needed to sign other certificates and it is critical to keep it secure. Note that we will **never copy this file to other hosts**.
+
+
+Available options to verify the hosts
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+After creating your ``CA``, you have these options to register the agents verifying the hosts:
+
+* :doc:`Registration with Manager verification<manager-verification/agent-verification-registration>`
+* :doc:`Registration with Agent verification<manager-verification/manager-verification-registration>`

--- a/source/user-manual/registering/simple-registration-method.rst
+++ b/source/user-manual/registering/simple-registration-method.rst
@@ -3,20 +3,11 @@
 .. _simple-registration-service:
 
 Registering agents using simple registration service
-----------------------------------------------------
+====================================================
 
-This is the easiest method to register agents. It doesn’t require any kind of authorization or host verification. If the ``OpenSSL`` package is installed before installing the manager, the package will create the certificate and key needed to run the authentication process called ``ossec-authd``. This certificate and key can be found on the manager in ``/var/ossec/etc/sslmanager.cert`` and
-``/var/ossec/etc/sslmanager.key``.
+.. toctree::
+    :maxdepth: 1
 
-The ``ossec-authd`` service is used to obtain a unique key, one per each agent, which allows to authenticate with the Wazuh communication service and to encrypt traffic. The communication is done over TLS protocol.
-The ``agent-auth`` program is the client application used along with ``ossec-authd`` to automatically add agent to the manager.
-
-Registering the Agents
-^^^^^^^^^^^^^^^^^^^^^^
-
-    .. toctree::
-        :maxdepth: 1
-
-        linux-unix-simple-registration
-        windows-simple-registration
-        macos-simple-registration
+    Linux<linux-unix-simple-registration>
+    Windows<windows-simple-registration>
+    MacOS<macos-simple-registration>


### PR DESCRIPTION
Live example of this fix: https://documentation-dev.wazuh.com/3.11-registering-agents-rework-2-fix/user-manual/registering/index.html

# How to insert empty nodes in the toctree

## Use case

Wazuh Doc toctree does not include section headings in the toctree by default. To insert a new node, you need to create a new `.rst` file. However, sometimes is useful to have subsections grouped in the same view and also in the sidebar navigation.

Let's see an example:

`main_section.rst` contents looks like:

---
### Main title

Lorem ipsum dolor sit amet consectetur adipiscing elit consequat, varius praesent tristique id gravida est aptent, venenatis augue hendrerit natoque inceptos felis mi ullamcorper, erat ut nostra risus accumsan orci.

#### Section 1

Lorem ipsum dolor sit amet consectetur adipiscing elit consequat, varius praesent tristique id gravida est aptent, venenatis augue hendrerit natoque inceptos felis mi ullamcorper, erat ut nostra risus accumsan orci.

**Table of contents for section 1**

- [Section 1.1]()
- [Section 1.2]()
- [Section 1.3]()

---

And our desired toctree would be:

```
Main title
|  Section 1
|  |  Section 1.1
|  |  Section 1.2
|  |  Section 1.3
```

---

In the previous example, `Section 1` is an empty toctree node. Its contents are included in the `main_section.rst` file, so it doesn't have a content page of its own, but it is part of the Docs structure, and must show up in the toctree.

## How to achieve it

Empty nodes are `.rst` files that only include a toctree section. In the previous example, file `section_1.rst` would be:

```rst

.. _section-1:

Section 1
=========

.. toctree::

  section-1-1
  section-1-2
  section-1-3
```

While `main_section.rst` would be:

```rst
Main section
============

.. toctree::
  :hidden:

  section-1

Lorem ipsum dolor sit amet consectetur adipiscing elit consequat, 
varius praesent tristique id gravida est aptent, venenatis augue 
hendrerit natoque inceptos felis mi ullamcorper, erat ut nostra risus 
accumsan orci.

Section 1
---------

Lorem ipsum dolor sit amet consectetur adipiscing elit consequat, 
varius praesent tristique id gravida est aptent, venenatis augue 
hendrerit natoque inceptos felis mi ullamcorper, erat ut nostra risus 
accumsan orci.

.. topic:: Table of Contents

* :doc:`Section 1.1<section-1-1>`
* :doc:`Section 1.2<section-1-2>`
* :doc:`Section 1.3<section-1-3>`
```

Notice how the **Table of contents** is just a list of links, and not a real toctree. This way, `Section 1.1`, `Section 1.2` and `Section 1.3` are not interpreted as siblings of `Section 1`.

The main problem with this approach would be that, if the user clicks in the `Section 1` link on the sidebar, an empty page would be displayed. To avoid this, we use Javascript to prevent this link to redirect to its corresponding page.

Example: [https://documentation.wazuh.com/3.11/index.html](https://documentation.wazuh.com/3.11/index.html). If you try to click on the `User manual` link, it will only display its child nodes, without actually taking you to the `User manual` page.

Empty toctree nodes are listed in a Javascript array on `source/_static/js/style.js`, called `emptyTocNodes`. In this example, `section-1` should be added as an element of this array:

```javascript
const emptyTocNodes = [
  'some-file',
  'some-other-file',
  // ... more empty nodes
  'section-1'
]
```

This way, now both our `Main section` contents and out toctree behave the way intended, without changing the toctree configuration for the whole page.