### PR TITLE
Fixed the outdated URL and added |WAZUH_LATEST_MINOR| for replacements

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -404,6 +404,7 @@ def customReplacements(app, docname, source):
 
 custom_replacements = {
     "|WAZUH_LATEST|" : "3.11.4",
+    "|WAZUH_LATEST_MINOR|" : "3.11",
     "|WAZUH_LATEST_ANSIBLE|" : "3.11.4",
     "|WAZUH_LATEST_KUBERNETES|" : "3.11.4",
     "|WAZUH_LATEST_PUPPET|" : "3.11.4",

--- a/source/installation-guide/installing-wazuh-agent/hpux/wazuh_agent_sources_hpux.rst
+++ b/source/installation-guide/installing-wazuh-agent/hpux/wazuh_agent_sources_hpux.rst
@@ -64,7 +64,7 @@ Installing Wazuh agent
    .. code-block:: console
 
         # cd wazuh-*
-        # /usr/local/bin/gmake -C src deps RESOURCES_URL=http://packages.wazuh.com/deps/3.10
+        # /usr/local/bin/gmake -C src deps RESOURCES_URL=http://packages.wazuh.com/deps/|WAZUH_LATEST_MINOR|
         # /usr/local/bin/gmake -C src TARGET=agent USE_SELINUX=no DISABLE_SHARED=yes
 
 4. Run the ``install.sh`` script. This will run a wizard that will guide you through the installation process using the Wazuh sources:


### PR DESCRIPTION
Hello team!

This issue closes #2501 

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description
I've added in the `config.py` a new value for replacements `|WAZUH_LATEST_MINOR|` which indicates the latest minor of this branch. I've used this value to fix the outdated url [here](https://documentation.wazuh.com/3.11/installation-guide/installing-wazuh-agent/hpux/wazuh_agent_sources_hpux.html#wazuh-agent-sources-hpux).
<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->
Regards,

David