### PR TITLE
Fixing documentation for Vulnerability Detector when using <url> tag for NVD

### DIFF
--- a/source/user-manual/capabilities/vulnerability-detection/offline_update.rst
+++ b/source/user-manual/capabilities/vulnerability-detection/offline_update.rst
@@ -177,13 +177,13 @@ It is possible that the script will output error messages like the following:
 
 This indicates that the National Vulnerability Database servers may be temporarily unavailable to you. The script will continue trying to finish the download until it acquires the full feed.
 
-Finally, you will have the feed divided into a succession of numbered files whose name follows format ``nvd-feed<number>.json.gz``. To update locally, the path to those files must be indicated by a regular expression as such:
+Finally, you will have the feed divided into a succession of numbered files whose name follows format ``nvd-feed<number>.json.gz``. Those files are compressed and should be extracted. To update locally, the path to those files must be indicated by a regular expression as such:
 
 .. code-block:: xml
 
     <provider name="nvd">
         <enabled>no</enabled>
-        <path>/local_path/nvd-feed.*json.gz$</path>
+        <path>/local_path/nvd-feed.*json$</path>
         <update_interval>1h</update_interval>
     </provider>
 

--- a/source/user-manual/capabilities/vulnerability-detection/offline_update.rst
+++ b/source/user-manual/capabilities/vulnerability-detection/offline_update.rst
@@ -188,12 +188,12 @@ Finally, you will have the feed divided into a succession of numbered files whos
     </provider>
 
 
-If you want to upload these files to a local server, they must follow the same numerical sequence in the link and indicate their position with the ``[-]`` tag helped by the ``start`` and ``end`` attributes to indicate the numerical range. For example, if you have the files from 2015 to 2019, the configuration would look like this:
+If you want to upload these files to a local server, they must follow the same numerical sequence in the link and indicate their position with the ``[-]`` tag helped by the ``start`` and ``end`` attributes to indicate the numerical range. For example, if you have the files from 2015 to 2020, the configuration would look like this:
 
 .. code-block:: xml
 
     <provider name="nvd">
         <enabled>no</enabled>
-        <url start="2015" end="2019">http://local_repo/nvd-feed[-].json.gz</url>
+        <url start="2015" end="2020">http://local_repo/nvd-feed[-].json</url>
         <update_interval>1h</update_interval>
     </provider>


### PR DESCRIPTION
This PR improves the explanation on how to configure the local feed update for Vulnerability Detector.
The current text could be interpreted by the users as a possibility to use compressed files but that is not currently supported. The changes introduced in this PR clarify that detail.