### PR TITLE
[3.9] Delete cached redirection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,5 @@ node_modules
 .eslintrc
 package-lock.json
 package.json
-source/_static/css/style.min.css
-source/_static/css/wazuh-icons.min.css
-source/_static/js/style.min.js
-source/_static/js/version-selector.min.js
-source/_static/js/redirects.min.js
+source/_static/css/*.min.css
+source/_static/js/*.min.js

--- a/source/_static/js/delete-cache.js
+++ b/source/_static/js/delete-cache.js
@@ -1,0 +1,8 @@
+  /* Delete old cached redirects from /current */
+  const current_url = window.location.href;
+  const parts = current_url.split('/');
+  const fetch_url = parts[0] + '//' + parts[2] + '/current/' + parts.slice(4).join('/');
+  fetch(fetch_url, {cache: "no-cache"})
+    .then(response => {
+      /* Fixed redirects, do nothing */
+    });

--- a/source/conf.py
+++ b/source/conf.py
@@ -353,6 +353,7 @@ def minification(actual_path):
         ['css/wazuh-icons','css'],
         ['js/version-selector','js'],
         ['js/redirects','js'],
+        ['js/delete-cache','js'],
         ['js/style','js']
     ]
 
@@ -416,6 +417,8 @@ def setup(app):
         os.path.join(actual_path, "_static/js/style.js")).st_mtime)
     app.add_js_file("js/redirects.min.js?ver=%s" % os.stat(
         os.path.join(actual_path, "_static/js/redirects.js")).st_mtime)
+    app.add_js_file("js/delete-cache.min.js?ver=%s" % os.stat(
+        os.path.join(actual_path, "_static/js/delete-cache.js")).st_mtime)
 
 	# List of compiled documents
     app.connect('html-page-context', collect_compiled_pagename)
@@ -452,6 +455,7 @@ exclude_patterns = [
     "css/style.css",
     "js/version-selector.js",
     "js/redirects.js",
+    "js/delete-cache.js",
     "js/style.js"
 ]
 


### PR DESCRIPTION
## Description

Our `/current` documentation URLs have been using `301` redirections for a while. Those redirections get cached in browsers and are hard to remove, so I've added a script that refreshes redirections cache in the browser. It is necessary for every release since the expected destination of `/current` URLs must change.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).