### PR TITLE
Added the clarification of the rotate_interval option - branch 3.9

### DIFF
--- a/source/user-manual/reference/internal-options.rst
+++ b/source/user-manual/reference/internal-options.rst
@@ -101,6 +101,8 @@ Agent
 |                           |                | 1: Remote configuration is enable.                                               |
 +---------------------------+----------------+----------------------------------------------------------------------------------+
 
+.. _ossec_internal_analysisd:
+
 Analysisd
 ---------
 
@@ -1052,7 +1054,7 @@ Rootcheck
 Security Configuration Assessment
 ---------------------------------
 
-.. versionadded:: 3.9.0 
+.. versionadded:: 3.9.0
 
 +-----------------------------------+----------------+------------------------------------------------------------------------------------------------------------------+
 |    **sca.request_db_interval**    | Description    | In case of integrity fail, this is the maximum interval (minutes) to resend the scan information to the manager. |

--- a/source/user-manual/reference/ossec-conf/global.rst
+++ b/source/user-manual/reference/ossec-conf/global.rst
@@ -385,13 +385,17 @@ rotate_interval
 
 .. versionadded:: 3.1.0
 
-This option sets the interval between file rotation. The range of possible values is from ``10s`` (10 seconds) to ``1d`` (1 day).
+This option sets the interval between file rotation. The range of possible values is from ``10m`` (10 minutes) to ``1d`` (1 day).
 
 +-------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
 | **Default value**       | 0 (disabled)                                                                                                                      |
 +-------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
 | **Allowed values**      | A positive number that should ends with character indicating a time unit, such as, s (seconds), m (minutes), h (hours), d (days). |
 +-------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
+
+.. note::
+
+  The default minimum value ``10m`` is set in the :ref:`analysisd.min_rotate_interval <ossec_internal_analysisd>` option found in the internal configuration file ``/var/ossec/etc/internal_options.conf``.
 
 Example:
 


### PR DESCRIPTION
Hello Team,
this PR refers to #2498  
 
## Description

The file contains the clarification of the **rotate_interval** option found in the **global** section of the local configuration file **ossec.conf**  documentation.

## Checks

- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 

All the best,
Daria