### PR TITLE
Fixing information to configure local NVD feed

### DIFF
--- a/source/user-manual/capabilities/vulnerability-detection/offline_update.rst
+++ b/source/user-manual/capabilities/vulnerability-detection/offline_update.rst
@@ -177,13 +177,13 @@ It is possible that the script will output error messages like the following:
 
 This indicates that the National Vulnerability Database servers may be temporarily unavailable to you. The script will continue trying to finish the download until it acquires the full feed.
 
-Finally, you will have the feed divided into a succession of numbered files whose name follows format ``nvd-feed<number>.json.gz``. To update locally, the path to those files must be indicated by a regular expression as such:
+Finally, you will have the feed divided into a succession of numbered files whose name follows format ``nvd-feed<number>.json.gz``. Those files are compressed and should be extracted. To update locally, the path to those files must be indicated by a regular expression as such:
 
 .. code-block:: xml
 
     <provider name="nvd">
         <enabled>no</enabled>
-        <path>/local_path/nvd-feed.*json.gz$</path>
+        <path>/local_path/nvd-feed.*json$</path>
         <update_interval>1h</update_interval>
     </provider>
 


### PR DESCRIPTION
This PR introduces some changes to fix [4850](https://github.com/wazuh/wazuh/issues/4850).

Basically the documentation explained the offline NVD feed update by using compressed files. This is not supported and the files should be extracted before configuring the offline update.