### PR TITLE
Corrected sentence in hotfixes subsection of the ossec.conf section of the documentation.

### DIFF
--- a/source/user-manual/reference/ossec-conf/wodle-syscollector.rst
+++ b/source/user-manual/reference/ossec-conf/wodle-syscollector.rst
@@ -173,7 +173,7 @@ Enables the hotfixes scan. It reports the Windows updates installed.
 +--------------------+---------+
 
 .. note::
-  This option is enabled by default but no included in the initial configuration.
+  This option is enabled by default but not included in the initial configuration.
 
 
 Example of configuration


### PR DESCRIPTION
Hello Team,
this PR closes #2353 
 
## Description

The file contains corrected, previously misspelled, sentence in **hotfixes** subsection of the **ossec.conf** section of the documentation.

https://documentation.wazuh.com/3.12/user-manual/reference/ossec-conf/wodle-syscollector.html#hotfixes

## Checks

- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 

All the best,
Daria