### PR TITLE
Fix instalation Kibana app plugin

### DIFF
--- a/source/installation-guide/installing-elastic-stack/elastic_server_deb.rst
+++ b/source/installation-guide/installing-elastic-stack/elastic_server_deb.rst
@@ -94,13 +94,15 @@ Kibana is a flexible and intuitive web interface for mining and visualizing the 
 
   .. code-block:: console
 
-    # sudo -u kibana /usr/share/kibana/bin/kibana-plugin install https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.3_7.6.0.zip
+    # cd /usr/share/kibana/
+    # sudo -u kibana bin/kibana-plugin install https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.3_7.6.0.zip
 
   * Install from the package:
 
   .. code-block:: console
 
-     # sudo -u kibana /usr/share/kibana/bin/kibana-plugin install file:///path/wazuhapp-3.11.3_7.6.0.zip
+    # cd /usr/share/kibana/
+    # sudo -u kibana bin/kibana-plugin install file:///path/wazuhapp-3.11.3_7.6.0.zip
 
   .. note:: The `path` should have *read* permissions for *others*. E.g: The directory `/tmp/` accomplishes this.
 

--- a/source/installation-guide/installing-elastic-stack/elastic_server_rpm.rst
+++ b/source/installation-guide/installing-elastic-stack/elastic_server_rpm.rst
@@ -104,13 +104,15 @@ Kibana is a flexible and intuitive web interface for mining and visualizing the 
 
   .. code-block:: console
 
-    # sudo -u kibana /usr/share/kibana/bin/kibana-plugin install https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.3_7.6.0.zip
+    # cd /usr/share/kibana/
+    # sudo -u kibana bin/kibana-plugin install https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.3_7.6.0.zip
 
   * Install from the package:
 
   .. code-block:: console
 
-     # sudo -u kibana /usr/share/kibana/bin/kibana-plugin install file:///path/wazuhapp-3.11.3_7.6.0.zip
+    # cd /usr/share/kibana/
+    # sudo -u kibana bin/kibana-plugin install file:///path/wazuhapp-3.11.3_7.6.0.zip
 
   .. note:: The `path` should have *read* permissions for *others*. E.g: The directory `/tmp/` accomplishes this.
 

--- a/source/installation-guide/installing-elastic-stack/protect-installation/searchguard.rst
+++ b/source/installation-guide/installing-elastic-stack/protect-installation/searchguard.rst
@@ -217,7 +217,8 @@ Kibana needs the Search Guard plugin too. Plugin versioning works like Elasticse
 
 .. code-block:: none
 
-    $ sudo -u kibana /usr/share/kibana/bin/kibana-plugin install https://search.maven.org/remotecontent?filepath=com/floragunn/search-guard-kibana-plugin/7.1.1-35.2.0/search-guard-kibana-plugin-7.1.1-35.2.0.zip
+    $ cd /usr/share/kibana/
+    $ sudo -u kibana bin/kibana-plugin install https://search.maven.org/remotecontent?filepath=com/floragunn/search-guard-kibana-plugin/7.1.1-35.2.0/search-guard-kibana-plugin-7.1.1-35.2.0.zip
 
 2. Edit the Kibana configuration file, it's located at */etc/kibana/kibana.yml*, add the following lines:
 

--- a/source/learning-wazuh/build-lab/install-elastic-stack.rst
+++ b/source/learning-wazuh/build-lab/install-elastic-stack.rst
@@ -105,7 +105,8 @@ events and archives stored in Elasticsearch. More info at `Kibana
 
   .. code-block:: console
 
-    # sudo -u kibana /usr/share/kibana/bin/kibana-plugin install https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.3_7.6.0.zip
+    # cd /usr/share/kibana/
+    # sudo -u kibana bin/kibana-plugin install https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.3_7.6.0.zip
 
 3. Kibana will only listen on the loopback interface (localhost) by default,
    which means that it can be only accessed from the same machine. To access

--- a/source/upgrade-guide/upgrading-elastic-stack/elastic_server_hard_upgrade.rst
+++ b/source/upgrade-guide/upgrading-elastic-stack/elastic_server_hard_upgrade.rst
@@ -202,14 +202,16 @@ Upgrade Kibana
 
   .. code-block:: console
 
-    # sudo -u kibana /usr/share/kibana/bin/kibana-plugin remove wazuh
+    # cd /usr/share/kibana/
+    # sudo -u kibana bin/kibana-plugin remove wazuh
 
 3. Upgrade the Wazuh app:
 
   .. code-block:: console
 
-    # rm -rf /usr/share/kibana/optimize/bundles
-    # sudo -u kibana NODE_OPTIONS="--max-old-space-size=3072" /usr/share/kibana/bin/kibana-plugin install https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.3_6.8.6.zip
+    # cd /usr/share/kibana/
+    # rm -rf optimize/bundles
+    # sudo -u kibana NODE_OPTIONS="--max-old-space-size=3072" bin/kibana-plugin install https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.3_6.8.6.zip
 
   .. warning::
 

--- a/source/upgrade-guide/upgrading-elastic-stack/elastic_server_minor_upgrade.rst
+++ b/source/upgrade-guide/upgrading-elastic-stack/elastic_server_minor_upgrade.rst
@@ -183,7 +183,8 @@ Upgrade Kibana
 
     .. code-block:: console
 
-      # /usr/share/kibana/bin/kibana-plugin remove wazuh
+      # cd /usr/share/kibana/
+      # sudo -u kibana bin/kibana-plugin remove wazuh
 
 #. Upgrade Kibana.
 
@@ -216,7 +217,8 @@ Upgrade Kibana
 
     .. code-block:: console
 
-      # sudo -u kibana /usr/share/kibana/bin/kibana-plugin install https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.3_7.6.0.zip
+      # cd /usr/share/kibana/
+      # sudo -u kibana bin/kibana-plugin install https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.3_7.6.0.zip
 
 #. Restore the configuration file backup.
 

--- a/source/upgrade-guide/upgrading-elastic-stack/elastic_server_rolling_upgrade.rst
+++ b/source/upgrade-guide/upgrading-elastic-stack/elastic_server_rolling_upgrade.rst
@@ -218,7 +218,8 @@ Upgrade Kibana
 
     .. code-block:: console
 
-      # /usr/share/kibana/bin/kibana-plugin remove wazuh
+      # cd /usr/share/kibana/
+      # sudo -u kibana bin/kibana-plugin remove wazuh
 
 #. Upgrade Kibana.
 
@@ -238,7 +239,8 @@ Upgrade Kibana
 
     .. code-block:: console
 
-      # sudo -u kibana /usr/share/kibana/bin/kibana-plugin install https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.3_7.6.0.zip
+      # cd /usr/share/kibana/
+      # sudo -u kibana bin/kibana-plugin install https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.3_7.6.0.zip
 
 #. Restart Kibana.
 


### PR DESCRIPTION
Hi team,

After the new version of Kibana 7.6.0 you need to be in the Kibana home directory to install or remove any plugin. This PR adds this previous step to all Wazuh Kibana app installation commands.

Regards,