### PR TITLE
Delete cached redirects from browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ source/_static/css/wazuh-icons.min.css
 source/_static/js/style.min.js
 source/_static/js/version-selector.min.js
 source/_static/js/redirects.min.js
+source/_static/js/delete-cache.min.js

--- a/source/_static/js/delete-cache.js
+++ b/source/_static/js/delete-cache.js
@@ -4,6 +4,5 @@
   const fetch_url = parts[0] + '//' + parts[2] + '/current/' + parts.slice(4).join('/');
   fetch(fetch_url, {cache: "no-cache"})
     .then(response => {
-      console.log("Fixed redirect for " + fetch_url);
-      console.log("It now redirects to " +  response.url);
+      /* Fixed redirects, do nothing */
     });

--- a/source/_static/js/delete-cache.js
+++ b/source/_static/js/delete-cache.js
@@ -1,0 +1,9 @@
+  /* Delete old cached redirects from /current */
+  const current_url = window.location.href;
+  const parts = current_url.split('/');
+  const fetch_url = parts[0] + '//' + parts[2] + '/current/' + parts.slice(4).join('/');
+  fetch(fetch_url, {cache: "no-cache"})
+    .then(response => {
+      console.log("Fixed redirect for " + fetch_url);
+      console.log("It now redirects to " +  response.url);
+    });

--- a/source/conf.py
+++ b/source/conf.py
@@ -351,7 +351,8 @@ def minification(actual_path):
         ['css/wazuh-icons','css'],
         ['js/version-selector','js'],
         ['js/redirects','js'],
-        ['js/style','js']
+        ['js/style','js'],
+        ['js/delete-cache','js']
     ]
 
     for file in files:
@@ -439,6 +440,8 @@ def setup(app):
         os.path.join(actual_path, "_static/js/style.js")).st_mtime)
     app.add_javascript("js/redirects.min.js?ver=%s" % os.stat(
         os.path.join(actual_path, "_static/js/redirects.js")).st_mtime)
+    app.add_javascript("js/delete-cache.min.js?ver=%s" % os.stat(
+        os.path.join(actual_path, "_static/js/delete-cache.js")).st_mtime)
     app.add_config_value('custom_replacements', {}, True)
     app.connect('source-read', customReplacements)
 
@@ -447,6 +450,7 @@ exclude_patterns = [
     "css/style.css",
     "js/version-selector.js",
     "js/redirects.js",
+    "js/delete-cache.js",
     "js/style.js"
 ]
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -291,3 +291,13 @@ Wazuh is a free and open source platform for threat detection, security monitori
 .. raw:: html
 
    </div>
+
+  <script>
+  // Delete old cached redirects from /current
+  fetch('https://documentation-dev.wazuh.com/current', {cache: "no-cache"})
+  .then(response => {
+    if(response.url != 'https://documentation-dev.wazuh.com/3.11/') {
+      console.log("Cached redirections deleted");
+    }
+  });
+  </script>

--- a/source/index.rst
+++ b/source/index.rst
@@ -294,9 +294,9 @@ Wazuh is a free and open source platform for threat detection, security monitori
 
   <script>
   // Delete old cached redirects from /current
-  fetch('https://documentation-dev.wazuh.com/current', {cache: "no-cache"})
+  fetch('https://documentation-dev.wazuh.com/current/index.html', {cache: "no-cache"})
   .then(response => {
-    if(response.url != 'https://documentation-dev.wazuh.com/3.11/') {
+    if(response.url != 'https://documentation-dev.wazuh.com/3.11/index.html') {
       console.log("Cached redirections deleted");
     }
   });

--- a/source/index.rst
+++ b/source/index.rst
@@ -291,13 +291,3 @@ Wazuh is a free and open source platform for threat detection, security monitori
 .. raw:: html
 
    </div>
-
-  <script>
-  // Delete old cached redirects from /current
-  fetch('https://documentation-dev.wazuh.com/current/index.html', {cache: "no-cache"})
-  .then(response => {
-    if(response.url != 'https://documentation-dev.wazuh.com/3.11/index.html') {
-      console.log("Cached redirections deleted");
-    }
-  });
-  </script>


### PR DESCRIPTION
## Description

Browsers cache 301 redirections, so it's nearly impossible to undo one once a user has visited the page and received a 301 response. To update the cache with the new redirection code, we need to send an HTTP request with the `Cache-Control` header set to `no-cache`.

This fix sends an AJAX request using this HTTP header to the `current` branch every time the user lands in a page. This way, its browser will refresh the redirection established for this branch.

For example, given the following redirection structure:

`current -- 301 --> 3.11`

When a user visits the `current` branch, its browser will store a redirect to `3.11`. Then, when a new release is published (as in `3.12` branch) if we change the redirections to:

`current -- 301 --> 3.12`

It will only affect users who never visited `current` before. If the user's browser has cached the old redirection, visiting `current` the first time will result in displaying `3.11`. However, once the `3.11` page is loaded, this fix will send a `no-cache` AJAX request to `current`, updating the stored redirection. The **second** time the user tries to navigate to `current`, the `3.12` branch will be displayed.