### PR TITLE
Fix path in AWS wodle for GuardDuty

### DIFF
--- a/source/amazon/services/supported-services/guardduty.rst
+++ b/source/amazon/services/supported-services/guardduty.rst
@@ -106,7 +106,7 @@ Wazuh configuration
         <skip_on_error>yes</skip_on_error>
         <bucket type="guardduty">
           <name>wazuh-aws-wodle</name>
-          <path>guardduty</path>
+          <path>firehose/</path>
           <aws_profile>default</aws_profile>
         </bucket>
       </wodle>


### PR DESCRIPTION
## Description
Configuring the AWS wodle can be very confusing to a user, so we should be as much clear as possible when describing the process. 
In this case, the current documentation doesn't make it clear what to put inside the `path` option. If you follow the documentation, the `path` should be `firehose/` and not `guardduty` (which leads to confusion), so I think we should specify that in the example.

Regards,
Sergio.
