### PR TITLE
[3.12] Add new 3.13 URLs and set 3.13 as the latest version

### DIFF
--- a/source/_static/js/redirects.js
+++ b/source/_static/js/redirects.js
@@ -34,6 +34,20 @@ removedUrls['x.y'] = [
 ];
 */
 
+/* *** RELEASE 3.13 ****/
+
+newUrls['3.13'] = [
+  '/release-notes/release_3_13_0.html',
+  '/gcp/index.html',
+  '/gcp/prerequisites/considerations.html',
+  '/gcp/prerequisites/credentials.html',
+  '/gcp/prerequisites/dependencies.html',
+  '/gcp/prerequisites/index.html',
+  '/gcp/prerequisites/pubsub.html',
+  '/user-manual/reference/ossec-conf/gcp-pubsub.html',
+  '/user-manual/ruleset/mitre.html',
+];
+
 /* *** RELEASE 3.12 ****/
 
 /* Redirections from 3.11 to 3.12  */

--- a/source/_static/js/version-selector.js
+++ b/source/_static/js/version-selector.js
@@ -55,9 +55,10 @@ jQuery(function($) {
   */
 
   /* Versions main constants */
-  const currentVersion = '3.12';
+  const currentVersion = '3.13';
   const versions = [
-    {name: '3.12 (current)', url: '/'+currentVersion},
+    {name: '3.13 (current)', url: '/'+currentVersion},
+    {name: '3.12', url: '/3.12'},
     {name: '3.11', url: '/3.11'},
     {name: '3.10', url: '/3.10'},
     {name: '3.9', url: '/3.9'},

--- a/source/conf.py
+++ b/source/conf.py
@@ -31,7 +31,7 @@ author = u'Wazuh, Inc.'
 copyright = u'&copy; ' + str(datetime.datetime.now().year) + u' &middot; Wazuh Inc.'
 
 # The short X.Y version
-version = '3.13'
+version = '3.12'
 # The full version, including alpha/beta/rc tags
 release = version
 
@@ -406,12 +406,12 @@ def customReplacements(app, docname, source):
     source[0] = result
 
 custom_replacements = {
-    "|WAZUH_LATEST|" : "3.13.0",
-    "|WAZUH_LATEST_MINOR|" : "3.13.0,
+    "|WAZUH_LATEST|" : "3.12.0",
+    "|WAZUH_LATEST_MINOR|" : "3.12.3,
     "|WAZUH_LATEST_ANSIBLE|" : "3.12.2",
     "|WAZUH_LATEST_KUBERNETES|" : "3.12.2",
     "|WAZUH_LATEST_PUPPET|" : "3.12.2",
-    "|WAZUH_LATEST_OVA|" : "3.13.0",
+    "|WAZUH_LATEST_OVA|" : "3.12.2",
     "|WAZUH_LATEST_DOCKER|" : "3.12.2",
     "|ELASTICSEARCH_LATEST|" : "7.7.1",
     "|ELASTICSEARCH_LATEST_OVA|" : "7.6.2",

--- a/source/conf.py
+++ b/source/conf.py
@@ -31,7 +31,7 @@ author = u'Wazuh, Inc.'
 copyright = u'&copy; ' + str(datetime.datetime.now().year) + u' &middot; Wazuh Inc.'
 
 # The short X.Y version
-version = '3.12'
+version = '3.13'
 # The full version, including alpha/beta/rc tags
 release = version
 
@@ -406,12 +406,12 @@ def customReplacements(app, docname, source):
     source[0] = result
 
 custom_replacements = {
-    "|WAZUH_LATEST|" : "3.12.3",
-    "|WAZUH_LATEST_MINOR|" : "3.12",
+    "|WAZUH_LATEST|" : "3.13.0",
+    "|WAZUH_LATEST_MINOR|" : "3.13.0,
     "|WAZUH_LATEST_ANSIBLE|" : "3.12.2",
     "|WAZUH_LATEST_KUBERNETES|" : "3.12.2",
     "|WAZUH_LATEST_PUPPET|" : "3.12.2",
-    "|WAZUH_LATEST_OVA|" : "3.12.3",
+    "|WAZUH_LATEST_OVA|" : "3.13.0",
     "|WAZUH_LATEST_DOCKER|" : "3.12.2",
     "|ELASTICSEARCH_LATEST|" : "7.7.1",
     "|ELASTICSEARCH_LATEST_OVA|" : "7.6.2",

--- a/source/conf.py
+++ b/source/conf.py
@@ -407,7 +407,7 @@ def customReplacements(app, docname, source):
 
 custom_replacements = {
     "|WAZUH_LATEST|" : "3.12.3",
-    "|WAZUH_LATEST_MINOR|" : "3.12,
+    "|WAZUH_LATEST_MINOR|" : "3.12",
     "|WAZUH_LATEST_ANSIBLE|" : "3.12.2",
     "|WAZUH_LATEST_KUBERNETES|" : "3.12.2",
     "|WAZUH_LATEST_PUPPET|" : "3.12.2",

--- a/source/conf.py
+++ b/source/conf.py
@@ -406,12 +406,12 @@ def customReplacements(app, docname, source):
     source[0] = result
 
 custom_replacements = {
-    "|WAZUH_LATEST|" : "3.12.0",
-    "|WAZUH_LATEST_MINOR|" : "3.12.3,
+    "|WAZUH_LATEST|" : "3.12.3",
+    "|WAZUH_LATEST_MINOR|" : "3.12,
     "|WAZUH_LATEST_ANSIBLE|" : "3.12.2",
     "|WAZUH_LATEST_KUBERNETES|" : "3.12.2",
     "|WAZUH_LATEST_PUPPET|" : "3.12.2",
-    "|WAZUH_LATEST_OVA|" : "3.12.2",
+    "|WAZUH_LATEST_OVA|" : "3.12.3",
     "|WAZUH_LATEST_DOCKER|" : "3.12.2",
     "|ELASTICSEARCH_LATEST|" : "7.7.1",
     "|ELASTICSEARCH_LATEST_OVA|" : "7.6.2",


### PR DESCRIPTION
## Description 

Update all necessary files for version selector to include `3.13` in this branch.

## Checks
- [x] It compiles without warnings.
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

## Note to the reviewer

This PR includes changes to the `redirect.js` script that need to be included in all production branches.
