### PR TITLE
Clarify encryption method used

### DIFF
--- a/source/development/message-format.rst
+++ b/source/development/message-format.rst
@@ -175,11 +175,15 @@ So the ``<Padding>`` object is a string of 1 to 8 ``!`` symbols, so that the arr
 Encrypted data
 ++++++++++++++
 
-The padded data is encrypted using Blowfish::
+The padded data is encrypted using AES::
 
-    <Encrypted> = Blowfish(<Padding> <Block>)
+    <Encrypted> = AES(<Padding> <Block>)
 
 The initialization vector and the encryption key are described in `Encryption system`_.
+
+.. note::
+
+    The default encryption method is AES, although Blowfish is available as an alternative encryption method.
 
 Payload
 +++++++


### PR DESCRIPTION
Hello team!

This PR closes #1123 
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numerated branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

I have fixed a sentence that used the non-default encryption method and I have added a note to clarify that Blowfish method is available apart from AES.

![encyption](https://user-images.githubusercontent.com/60152567/76442687-9651c280-63c1-11ea-8f5b-762adbec6675.png)

<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 

Regards,

David
