### PR TITLE
Update API installation guide for 4.0

### DIFF
--- a/source/installation-guide/installing-wazuh-manager/linux/amazon/wazuh_server_packages_amazon.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/amazon/wazuh_server_packages_amazon.rst
@@ -71,7 +71,7 @@ You can check the API service status with:
       # service wazuh-api status
 
 .. note::
-    Check out the section :ref:`securing_api` to set up some additional settings.
+    Check out the section :doc:`RESTful API <../../../../user-manual/api/index>` for more information on how to set up and use Wazuh API.
 
 **Optional:** Disable the Wazuh repository.
 

--- a/source/installation-guide/installing-wazuh-manager/linux/amazon/wazuh_server_packages_amazon.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/amazon/wazuh_server_packages_amazon.rst
@@ -52,28 +52,11 @@ Once the process is complete, you can check the service status with:
 
         # service wazuh-manager status
 
-Installing the Wazuh API
-------------------------
+.. versionadded:: 4.0.0
 
-1. NodeJS >= 4.6.1 is required in order to run the Wazuh API. If you do not have NodeJS installed or your version is older than 4.6.1, we recommend that you add the official NodeJS repository like this:
+The Wazuh API will be installed along the Wazuh manager. You do not need any extra requirement for this.
 
-  .. code-block:: console
-
-    # curl --silent --location https://rpm.nodesource.com/setup_10.x | bash -
-
-  and then, install NodeJS:
-
-  .. code-block:: console
-
-    # yum install nodejs
-
-2. Install the Wazuh API. It will update NodeJS if it is required:
-
-  .. code-block:: console
-
-    # yum install wazuh-api
-
-3. Once the process is complete, you can check the service status with:
+You can check the API service status with:
 
   * For Systemd:
 
@@ -88,9 +71,9 @@ Installing the Wazuh API
       # service wazuh-api status
 
 .. note::
-    Now that the Wazuh API is installed, check out the section :ref:`securing_api` to set up some additional settings.
+    Check out the section :ref:`securing_api` to set up some additional settings.
 
-4. (Optional) Disable the Wazuh repository:
+**Optional:** Disable the Wazuh updates:
 
   It is recommended that the Wazuh repository be disabled in order to prevent accidental upgrades. To do this, use the following command:
 

--- a/source/installation-guide/installing-wazuh-manager/linux/amazon/wazuh_server_packages_amazon.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/amazon/wazuh_server_packages_amazon.rst
@@ -73,9 +73,9 @@ You can check the API service status with:
 .. note::
     Check out the section :ref:`securing_api` to set up some additional settings.
 
-**Optional:** Disable the Wazuh updates:
+**Optional:** Disable the Wazuh repository.
 
-  It is recommended that the Wazuh repository be disabled in order to prevent accidental upgrades. To do this, use the following command:
+  It is recommended to disable the Wazuh repository in order to prevent accidental upgrades. To do this, use the following command:
 
   .. code-block:: console
 

--- a/source/installation-guide/installing-wazuh-manager/linux/amazon/wazuh_server_sources_amazon.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/amazon/wazuh_server_sources_amazon.rst
@@ -112,7 +112,7 @@ You can check the API service status with:
 
       # service wazuh-api status
 
-.. note:: Check out the section :ref:`securing_api` to set up some additional settings.
+.. note:: Check out the section :doc:`RESTful API <../../../../user-manual/api/index>` for more information on how to set up and use Wazuh API.
 
 Installing Filebeat
 -------------------

--- a/source/installation-guide/installing-wazuh-manager/linux/amazon/wazuh_server_sources_amazon.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/amazon/wazuh_server_sources_amazon.rst
@@ -92,24 +92,11 @@ Installing Wazuh manager
 
       # service wazuh-manager status
 
-Installing Wazuh API
---------------------
+.. versionadded:: 4.0.0
 
-1. NodeJS >= 4.6.1 is required in order to run the Wazuh API. If you do not have NodeJS installed or your version is older than 4.6.1, we recommend you add the official repository as this has more recent versions.
+The Wazuh API will be installed along the Wazuh manager. You do not need any extra requirement for this.
 
-    .. code-block:: console
-
-      # curl --silent --location https://rpm.nodesource.com/setup_10.x | bash -
-      # yum -y install nodejs
-      # npm config set user 0
-
-2. Download and execute the installation script:
-
-  .. code-block:: console
-
-      # curl -s -o install_api.sh https://raw.githubusercontent.com/wazuh/wazuh-api/v|WAZUH_LATEST|/install_api.sh && bash ./install_api.sh download
-
-3. Once the process is complete, you can check the service status with:
+You can check the API service status with:
 
   * For Systemd:
 

--- a/source/installation-guide/installing-wazuh-manager/linux/amazon/wazuh_server_sources_amazon.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/amazon/wazuh_server_sources_amazon.rst
@@ -92,6 +92,8 @@ Installing Wazuh manager
 
       # service wazuh-manager status
 
+.. note:: You can also run an :ref:`unattended installation <unattended-installation>` for the Wazuh manager and API.
+
 .. versionadded:: 4.0.0
 
 The Wazuh API will be installed along the Wazuh manager. You do not need any extra requirement for this.
@@ -110,7 +112,7 @@ You can check the API service status with:
 
       # service wazuh-api status
 
-.. note:: You can also run an :ref:`unattended installation <unattended-installation>` for the Wazuh manager and API.
+.. note:: Check out the section :ref:`securing_api` to set up some additional settings.
 
 Installing Filebeat
 -------------------

--- a/source/installation-guide/installing-wazuh-manager/linux/centos/wazuh_server_packages_centos.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/centos/wazuh_server_packages_centos.rst
@@ -71,7 +71,7 @@ You can check the API service status with:
       # service wazuh-api status
 
 .. note::
-    Check out the section :ref:`securing_api` to set up some additional settings.
+    Check out the section :doc:`RESTful API <../../../../user-manual/api/index>` for more information on how to set up and use Wazuh API.
 
 **Optional:** Disable the Wazuh repository.
 

--- a/source/installation-guide/installing-wazuh-manager/linux/centos/wazuh_server_packages_centos.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/centos/wazuh_server_packages_centos.rst
@@ -52,28 +52,11 @@ Once the process is complete, you can check the service status with:
 
         # service wazuh-manager status
 
-Installing the Wazuh API
-------------------------
+.. versionadded:: 4.0.0
 
-1. NodeJS >= 4.6.1 is required in order to run the Wazuh API. If you do not have NodeJS installed or your version is older than 4.6.1, we recommend that you add the official NodeJS repository like this:
+The Wazuh API will be installed along the Wazuh manager. You do not need any extra requirement for this.
 
-  .. code-block:: console
-
-    # curl --silent --location https://rpm.nodesource.com/setup_10.x | bash -
-
-  and then, install NodeJS:
-
-  .. code-block:: console
-
-    # yum install nodejs
-
-2. Install the Wazuh API. It will update NodeJS if it is required:
-
-  .. code-block:: console
-
-    # yum install wazuh-api
-
-3. Once the process is complete, you can check the service status with:
+You can check the API service status with:
 
   * For Systemd:
 
@@ -88,9 +71,9 @@ Installing the Wazuh API
       # service wazuh-api status
 
 .. note::
-    Now that the Wazuh API is installed, check out the section :ref:`securing_api` to set up some additional settings.
+    Check out the section :ref:`securing_api` to set up some additional settings.
 
-4. (Optional) Disable the Wazuh repository:
+**Optional:** Disable the Wazuh updates:
 
   It is recommended that the Wazuh repository be disabled in order to prevent accidental upgrades. To do this, use the following command:
 

--- a/source/installation-guide/installing-wazuh-manager/linux/centos/wazuh_server_packages_centos.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/centos/wazuh_server_packages_centos.rst
@@ -73,9 +73,9 @@ You can check the API service status with:
 .. note::
     Check out the section :ref:`securing_api` to set up some additional settings.
 
-**Optional:** Disable the Wazuh updates:
+**Optional:** Disable the Wazuh repository.
 
-  It is recommended that the Wazuh repository be disabled in order to prevent accidental upgrades. To do this, use the following command:
+  It is recommended to disable the Wazuh repository in order to prevent accidental upgrades. To do this, use the following command:
 
   .. code-block:: console
 

--- a/source/installation-guide/installing-wazuh-manager/linux/centos/wazuh_server_sources_centos.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/centos/wazuh_server_sources_centos.rst
@@ -112,7 +112,7 @@ You can check the API service status with:
 
       # service wazuh-api status
 
-.. note:: Check out the section :ref:`securing_api` to set up some additional settings.
+.. note:: Check out the section :doc:`RESTful API <../../../../user-manual/api/index>` for more information on how to set up and use Wazuh API.
 
 Installing Filebeat
 -------------------

--- a/source/installation-guide/installing-wazuh-manager/linux/centos/wazuh_server_sources_centos.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/centos/wazuh_server_sources_centos.rst
@@ -92,24 +92,11 @@ Installing Wazuh manager
 
       # service wazuh-manager status
 
-Installing Wazuh API
---------------------
+.. versionadded:: 4.0.0
 
-1. NodeJS >= 4.6.1 is required in order to run the Wazuh API. If you do not have NodeJS installed or your version is older than 4.6.1, we recommend you add the official repository as this has more recent versions.
+The Wazuh API will be installed along the Wazuh manager. You do not need any extra requirement for this.
 
-    .. code-block:: console
-
-      # curl --silent --location https://rpm.nodesource.com/setup_10.x | bash -
-      # yum -y install nodejs
-      # npm config set user 0
-
-2. Download and execute the installation script:
-
-  .. code-block:: console
-
-      # curl -s -o install_api.sh https://raw.githubusercontent.com/wazuh/wazuh-api/v|WAZUH_LATEST|/install_api.sh && bash ./install_api.sh download
-
-3. Once the process is complete, you can check the service status with:
+You can check the API service status with:
 
   * For Systemd:
 

--- a/source/installation-guide/installing-wazuh-manager/linux/centos/wazuh_server_sources_centos.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/centos/wazuh_server_sources_centos.rst
@@ -92,6 +92,8 @@ Installing Wazuh manager
 
       # service wazuh-manager status
 
+.. note:: You can also run an :ref:`unattended installation <unattended-installation>` for the Wazuh manager and API.
+
 .. versionadded:: 4.0.0
 
 The Wazuh API will be installed along the Wazuh manager. You do not need any extra requirement for this.
@@ -110,7 +112,7 @@ You can check the API service status with:
 
       # service wazuh-api status
 
-.. note:: You can also run an :ref:`unattended installation <unattended-installation>` for the Wazuh manager and API.
+.. note:: Check out the section :ref:`securing_api` to set up some additional settings.
 
 Installing Filebeat
 -------------------

--- a/source/installation-guide/installing-wazuh-manager/linux/debian/wazuh_server_packages_deb.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/debian/wazuh_server_packages_deb.rst
@@ -81,7 +81,7 @@ You can check the API service status with:
       # service wazuh-api status
 
 .. note::
-    Check out the section :ref:`securing_api` to set up some additional settings.
+    Check out the section :doc:`RESTful API <../../../../user-manual/api/index>` for more information on how to set up and use Wazuh API.
 
 **Optional:** Disable the Wazuh repository.
 

--- a/source/installation-guide/installing-wazuh-manager/linux/debian/wazuh_server_packages_deb.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/debian/wazuh_server_packages_deb.rst
@@ -62,36 +62,11 @@ Once the process is completed, you can check the service status with:
 
       # service wazuh-manager status
 
-Installing the Wazuh API
-------------------------
+.. versionadded:: 4.0.0
 
-1. NodeJS >= 4.6.1 is required in order to run the Wazuh API. If you do not have NodeJS installed or your version is older than 4.6.1, we recommend that you add the official NodeJS repository like this:
+The Wazuh API will be installed along the Wazuh manager. You do not need any extra requirement for this.
 
-  .. code-block:: console
-
-    # curl -sL https://deb.nodesource.com/setup_10.x | bash -
-
-  .. note::
-
-      If you are using **Debian 7 (Wheezy)** you must install NodeJS 6 using the command below:
-
-      .. code-block:: console
-
-        # curl -sL https://deb.nodesource.com/setup_6.x | bash -
-
-  and then, install NodeJS:
-
-  .. code-block:: console
-
-    # apt-get install nodejs
-
-2. Install the Wazuh API. It will update NodeJS if it is required:
-
-  .. code-block:: console
-
-    # apt-get install wazuh-api
-
-3. Once the process is complete, you can check the service status with:
+You can check the API service status with:
 
   * For Systemd:
 
@@ -106,9 +81,9 @@ Installing the Wazuh API
       # service wazuh-api status
 
 .. note::
-    Now that the Wazuh API is installed, check out the section :ref:`securing_api` to set up some additional settings.
+    Check out the section :ref:`securing_api` to set up some additional settings.
 
-4. (Optional) Disable the Wazuh updates:
+**Optional:** Disable the Wazuh updates:
 
   It is recommended that the Wazuh repository be disabled in order to prevent accidental upgrades. To do this, use the following command:
 

--- a/source/installation-guide/installing-wazuh-manager/linux/debian/wazuh_server_packages_deb.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/debian/wazuh_server_packages_deb.rst
@@ -83,9 +83,9 @@ You can check the API service status with:
 .. note::
     Check out the section :ref:`securing_api` to set up some additional settings.
 
-**Optional:** Disable the Wazuh updates:
+**Optional:** Disable the Wazuh repository.
 
-  It is recommended that the Wazuh repository be disabled in order to prevent accidental upgrades. To do this, use the following command:
+  It is recommended to disable the Wazuh repository in order to prevent accidental upgrades. To do this, use the following command:
 
   .. code-block:: console
 

--- a/source/installation-guide/installing-wazuh-manager/linux/debian/wazuh_server_sources_deb.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/debian/wazuh_server_sources_deb.rst
@@ -94,30 +94,11 @@ Installing Wazuh manager
 
       # service wazuh-manager status
 
-Installing Wazuh API
---------------------
+.. versionadded:: 4.0.0
 
-1. NodeJS >= 4.6.1 is required in order to run the Wazuh API. If you do not have NodeJS installed or your version is older than 4.6.1, we recommend you add the official repository as this has more recent versions.
+The Wazuh API will be installed along the Wazuh manager. You do not need any extra requirement for this.
 
-    .. code-block:: console
-
-      # curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
-      # apt-get install -y nodejs
-      # npm config set user 0
-
-  .. note::
-
-    If you are using **Debian 7 (Wheezy)** you must install NodeJS 6 using the command below: ``# curl -sL https://deb.nodesource.com/setup_6.x | bash -``
-
-    For more information, see the `Official guide to install NodeJS <https://nodejs.org/en/download/package-manager/>`_.
-
-2. Download and execute the installation script:
-
-  .. code-block:: console
-
-      # curl -s -o install_api.sh https://raw.githubusercontent.com/wazuh/wazuh-api/v|WAZUH_LATEST|/install_api.sh && bash ./install_api.sh download
-
-3. Once the process is complete, you can check the service status with:
+You can check the API service status with:
 
   * For Systemd:
 

--- a/source/installation-guide/installing-wazuh-manager/linux/debian/wazuh_server_sources_deb.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/debian/wazuh_server_sources_deb.rst
@@ -114,7 +114,7 @@ You can check the API service status with:
 
       # service wazuh-api status
 
-.. note:: Check out the section :ref:`securing_api` to set up some additional settings.
+.. note:: Check out the section :doc:`RESTful API <../../../../user-manual/api/index>` for more information on how to set up and use Wazuh API.
 
 Installing Filebeat
 -------------------

--- a/source/installation-guide/installing-wazuh-manager/linux/debian/wazuh_server_sources_deb.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/debian/wazuh_server_sources_deb.rst
@@ -94,6 +94,8 @@ Installing Wazuh manager
 
       # service wazuh-manager status
 
+.. note:: You can also run an :ref:`unattended installation <unattended-installation>` for the Wazuh manager and API.
+
 .. versionadded:: 4.0.0
 
 The Wazuh API will be installed along the Wazuh manager. You do not need any extra requirement for this.
@@ -112,7 +114,7 @@ You can check the API service status with:
 
       # service wazuh-api status
 
-.. note:: You can also run an :ref:`unattended installation <unattended-installation>` for the Wazuh manager and API.
+.. note:: Check out the section :ref:`securing_api` to set up some additional settings.
 
 Installing Filebeat
 -------------------

--- a/source/installation-guide/installing-wazuh-manager/linux/fedora/wazuh_server_packages_fedora.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/fedora/wazuh_server_packages_fedora.rst
@@ -56,31 +56,11 @@ Once the process is complete, you can check the service status with:
 
         # service wazuh-manager status
 
-Installing the Wazuh API
-------------------------
+.. versionadded:: 4.0.0
 
-.. note::
+The Wazuh API will be installed along the Wazuh manager. You do not need any extra requirement for this.
 
-  If you have Fedora v24 or lower, you need to add the official NodeJS repository previously:
-
-
-    .. code-block:: console
-
-      # curl --silent --location https://rpm.nodesource.com/setup_10.x | bash -
-
-1. Install NodeJS:
-
-  .. code-block:: console
-
-    # dnf install nodejs
-
-2. Install the Wazuh API:
-
-  .. code-block:: console
-
-    # dnf install wazuh-api
-
-3. Once the process is complete, you can check the service status with:
+You can check the API service status with:
 
   * For Systemd:
 
@@ -95,9 +75,9 @@ Installing the Wazuh API
       # service wazuh-api status
 
 .. note::
-    Now that the Wazuh API is installed, check out the section :ref:`securing_api` to set up some additional settings.
+    Check out the section :ref:`securing_api` to set up some additional settings.
 
-4. (Optional) Disable the Wazuh repository:
+**Optional:** Disable the Wazuh updates:
 
   It is recommended that the Wazuh repository be disabled in order to prevent accidental upgrades. To do this, use the following command:
 

--- a/source/installation-guide/installing-wazuh-manager/linux/fedora/wazuh_server_packages_fedora.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/fedora/wazuh_server_packages_fedora.rst
@@ -77,9 +77,9 @@ You can check the API service status with:
 .. note::
     Check out the section :ref:`securing_api` to set up some additional settings.
 
-**Optional:** Disable the Wazuh updates:
+**Optional:** Disable the Wazuh repository.
 
-  It is recommended that the Wazuh repository be disabled in order to prevent accidental upgrades. To do this, use the following command:
+  It is recommended to disable the Wazuh repository in order to prevent accidental upgrades. To do this, use the following command:
 
   .. code-block:: console
 

--- a/source/installation-guide/installing-wazuh-manager/linux/fedora/wazuh_server_packages_fedora.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/fedora/wazuh_server_packages_fedora.rst
@@ -75,7 +75,7 @@ You can check the API service status with:
       # service wazuh-api status
 
 .. note::
-    Check out the section :ref:`securing_api` to set up some additional settings.
+    Check out the section :doc:`RESTful API <../../../../user-manual/api/index>` for more information on how to set up and use Wazuh API.
 
 **Optional:** Disable the Wazuh repository.
 

--- a/source/installation-guide/installing-wazuh-manager/linux/fedora/wazuh_server_sources_fedora.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/fedora/wazuh_server_sources_fedora.rst
@@ -112,7 +112,7 @@ You can check the API service status with:
 
       # service wazuh-api status
 
-.. note:: Check out the section :ref:`securing_api` to set up some additional settings.
+.. note:: Check out the section :doc:`RESTful API <../../../../user-manual/api/index>` for more information on how to set up and use Wazuh API.
 
 Installing Filebeat
 -------------------

--- a/source/installation-guide/installing-wazuh-manager/linux/fedora/wazuh_server_sources_fedora.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/fedora/wazuh_server_sources_fedora.rst
@@ -92,30 +92,11 @@ Installing Wazuh manager
 
       # service wazuh-manager status
 
-Installing Wazuh API
---------------------
+.. versionadded:: 4.0.0
 
-1. NodeJS >= 4.6.1 is required in order to run the Wazuh API. If you do not have NodeJS installed or your version is older than 4.6.1, we recommend you add the official repository as this has more recent versions.
+The Wazuh API will be installed along the Wazuh manager. You do not need any extra requirement for this.
 
-    .. code-block:: console
-
-      # curl --silent --location https://rpm.nodesource.com/setup_10.x | bash -
-      # dnf -y install nodejs
-      # npm config set user 0
-
-    .. note:: If you have Fedora v24 or lower, you need to add the official NodeJS repository previously:
-
-        .. code-block:: console
-
-          # curl --silent --location https://rpm.nodesource.com/setup_6.x | bash -
-
-2. Download and execute the installation script:
-
-  .. code-block:: console
-
-      # curl -s -o install_api.sh https://raw.githubusercontent.com/wazuh/wazuh-api/v|WAZUH_LATEST|/install_api.sh && bash ./install_api.sh download
-
-3. Once the process is complete, you can check the service status with:
+You can check the API service status with:
 
   * For Systemd:
 

--- a/source/installation-guide/installing-wazuh-manager/linux/fedora/wazuh_server_sources_fedora.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/fedora/wazuh_server_sources_fedora.rst
@@ -92,6 +92,8 @@ Installing Wazuh manager
 
       # service wazuh-manager status
 
+.. note:: You can also run an :ref:`unattended installation <unattended-installation>` for the Wazuh manager and API.
+
 .. versionadded:: 4.0.0
 
 The Wazuh API will be installed along the Wazuh manager. You do not need any extra requirement for this.
@@ -110,7 +112,7 @@ You can check the API service status with:
 
       # service wazuh-api status
 
-.. note:: You can also run an :ref:`unattended installation <unattended-installation>` for the Wazuh manager and API.
+.. note:: Check out the section :ref:`securing_api` to set up some additional settings.
 
 Installing Filebeat
 -------------------

--- a/source/installation-guide/installing-wazuh-manager/linux/opensuse/wazuh_server_packages_opensuse.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/opensuse/wazuh_server_packages_opensuse.rst
@@ -71,7 +71,7 @@ You can check the API service status with:
       # service wazuh-api status
 
 .. note::
-    Check out the section :ref:`securing_api` to set up some additional settings.
+    Check out the section :doc:`RESTful API <../../../../user-manual/api/index>` for more information on how to set up and use Wazuh API.
 
 **Optional:** Disable the Wazuh repository.
 

--- a/source/installation-guide/installing-wazuh-manager/linux/opensuse/wazuh_server_packages_opensuse.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/opensuse/wazuh_server_packages_opensuse.rst
@@ -52,28 +52,11 @@ Once the process is complete, you can check the service status with:
 
         # service wazuh-manager status
 
-Installing the Wazuh API
-------------------------
+.. versionadded:: 4.0.0
 
-1. NodeJS >= 4.6.1 is required in order to run the Wazuh API. If you do not have NodeJS installed or your version is older than 4.6.1, we recommend that you add the official NodeJS repository like this:
+The Wazuh API will be installed along the Wazuh manager. You do not need any extra requirement for this.
 
-  .. code-block:: console
-
-    # curl --silent --location https://rpm.nodesource.com/setup_10.x | bash -
-
-  and then, install NodeJS:
-
-  .. code-block:: console
-
-    # zypper install nodejs
-
-2. Install the Wazuh API. It will update NodeJS if it is required:
-
-  .. code-block:: console
-
-    # zypper install wazuh-api
-
-3. Once the process is complete, you can check the service status with:
+You can check the API service status with:
 
   * For Systemd:
 
@@ -88,9 +71,9 @@ Installing the Wazuh API
       # service wazuh-api status
 
 .. note::
-    Now that the Wazuh API is installed, check out the section :ref:`securing_api` to set up some additional settings.
+    Check out the section :ref:`securing_api` to set up some additional settings.
 
-4. (Optional) Disable the Wazuh repository:
+**Optional:** Disable the Wazuh updates:
 
   It is recommended that the Wazuh repository be disabled in order to prevent accidental upgrades. To do this, use the following command:
 

--- a/source/installation-guide/installing-wazuh-manager/linux/opensuse/wazuh_server_packages_opensuse.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/opensuse/wazuh_server_packages_opensuse.rst
@@ -73,9 +73,9 @@ You can check the API service status with:
 .. note::
     Check out the section :ref:`securing_api` to set up some additional settings.
 
-**Optional:** Disable the Wazuh updates:
+**Optional:** Disable the Wazuh repository.
 
-  It is recommended that the Wazuh repository be disabled in order to prevent accidental upgrades. To do this, use the following command:
+  It is recommended to disable the Wazuh repository in order to prevent accidental upgrades. To do this, use the following command:
 
   .. code-block:: console
 

--- a/source/installation-guide/installing-wazuh-manager/linux/opensuse/wazuh_server_sources_opensuse.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/opensuse/wazuh_server_sources_opensuse.rst
@@ -112,7 +112,7 @@ You can check the API service status with:
 
       # service wazuh-api status
 
-.. note:: Check out the section :ref:`securing_api` to set up some additional settings.
+.. note:: Check out the section :doc:`RESTful API <../../../../user-manual/api/index>` for more information on how to set up and use Wazuh API.
 
 Installing Filebeat
 -------------------

--- a/source/installation-guide/installing-wazuh-manager/linux/opensuse/wazuh_server_sources_opensuse.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/opensuse/wazuh_server_sources_opensuse.rst
@@ -92,24 +92,11 @@ Installing Wazuh manager
 
       # service wazuh-manager status
 
-Installing Wazuh API
---------------------
+.. versionadded:: 4.0.0
 
-1. NodeJS >= 4.6.1 is required in order to run the Wazuh API. If you do not have NodeJS installed or your version is older than 4.6.1, we recommend you add the official repository as this has more recent versions.
+The Wazuh API will be installed along the Wazuh manager. You do not need any extra requirement for this.
 
-    .. code-block:: console
-
-          # zypper install nodejs6
-
-    You can find more information in the `NodeJS documentation <https://nodejs.org/en/download/package-manager/#opensuse-and-sle>`_.
-
-2. Download and execute the installation script:
-
-  .. code-block:: console
-
-      # curl -s -o install_api.sh https://raw.githubusercontent.com/wazuh/wazuh-api/v|WAZUH_LATEST|/install_api.sh && bash ./install_api.sh download
-
-3. Once the process is complete, you can check the service status with:
+You can check the API service status with:
 
   * For Systemd:
 

--- a/source/installation-guide/installing-wazuh-manager/linux/opensuse/wazuh_server_sources_opensuse.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/opensuse/wazuh_server_sources_opensuse.rst
@@ -92,6 +92,8 @@ Installing Wazuh manager
 
       # service wazuh-manager status
 
+.. note:: You can also run an :ref:`unattended installation <unattended-installation>` for the Wazuh manager and API.
+
 .. versionadded:: 4.0.0
 
 The Wazuh API will be installed along the Wazuh manager. You do not need any extra requirement for this.
@@ -110,7 +112,7 @@ You can check the API service status with:
 
       # service wazuh-api status
 
-.. note:: You can also run an :ref:`unattended installation <unattended-installation>` for the Wazuh manager and API.
+.. note:: Check out the section :ref:`securing_api` to set up some additional settings.
 
 Installing Filebeat
 -------------------

--- a/source/installation-guide/installing-wazuh-manager/linux/oracle/wazuh_server_packages_oracle.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/oracle/wazuh_server_packages_oracle.rst
@@ -72,7 +72,7 @@ You can check the API service status with:
       # service wazuh-api status
 
 .. note::
-    Check out the section :ref:`securing_api` to set up some additional settings.
+    Check out the section :doc:`RESTful API <../../../../user-manual/api/index>` for more information on how to set up and use Wazuh API.
 
 **Optional:** Disable the Wazuh repository.
 

--- a/source/installation-guide/installing-wazuh-manager/linux/oracle/wazuh_server_packages_oracle.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/oracle/wazuh_server_packages_oracle.rst
@@ -74,9 +74,9 @@ You can check the API service status with:
 .. note::
     Check out the section :ref:`securing_api` to set up some additional settings.
 
-**Optional:** Disable the Wazuh updates:
+**Optional:** Disable the Wazuh repository.
 
-  It is recommended that the Wazuh repository be disabled in order to prevent accidental upgrades. To do this, use the following command:
+  It is recommended to disable the Wazuh repository in order to prevent accidental upgrades. To do this, use the following command:
 
   .. code-block:: console
 

--- a/source/installation-guide/installing-wazuh-manager/linux/oracle/wazuh_server_packages_oracle.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/oracle/wazuh_server_packages_oracle.rst
@@ -53,28 +53,11 @@ Once the process is complete, you can check the service status with:
 
         # service wazuh-manager status
 
-Installing the Wazuh API
-------------------------
+.. versionadded:: 4.0.0
 
-1. NodeJS >= 4.6.1 is required in order to run the Wazuh API. If you do not have NodeJS installed or your version is older than 4.6.1, we recommend that you add the official NodeJS repository like this:
+The Wazuh API will be installed along the Wazuh manager. You do not need any extra requirement for this.
 
-  .. code-block:: console
-
-    # curl --silent --location https://rpm.nodesource.com/setup_10.x | bash -
-
-  and then, install NodeJS:
-
-  .. code-block:: console
-
-    # yum install nodejs
-
-2. Install the Wazuh API. It will update NodeJS if it is required:
-
-  .. code-block:: console
-
-    # yum install wazuh-api
-
-3. Once the process is complete, you can check the service status with:
+You can check the API service status with:
 
   * For Systemd:
 
@@ -89,9 +72,9 @@ Installing the Wazuh API
       # service wazuh-api status
 
 .. note::
-    Now that the Wazuh API is installed, check out the section :ref:`securing_api` to set up some additional settings.
+    Check out the section :ref:`securing_api` to set up some additional settings.
 
-4. (Optional) Disable the Wazuh repository:
+**Optional:** Disable the Wazuh updates:
 
   It is recommended that the Wazuh repository be disabled in order to prevent accidental upgrades. To do this, use the following command:
 

--- a/source/installation-guide/installing-wazuh-manager/linux/oracle/wazuh_server_sources_oracle.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/oracle/wazuh_server_sources_oracle.rst
@@ -112,7 +112,7 @@ You can check the API service status with:
 
       # service wazuh-api status
 
-.. note:: Check out the section :ref:`securing_api` to set up some additional settings.
+.. note:: Check out the section :doc:`RESTful API <../../../../user-manual/api/index>` for more information on how to set up and use Wazuh API.
 
 Installing Filebeat
 -------------------

--- a/source/installation-guide/installing-wazuh-manager/linux/oracle/wazuh_server_sources_oracle.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/oracle/wazuh_server_sources_oracle.rst
@@ -92,24 +92,11 @@ Installing Wazuh manager
 
       # service wazuh-manager status
 
-Installing Wazuh API
---------------------
+.. versionadded:: 4.0.0
 
-1. NodeJS >= 4.6.1 is required in order to run the Wazuh API. If you do not have NodeJS installed or your version is older than 4.6.1, we recommend you add the official repository as this has more recent versions.
+The Wazuh API will be installed along the Wazuh manager. You do not need any extra requirement for this.
 
-    .. code-block:: console
-
-      # curl --silent --location https://rpm.nodesource.com/setup_10.x | bash -
-      # yum -y install nodejs
-      # npm config set user 0
-
-2. Download and execute the installation script:
-
-  .. code-block:: console
-
-      # curl -s -o install_api.sh https://raw.githubusercontent.com/wazuh/wazuh-api/v|WAZUH_LATEST|/install_api.sh && bash ./install_api.sh download
-
-3. Once the process is complete, you can check the service status with:
+You can check the API service status with:
 
   * For Systemd:
 

--- a/source/installation-guide/installing-wazuh-manager/linux/oracle/wazuh_server_sources_oracle.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/oracle/wazuh_server_sources_oracle.rst
@@ -92,6 +92,8 @@ Installing Wazuh manager
 
       # service wazuh-manager status
 
+.. note:: You can also run an :ref:`unattended installation <unattended-installation>` for the Wazuh manager and API.
+
 .. versionadded:: 4.0.0
 
 The Wazuh API will be installed along the Wazuh manager. You do not need any extra requirement for this.
@@ -110,7 +112,7 @@ You can check the API service status with:
 
       # service wazuh-api status
 
-.. note:: You can also run an :ref:`unattended installation <unattended-installation>` for the Wazuh manager and API.
+.. note:: Check out the section :ref:`securing_api` to set up some additional settings.
 
 Installing Filebeat
 -------------------

--- a/source/installation-guide/installing-wazuh-manager/linux/rhel/wazuh_server_packages_rhel.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/rhel/wazuh_server_packages_rhel.rst
@@ -71,7 +71,7 @@ You can check the API service status with:
       # service wazuh-api status
 
 .. note::
-    Check out the section :ref:`securing_api` to set up some additional settings.
+    Check out the section :doc:`RESTful API <../../../../user-manual/api/index>` for more information on how to set up and use Wazuh API.
 
 **Optional:** Disable the Wazuh repository.
 

--- a/source/installation-guide/installing-wazuh-manager/linux/rhel/wazuh_server_packages_rhel.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/rhel/wazuh_server_packages_rhel.rst
@@ -52,28 +52,11 @@ Once the process is complete, you can check the service status with:
 
         # service wazuh-manager status
 
-Installing the Wazuh API
-------------------------
+.. versionadded:: 4.0.0
 
-1. NodeJS >= 4.6.1 is required in order to run the Wazuh API. If you do not have NodeJS installed or your version is older than 4.6.1, we recommend that you add the official NodeJS repository like this:
+The Wazuh API will be installed along the Wazuh manager. You do not need any extra requirement for this.
 
-  .. code-block:: console
-
-    # curl --silent --location https://rpm.nodesource.com/setup_10.x | bash -
-
-  and then, install NodeJS:
-
-  .. code-block:: console
-
-    # yum install nodejs
-
-2. Install the Wazuh API. It will update NodeJS if it is required:
-
-  .. code-block:: console
-
-    # yum install wazuh-api
-
-3. Once the process is complete, you can check the service status with:
+You can check the API service status with:
 
   * For Systemd:
 
@@ -88,9 +71,9 @@ Installing the Wazuh API
       # service wazuh-api status
 
 .. note::
-    Now that the Wazuh API is installed, check out the section :ref:`securing_api` to set up some additional settings.
+    Check out the section :ref:`securing_api` to set up some additional settings.
 
-4. (Optional) Disable the Wazuh repository:
+**Optional:** Disable the Wazuh updates:
 
   It is recommended that the Wazuh repository be disabled in order to prevent accidental upgrades. To do this, use the following command:
 

--- a/source/installation-guide/installing-wazuh-manager/linux/rhel/wazuh_server_packages_rhel.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/rhel/wazuh_server_packages_rhel.rst
@@ -73,9 +73,9 @@ You can check the API service status with:
 .. note::
     Check out the section :ref:`securing_api` to set up some additional settings.
 
-**Optional:** Disable the Wazuh updates:
+**Optional:** Disable the Wazuh repository.
 
-  It is recommended that the Wazuh repository be disabled in order to prevent accidental upgrades. To do this, use the following command:
+  It is recommended to disable the Wazuh repository in order to prevent accidental upgrades. To do this, use the following command:
 
   .. code-block:: console
 

--- a/source/installation-guide/installing-wazuh-manager/linux/rhel/wazuh_server_sources_rhel.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/rhel/wazuh_server_sources_rhel.rst
@@ -112,7 +112,7 @@ You can check the API service status with:
 
       # service wazuh-api status
 
-.. note:: Check out the section :ref:`securing_api` to set up some additional settings.
+.. note:: Check out the section :doc:`RESTful API <../../../../user-manual/api/index>` for more information on how to set up and use Wazuh API.
 
 Installing Filebeat
 -------------------

--- a/source/installation-guide/installing-wazuh-manager/linux/rhel/wazuh_server_sources_rhel.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/rhel/wazuh_server_sources_rhel.rst
@@ -92,24 +92,11 @@ Installing Wazuh manager
 
       # service wazuh-manager status
 
-Installing Wazuh API
---------------------
+.. versionadded:: 4.0.0
 
-1. NodeJS >= 4.6.1 is required in order to run the Wazuh API. If you do not have NodeJS installed or your version is older than 4.6.1, we recommend you add the official repository as this has more recent versions.
+The Wazuh API will be installed along the Wazuh manager. You do not need any extra requirement for this.
 
-    .. code-block:: console
-
-      # curl --silent --location https://rpm.nodesource.com/setup_10.x | bash -
-      # yum -y install nodejs
-      # npm config set user 0
-
-2. Download and execute the installation script:
-
-  .. code-block:: console
-
-      # curl -s -o install_api.sh https://raw.githubusercontent.com/wazuh/wazuh-api/v|WAZUH_LATEST|/install_api.sh && bash ./install_api.sh download
-
-3. Once the process is complete, you can check the service status with:
+You can check the API service status with:
 
   * For Systemd:
 

--- a/source/installation-guide/installing-wazuh-manager/linux/rhel/wazuh_server_sources_rhel.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/rhel/wazuh_server_sources_rhel.rst
@@ -92,6 +92,8 @@ Installing Wazuh manager
 
       # service wazuh-manager status
 
+.. note:: You can also run an :ref:`unattended installation <unattended-installation>` for the Wazuh manager and API.
+
 .. versionadded:: 4.0.0
 
 The Wazuh API will be installed along the Wazuh manager. You do not need any extra requirement for this.
@@ -110,7 +112,7 @@ You can check the API service status with:
 
       # service wazuh-api status
 
-.. note:: You can also run an :ref:`unattended installation <unattended-installation>` for the Wazuh manager and API.
+.. note:: Check out the section :ref:`securing_api` to set up some additional settings.
 
 Installing Filebeat
 -------------------

--- a/source/installation-guide/installing-wazuh-manager/linux/suse/wazuh_server_packages_suse.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/suse/wazuh_server_packages_suse.rst
@@ -71,7 +71,7 @@ You can check the API service status with:
       # service wazuh-api status
 
 .. note::
-    Check out the section :ref:`securing_api` to set up some additional settings.
+    Check out the section :doc:`RESTful API <../../../../user-manual/api/index>` for more information on how to set up and use Wazuh API.
 
 **Optional:** Disable the Wazuh repository.
 

--- a/source/installation-guide/installing-wazuh-manager/linux/suse/wazuh_server_packages_suse.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/suse/wazuh_server_packages_suse.rst
@@ -52,28 +52,11 @@ Once the process is complete, you can check the service status with:
 
         # service wazuh-manager status
 
-Installing the Wazuh API
-------------------------
+.. versionadded:: 4.0.0
 
-1. NodeJS >= 4.6.1 is required in order to run the Wazuh API. If you do not have NodeJS installed or your version is older than 4.6.1, we recommend that you add the official NodeJS repository like this:
+The Wazuh API will be installed along the Wazuh manager. You do not need any extra requirement for this.
 
-  .. code-block:: console
-
-    # curl --silent --location https://rpm.nodesource.com/setup_10.x | bash -
-
-  and then, install NodeJS:
-
-  .. code-block:: console
-
-    # zypper install nodejs
-
-2. Install the Wazuh API. It will update NodeJS if it is required:
-
-  .. code-block:: console
-
-    # zypper install wazuh-api
-
-3. Once the process is complete, you can check the service status with:
+You can check the API service status with:
 
   * For Systemd:
 
@@ -88,9 +71,9 @@ Installing the Wazuh API
       # service wazuh-api status
 
 .. note::
-    Now that the Wazuh API is installed, check out the section :ref:`securing_api` to set up some additional settings.
+    Check out the section :ref:`securing_api` to set up some additional settings.
 
-4. (Optional) Disable the Wazuh repository:
+**Optional:** Disable the Wazuh updates:
 
   It is recommended that the Wazuh repository be disabled in order to prevent accidental upgrades. To do this, use the following command:
 

--- a/source/installation-guide/installing-wazuh-manager/linux/suse/wazuh_server_packages_suse.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/suse/wazuh_server_packages_suse.rst
@@ -73,9 +73,9 @@ You can check the API service status with:
 .. note::
     Check out the section :ref:`securing_api` to set up some additional settings.
 
-**Optional:** Disable the Wazuh updates:
+**Optional:** Disable the Wazuh repository.
 
-  It is recommended that the Wazuh repository be disabled in order to prevent accidental upgrades. To do this, use the following command:
+  It is recommended to disable the Wazuh repository in order to prevent accidental upgrades. To do this, use the following command:
 
   .. code-block:: console
 

--- a/source/installation-guide/installing-wazuh-manager/linux/suse/wazuh_server_sources_suse.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/suse/wazuh_server_sources_suse.rst
@@ -112,7 +112,7 @@ You can check the API service status with:
 
       # service wazuh-api status
 
-.. note:: Check out the section :ref:`securing_api` to set up some additional settings.
+.. note:: Check out the section :doc:`RESTful API <../../../../user-manual/api/index>` for more information on how to set up and use Wazuh API.
 
 Installing Filebeat
 -------------------

--- a/source/installation-guide/installing-wazuh-manager/linux/suse/wazuh_server_sources_suse.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/suse/wazuh_server_sources_suse.rst
@@ -92,24 +92,11 @@ Installing Wazuh manager
 
       # service wazuh-manager status
 
-Installing Wazuh API
---------------------
+.. versionadded:: 4.0.0
 
-1. NodeJS >= 4.6.1 is required in order to run the Wazuh API. If you do not have NodeJS installed or your version is older than 4.6.1, we recommend you add the official repository as this has more recent versions.
+The Wazuh API will be installed along the Wazuh manager. You do not need any extra requirement for this.
 
-    .. code-block:: console
-
-      # curl --silent --location https://rpm.nodesource.com/setup_10.x | bash -
-      # zypper -y install nodejs
-      # npm config set user 0
-
-2. Download and execute the installation script:
-
-  .. code-block:: console
-
-      # curl -s -o install_api.sh https://raw.githubusercontent.com/wazuh/wazuh-api/v|WAZUH_LATEST|/install_api.sh && bash ./install_api.sh download
-
-3. Once the process is complete, you can check the service status with:
+You can check the API service status with:
 
   * For Systemd:
 

--- a/source/installation-guide/installing-wazuh-manager/linux/suse/wazuh_server_sources_suse.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/suse/wazuh_server_sources_suse.rst
@@ -92,6 +92,8 @@ Installing Wazuh manager
 
       # service wazuh-manager status
 
+.. note:: You can also run an :ref:`unattended installation <unattended-installation>` for the Wazuh manager and API.
+
 .. versionadded:: 4.0.0
 
 The Wazuh API will be installed along the Wazuh manager. You do not need any extra requirement for this.
@@ -110,7 +112,7 @@ You can check the API service status with:
 
       # service wazuh-api status
 
-.. note:: You can also run an :ref:`unattended installation <unattended-installation>` for the Wazuh manager and API.
+.. note:: Check out the section :ref:`securing_api` to set up some additional settings.
 
 Installing Filebeat
 -------------------

--- a/source/installation-guide/installing-wazuh-manager/linux/ubuntu/wazuh_server_packages_ubuntu.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/ubuntu/wazuh_server_packages_ubuntu.rst
@@ -81,7 +81,7 @@ You can check the API service status with:
       # service wazuh-api status
 
 .. note::
-    Check out the section :ref:`securing_api` to set up some additional settings.
+    Check out the section :doc:`RESTful API <../../../../user-manual/api/index>` for more information on how to set up and use Wazuh API.
 
 **Optional:** Disable the Wazuh repository.
 

--- a/source/installation-guide/installing-wazuh-manager/linux/ubuntu/wazuh_server_packages_ubuntu.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/ubuntu/wazuh_server_packages_ubuntu.rst
@@ -62,32 +62,11 @@ Once the process is completed, you can check the service status with:
 
       # service wazuh-manager status
 
-Installing the Wazuh API
-------------------------
+.. versionadded:: 4.0.0
 
-1. NodeJS >= 4.6.1 is required in order to run the Wazuh API. If you do not have NodeJS installed or your version is older than 4.6.1, we recommend that you add the official NodeJS repository like this:
+The Wazuh API will be installed along the Wazuh manager. You do not need any extra requirement for this.
 
-  .. code-block:: console
-
-    # curl -sL https://deb.nodesource.com/setup_10.x | bash -
-
-  .. note::
-
-      If you are using **Ubuntu 12.04 (Precise)** you must install NodeJS 6 using the command below: ``# curl -sL https://deb.nodesource.com/setup_6.x | bash -``
-
-  and then, install NodeJS:
-
-  .. code-block:: console
-
-    # apt-get install nodejs
-
-2. Install the Wazuh API. It will update NodeJS if it is required:
-
-  .. code-block:: console
-
-    # apt-get install wazuh-api
-
-3. Once the process is complete, you can check the service status with:
+You can check the API service status with:
 
   * For Systemd:
 
@@ -102,9 +81,9 @@ Installing the Wazuh API
       # service wazuh-api status
 
 .. note::
-    Now that the Wazuh API is installed, check out the section :ref:`securing_api` to set up some additional settings.
+    Check out the section :ref:`securing_api` to set up some additional settings.
 
-4. (Optional) Disable the Wazuh updates:
+**Optional:** Disable the Wazuh updates:
 
   It is recommended that the Wazuh repository be disabled in order to prevent accidental upgrades. To do this, use the following command:
 

--- a/source/installation-guide/installing-wazuh-manager/linux/ubuntu/wazuh_server_packages_ubuntu.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/ubuntu/wazuh_server_packages_ubuntu.rst
@@ -83,9 +83,9 @@ You can check the API service status with:
 .. note::
     Check out the section :ref:`securing_api` to set up some additional settings.
 
-**Optional:** Disable the Wazuh updates:
+**Optional:** Disable the Wazuh repository.
 
-  It is recommended that the Wazuh repository be disabled in order to prevent accidental upgrades. To do this, use the following command:
+  It is recommended to disable the Wazuh repository in order to prevent accidental upgrades. To do this, use the following command:
 
   .. code-block:: console
 

--- a/source/installation-guide/installing-wazuh-manager/linux/ubuntu/wazuh_server_sources_ubuntu.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/ubuntu/wazuh_server_sources_ubuntu.rst
@@ -94,30 +94,11 @@ Installing Wazuh manager
 
       # service wazuh-manager status
 
-Installing Wazuh API
---------------------
+.. versionadded:: 4.0.0
 
-1. NodeJS >= 4.6.1 is required in order to run the Wazuh API. If you do not have NodeJS installed or your version is older than 4.6.1, we recommend you add the official repository as this has more recent versions.
+The Wazuh API will be installed along the Wazuh manager. You do not need any extra requirement for this.
 
-    .. code-block:: console
-
-      # curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
-      # apt-get install -y nodejs
-      # npm config set user 0
-
-  .. note::
-
-    If you are using **Ubuntu 12.04 (Precise)** you must install NodeJS 6 using the command below: ``# curl -sL https://deb.nodesource.com/setup_6.x | bash -``
-
-    For more information, see the `Official guide to install NodeJS <https://nodejs.org/en/download/package-manager/>`_.
-
-2. Download and execute the installation script:
-
-  .. code-block:: console
-
-      # curl -s -o install_api.sh https://raw.githubusercontent.com/wazuh/wazuh-api/v|WAZUH_LATEST|/install_api.sh && bash ./install_api.sh download
-
-3. Once the process is complete, you can check the service status with:
+You can check the API service status with:
 
   * For Systemd:
 

--- a/source/installation-guide/installing-wazuh-manager/linux/ubuntu/wazuh_server_sources_ubuntu.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/ubuntu/wazuh_server_sources_ubuntu.rst
@@ -114,7 +114,7 @@ You can check the API service status with:
 
       # service wazuh-api status
 
-.. note:: Check out the section :ref:`securing_api` to set up some additional settings.
+.. note:: Check out the section :doc:`RESTful API <../../../../user-manual/api/index>` for more information on how to set up and use Wazuh API.
 
 Installing Filebeat
 -------------------

--- a/source/installation-guide/installing-wazuh-manager/linux/ubuntu/wazuh_server_sources_ubuntu.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/ubuntu/wazuh_server_sources_ubuntu.rst
@@ -94,6 +94,8 @@ Installing Wazuh manager
 
       # service wazuh-manager status
 
+.. note:: You can also run an :ref:`unattended installation <unattended-installation>` for the Wazuh manager and API.
+
 .. versionadded:: 4.0.0
 
 The Wazuh API will be installed along the Wazuh manager. You do not need any extra requirement for this.
@@ -112,7 +114,7 @@ You can check the API service status with:
 
       # service wazuh-api status
 
-.. note:: You can also run an :ref:`unattended installation <unattended-installation>` for the Wazuh manager and API.
+.. note:: Check out the section :ref:`securing_api` to set up some additional settings.
 
 Installing Filebeat
 -------------------


### PR DESCRIPTION
Hello team, this closes #2476 .

We have updated every `Installing Wazuh API` section since the Wazuh API will be installed along the Wazuh manager from `4.0` on.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

Regards.
