### PR TITLE
[3.12] Removed duplicated '#' as comment within a heredoc

### DIFF
--- a/source/learning-wazuh/build-lab/xpack-security-setup.rst
+++ b/source/learning-wazuh/build-lab/xpack-security-setup.rst
@@ -75,18 +75,18 @@ Configure SSL in Elasticsearch
 
     [root@elastic-server ~]# cat >> /etc/elasticsearch/elasticsearch.yml << EOF
 
-    ## Unbind to a specific IP:
+    # Unbind to a specific IP:
     network.host: 0.0.0.0
     discovery.seed_hosts: ["172.30.0.20"]
 
-    ## Transport layer
+    # Transport layer
     xpack.security.transport.ssl.enabled: true
     xpack.security.transport.ssl.verification_mode: certificate
     xpack.security.transport.ssl.key: /etc/elasticsearch/certs/elasticsearch.key
     xpack.security.transport.ssl.certificate: /etc/elasticsearch/certs/elasticsearch.crt
     xpack.security.transport.ssl.certificate_authorities: [ "/etc/elasticsearch/certs/ca/ca.crt" ]
 
-    ## HTTP layer
+    # HTTP layer
     xpack.security.http.ssl.enabled: true
     xpack.security.http.ssl.verification_mode: certificate
     xpack.security.http.ssl.key: /etc/elasticsearch/certs/elasticsearch.key
@@ -121,13 +121,13 @@ Configure SSL in Kibana
 
     [root@elastic-server ~]# cat >> /etc/kibana/kibana.yml << EOF
 
-    ## Elasticsearch from/to Kibana
+    # Elasticsearch from/to Kibana
     elasticsearch.hosts: ["https://172.30.0.20:9200"]
     elasticsearch.ssl.certificateAuthorities: ["/etc/kibana/certs/ca/ca.crt"]
     elasticsearch.ssl.certificate: "/etc/kibana/certs/kibana.crt"
     elasticsearch.ssl.key: "/etc/kibana/certs/kibana.key"
 
-    ## Browser from/to Kibana
+    # Browser from/to Kibana
     server.ssl.enabled: true
     server.ssl.certificate: "/etc/kibana/certs/kibana.crt"
     server.ssl.key: "/etc/kibana/certs/kibana.key"


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numerated branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

Recently, we have solved a problem with commented lines within a heredoc in code-blocks. However, the code-blocks in which this problem was detected still have the partial solution we implemented, presenting duplicated `#` to indicate the commented line.
This PR modifies the commented lines so they use a single `#` symbol.

Related issue: https://github.com/wazuh/wazuh-website/issues/1266

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
