### PR TITLE
Fix wrong configurations in Vulnerability Detector offline update documentation (3.12)

### DIFF
--- a/source/user-manual/capabilities/vulnerability-detection/offline_update.rst
+++ b/source/user-manual/capabilities/vulnerability-detection/offline_update.rst
@@ -33,7 +33,7 @@ To fetch the vulnerability feeds from an alternative repository, the configurati
 .. code-block:: xml
 
     <provider name="canonical">
-        <enabled>no</enabled>
+        <enabled>yes</enabled>
         <os url="http://local_repo/com.ubuntu.bionic.cve.oval.xml.bz2">bionic</os>
         <os url="http://local_repo/com.ubuntu.xenial.cve.oval.xml.bz2">xenial</os>
         <os url="http://local_repo/com.ubuntu.trusty.cve.oval.xml.bz2">trusty</os>
@@ -48,7 +48,7 @@ Alternatively, the feeds can be loaded from a local path. To achieve it, the ``p
 .. code-block:: xml
 
     <provider name="canonical">
-        <enabled>no</enabled>
+        <enabled>yes</enabled>
         <os path="/local_path/com.ubuntu.bionic.cve.oval.xml">bionic</os>
         <os path="/local_path/com.ubuntu.xenial.cve.oval.xml">xenial</os>
         <os path="/local_path/com.ubuntu.trusty.cve.oval.xml">trusty</os>
@@ -75,7 +75,7 @@ In order to use a local feed file, just use the ``path`` attribute accompanying 
 .. code-block:: xml
 
     <provider name="debian">
-        <enabled>no</enabled>
+        <enabled>yes</enabled>
         <os path="/local_path/oval-definitions-stretch.xml">stretch</os>
         <os path="/local_path/oval-definitions-jessie.xml">jessie</os>
         <os path="/local_path/oval-definitions-wheezy.xml">wheezy</os>
@@ -87,7 +87,7 @@ In order to update the vulnerability feeds from an alternative repository, the c
 .. code-block:: xml
 
     <provider name="debian">
-        <enabled>no</enabled>
+        <enabled>yes</enabled>
         <os url="http://local_repo/oval-definitions-stretch.xml">stretch</os>
         <os url="http://local_repo/oval-definitions-jessie.xml">jessie</os>
         <os url="http://local_repo/oval-definitions-wheezy.xml">wheezy</os>
@@ -130,7 +130,7 @@ Finally, you will have the feed divided into a succession of numbered files whos
 .. code-block:: xml
 
     <provider name="redhat">
-        <enabled>no</enabled>
+        <enabled>yes</enabled>
         <path>/local_path/rh-feed/redhat-feed.*json$</path>
         <update_interval>1h</update_interval>
     </provider>
@@ -140,7 +140,7 @@ If you want to upload these files to a local server, they must follow the same n
 .. code-block:: xml
 
     <provider name="redhat">
-        <enabled>no</enabled>
+        <enabled>yes</enabled>
         <url start="1" end="15">http://local_repo/rh-feed/redhat-feed[-].json</url>
         <update_interval>1h</update_interval>
     </provider>
@@ -181,7 +181,7 @@ Finally, you will have the feed divided into a succession of numbered files whos
 .. code-block:: xml
 
     <provider name="nvd">
-        <enabled>no</enabled>
+        <enabled>yes</enabled>
         <path>/local_path/nvd-feed.*json$</path>
         <update_interval>1h</update_interval>
     </provider>
@@ -192,7 +192,7 @@ If you want to upload these files to a local server, they must follow the same n
 .. code-block:: xml
 
     <provider name="nvd">
-        <enabled>no</enabled>
+        <enabled>yes</enabled>
         <url start="2015" end="2019">http://local_repo/nvd-feed[-].json.gz</url>
         <update_interval>1h</update_interval>
     </provider>


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description
There is something wrong in the configurations shown on this page: https://documentation.wazuh.com/3.12/user-manual/capabilities/vulnerability-detection/offline_update.html.

The option `enabled` should be `yes` to enable a provider, otherwise it will be disabled and vulnerability detector will not work properly.

Same PR for 3.11: https://github.com/wazuh/wazuh-documentation/pull/2439.

Regards,
Sergio.
<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

## Checks
- [ ] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

## Note to the reviewer

This PR includes changes to the `redirect.js` script that need to be included in all production branches.
