### PR TITLE
Update IIS location

### DIFF
--- a/source/user-manual/capabilities/log-data-collection/log-data-configuration.rst
+++ b/source/user-manual/capabilities/log-data-collection/log-data-configuration.rst
@@ -58,7 +58,7 @@ Environment variables like ``%WinDir%`` can be used in the location pattern. The
 .. code-block:: xml
 
     <localfile>
-        <location>%WinDir%\System32\LogFiles\W3SVC3\ex%y%m%d.log</location>
+        <location>%SystemDrive%\inetpub\logs\LogFiles\W3SVC1\u_ex%y%m%d.log</location>
         <log_format>iis</log_format>
     </localfile>
 

--- a/source/user-manual/reference/ossec-conf/localfile.rst
+++ b/source/user-manual/reference/ossec-conf/localfile.rst
@@ -278,7 +278,7 @@ Set the format of the log to be read. **field is required**
 |                    | nmapg              | Used for monitoring files conforming to the grep-able output from ``nmap``.                      |
 +                    +--------------------+--------------------------------------------------------------------------------------------------
 +
-|                    | iis              | Used for ``iis`` (Windows Web Server) logs.                      
+|                    | iis              | Used for ``iis`` (Windows Web Server) logs.                                   |
 +                    +--------------------+--------------------------------------------------------------------------------------------------+
 |                    | command            | Used to read the output from the command (as run by root) specified by the command tag.          |
 |                    |                    |                                                                                                  |

--- a/source/user-manual/reference/ossec-conf/localfile.rst
+++ b/source/user-manual/reference/ossec-conf/localfile.rst
@@ -276,6 +276,9 @@ Set the format of the log to be read. **field is required**
 |                    | postgresql_log     | Used for ``PostgreSQL`` logs, however, this value does not support multi-line logs.              |
 +                    +--------------------+--------------------------------------------------------------------------------------------------+
 |                    | nmapg              | Used for monitoring files conforming to the grep-able output from ``nmap``.                      |
++                    +--------------------+--------------------------------------------------------------------------------------------------
++
+|                    | iis              | Used for ``iis`` (Windows Web Server) logs.                      
 +                    +--------------------+--------------------------------------------------------------------------------------------------+
 |                    | command            | Used to read the output from the command (as run by root) specified by the command tag.          |
 |                    |                    |                                                                                                  |

--- a/source/user-manual/reference/ossec-conf/localfile.rst
+++ b/source/user-manual/reference/ossec-conf/localfile.rst
@@ -276,9 +276,8 @@ Set the format of the log to be read. **field is required**
 |                    | postgresql_log     | Used for ``PostgreSQL`` logs, however, this value does not support multi-line logs.              |
 +                    +--------------------+--------------------------------------------------------------------------------------------------+
 |                    | nmapg              | Used for monitoring files conforming to the grep-able output from ``nmap``.                      |
-+                    +--------------------+--------------------------------------------------------------------------------------------------
-+
-|                    | iis              | Used for ``iis`` (Windows Web Server) logs.                                   |
++                    +--------------------+--------------------------------------------------------------------------------------------------+
+|                    | iis                | Used for ``iis`` (Windows Web Server) logs.                                                      |
 +                    +--------------------+--------------------------------------------------------------------------------------------------+
 |                    | command            | Used to read the output from the command (as run by root) specified by the command tag.          |
 |                    |                    |                                                                                                  |


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
Hello Team!

This PR aims to update the ISS location as they are now by default stored under `C:\inetpub\logs\LogFiles\W3SVC1` .

It worth mentioning, that the `log_format: iis` needs to be included here https://documentation.wazuh.com/3.12/user-manual/reference/ossec-conf/localfile.html#log-format.

Regards,
Wali
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

## Checks
- [ ] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
