### PR TITLE
[3.11] Update gitignore to ignore all minified assets (current and future)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,5 @@ node_modules
 .eslintrc
 package-lock.json
 package.json
-source/_static/css/style.min.css
-source/_static/css/wazuh-icons.min.css
-source/_static/js/style.min.js
-source/_static/js/version-selector.min.js
-source/_static/js/redirects.min.js
-source/_static/js/delete-cache.min.js
+source/_static/css/*.min.css
+source/_static/js/*.min.js


### PR DESCRIPTION
## Description

Every time we add a new script or style file, we need to remember to add its minified version to the `.gitignore` list. With this change, all minified assets are ignored by default.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).