### PR TITLE
Fixed the name of the script for generating the Wazuh Splunk app

### DIFF
--- a/source/development/packaging/generate-wazuh-splunk-app.rst
+++ b/source/development/packaging/generate-wazuh-splunk-app.rst
@@ -21,7 +21,7 @@ Download our wazuh-packages repository from GitHub and go to the splunkapp direc
 
   $ git clone https://github.com/wazuh/wazuh-packages && cd wazuh-packages/splunkapp
 
-Execute the ``generate_wazuh_app.sh`` script, with the different options you desire. This script will build a Docker image with all the necessary tools to create the Wazuh Splunk App package and run a container that will build it:
+Execute the ``generate_wazuh_splunk_app.sh`` script, with the different options you desire. This script will build a Docker image with all the necessary tools to create the Wazuh Splunk App package and run a container that will build it:
 
 .. code-block:: console
 
@@ -42,13 +42,13 @@ Below, you will find some examples of how to build Wazuh Splunk App packages.
 
 .. code-block:: console
 
-  # ./generate_wazuh_app.sh -b v|WAZUH_LATEST|-|SPLUNK_LATEST| -s /splunk-app -r 1
+  # ./generate_wazuh_splunk_app.sh -b v|WAZUH_LATEST|-|SPLUNK_LATEST| -s /splunk-app -r 1
 
 This will generate a Wazuh Splunk app package for Wazuh |WAZUH_LATEST| and Splunk |SPLUNK_LATEST| with revision 1 and store it in /splunk-app.
 
 .. code-block:: console
 
-  # ./generate_wazuh_app.sh -b v|WAZUH_LATEST|-|SPLUNK_LATEST| -s /wazuh-app -r 1 -c
+  # ./generate_wazuh_splunk_app.sh -b v|WAZUH_LATEST|-|SPLUNK_LATEST| -s /splunk-app -r 1 -c
 
 This will generate a Wazuh Splunk app package for Wazuh |WAZUH_LATEST| and Splunk |SPLUNK_LATEST| with revision 1, the sha512 checksum and store them in /splunk-app.
 


### PR DESCRIPTION
Hello team!

This issue closes #2653 for branch `3.12`


## Description
I've modified all the appearances of the script that were not named correctly. 
<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->
Regards,

David