### PR TITLE
Clarified that agent_upgrade must be executed on the node where it is connected

### DIFF
--- a/source/user-manual/reference/tools/agent_upgrade.rst
+++ b/source/user-manual/reference/tools/agent_upgrade.rst
@@ -9,7 +9,7 @@ agent_upgrade
 
 The agent_upgrade program allows you to list outdated agents and upgrade them.
 
-.. note:: In case of having a multi-node Wazuh cluster agent_upgrade must be executed on the node where the agent is connected.
+.. note:: In case of having a multi-node Wazuh cluster, agent_upgrade must be executed on the node where the agent is connected.
 
 +--------------------------------------------+---------------------------------------------------------+
 | ``-h, --help``                             | Display the help message.                               |

--- a/source/user-manual/reference/tools/agent_upgrade.rst
+++ b/source/user-manual/reference/tools/agent_upgrade.rst
@@ -9,6 +9,8 @@ agent_upgrade
 
 The agent_upgrade program allows you to list outdated agents and upgrade them.
 
+.. note:: In case of having a multi-node Wazuh cluster agent_upgrade must be executed on the node where the agent is connected.
+
 +--------------------------------------------+---------------------------------------------------------+
 | ``-h, --help``                             | Display the help message.                               |
 +--------------------------------------------+---------------------------------------------------------+


### PR DESCRIPTION
Hello team! This issue aims to close #2130 .

I have added a note explaining that in case of having a multi-node cluster, agent_upgrade has to be executed on the node where the agent is connected.

![agent_upgrade](https://user-images.githubusercontent.com/60152567/75057508-7709f880-54d9-11ea-914e-f6bedc378609.png)
