### PR TITLE
Clarify how to apply Canonical feeds to Vulnerability Detector

### DIFF
--- a/source/user-manual/capabilities/vulnerability-detection/offline_update.rst
+++ b/source/user-manual/capabilities/vulnerability-detection/offline_update.rst
@@ -28,7 +28,7 @@ To perform an offline update of the Canonical feeds, you must download the corre
 | Trusty     | `<https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.trusty.cve.oval.xml.bz2>`_     |
 +------------+------------------------------------------------------------------------------------------------+
 
-In order to update the vulnerability feeds from an alternative repository, the configuration is similar to the following:
+To fetch the vulnerability feeds from an alternative repository, the configuration is similar to the following:
 
 .. code-block:: xml
 
@@ -43,7 +43,7 @@ In order to update the vulnerability feeds from an alternative repository, the c
 .. note::
     Since March 2020, Canonical stores its feeds compressed in the ``bunzip2`` format. Therefore, the Vulnerability Detector expects the feed in that format when downloaded from a remote repository. On the other hand, when the feeds are loaded from a local path, they must be uncompressed.
 
-In order to use a local feed file, use the ``path`` attribute accompanying the ``os`` option as follows:
+Alternatively, the feeds can be loaded from a local path. To achieve it, the ``path`` attribute is available as this example shows:
 
 .. code-block:: xml
 

--- a/source/user-manual/capabilities/vulnerability-detection/offline_update.rst
+++ b/source/user-manual/capabilities/vulnerability-detection/offline_update.rst
@@ -16,17 +16,32 @@ If the manager does not have a direct connection to the Internet, it is possible
 Canonical
 ^^^^^^^^^
 
-To perform an offline update of Canonical feeds, you must download the corresponding OVAL files:
+To perform an offline update of the Canonical feeds, you must download the corresponding OVAL files:
 
-+------------+--------------------------------------------------------------------------------------------+
-| OS         | Link                                                                                       |
-+============+============================================================================================+
-| Bionic     | `<https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.bionic.cve.oval.xml>`_     |
-+------------+--------------------------------------------------------------------------------------------+
-| Xenial     | `<https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.xenial.cve.oval.xml>`_     |
-+------------+--------------------------------------------------------------------------------------------+
-| Trusty     | `<https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.trusty.cve.oval.xml>`_     |
-+------------+--------------------------------------------------------------------------------------------+
++------------+------------------------------------------------------------------------------------------------+
+| OS         | Link                                                                                           |
++============+================================================================================================+
+| Bionic     | `<https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.bionic.cve.oval.xml.bz2>`_     |
++------------+------------------------------------------------------------------------------------------------+
+| Xenial     | `<https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.xenial.cve.oval.xml.bz2>`_     |
++------------+------------------------------------------------------------------------------------------------+
+| Trusty     | `<https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.trusty.cve.oval.xml.bz2>`_     |
++------------+------------------------------------------------------------------------------------------------+
+
+In order to update the vulnerability feeds from an alternative repository, the configuration is similar to the following:
+
+.. code-block:: xml
+
+    <provider name="canonical">
+        <enabled>no</enabled>
+        <os url="http://local_repo/com.ubuntu.bionic.cve.oval.xml.bz2">bionic</os>
+        <os url="http://local_repo/com.ubuntu.xenial.cve.oval.xml.bz2">xenial</os>
+        <os url="http://local_repo/com.ubuntu.trusty.cve.oval.xml.bz2">trusty</os>
+        <update_interval>1h</update_interval>
+    </provider>
+
+.. note::
+    Since March 2020, Canonical stores its feeds compressed in the ``bunzip2`` format. Therefore, the Vulnerability Detector expects the feed in that format when downloaded from a remote repository. On the other hand, when the feeds are loaded from a local path, they must be uncompressed.
 
 In order to use a local feed file, use the ``path`` attribute accompanying the ``os`` option as follows:
 
@@ -37,18 +52,6 @@ In order to use a local feed file, use the ``path`` attribute accompanying the `
         <os path="/local_path/com.ubuntu.bionic.cve.oval.xml">bionic</os>
         <os path="/local_path/com.ubuntu.xenial.cve.oval.xml">xenial</os>
         <os path="/local_path/com.ubuntu.trusty.cve.oval.xml">trusty</os>
-        <update_interval>1h</update_interval>
-    </provider>
-
-In order to update the vulnerability feeds from an alternative repository, the configuration is similar to the following:
-
-.. code-block:: xml
-
-    <provider name="canonical">
-        <enabled>no</enabled>
-        <os url="http://local_repo/com.ubuntu.bionic.cve.oval.xml">bionic</os>
-        <os url="http://local_repo/com.ubuntu.xenial.cve.oval.xml">xenial</os>
-        <os url="http://local_repo/com.ubuntu.trusty.cve.oval.xml">trusty</os>
         <update_interval>1h</update_interval>
     </provider>
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

Hi team,

This PR fixes the explanation about how to update the Canonical feeds for Vulnerability Detector offline since Canonical decided to compress the feeds located at its security repository.

Since the changes made at https://github.com/wazuh/wazuh/pull/4834, the Vulnerability Detector expects that the Canonical feeds are compressed in `bunzip2`.

It also fixes the links to download the feeds compressed.

Best regards.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
