### PR TITLE
[3.11] Rule ID change

### DIFF
--- a/source/learning-wazuh/rdp-brute-force.rst
+++ b/source/learning-wazuh/rdp-brute-force.rst
@@ -57,7 +57,7 @@ Other things that could additionally or alternatively take place might be:
 
 1. An email, Slack, or PagerDuty message could be generated about this alert.
 
-2. A high severity local rule of your own making, child of rule 18152, could fire if the attacked account name specifically matches your secret Windows admin account name.
+2. A high severity local rule of your own making, child of rule 60204, could fire if the attacked account name specifically matches your secret Windows admin account name.
 
 3. An active response could be triggered causing windows-agent to null-route the attacking IP address.
 


### PR DESCRIPTION
Rule ID was in Event Log but the picture was in Event Channel. 

The explanation could lead to confusion, as it used the rule ID for Event Log, which was previously the standard. Now it is recommended to use Event Channel over Event Log.

The picture showed rule `60204`  while the explanation showed rule `18152`. The explanation was changed to match `60204`.

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numerated branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description


<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

## Checks
- [ ] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
