### PR TITLE
[3.8] Add new 3.13 URLs

### DIFF
--- a/source/_static/js/redirects.js
+++ b/source/_static/js/redirects.js
@@ -34,6 +34,20 @@ removedUrls['x.y'] = [
 ];
 */
 
+/* *** RELEASE 3.13 ****/
+
+newUrls['3.13'] = [
+  '/release-notes/release_3_13_0.html',
+  '/gcp/index.html',
+  '/gcp/prerequisites/considerations.html',
+  '/gcp/prerequisites/credentials.html',
+  '/gcp/prerequisites/dependencies.html',
+  '/gcp/prerequisites/index.html',
+  '/gcp/prerequisites/pubsub.html',
+  '/user-manual/reference/ossec-conf/gcp-pubsub.html',
+  '/user-manual/ruleset/mitre.html',
+];
+
 /* *** RELEASE 3.12 ****/
 
 /* Redirections from 3.11 to 3.12  */


### PR DESCRIPTION
## Description

Added new `3.13` documentation pages to the redirections array.

## Checks
- [x] It compiles without warnings.
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

## Note to the reviewer

This PR includes changes to the `redirect.js` script that need to be included in all production branches.
