### PR TITLE
[3.0] Increased compatibility with Sphinx 3.0.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-Sphinx==1.8.5
-sphinxcontrib-images==0.8.0
+Sphinx==3.0.3
+sphinxcontrib-images==0.9.2
 sphinxprettysearchresults==0.3.5
+sphinx_tabs==1.1.13

--- a/source/_static/css/style.css
+++ b/source/_static/css/style.css
@@ -696,7 +696,8 @@ ol.simple dl dt {
 }
 
 ul.simple dl dd,
-ol.simple dl dd {
+ol.simple dl dd,
+.simple li > p {
 
   margin-bottom: 0;
 }
@@ -1546,8 +1547,19 @@ footer .contact-info .fa-paper-plane-o {
   font-weight: 400;
 }
 
-.sphinx-tabs .sphinx-menu a.item{
+.sphinx-tabs .sphinx-menu a.item {
   color: #0094ce !important;
+}
+
+.sphinx-tabs .sphinx-menu a.item p,
+table tr p {
+	color: inherit;
+	font-weight: inherit;
+	margin: inherit;
+}
+
+table tr p {
+  margin: 0.3rem 0px 0.3rem 0;
 }
 
 #main-content .sphinx-tabs .menu .item.docutils.container{
@@ -2233,9 +2245,13 @@ label {
 	border-radius: 4px 4px 0 0;
 }
 
-.admonition p {
+.admonition > p {
   padding: 1rem;
   margin: 0;
+}
+
+.admonition li p {
+	margin: 0;
 }
 
 .admonition.note > [class*="highlight-"],
@@ -2271,7 +2287,7 @@ p.admonition-title {
 	padding: 0.25rem 1rem;
 }
 
-p.first.admonition-title::before,
+p.admonition-title::before,
 .no-latest-notice span::before {
   display: inline-block;
   font: normal bold normal 1.1rem/.5 FontAwesome;
@@ -2328,12 +2344,12 @@ p.first.admonition-title::before,
 	color: #ffffff;
 }
 
-.note p.first.admonition-title::before,
-.admonition-generic-admonition p.first.admonition-title::before {
+.note p.admonition-title::before,
+.admonition-generic-admonition p.admonition-title::before {
   content: '\f06a';
 }
 
-.output p.first.admonition-title::before {
+.output p.admonition-title::before {
   content: '\f138';
 }
 
@@ -2389,14 +2405,14 @@ p.first.admonition-title::before,
   margin-right: 1rem;
 }
 
-.error p.first.admonition-title::before,
-.danger p.first.admonition-title::before,
-.hint p.first.admonition-title::before,
-.important p.first.admonition-title::before,
-.tip p.first.admonition-title::before,
-.attention p.first.admonition-title::before,
-.caution p.first.admonition-title::before,
-.warning p.first.admonition-title::before,
+.error p.admonition-title::before,
+.danger p.admonition-title::before,
+.hint p.admonition-title::before,
+.important p.admonition-title::before,
+.tip p.admonition-title::before,
+.attention p.admonition-title::before,
+.caution p.admonition-title::before,
+.warning p.admonition-title::before,
 .no-latest-notice span::before {
   content: '\f071';
 }

--- a/source/conf.py
+++ b/source/conf.py
@@ -401,18 +401,18 @@ def setup(app):
 
     minification(actual_path)
 
-    app.add_stylesheet("css/fontawesome.min.css?ver=%s" % os.stat(
+    app.add_css_file("css/fontawesome.min.css?ver=%s" % os.stat(
         os.path.join(actual_path, "_static/css/fontawesome.min.css")).st_mtime)
-    app.add_stylesheet("css/wazuh-icons.min.css?ver=%s" % os.stat(
+    app.add_css_file("css/wazuh-icons.min.css?ver=%s" % os.stat(
         os.path.join(actual_path, "_static/css/wazuh-icons.css")).st_mtime)
-    app.add_stylesheet("css/style.min.css?ver=%s" % os.stat(
+    app.add_css_file("css/style.min.css?ver=%s" % os.stat(
         os.path.join(actual_path, "_static/css/style.css")).st_mtime)
 
-    app.add_javascript("js/version-selector.min.js?ver=%s" % os.stat(
+    app.add_js_file("js/version-selector.min.js?ver=%s" % os.stat(
         os.path.join(actual_path, "_static/js/version-selector.js")).st_mtime)
-    app.add_javascript("js/style.min.js?ver=%s" % os.stat(
+    app.add_js_file("js/style.min.js?ver=%s" % os.stat(
         os.path.join(actual_path, "_static/js/style.js")).st_mtime)
-    app.add_javascript("js/redirects.min.js?ver=%s" % os.stat(
+    app.add_js_file("js/redirects.min.js?ver=%s" % os.stat(
         os.path.join(actual_path, "_static/js/redirects.js")).st_mtime)
 
 	# List of compiled documents


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

This PR maximizes the compatibility of our documentation with Sphinx 3.0.3 while keeping the style. The requirements have been updated with the new version recommendation:
- Sphinx==3.0.3
- sphinxcontrib-images==0.9.2
- sphinxprettysearchresults==0.3.5
- sphinx_tabs==1.1.13

With these changes, the documentation can still be compiled using Sphinx 1.8.0+ but it will no longer work with older versions.

Related issue: https://github.com/wazuh/wazuh-website/issues/1315

## Checks
- [ ] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
