### PR TITLE
Adding direct download package link

### DIFF
--- a/source/installation-guide/installing-wazuh-agent/aix/wazuh_agent_package_aix.rst
+++ b/source/installation-guide/installing-wazuh-agent/aix/wazuh_agent_package_aix.rst
@@ -5,7 +5,7 @@
 AIX from package
 ================
 
-The Wazuh agent for AIX can be downloaded from our :ref:`packages list <packages>`. You can choose installation or a deployment:
+You can download the  `AIX installer <https://packages.wazuh.com/3.x/aix/wazuh-agent-3.11.3-1.aix.ppc.rpm>`_ from our :ref:`packages list <packages>`. You can choose installation or a deployment:
 
   a) Installation:
 

--- a/source/installation-guide/installing-wazuh-agent/aix/wazuh_agent_package_aix.rst
+++ b/source/installation-guide/installing-wazuh-agent/aix/wazuh_agent_package_aix.rst
@@ -5,7 +5,7 @@
 AIX from package
 ================
 
-You can download the  `AIX installer <https://packages.wazuh.com/3.x/aix/wazuh-agent-3.11.3-1.aix.ppc.rpm>`_ from our :ref:`packages list <packages>`. You can choose installation or a deployment:
+You can download the `AIX installer <https://packages.wazuh.com/3.x/aix/wazuh-agent-3.11.3-1.aix.ppc.rpm>`_ from our :ref:`packages list <packages>`. You can choose installation or a deployment:
 
   a) Installation:
 

--- a/source/installation-guide/installing-wazuh-agent/hpux/wazuh_agent_package_hpux.rst
+++ b/source/installation-guide/installing-wazuh-agent/hpux/wazuh_agent_package_hpux.rst
@@ -4,8 +4,7 @@
 
 HP-UX from package
 ==================
-
-The Wazuh agent for HP-UX can be downloaded from our :ref:`packages list<packages>`. The installation steps are:
+You can download the  `HP-UX installer <https://packages.wazuh.com/3.x/hp-ux/wazuh-agent-3.11.3-1-hpux-11v3-ia64.tar>`_ from our  :ref:`packages list<packages>`. The installation steps are:
 
 Create the user and the group OSSEC:
 

--- a/source/installation-guide/installing-wazuh-agent/hpux/wazuh_agent_package_hpux.rst
+++ b/source/installation-guide/installing-wazuh-agent/hpux/wazuh_agent_package_hpux.rst
@@ -4,7 +4,7 @@
 
 HP-UX from package
 ==================
-You can download the  `HP-UX installer <https://packages.wazuh.com/3.x/hp-ux/wazuh-agent-3.11.3-1-hpux-11v3-ia64.tar>`_ from our  :ref:`packages list<packages>`. The installation steps are:
+You can download the `HP-UX installer <https://packages.wazuh.com/3.x/hp-ux/wazuh-agent-3.11.3-1-hpux-11v3-ia64.tar>`_ from our :ref:`packages list<packages>`. The installation steps are:
 
 Create the user and the group OSSEC:
 

--- a/source/installation-guide/installing-wazuh-agent/macos/wazuh_agent_package_macos.rst
+++ b/source/installation-guide/installing-wazuh-agent/macos/wazuh_agent_package_macos.rst
@@ -5,7 +5,7 @@
 macOS from package
 ==================
 
-The package for macOS is suitable for macOS Sierra or greater. You can download the  `macOS installer <https://packages.wazuh.com/3.x/osx/wazuh-agent-3.11.3-1.pkg>`_ from our :ref:`packages list<packages>`. You can install it by using the command line or following the GUI steps:
+The package for macOS is suitable for macOS Sierra or greater. You can download the `macOS installer <https://packages.wazuh.com/3.x/osx/wazuh-agent-3.11.3-1.pkg>`_ from our :ref:`packages list<packages>`. You can install it by using the command line or following the GUI steps:
 
   a) Using the command line, you can choose installation or deployment:
 

--- a/source/installation-guide/installing-wazuh-agent/macos/wazuh_agent_package_macos.rst
+++ b/source/installation-guide/installing-wazuh-agent/macos/wazuh_agent_package_macos.rst
@@ -5,7 +5,7 @@
 macOS from package
 ==================
 
-The package for macOS is suitable for macOS Sierra or greater. The macOS agent can be downloaded from :ref:`packages list<packages>`. You can install it by using the command line or following the GUI steps:
+The package for macOS is suitable for macOS Sierra or greater. You can download the  `macOS installer <https://packages.wazuh.com/3.x/osx/wazuh-agent-3.11.3-1.pkg>`_ from our :ref:`packages list<packages>`. You can install it by using the command line or following the GUI steps:
 
   a) Using the command line, you can choose installation or deployment:
 

--- a/source/installation-guide/installing-wazuh-agent/solaris/solaris10/wazuh_agent_package_solaris10.rst
+++ b/source/installation-guide/installing-wazuh-agent/solaris/solaris10/wazuh_agent_package_solaris10.rst
@@ -4,8 +4,7 @@
 
 Solaris 10 from package
 =======================
-
-The Wazuh agent for Solaris 10 can be downloaded from our :ref:`packages list<packages>`. The current version has been tested on Solaris 10 version 5.10. Install the agent as follows:
+You can download the  `Solaris10 installer (Intel architecture) <https://packages.wazuh.com/3.x/solaris/i386/10/wazuh-agent_v3.11.3-sol10-i386.pkg>`_ or `Solaris10 installer (SPARC architecture) <href="https://packages.wazuh.com/3.x/solaris/sparc/10/wazuh-agent_v3.11.3-sol10-sparc.pkg">`_ from our from our :ref:`packages list<packages>`. The current version has been tested on Solaris 10 version 5.10. Install the agent as follows:
 
   a) For Solaris 10 i386:
 

--- a/source/installation-guide/installing-wazuh-agent/solaris/solaris10/wazuh_agent_package_solaris10.rst
+++ b/source/installation-guide/installing-wazuh-agent/solaris/solaris10/wazuh_agent_package_solaris10.rst
@@ -4,7 +4,7 @@
 
 Solaris 10 from package
 =======================
-You can download the  `Solaris10 installer (Intel architecture) <https://packages.wazuh.com/3.x/solaris/i386/10/wazuh-agent_v3.11.3-sol10-i386.pkg>`_ or `Solaris10 installer (SPARC architecture) <href="https://packages.wazuh.com/3.x/solaris/sparc/10/wazuh-agent_v3.11.3-sol10-sparc.pkg">`_ from our from our :ref:`packages list<packages>`. The current version has been tested on Solaris 10 version 5.10. Install the agent as follows:
+You can download the `Solaris10 installer (Intel architecture) <https://packages.wazuh.com/3.x/solaris/i386/10/wazuh-agent_v3.11.3-sol10-i386.pkg>`_ or `Solaris10 installer (SPARC architecture) <href="https://packages.wazuh.com/3.x/solaris/sparc/10/wazuh-agent_v3.11.3-sol10-sparc.pkg">`_ from our from our :ref:`packages list<packages>`. The current version has been tested on Solaris 10 version 5.10. Install the agent as follows:
 
   a) For Solaris 10 i386:
 

--- a/source/installation-guide/installing-wazuh-agent/solaris/solaris11/wazuh_agent_package_solaris11.rst
+++ b/source/installation-guide/installing-wazuh-agent/solaris/solaris11/wazuh_agent_package_solaris11.rst
@@ -5,7 +5,7 @@
 Solaris 11 from package
 =======================
 
-The Wazuh agent for Solaris can be downloaded from our :ref:`packages list<packages>`. The current version has been tested on Solaris 11 version 5.11. Install the agent as follows:
+You can download the  `Solaris11 installer (Intel architecture) <https://packages.wazuh.com/3.x/solaris/i386/11/wazuh-agent_v3.11.3-sol11-i386.p5p>`_ or `Solaris11 installer (SPARC architecture) <https://packages.wazuh.com/3.x/solaris/sparc/11/wazuh-agent_v3.11.3-sol11-sparc.p5p>`_ from our  :ref:`packages list<packages>`. The current version has been tested on Solaris 11 version 5.11. Install the agent as follows:
 
   a) For Solaris 11 i386:
 

--- a/source/installation-guide/installing-wazuh-agent/solaris/solaris11/wazuh_agent_package_solaris11.rst
+++ b/source/installation-guide/installing-wazuh-agent/solaris/solaris11/wazuh_agent_package_solaris11.rst
@@ -5,7 +5,7 @@
 Solaris 11 from package
 =======================
 
-You can download the  `Solaris11 installer (Intel architecture) <https://packages.wazuh.com/3.x/solaris/i386/11/wazuh-agent_v3.11.3-sol11-i386.p5p>`_ or `Solaris11 installer (SPARC architecture) <https://packages.wazuh.com/3.x/solaris/sparc/11/wazuh-agent_v3.11.3-sol11-sparc.p5p>`_ from our  :ref:`packages list<packages>`. The current version has been tested on Solaris 11 version 5.11. Install the agent as follows:
+You can download the `Solaris11 installer (Intel architecture) <https://packages.wazuh.com/3.x/solaris/i386/11/wazuh-agent_v3.11.3-sol11-i386.p5p>`_ or `Solaris11 installer (SPARC architecture) <https://packages.wazuh.com/3.x/solaris/sparc/11/wazuh-agent_v3.11.3-sol11-sparc.p5p>`_ from our :ref:`packages list<packages>`. The current version has been tested on Solaris 11 version 5.11. Install the agent as follows:
 
   a) For Solaris 11 i386:
 


### PR DESCRIPTION
This issue aims to close #2218

Direct download Wazuh agent packages links were added to 

- AIX
- HP-UX
- macOS
- Solaris10 & Solaris11