### PR TITLE
Replaced Intel architecture by i386 architecture

### DIFF
--- a/source/installation-guide/installing-wazuh-agent/solaris/solaris10/wazuh_agent_package_solaris10.rst
+++ b/source/installation-guide/installing-wazuh-agent/solaris/solaris10/wazuh_agent_package_solaris10.rst
@@ -4,7 +4,7 @@
 
 Solaris 10 from package
 =======================
-You can download the `Solaris10 installer (Intel architecture) <https://packages.wazuh.com/3.x/solaris/i386/10/wazuh-agent_v|WAZUH_LATEST|-sol10-i386.pkg>`_ or `Solaris10 installer (SPARC architecture) <https://packages.wazuh.com/3.x/solaris/sparc/10/wazuh-agent_v|WAZUH_LATEST|-sol10-sparc.pkg>`_ from our from our :ref:`packages list<packages>`. The current version has been tested on Solaris 10 version 5.10. Install the agent as follows:
+You can download the `Solaris10 installer (i386 architecture) <https://packages.wazuh.com/3.x/solaris/i386/10/wazuh-agent_v|WAZUH_LATEST|-sol10-i386.pkg>`_ or `Solaris10 installer (SPARC architecture) <https://packages.wazuh.com/3.x/solaris/sparc/10/wazuh-agent_v|WAZUH_LATEST|-sol10-sparc.pkg>`_ from our from our :ref:`packages list<packages>`. The current version has been tested on Solaris 10 version 5.10. Install the agent as follows:
 
   a) For Solaris 10 i386:
 

--- a/source/installation-guide/installing-wazuh-agent/solaris/solaris11/wazuh_agent_package_solaris11.rst
+++ b/source/installation-guide/installing-wazuh-agent/solaris/solaris11/wazuh_agent_package_solaris11.rst
@@ -5,7 +5,7 @@
 Solaris 11 from package
 =======================
 
-You can download the `Solaris11 installer (Intel architecture) <https://packages.wazuh.com/3.x/solaris/i386/11/wazuh-agent_v|WAZUH_LATEST|-sol11-i386.p5p>`_ or `Solaris11 installer (SPARC architecture) <https://packages.wazuh.com/3.x/solaris/sparc/11/wazuh-agent_v|WAZUH_LATEST|-sol11-sparc.p5p>`_ from our :ref:`packages list<packages>`. The current version has been tested on Solaris 11 version 5.11. Install the agent as follows:
+You can download the `Solaris11 installer (i386 architecture) <https://packages.wazuh.com/3.x/solaris/i386/11/wazuh-agent_v|WAZUH_LATEST|-sol11-i386.p5p>`_ or `Solaris11 installer (SPARC architecture) <https://packages.wazuh.com/3.x/solaris/sparc/11/wazuh-agent_v|WAZUH_LATEST|-sol11-sparc.p5p>`_ from our :ref:`packages list<packages>`. The current version has been tested on Solaris 11 version 5.11. Install the agent as follows:
 
   a) For Solaris 11 i386:
 


### PR DESCRIPTION
Hello team!

This PR closes #2373 

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numerated branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

I have replaced `Intel architecture` by `i386 architecture` in Solaris' installation guide.

<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 

Regards,

David