### PR TITLE
[3.2] Added sitemap generation during the compilation process

### DIFF
--- a/source/_themes/wazuh_doc_theme/theme.conf
+++ b/source/_themes/wazuh_doc_theme/theme.conf
@@ -13,4 +13,5 @@ titles_only =
 display_version = True
 prev_next_buttons_location = bottom
 wazuh_web_url = https://wazuh.com
+wazuh_doc_url = https://documentation.wazuh.com
 globaltoc_depth = 4

--- a/source/conf.py
+++ b/source/conf.py
@@ -17,6 +17,7 @@ import os
 import re
 import shlex
 import datetime
+from requests.utils import requote_uri
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -115,6 +116,7 @@ html_theme = 'wazuh_doc_theme'
 # documentation.
 html_theme_options = {
     'wazuh_web_url': 'https://wazuh.com',
+    'wazuh_doc_url': 'https://documentation.wazuh.com',
     'globaltoc_depth': 5,
     'includehidden': True,
     'collapse_navigation': False,
@@ -430,13 +432,20 @@ def collect_compiled_pagename(app, pagename, templatename, context, doctree):
         pass
 
 def creating_file_list(app, exception):
-		''' Creates a document `.doclist` containing the path to every html file that was compiled '''
-		if app.builder.name == 'html':
-				build_path = app.outdir
-				separator = '\n'
-				with open(build_path+'/.doclist', 'w') as doclist_file:
-						list_text = separator.join(list_compiled_html)
-						doclist_file.write(list_text)
+	''' Creates a files containing the path to every html file that was compiled. This files are `.doclist` and the sitemap. '''
+	if app.builder.name == 'html':
+		build_path = app.outdir
+		separator = '\n'
+		with open(build_path+'/.doclist', 'w') as doclist_file:
+			list_text = separator.join(list_compiled_html)
+			doclist_file.write(list_text)
+		sitemap = '<?xml version=\'1.0\' encoding=\'utf-8\'?>'+separator
+		sitemap += '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'+separator
+		for compiled_html in list_compiled_html:
+			sitemap += '\t<url><loc>' + requote_uri(html_theme_options.get('wazuh_doc_url') + '/' + version + '/' + compiled_html) + '</loc></url>' + separator
+		sitemap += '</urlset>'
+		with open(build_path+'/'+version+'-sitemap.xml', 'w') as sitemap_file:
+			sitemap_file.write(sitemap)
 
 exclude_patterns = [
     "css/wazuh-icons.css",


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

This PR adds a code which automatically generates the sitemap corresponding to the release branch during compilation, placing it in the root of the folder containing the compiled documentation `build/html`.

Related issue: https://github.com/wazuh/wazuh-website/issues/1301

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
