### PR TITLE
Rename and move all-in-one installation  to installation guide

### DIFF
--- a/source/getting-started/index.rst
+++ b/source/getting-started/index.rst
@@ -27,5 +27,4 @@ Our centralized components, the Wazuh server and Elastic Stack, have been design
    components
    architecture
    use-cases
-   all_in_one
    packages-list

--- a/source/getting-started/introduction.rst
+++ b/source/getting-started/introduction.rst
@@ -35,7 +35,7 @@ Installation types
 
 The Wazuh server and Elastic stack can be installed and operated in one of these five deployments:
 
-- All in one: the Wazuh server and Elastic Stack subsystems run on a single host.
+- All-in-one: the Wazuh server and Elastic Stack subsystems run on a single host.
 
 .. thumbnail:: ../images/installation/installing_wazuh_architecture_onehost.png
     :title: Installing Wazuh manager - single server architecture
@@ -127,9 +127,9 @@ The server usually runs on a stand-alone physical machine, virtual machine or cl
 
 + **RESTful API:** This provides an interface to manage and monitor the configuration and deployment status of agents. It is also used by the Wazuh web interface, which is a Kibana app.
 
-Jumpstart to Wazuh
-------------------
+All-in-One installation
+-----------------------
 
-The Jumpstart to Wazuh guide will focus in the first installation type: all the components in the same host. Follow `this document <all_in_one>`_ to start configuring the Jumpstart to Wazuh for non-production or small environments.
+The All-in-One installation guide will focus on the first installation type: all the components in the same host. Follow `this document <all_in_one>`_ to start configuring the All-in-One installation for non-production or small environments.
 
 

--- a/source/installation-guide/all_in_one.rst
+++ b/source/installation-guide/all_in_one.rst
@@ -4,8 +4,8 @@
 
 .. _all_in_one:
 
-Jumpstart to Wazuh
-==================
+All-in-One installation
+=======================
 This document guides through an installation of the Wazuh server and Elastic stack components in an all-in-one configuration.
 
 .. note:: Root user privileges are required to execute all the commands described below.

--- a/source/installation-guide/index.rst
+++ b/source/installation-guide/index.rst
@@ -8,7 +8,7 @@ Installation guide
 .. meta::
   :description: Find useful technical documentation about how Wazuh works, suitable for developers and tech enthusiasts.
 
-A Jumpstart to Wazuh guide is included in the :ref:`Getting started section<all_in_one>`, which aims to introduce Wazuh by installing it along with Elastic Stack on a single system (server). The jumpstart guide can be used for learning purposes or small production environments but it will not benefit from the high availability of a distributed environment.
+A All-in-One installation guide is included in the :ref:`Getting started section<all_in_one>`, which aims to introduce Wazuh by installing it along with Elastic Stack on a single system (server). The jumpstart guide can be used for learning purposes or small production environments but it will not benefit from the high availability of a distributed environment.
 
 This section however, will explain how to build a production environment with data and services high availability, scalability, etc. The introduction document will go through the basic concepts and architecture of a Wazuh production environment.
 
@@ -18,6 +18,7 @@ This section however, will explain how to build a production environment with da
         :maxdepth: 2
 
         introduction/index
+        all_in_one
         elasticsearch-cluster/index
         wazuh-cluster/index
         kibana/index

--- a/source/installation-guide/index.rst
+++ b/source/installation-guide/index.rst
@@ -8,7 +8,7 @@ Installation guide
 .. meta::
   :description: Find useful technical documentation about how Wazuh works, suitable for developers and tech enthusiasts.
 
-A All-in-One installation guide is included in the :ref:`Getting started section<all_in_one>`, which aims to introduce Wazuh by installing it along with Elastic Stack on a single system (server). The jumpstart guide can be used for learning purposes or small production environments but it will not benefit from the high availability of a distributed environment.
+An All-in-One installation guide is included in the :ref:`Getting started section<all_in_one>`, which aims to introduce Wazuh by installing it along with Elastic Stack on a single system (server). The jumpstart guide can be used for learning purposes or small production environments but it will not benefit from the high availability of a distributed environment.
 
 This section however, will explain how to build a production environment with data and services high availability, scalability, etc. The introduction document will go through the basic concepts and architecture of a Wazuh production environment.
 

--- a/source/installation-guide/index.rst
+++ b/source/installation-guide/index.rst
@@ -8,7 +8,7 @@ Installation guide
 .. meta::
   :description: Find useful technical documentation about how Wazuh works, suitable for developers and tech enthusiasts.
 
-An All-in-One installation guide is included in the :ref:`Getting started section<all_in_one>`, which aims to introduce Wazuh by installing it along with Elastic Stack on a single system (server). The jumpstart guide can be used for learning purposes or small production environments but it will not benefit from the high availability of a distributed environment.
+An All-in-One installation guide is included in the :ref:`Installation guide section<all_in_one>`, which aims to introduce Wazuh by installing it along with Elastic Stack on a single system (server). The jumpstart guide can be used for learning purposes or small production environments but it will not benefit from the high availability of a distributed environment.
 
 This section however, will explain how to build a production environment with data and services high availability, scalability, etc. The introduction document will go through the basic concepts and architecture of a Wazuh production environment.
 

--- a/source/installation-guide/introduction/index.rst
+++ b/source/installation-guide/introduction/index.rst
@@ -8,7 +8,7 @@ Introduction
 ============
 
 
-This section covers different options to set up Wazuh with Elastic Stack in a production environment. Although the :ref:`Jumpstart to Wazuh<all_in_one>` guide could be used in small production environments, it is not designed for high availability and scalable environments. This section is aimed to configure an environment with different levels of distribution and, in consequence, scalable environments with high availability.
+This section covers different options to set up Wazuh with Elastic Stack in a production environment. Although the :ref:`All-in-One installation<all_in_one>` guide could be used in small production environments, it is not designed for high availability and scalable environments. This section is aimed to configure an environment with different levels of distribution and, in consequence, scalable environments with high availability.
 
 
 Community


### PR DESCRIPTION
Hello team!

This PR closes #2343 
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numerated branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

I have moved the Jumpstart to Wazuh from the "Getting started" section to the "Installation guide". Besides I've changed the name "Jumpstart to Wazuh" to "All-in-One installation".

<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 

Regards,

David