### PR TITLE
Improved command's option allowed values explanation

### DIFF
--- a/source/user-manual/reference/ossec-conf/wodle-command.rst
+++ b/source/user-manual/reference/ossec-conf/wodle-command.rst
@@ -84,11 +84,13 @@ command
 
 Path and arguments of the command to be executed.
 
-+--------------------+-----------------------------+
-| **Default value**  | N/A                         |
-+--------------------+-----------------------------+
-| **Allowed values** | An existing command         |
-+--------------------+-----------------------------+
++--------------------+-----------------------+
+| **Default value**  | N/A                   |
++--------------------+-----------------------+
+| **Allowed values** | - An existing command |
+|                    | - Path to a binary    |
+|                    | - Path to a script    |
++--------------------+-----------------------+
 
 interval
 ^^^^^^^^
@@ -143,7 +145,7 @@ verify_md5
 
 .. versionadded:: 3.6.0
 
-Verify the binary MD5 sum.
+Verify the MD5 sum of the binary or the script specified on the command option.
 
 +--------------------+--------------+
 | **Default value**  | n/a          |
@@ -157,7 +159,7 @@ verify_sha1
 
 .. versionadded:: 3.6.0
 
-Verify the binary SHA1 sum.
+Verify the SHA1 sum of the binary or the script specified on the command option.
 
 +--------------------+---------------+
 | **Default value**  | n/a           |
@@ -171,7 +173,7 @@ verify_sha256
 
 .. versionadded:: 3.6.0
 
-Verify the binary SHA256 sum.
+Verify the SHA256 sum of the binary or the script specified on the command option.
 
 +--------------------+-----------------+
 | **Default value**  | n/a             |


### PR DESCRIPTION
Hello team!

This PR closes #1152
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numerated branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description
I have clarified that in `command` can be specified apart from an existing command, a path to a binary or a script: 

![command](https://user-images.githubusercontent.com/60152567/76642774-258edf80-6554-11ea-869b-ccf800fdaf7b.png)


<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 

Regards,

David