### PR TITLE
Updated GPG key url

### DIFF
--- a/source/installation-guide/installing-elastic-stack/elastic_server_rpm.rst
+++ b/source/installation-guide/installing-elastic-stack/elastic_server_rpm.rst
@@ -16,7 +16,7 @@ Preparation
 
   .. code-block:: console
 
-    # rpm --import https://packages.elastic.co/GPG-KEY-elasticsearch
+    # rpm --import https://artifacts.elastic.co/GPG-KEY-elasticsearch
     # cat > /etc/yum.repos.d/elastic.repo << EOF
     [elasticsearch-7.x]
     name=Elasticsearch repository for 7.x packages


### PR DESCRIPTION
Hello team! This pull request aims to close #2224 
Since Elasticsearch's documentation uses [ https://artifacts.elastic.co/GPG-KEY-elasticsearch]( https://artifacts.elastic.co/GPG-KEY-elasticsearch), I have modified our documentation to use the same url. 

Regards,

David

