### PR TITLE
Fix check rule addition command in auditing who-data

### DIFF
--- a/source/user-manual/capabilities/auditing-whodata/who-linux.rst
+++ b/source/user-manual/capabilities/auditing-whodata/who-linux.rst
@@ -46,9 +46,9 @@ We can check if the Audit rule for monitoring the selected folder is applied. To
 
 and check if the rule was added:
 
-.. code-block:: bash
+.. code-block:: console
 
-    -w /etc -p wa -k wazuh_fim
+    # auditctl -w /etc -p wa -k wazuh_fim
 
 When the agent is stopped, we can use the same command to check that the added rule was successfully removed.
 


### PR DESCRIPTION
Hello team!

This PR closes #2066 
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numerated branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description
I have added the command `auditctl` that was missing

![auditctl](https://user-images.githubusercontent.com/60152567/76332567-d432e600-62f0-11ea-9027-2c681cc6d7e6.png)

<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 

Regards,

David