### PR TITLE
Deploying a Wazuh cluster - "agent_control -l" command explanation improvement.

### DIFF
--- a/source/user-manual/configuring-cluster/index.rst
+++ b/source/user-manual/configuring-cluster/index.rst
@@ -186,7 +186,7 @@ Deploying a Wazuh cluster
             # systemctl restart wazuh-agent
 
 
-    Let's execute the following command (works on both, worker and master nodes) to check that the agents are correctly connected:
+    Execute the following command on the ``master node`` to verify that the Wazuh agents are correctly connected:
 
         .. code-block:: console
 


### PR DESCRIPTION
Hello Team,
this PR closes #2377  


## Description
Changes in **User manual** - **Deploying a Wazuh cluster** section.

The file contains a correct explanation of the command:
`# /var/ossec/bin/agent_control -l`

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 

All the best,
Daria