### PR TITLE
2216 steps for enabling repos before upgrade

### DIFF
--- a/source/installation-guide/installing-wazuh-agent/solaris/solaris10/wazuh_agent_package_solaris10.rst
+++ b/source/installation-guide/installing-wazuh-agent/solaris/solaris10/wazuh_agent_package_solaris10.rst
@@ -40,3 +40,32 @@ To uninstall the agent in Solaris 10:
     .. code-block:: console
 
       # pkgrm wazuh-agent
+
+Disabling repositories
+^^^^^^^^^^^^^^^^^^^^^^
+
+    * For CentOS/RHEL/Fedora:
+
+      .. code-block:: console
+
+        # sed -i "s/^enabled=1/enabled=0/" /etc/yum.repos.d/elastic.repo
+
+    * For Debian/Ubuntu:
+
+      .. code-block:: console
+
+        # sed -i "s/^deb/#deb/" /etc/apt/sources.list.d/elastic-7.x.list
+        # apt-get update
+
+      Alternatively, you can set the package state to ``hold``, which will stop updates (although you can still upgrade it manually using ``apt-get install``).
+
+      .. code-block:: console
+
+        # echo "elasticsearch hold" | sudo dpkg --set-selections
+        # echo "kibana hold" | sudo dpkg --set-selections
+
+    * For openSUSE:
+
+      .. code-block:: console
+
+        # sed -i "s/^enabled=1/enabled=0/" /etc/zypp/repos.d/elastic.repo

--- a/source/installation-guide/installing-wazuh-agent/solaris/solaris10/wazuh_agent_package_solaris10.rst
+++ b/source/installation-guide/installing-wazuh-agent/solaris/solaris10/wazuh_agent_package_solaris10.rst
@@ -4,7 +4,7 @@
 
 Solaris 10 from package
 =======================
-You can download the `Solaris10 installer (Intel architecture) <https://packages.wazuh.com/3.x/solaris/i386/10/wazuh-agent_v3.11.3-sol10-i386.pkg>`_ or `Solaris10 installer (SPARC architecture) <href="https://packages.wazuh.com/3.x/solaris/sparc/10/wazuh-agent_v3.11.3-sol10-sparc.pkg">`_ from our from our :ref:`packages list<packages>`. The current version has been tested on Solaris 10 version 5.10. Install the agent as follows:
+You can download the `Solaris10 installer (Intel architecture) <https://packages.wazuh.com/3.x/solaris/i386/10/wazuh-agent_v3.11.3-sol10-i386.pkg>`_ or `Solaris10 installer (SPARC architecture) <https://packages.wazuh.com/3.x/solaris/sparc/10/wazuh-agent_v3.11.3-sol10-sparc.pkg>`_ from our from our :ref:`packages list<packages>`. The current version has been tested on Solaris 10 version 5.10. Install the agent as follows:
 
   a) For Solaris 10 i386:
 

--- a/source/installation-guide/installing-wazuh-agent/solaris/solaris10/wazuh_agent_package_solaris10.rst
+++ b/source/installation-guide/installing-wazuh-agent/solaris/solaris10/wazuh_agent_package_solaris10.rst
@@ -40,32 +40,3 @@ To uninstall the agent in Solaris 10:
     .. code-block:: console
 
       # pkgrm wazuh-agent
-
-Disabling repositories
-^^^^^^^^^^^^^^^^^^^^^^
-
-    * For CentOS/RHEL/Fedora:
-
-      .. code-block:: console
-
-        # sed -i "s/^enabled=1/enabled=0/" /etc/yum.repos.d/elastic.repo
-
-    * For Debian/Ubuntu:
-
-      .. code-block:: console
-
-        # sed -i "s/^deb/#deb/" /etc/apt/sources.list.d/elastic-7.x.list
-        # apt-get update
-
-      Alternatively, you can set the package state to ``hold``, which will stop updates (although you can still upgrade it manually using ``apt-get install``).
-
-      .. code-block:: console
-
-        # echo "elasticsearch hold" | sudo dpkg --set-selections
-        # echo "kibana hold" | sudo dpkg --set-selections
-
-    * For openSUSE:
-
-      .. code-block:: console
-
-        # sed -i "s/^enabled=1/enabled=0/" /etc/zypp/repos.d/elastic.repo

--- a/source/upgrade-guide/upgrading-elastic-stack/elastic_server_hard_upgrade.rst
+++ b/source/upgrade-guide/upgrading-elastic-stack/elastic_server_hard_upgrade.rst
@@ -224,3 +224,32 @@ Upgrade Kibana
     # systemctl daemon-reload
     # systemctl enable kibana.service
     # systemctl start kibana.service
+
+Disabling repositories
+^^^^^^^^^^^^^^^^^^^^^^
+
+    * For CentOS/RHEL/Fedora:
+
+      .. code-block:: console
+
+        # sed -i "s/^enabled=1/enabled=0/" /etc/yum.repos.d/elastic.repo
+
+    * For Debian/Ubuntu:
+
+      .. code-block:: console
+
+        # sed -i "s/^deb/#deb/" /etc/apt/sources.list.d/elastic-7.x.list
+        # apt-get update
+
+      Alternatively, you can set the package state to ``hold``, which will stop updates (although you can still upgrade it manually using ``apt-get install``).
+
+      .. code-block:: console
+
+        # echo "elasticsearch hold" | sudo dpkg --set-selections
+        # echo "kibana hold" | sudo dpkg --set-selections
+
+    * For openSUSE:
+
+      .. code-block:: console
+
+        # sed -i "s/^enabled=1/enabled=0/" /etc/zypp/repos.d/elastic.repo

--- a/source/upgrade-guide/upgrading-elastic-stack/elastic_server_hard_upgrade.rst
+++ b/source/upgrade-guide/upgrading-elastic-stack/elastic_server_hard_upgrade.rst
@@ -16,6 +16,47 @@ Prepare the Elastic Stack
     # systemctl stop filebeat
     # systemctl stop kibana
 
+2. Add the new repository for Elastic Stack 7.x:
+
+    * For CentOS/RHEL/Fedora:
+
+      .. code-block:: console
+
+        # rpm --import https://packages.elastic.co/GPG-KEY-elasticsearch
+        # cat > /etc/yum.repos.d/elastic.repo << EOF
+        [elasticsearch-7.x]
+        name=Elasticsearch repository for 7.x packages
+        baseurl=https://artifacts.elastic.co/packages/7.x/yum
+        gpgcheck=1
+        gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
+        enabled=1
+        autorefresh=1
+        type=rpm-md
+        EOF
+
+    * For Debian/Ubuntu:
+
+      .. code-block:: console
+
+        # curl -s https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add -
+        # echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee /etc/apt/sources.list.d/elastic-7.x.list
+
+    * openSUSE:
+
+      .. code-block:: console
+
+        # rpm --import https://packages.elastic.co/GPG-KEY-elasticsearch
+        # cat > /etc/zypp/repos.d/elastic.repo << EOF
+        [elasticsearch-7.x]
+        name=Elasticsearch repository for 7.x packages
+        baseurl=https://artifacts.elastic.co/packages/7.x/yum
+        gpgcheck=1
+        gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
+        enabled=1
+        autorefresh=1
+        type=rpm-md
+        EOF        
+
 Upgrade Elasticsearch
 ---------------------
 

--- a/source/upgrade-guide/upgrading-elastic-stack/elastic_server_minor_upgrade.rst
+++ b/source/upgrade-guide/upgrading-elastic-stack/elastic_server_minor_upgrade.rst
@@ -239,3 +239,32 @@ Upgrade Kibana
 
       # systemctl daemon-reload
       # systemctl restart kibana
+
+Disabling repositories
+^^^^^^^^^^^^^^^^^^^^^^
+
+    * For CentOS/RHEL/Fedora:
+
+      .. code-block:: console
+
+        # sed -i "s/^enabled=1/enabled=0/" /etc/yum.repos.d/elastic.repo
+
+    * For Debian/Ubuntu:
+
+      .. code-block:: console
+
+        # sed -i "s/^deb/#deb/" /etc/apt/sources.list.d/elastic-7.x.list
+        # apt-get update
+
+      Alternatively, you can set the package state to ``hold``, which will stop updates (although you can still upgrade it manually using ``apt-get install``).
+
+      .. code-block:: console
+
+        # echo "elasticsearch hold" | sudo dpkg --set-selections
+        # echo "kibana hold" | sudo dpkg --set-selections
+
+    * For openSUSE:
+
+      .. code-block:: console
+
+        # sed -i "s/^enabled=1/enabled=0/" /etc/zypp/repos.d/elastic.repo

--- a/source/upgrade-guide/upgrading-elastic-stack/elastic_server_minor_upgrade.rst
+++ b/source/upgrade-guide/upgrading-elastic-stack/elastic_server_minor_upgrade.rst
@@ -40,6 +40,22 @@ Prepare the Elastic Stack
         # curl -s https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add -
         # echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee /etc/apt/sources.list.d/elastic-7.x.list
 
+    * openSUSE:
+
+      .. code-block:: console
+
+        # rpm --import https://packages.elastic.co/GPG-KEY-elasticsearch
+        # cat > /etc/zypp/repos.d/elastic.repo << EOF
+        [elasticsearch-7.x]
+        name=Elasticsearch repository for 7.x packages
+        baseurl=https://artifacts.elastic.co/packages/7.x/yum
+        gpgcheck=1
+        gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
+        enabled=1
+        autorefresh=1
+        type=rpm-md
+        EOF        
+
 
 Upgrade Elasticsearch
 ---------------------

--- a/source/upgrade-guide/upgrading-elastic-stack/elastic_server_rolling_upgrade.rst
+++ b/source/upgrade-guide/upgrading-elastic-stack/elastic_server_rolling_upgrade.rst
@@ -43,6 +43,22 @@ Prepare the Elastic Stack
         # curl -s https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add -
         # echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee /etc/apt/sources.list.d/elastic-7.x.list
 
+    * openSUSE:
+
+      .. code-block:: console
+
+        # rpm --import https://packages.elastic.co/GPG-KEY-elasticsearch
+        # cat > /etc/zypp/repos.d/elastic.repo << EOF
+        [elasticsearch-7.x]
+        name=Elasticsearch repository for 7.x packages
+        baseurl=https://artifacts.elastic.co/packages/7.x/yum
+        gpgcheck=1
+        gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
+        enabled=1
+        autorefresh=1
+        type=rpm-md
+        EOF
+
 
 Upgrade Elasticsearch
 ---------------------


### PR DESCRIPTION
Hello team! This pr aims to close #2216 

Instructions about how to enable and disable Elasticsearch's repository have been added. 
In installation guide we recommend disabling Elasticsearch's repository, and if it is not enabled back before upgrading, users will run intro trouble.

![enabling_repos](https://user-images.githubusercontent.com/60152567/75052317-afa4d480-54cf-11ea-91de-d608db1b7412.png)


I have also added instructions to disable the repository after upgrading.

![disabling_repos](https://user-images.githubusercontent.com/60152567/75052328-b5021f00-54cf-11ea-9669-89480bc8da0b.png)
