### PR TITLE
Clarify regex label usage and its mandatory settings

### DIFF
--- a/source/user-manual/ruleset/ruleset-xml-syntax/decoders.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/decoders.rst
@@ -208,7 +208,9 @@ An example is this regex that matches any numeral:
 | **Allowed values** | Any `regex expression <regex.html#regex-os-regex-syntax>`_         |
 +--------------------+--------------------------------------------------------------------+
 
-The attribute below is optional, it allows to discard some of the content of the entry.
+When using the ``regex`` label it is mandatory to define an ``order`` label as well. Besides, ``regex`` label requires a ``prematch`` or a ``program_name`` label defined on the same decoder or a ``parent`` with a ``prematch`` or a ``program_name defined`` label defined on it.
+
+The attribute below is optional. It allows to discard some of the content of the entry.
 
 +--------------------+--------------------+
 | Attribute          | Value              |
@@ -240,7 +242,7 @@ Show when a user executed the sudo command for the first time:
 order
 ^^^^^^
 
-It defines what the parenthesis groups contain and the order in which they were received.
+It defines what the parenthesis groups contain and the order in which they were received. It requires a ``regex`` label defined on the same decoder.
 
 +--------------------+--------------------------------------------------------------------+
 | **Default Value**  | n/a                                                                |


### PR DESCRIPTION
Hello team!
This pull request closes #2091
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numerated branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

I have clarified which labels are mandatory when using `regex` label: 

![regex](https://user-images.githubusercontent.com/60152567/76205872-5b9e2d80-61fb-11ea-9946-6ed61214866a.png)

I have also remarked that `order` label cannot be used without a `regex` label defined: 

![order](https://user-images.githubusercontent.com/60152567/76205947-7ec8dd00-61fb-11ea-87b1-6b27da4f489b.png)

<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 

Regards,

David