### PR TITLE
Added clarification to the command explanation.

### DIFF
--- a/source/user-manual/capabilities/sec-config-assessment/how_to_configure.rst
+++ b/source/user-manual/capabilities/sec-config-assessment/how_to_configure.rst
@@ -51,7 +51,7 @@ the Wazuh manager has the ability to push files and configurations to connected 
 This feature can be used to push policy files to the Wazuh agents in defined groups. By default, every Wazuh agent belongs
 to the ``default`` group, which is used here as an example:
 
-#. Edit the Wazuh agent's ``local_internal_options.conf`` file to allow remote SCA policies sent from the Wazuh manager:
+#. Edit the Wazuh agent’s ``local_internal_options.conf`` file to allow the execution of commands in SCA policies sent from the Wazuh manager:
 
      .. code-block:: console
 


### PR DESCRIPTION
Hello Team,
this PR closes #2484  
 
## Description

The file contains the clarification of "sca.remote_commands" command explanation in **User manual > Capabilities > Security Configuration Assessment > How to configure SCA > How to share policy files and configuration with the Wazuh agents** section of the documentation.

## Checks

- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 

All the best,
Daria
