### PR TITLE
Removed spare service restart instructions

### DIFF
--- a/source/upgrade-guide/upgrading-elastic-stack/elastic_server_hard_upgrade.rst
+++ b/source/upgrade-guide/upgrading-elastic-stack/elastic_server_hard_upgrade.rst
@@ -77,7 +77,6 @@ Upgrade Elasticsearch
     .. code-block:: console
 
       # apt-get install elasticsearch=|ELASTIC_6_LATEST|
-      # systemctl restart elasticsearch
 
 5. Restart the service.
 

--- a/source/upgrade-guide/upgrading-elastic-stack/elastic_server_minor_upgrade.rst
+++ b/source/upgrade-guide/upgrading-elastic-stack/elastic_server_minor_upgrade.rst
@@ -76,7 +76,6 @@ Upgrade Elasticsearch
       .. code-block:: console
 
         # apt-get install elasticsearch=|ELASTICSEARCH_LATEST|
-        # systemctl restart elasticsearch
 
 #. Restart the service.
 

--- a/source/upgrade-guide/upgrading-elastic-stack/elastic_server_minor_upgrade.rst
+++ b/source/upgrade-guide/upgrading-elastic-stack/elastic_server_minor_upgrade.rst
@@ -167,11 +167,6 @@ Upgrade Kibana
 .. warning::
   Since Wazuh 3.12.0 release (regardless of the Elastic Stack version) the location of the wazuh.yml has been moved from /usr/share/kibana/plugins/wazuh/wazuh.yml to /usr/share/kibana/optimize/wazuh/config/wazuh.yml.
 
-#. Stop Kibana.
-
-    .. code-block:: console
-
-      # systemctl stop kibana
 
 #. Copy the wazuh.yml to its new location. (Only needed for upgrades from 3.11.x to 3.12.y).
 

--- a/source/upgrade-guide/upgrading-elastic-stack/elastic_server_rolling_upgrade.rst
+++ b/source/upgrade-guide/upgrading-elastic-stack/elastic_server_rolling_upgrade.rst
@@ -100,7 +100,6 @@ Upgrade Elasticsearch
       .. code-block:: console
 
         # apt-get install elasticsearch=|ELASTICSEARCH_LATEST|
-        # systemctl restart elasticsearch
 
 #. Starting with Elasticsearch 7.0, master nodes require a configuration setting with the list of the cluster master nodes. The following settings must be added in the configuration of the Elasticsearch master node (``elasticsearch.yml``).
 


### PR DESCRIPTION
Hello team!

This PR closes #2335 
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numerated branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

There was an incorrect placed instruction to restart the Elasticsearch service in the upgrade guide.
I've removed it. Besides, instructions to stop Kibana service was duplicated too. It has been removed too.

<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
