### PR TITLE
[3.5] Add GCP supported services to new URLs in 3.13

### DIFF
--- a/source/_static/js/redirects.js
+++ b/source/_static/js/redirects.js
@@ -44,6 +44,7 @@ newUrls['3.13'] = [
   '/gcp/prerequisites/dependencies.html',
   '/gcp/prerequisites/index.html',
   '/gcp/prerequisites/pubsub.html',
+  '/gcp/supported-services/index.html',
   '/user-manual/reference/ossec-conf/gcp-pubsub.html',
   '/user-manual/ruleset/mitre.html',
 ];


### PR DESCRIPTION
## Description

URL testing in the production documentation of 3.13 has reported 404 errors in version selector, in the URL:

https://documentation.wazuh.com/3.13/gcp/supported-services/index.html

I've added this page to the new pages array for 3.13, since it is a new 3.13 feature.

## Checks
- [x] It compiles without warnings.
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

## Note to the reviewer

This PR includes changes to the `redirect.js` script that need to be included in all production branches.
