### PR TITLE
3.12 - Fix typos in syscheck.rst

### DIFF
--- a/source/user-manual/reference/ossec-conf/syscheck.rst
+++ b/source/user-manual/reference/ossec-conf/syscheck.rst
@@ -593,7 +593,7 @@ restart_audit
 
 .. note::  This option is set inside the ``<whodata>`` tag since version 3.9.0.
 
-Allows the system to restart ```Auditd`` after installing the plugin. Note that setting this field to ``no`` the new
+Allows the system to restart ``Auditd`` after installing the plugin. Note that setting this field to ``no`` the new
 whodata rules won't be applied automatically.
 
 +--------------------+---------+
@@ -682,7 +682,7 @@ skip_dev
 
 .. versionadded:: 3.12.0
 
-Specifies if syscheck should scan the ```/dev`` directory. This option works on Linux and FreeBSD systems.
+Specifies if syscheck should scan the ``/dev`` directory. This option works on Linux and FreeBSD systems.
 
 +--------------------+----------+
 | **Default value**  | yes      |
@@ -724,7 +724,7 @@ skip_proc
 
 .. versionadded:: 3.12.0
 
-Specifies if syscheck should scan the ```/proc`` directory. This option works on Linux and FreeBSD systems.
+Specifies if syscheck should scan the ``/proc`` directory. This option works on Linux and FreeBSD systems.
 
 +--------------------+----------+
 | **Default value**  | yes      |
@@ -882,7 +882,7 @@ The Whodata options will be configured inside this tag.
 
 .. versionadded:: 3.9.0
 
-Allows the system to restart ```Auditd`` after installing the plugin. Note that setting this field to ``no`` the new
+Allows the system to restart ``Auditd`` after installing the plugin. Note that setting this field to ``no`` the new
 whodata rules won't be applied automatically.
 
 +--------------------+---------+


### PR DESCRIPTION

Hello team, 

This PR fixes some typos I saw in the `syscheck` section.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

Regards.
