### PR TITLE
Add buster example for offline vulnerability updates

### DIFF
--- a/source/user-manual/capabilities/vulnerability-detection/offline_update.rst
+++ b/source/user-manual/capabilities/vulnerability-detection/offline_update.rst
@@ -63,6 +63,8 @@ To perform an offline update of Debian feeds, you must download the correspondin
 +------------+--------------------------------------------------------------------------------------------+
 | OS         | Link                                                                                       |
 +============+============================================================================================+
+| Buster     | `<https://www.debian.org/security/oval/oval-definitions-buster.xml>`_                      |
++------------+--------------------------------------------------------------------------------------------+
 | Stretch    | `<https://www.debian.org/security/oval/oval-definitions-stretch.xml>`_                     |
 +------------+--------------------------------------------------------------------------------------------+
 | Jessie     | `<https://www.debian.org/security/oval/oval-definitions-jessie.xml>`_                      |
@@ -76,6 +78,7 @@ In order to use a local feed file, just use the ``path`` attribute accompanying 
 
     <provider name="debian">
         <enabled>yes</enabled>
+        <os path="/local_path/oval-definitions-buster.xml">buster</os>
         <os path="/local_path/oval-definitions-stretch.xml">stretch</os>
         <os path="/local_path/oval-definitions-jessie.xml">jessie</os>
         <os path="/local_path/oval-definitions-wheezy.xml">wheezy</os>
@@ -88,6 +91,7 @@ In order to update the vulnerability feeds from an alternative repository, the c
 
     <provider name="debian">
         <enabled>yes</enabled>
+        <os url="http://local_repo/oval-definitions-buster.xml">buster</os>
         <os url="http://local_repo/oval-definitions-stretch.xml">stretch</os>
         <os url="http://local_repo/oval-definitions-jessie.xml">jessie</os>
         <os url="http://local_repo/oval-definitions-wheezy.xml">wheezy</os>


### PR DESCRIPTION
## Description
This PR adds an example for the Buster feed on the offline update page. (vulnerabilitiy detection capability)

Closes #2495 


## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
