### PR TITLE
Fixed typo

### DIFF
--- a/source/installation-guide/installing-wazuh-agent/hpux/wazuh_agent_sources_hpux.rst
+++ b/source/installation-guide/installing-wazuh-agent/hpux/wazuh_agent_sources_hpux.rst
@@ -18,7 +18,7 @@ Installing Wazuh agent
 
       .. code-block:: console
 
-        # /usr/local/bin/wget https://github.com/wazuh/wazuh-packages/raw/master/hpux/depothelper-2.10-hppa_32-11.31.depot --no-check-certificate
+        # /usr/local/bin/wget https://github.com/wazuh/wazuh-packages/raw/master/hp-ux/depothelper-2.10-hppa_32-11.31.depot --no-check-certificate
 
       .. note:: If you can't download the script this way, then you should copy it through the scp utility.
 
@@ -38,7 +38,7 @@ Installing Wazuh agent
 
       .. code-block:: console
 
-        # /usr/local/bin/wget https://raw.githubusercontent.com/wazuh/wazuh-packages/master/hpux/generate_wazuh_packages.sh --no-check-certificate
+        # /usr/local/bin/wget https://raw.githubusercontent.com/wazuh/wazuh-packages/master/hp-ux/generate_wazuh_packages.sh --no-check-certificate
 
       .. note:: If you can't download the script this way, then you should copy it through the scp utility.
 


### PR DESCRIPTION
Hello team!

This PR closes #2486 

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

I've replaced the URL in point 1.4 from `https://raw.githubusercontent.com/wazuh/wazuh-packages/master/hpux/generate_wazuh_packages.sh --no-check-certificate` to `https://raw.githubusercontent.com/wazuh/wazuh-packages/master/hp-ux/generate_wazuh_packages.sh --no-check-certificate`

I've also detected a similar typo in point 1.1 where it was written `hpux` instead of `hp-ux`

<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->
Regards,

David
