### PR TITLE
Limited number of directories in one line

### DIFF
--- a/source/user-manual/reference/ossec-conf/syscheck.rst
+++ b/source/user-manual/reference/ossec-conf/syscheck.rst
@@ -50,6 +50,8 @@ Drive letters without directories are not valid. At a minimum the '.' should be 
 
 This is to be set on the system to be monitored (or in the ``agent.conf``, if appropriate).
 
+The length of a directory must be less than 64.
+
 +--------------------+------------------------------------+
 | **Default value**  | /etc,/usr/bin,/usr/sbin,/bin,/sbin |
 +--------------------+------------------------------------+

--- a/source/user-manual/reference/ossec-conf/syscheck.rst
+++ b/source/user-manual/reference/ossec-conf/syscheck.rst
@@ -50,7 +50,7 @@ Drive letters without directories are not valid. At a minimum the '.' should be 
 
 This is to be set on the system to be monitored (or in the ``agent.conf``, if appropriate).
 
-The length of a directory must be less than 64.
+There exists a limit in the number of directories that can be written in one line separated by commas, this is limited to 64 directories.
 
 +--------------------+------------------------------------+
 | **Default value**  | /etc,/usr/bin,/usr/sbin,/bin,/sbin |


### PR DESCRIPTION
## Description
Hi team. 
As mentioned in #2265, the user can write more than 64 directories in one line of the configuration file in the syscheck section.  This limitation should be mentioned, since there have been some troubles when making the integration test. 
Regards
<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->