### PR TITLE
Clarify the command expect option

### DIFF
--- a/source/user-manual/reference/ossec-conf/commands.rst
+++ b/source/user-manual/reference/ossec-conf/commands.rst
@@ -54,7 +54,7 @@ These files are located in ``/var/ossec/active-response/bin`` directory in Linux
 expect
 ^^^^^^
 
-Specifies the lists of extracted fields that are to be passed as parameters to the command. If any of the listed fields were not extracted in a certain instance, those field values would be passed as a dash (``-``) instead of as no value at all.
+Specifies the lists of extracted fields that are to be passed as parameters to the command. If any of the listed fields were not declared in a certain instance, those field values would be passed as a dash (``-``) instead of as no value at all. The command requires finding the expected fields in the alert, otherwise, the AR will be skipped.
 
 A good example is the firewall-block command which expects the ``srcip`` field in order to knows which IP address to block.  Multiple expected field names are comma separated.
 


### PR DESCRIPTION
An AR will be skipped if the current alert misses any of the fields declared in `<expect>`.

## Checks
- [ ] It compiles without warnings.
- [X] Spelling and grammar. 
- [X] Used impersonal speech. 
- [X] Used uppercase only on nouns. 
