### PR TITLE
Added install from file instructios in Upgrading Elastic Stack section

### DIFF
--- a/source/upgrade-guide/upgrading-elastic-stack/elastic_server_hard_upgrade.rst
+++ b/source/upgrade-guide/upgrading-elastic-stack/elastic_server_hard_upgrade.rst
@@ -248,11 +248,21 @@ Upgrade Kibana
 
 3. Upgrade the Wazuh app:
 
+  * Install from URL:
+
   .. code-block:: console
 
     # cd /usr/share/kibana/
     # rm -rf optimize/bundles
     # sudo -u kibana NODE_OPTIONS="--max-old-space-size=3072" bin/kibana-plugin install https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.4_6.8.6.zip
+
+  * Install from the package:
+
+  .. code-block:: console
+
+    # cd /usr/share/kibana/
+    # rm -rf optimize/bundles
+    # sudo -u kibana NODE_OPTIONS="--max-old-space-size=3072" bin/kibana-plugin install file:///path/wazuhapp-3.11.4_7.6.0.zip
 
   .. warning::
 

--- a/source/upgrade-guide/upgrading-elastic-stack/elastic_server_minor_upgrade.rst
+++ b/source/upgrade-guide/upgrading-elastic-stack/elastic_server_minor_upgrade.rst
@@ -231,10 +231,19 @@ Upgrade Kibana
 
 #. Install the Wazuh app.
 
+    * From URL:
+
     .. code-block:: console
 
       # cd /usr/share/kibana/
       # sudo -u kibana bin/kibana-plugin install https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.4_7.6.0.zip
+
+    * From the package:
+
+    .. code-block:: console
+
+      # cd /usr/share/kibana/
+      # sudo -u kibana bin/kibana-plugin install file:///path/wazuhapp-3.11.4_7.6.0.zip
 
 #. Restore the configuration file backup.
 

--- a/source/upgrade-guide/upgrading-elastic-stack/elastic_server_rolling_upgrade.rst
+++ b/source/upgrade-guide/upgrading-elastic-stack/elastic_server_rolling_upgrade.rst
@@ -253,10 +253,19 @@ Upgrade Kibana
 
 #. Install the Wazuh app.
 
+    * From URL:
+
     .. code-block:: console
 
       # cd /usr/share/kibana/
       # sudo -u kibana bin/kibana-plugin install https://packages.wazuh.com/wazuhapp/wazuhapp-3.11.4_7.6.0.zip
+
+    * From the package:
+
+    .. code-block:: console
+
+      # cd /usr/share/kibana/
+      # sudo -u kibana bin/kibana-plugin install file:///path/wazuhapp-3.11.4_7.6.0.zip
 
 #. Restart Kibana.
 


### PR DESCRIPTION
Hello team! This PR closes #2257.
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numerated branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

In the installation section, it is explained how to install the Wazuh Kibana plugin from both URL and package. This was not included in the Upgrading Elastic Stack section so I have added it: 

![install-wazuh-kibana-app](https://user-images.githubusercontent.com/60152567/76000644-49bf4080-5f04-11ea-80bc-8fdde7f05ab8.png)

## Checks

- [x]  It compiles without warnings.

- [x] Spelling and grammar. 


Regards,

David
