### PR TITLE
Removed wrong instructions about Wazuh's agent installation on Solaris 10

### DIFF
--- a/source/installation-guide/installing-wazuh-agent/solaris/solaris10/wazuh_agent_package_solaris10.rst
+++ b/source/installation-guide/installing-wazuh-agent/solaris/solaris10/wazuh_agent_package_solaris10.rst
@@ -18,18 +18,6 @@ You can download the `Solaris10 installer (Intel architecture) <https://packages
 
       # pkgadd -d wazuh-agent_v|WAZUH_LATEST|-sol10-sparc.pkg
 
-After creating the repository install the package:
-
-    .. code-block:: console
-
-        # pkg install --accept wazuh-agent
-
-Finally, remove the publisher:
-
-    .. code-block:: console
-
-        # pkg unset-publisher wazuh
-
 Now that the agent is installed, the next step is to register and configure it to communicate with the manager. For more information about this process, please visit the document: :ref:`user manual<register_agents>`.
 
 Uninstall


### PR DESCRIPTION
Hello team!
This PR closes #1830 
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numerated branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description
In the Wazuh's agent installation section for Solaris 10 were some instructions that didn't belong to there so I removed them:

![image](https://user-images.githubusercontent.com/60152567/76621091-e5693600-652e-11ea-9225-acba95c9a6a9.png)

<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 

Regards,

David