### PR TITLE
Added a warning about a known audit bug that prevents from showing alerts

### DIFF
--- a/source/user-manual/capabilities/file-integrity/fim-configuration.rst
+++ b/source/user-manual/capabilities/file-integrity/fim-configuration.rst
@@ -75,7 +75,7 @@ This functionality uses Linux Audit subsystem and the Microsoft Windows SACL, so
   </syscheck>
 
 
-.. warning:: There is a known bug that affects to some versions of ``audit`` that shows a directory as ``null`` when it has been moved adding a ``/`` at the end of the directory. This bug will cause that no alerts related with this directory will be shown until a new event related to this directory is triggered when ``whodata`` is enabled.
+.. warning:: There is a known bug that affects to the versions 2.8.5 and 2.8.4 of ``audit`` that shows a directory as ``null`` when it has been moved adding a ``/`` at the end of the directory. This bug will cause that no alerts related with this directory will be shown until a new event related to this directory is triggered when ``whodata`` is enabled.
 
 
 .. _how_to_fim_report_changes:

--- a/source/user-manual/capabilities/file-integrity/fim-configuration.rst
+++ b/source/user-manual/capabilities/file-integrity/fim-configuration.rst
@@ -75,7 +75,7 @@ This functionality uses Linux Audit subsystem and the Microsoft Windows SACL, so
   </syscheck>
 
 
-.. warning:: There is a known bug that affects to some versions of ``audit`` that shows a directory as ``null`` when it has been moved adding a ``/`` at the end of the source directory. This bug will cause that no alerts related with this directory will be shown until a new event related to this directory is triggered when ``whodata`` is enabled.
+.. warning:: There is a known bug that affects to some versions of ``audit`` that shows a directory as ``null`` when it has been moved adding a ``/`` at the end of the directory. This bug will cause that no alerts related with this directory will be shown until a new event related to this directory is triggered when ``whodata`` is enabled.
 
 
 .. _how_to_fim_report_changes:

--- a/source/user-manual/capabilities/file-integrity/fim-configuration.rst
+++ b/source/user-manual/capabilities/file-integrity/fim-configuration.rst
@@ -74,6 +74,10 @@ This functionality uses Linux Audit subsystem and the Microsoft Windows SACL, so
     <directories check_all="yes" whodata="yes">/etc</directories>
   </syscheck>
 
+
+.. warning:: There is a known bug that affects to some versions of ``audit`` that shows a directory as ``null`` when it has been moved adding a ``/`` at the end of the source directory. This bug will cause that no alerts related with this directory will be shown until a new event related to this directory is triggered when ``whodata`` is enabled.
+
+
 .. _how_to_fim_report_changes:
 
 Configure to report changes


### PR DESCRIPTION
Hello team!

This PR closes #2266 
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numerated branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

I have added a warning to tell the user about a know bug that prevents alerts to be shown when a directory has been moved with a `/` on its end.


![warning](https://user-images.githubusercontent.com/60152567/76213666-711b5380-620b-11ea-825e-2addd40e67a1.png)


## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 

Regards,

David