### PR TITLE
[3.12] Fixed the code that excludes the release notes from the search results

### DIFF
--- a/source/_static/js/style.js
+++ b/source/_static/js/style.js
@@ -573,7 +573,7 @@ $(function() {
 
     /* Detects every result that is added to the list */
     const addedResult = function(mutationsList, observer) {
-      for (i = 0; i < mutationsList.length - 1; i++) {
+      for (i = 0; i < mutationsList.length; i++) {
         if (mutationsList[i].type === 'childList') {
           lastResult = $('ul.search li:last-child');
           splitURL = lastResult.children('a').prop('href').split('/');
@@ -591,7 +591,7 @@ $(function() {
 
     /* Checking that the list of search results exists */
     const existsResultList = function(mutationsList, observer) {
-      for (i = 0; i < mutationsList.length - 1; i++) {
+      for (i = 0; i < mutationsList.length; i++) {
         if (mutationsList[i].type === 'childList' && $(mutationsList[i].addedNodes[0]).hasClass('search')) {
           const ulSearch = $('ul.search');
 
@@ -607,7 +607,7 @@ $(function() {
 
     /* Replaces the result message */
     const changeResultText = function(mutationsList, observer) {
-      for (i = 0; i < mutationsList.length - 1; i++) {
+      for (i = 0; i < mutationsList.length; i++) {
         if (mutationsList[i].type === 'attributes') {
           observerResultText.disconnect();
           const totalResults = $('ul.search li').length;


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the enumerated branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

This PR fixes a small bug that was preventing the correct execution of the code that hides the release notes from the search results when the result page loads.

Before:
![imagen](https://user-images.githubusercontent.com/13232723/79745817-3f68d280-8309-11ea-927d-a0024a80da08.png)

After:
![imagen](https://user-images.githubusercontent.com/13232723/79746008-92db2080-8309-11ea-9502-d002ce01117e.png)

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 

Related issue: https://github.com/wazuh/wazuh-website/issues/1282
