### PR TITLE
Audit configuration for huge amount of events at the same time

### DIFF
--- a/source/user-manual/capabilities/file-integrity/fim-faq.rst
+++ b/source/user-manual/capabilities/file-integrity/fim-faq.rst
@@ -18,7 +18,7 @@ FAQ
 #. `How FIM manages historical records in his database?`_
 #. `How can I migrate my old DB information into a new SQLite database?`_
 #. `Can I hot-swap monitored directories?`_
-#. `How to edit audit configuration to deal with huge amount of whodata events at the same time.`_
+#. `How to tune audit to deal with a huge amount of who-data events at the same time.`_
 
 How often does syscheck run?
 --------------------------------
@@ -96,26 +96,24 @@ Can I hot-swap monitored directories?
 
 Yes, this can be done for Linux in both agents and manager by setting the monitoring of symbolic links to directories. To set the refresh interval, use option :doc:`syscheck.symlink_scan_interval <../../reference/internal-options>`.
 
-How to edit audit configuration to deal with huge amount of whodata events at the same time.
-----------------------------------------------------------------------------------------
+How to tune audit to deal with a huge amount of who-data events at the same time.
+---------------------------------------------------------------------------------
 
-It is possible to lose events when a lot of them are generated in a moment, there is a problem with audit socket and dispatcher that can be fixed by editing two values involved:
+It is possible to lose who-data events when a flood of events appears. The following options help the audit socket and dispatcher to deal with big amounts of events:
 ::
 
   /etc/audisp/audisp.conf  -> disp_qos = ["lossy", "lossless"]
   /etc/audit/audit.conf    -> q_dephs = [<Numerical value>]
 
-The first one (disp_qos) controls whether you want blocking/lossless or non-blocking/lossy communication between the audit daemon and the dispatcher. There is a 128k buffer between the audit daemon and dispatcher. This is good enogh for most uses. If lossy is chosen, incoming events going to the dispatcher are discarded when this queue is full. (Events are still written to disk if log_format is not nolog.) Otherwise the auditd daemon will wait for the queue to have an empty spot before logging to disk. The risk is that while the daemon is waiting for network IO, an event is not being recorded to disk.
-Valid values are: lossy and lossless.
-Default value is lossy.
+The first one (disp_qos) controls whether you want blocking/lossless or non-blocking/lossy communication between the audit daemon and the dispatcher. There is a 128k buffer between the audit daemon and dispatcher. This is good enough for most uses. If lossy is chosen, incoming events going to the dispatcher are discarded when this queue is full. (Events are still written to disk if log_format is not nolog.) Otherwise the auditd daemon will wait for the queue to have an empty spot before logging to disk. The risk is that while the daemon is waiting for network IO, an event is not being recorded to disk.
 Recommended value is lossless.
 
 The other one (q_dephs) is a numeric value that tells how big to make the internal queue of the audit event dispatcher. A bigger queue lets it handle a flood of events better, but could hold events that are not processed when the daemon is terminated. If you get messages in syslog about events getting dropped, increase this value.
 The default value is 80.
 
-There is another variable that can prevent loss of events, within the syscheck configuration:
+On the Wazuh side, the rt_delay variable from the internal FIM configuration can help to prevent the loss of events:
 ::
 
-  /var/ossec/etc/internal_options.conf  -> rt_delay = [<Numerical value>]
+  /var/ossec/etc/internal_options.conf -> rt_delay = [Numerical value]
 
-Time in milliseconds for delay between alerts in real-time. Low values are better to fix this problem.
+It sets a delay between real-time alerts in milliseconds. Decrease its value to process who-data events faster.

--- a/source/user-manual/capabilities/file-integrity/fim-faq.rst
+++ b/source/user-manual/capabilities/file-integrity/fim-faq.rst
@@ -18,6 +18,7 @@ FAQ
 #. `How FIM manages historical records in his database?`_
 #. `How can I migrate my old DB information into a new SQLite database?`_
 #. `Can I hot-swap monitored directories?`_
+#. `I lose whodata events when audit sends huge amount of them at the same time, what to do?`_
 
 How often does syscheck run?
 --------------------------------
@@ -94,3 +95,20 @@ Can I hot-swap monitored directories?
 --------------------------------------
 
 Yes, this can be done for Linux in both agents and manager by setting the monitoring of symbolic links to directories. To set the refresh interval, use option :doc:`syscheck.symlink_scan_interval <../../reference/internal-options>`.
+
+I lose whodata events when audit sends huge amount of them at the same time, what to do?
+----------------------------------------------------------------------------------------
+
+This is a problem with audit socket and dispatcher. You need to configure audit, there are two values involved:
+::
+
+  /etc/audisp/audisp.conf  -> disp_qos
+  /etc/audit/audit.conf    -> q_dephs
+
+The first one (disp_qos) controls whether you want blocking/lossless or non-blocking/lossy communication between the audit daemon and the dispatcher. There is a 128k buffer between the audit daemon and dispatcher. This is good enogh for most uses. If lossy is chosen, incoming events going to the dispatcher are discarded when this queue is full. (Events are still written to disk if log_format is not nolog.) Otherwise the auditd daemon will wait for the queue to have an empty spot before logging to disk. The risk is that while the daemon is waiting for network IO, an event is not being recorded to disk.
+Valid values are: lossy and lossless.
+Default value is lossy.
+Recommended value is lossless.
+
+The other one (q_dephs) is a numeric value that tells how big to make the internal queue of the audit event dispatcher. A bigger queue lets it handle a flood of events better, but could hold events that are not processed when the daemon is terminated. If you get messages in syslog about events getting dropped, increase this value.
+The default value is 80.


### PR DESCRIPTION
Its a explanation about how to edit audit configuration (and rt_delay from internal_options.conf) so you don't lose any event in whodata.