### PR TITLE
[3.10] Fixed errors in search results when compiling with Sphinx 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,8 @@ You can also join our [users mailing list](https://groups.google.com/d/forum/waz
 ## Software and libraries used
 
 - [Python](https://www.python.org/) 3.5+
-- [Sphinx](http://www.sphinx-doc.org/) 3.0.3
+- [Sphinx](http://www.sphinx-doc.org/) 3.0.4
 - [sphinxcontrib-images](https://pypi.org/project/sphinxcontrib-images/) 0.9.2
-- [sphinxprettysearchresults](https://pypi.org/project/sphinxprettysearchresults/) 0.3.5
 - [sphinx-tabs](https://github.com/djungelorm/sphinx-tabs) 1.1.13
 
 ## Copyright & License

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-Sphinx==3.0.3
+Sphinx==3.0.4
 sphinxcontrib-images==0.9.2
-sphinxprettysearchresults==0.3.5
 sphinx_tabs==1.1.13

--- a/source/_themes/wazuh_doc_theme/layout.html
+++ b/source/_themes/wazuh_doc_theme/layout.html
@@ -105,7 +105,7 @@
     ga('send', 'pageview');
   </script>
   {% endif %}
-  
+
 </head>
 {%- endblock head %}
 <body>
@@ -170,7 +170,7 @@
           {% endif %}
 
           {# Main content #}
-          <main>
+          <main role="main">
             {% block body %} {% endblock %}
           </main>
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -37,7 +37,7 @@ release = version
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.0'
+needs_sphinx = '1.8'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -45,7 +45,7 @@ release = version
 extensions = [
     'sphinx.ext.autodoc',
     'sphinxcontrib.images',
-    'sphinxprettysearchresults',
+    'sphinx_tabs.tabs',
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

As a result of the changes in Sphinx 3, the context text for each search result was missing from our documentation when compiled using this version, due to the lack of `role=main` in our theme's template. This PRs fixes this bug.

In addition, the extension [sphinxprettysearchresults](https://pypi.org/project/sphinxprettysearchresults/) is no longer necessary, thus it has been removed.

Related issue: https://github.com/wazuh/wazuh-website/issues/1315

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
