### PR TITLE
Add code-block xml to fim synchronization configuration

### DIFF
--- a/source/user-manual/capabilities/file-integrity/fim-configuration.rst
+++ b/source/user-manual/capabilities/file-integrity/fim-configuration.rst
@@ -183,7 +183,7 @@ Configuring synchronization
 
 Synchronization can be configured to change the synchronization interval, the number of events per second, the queue size and the response timeout.
 
-::
+.. code-block:: xml
 
   <syscheck>
     <synchronization>


### PR DESCRIPTION
## Description

I hava added a missing `.. code-block:: xml` that made the synchronization configuration not appear with colors.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
