### PR TITLE
Update API Examples section

### DIFF
--- a/source/user-manual/api/examples.rst
+++ b/source/user-manual/api/examples.rst
@@ -136,8 +136,8 @@ Code:
     endpoint = '/agents?select=lastKeepAlive&select=id&status=disconnected'
 
     protocol = 'https'
-    host = 'localhost'
-    port = '55000'
+    host = 'API_IP'
+    port = 'API_PORT'
     version = 'v4'
     user = 'wazuh'
     password = 'wazuh'
@@ -228,8 +228,8 @@ Code:
     $method = "get"
 
     $protocol = "https"
-    $host_name = "192.168.32.2"
-    $port = "55000"
+    $host_name = "API_IP"
+    $port = "API_PORT"
     $version = "v4"
     $username = "wazuh"
     $password = "wazuh"


### PR DESCRIPTION
This PR closes #2480 

## Description

This PR updates the CURL examples and the Python and Powershell scripts to work with the API 4.0. I added an UI workflow example, but finally I removed it since it is very intuitive and these examples are not useful.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
