### PR TITLE
[3.13] Decreased CLS to improve UX

### DIFF
--- a/source/_static/css/style.css
+++ b/source/_static/css/style.css
@@ -803,11 +803,6 @@ li.toctree-l5 > a {
   transition: opacity 0.3s ease;
 }
 
-#navbar.hidden {
-  visibility: hidden;
-  opacity: 0;
-}
-
 #navbar-globaltoc {
   height: calc(100vh - 165px); /* 40px search + 100px buttons + 25px padding = 165px */
   visibility: visible;

--- a/source/_static/js/style.js
+++ b/source/_static/js/style.js
@@ -38,13 +38,6 @@ $(function() {
     correctScrollTo(spaceBeforeAnchor);
   }
 
-  /* Finds current page section in globaltoc */
-  $('.globaltoc .toctree-l2.current a').each(function(e) {
-    if (!$(this).siblings('ul').length) {
-      $(this).addClass('leaf');
-    }
-  });
-
   /* Finds all nodes that contains subtrees within the globaltoc and appends a toggle button to them */
   $('.globaltoc .toctree-l1 a').each(function(e) {
     if ($(this).siblings('ul').length) {
@@ -53,39 +46,11 @@ $(function() {
     }
   });
 
-  showCurrentSubtree();
   hideSubtree(hideSubtreeNodes);
 
-  /* Show the hidden menu */
-  setTimeout(function() {
-    $('#navbar').removeClass('hidden');
-  }, 100);
-
   $(window).on('hashchange', function() {
-    updateFromHash();
     correctScrollTo(spaceBeforeAnchor);
   });
-
-  /**
-   * Updates the hash value (from the URL) in order to update the selected leaf from the globl toctree.
-   * That is, when the sections within a document are included in the toctree.
-   */
-  function updateFromHash() {
-    loc = location.hash;
-    selectLeaf(loc);
-  }
-
-  /**
-   * When sections of a document are included in the toctree, this updates the selected section in the global toctree.
-   * @param {string} hash String that appearse after the sign # in the URL.
-   */
-  function selectLeaf(hash) {
-    if (hash.length > 0) {
-      $('.globaltoc [href="' + hash + '"]').addClass('current');
-    } else {
-      $('.globaltoc [href="#"]').addClass('current');
-    }
-  }
 
   /* Turn all tables in responsive table */
   reponsiveTables();
@@ -203,22 +168,6 @@ $(function() {
       }
     }, {passive: false});
   }
-
-  /* $('#navbar-globaltoc').on('mousewheel', function(e) {
-    eventScroll = 'mousewheel';
-    if (e.originalEvent.wheelDelta > 0 || e.originalEvent.detail < 0) {
-      scrollDirection = 'up';
-    } else {
-      scrollDirection = 'down';
-    }
-    enableDisableScroll();
-    if (disableScroll) {
-      e.preventDefault();
-      e.stopPropagation();
-      e.returnValue = false;
-      return false;
-    }
-  }); */
 
   $('#navbar-globaltoc').keydown(function(e) {
     eventScroll = 'keys';
@@ -366,26 +315,6 @@ $(function() {
   });
 
   /**
-   * Shows the selected style for the parent document of pages that don't appear in the globaltoc
-   * @return {boolean} Returns true only if this funcionability in not applicable to the current page.
-   */
-  function showCurrentSubtree() {
-    updateFromHash();
-    if ($('ul li.toctree-l1 a.current.reference.internal, ul li.toctree-l1 .current > .leaf').length == 0 && !$('#page').hasClass('index') && !$('#page').hasClass('not-indexed')) {
-      $('.globaltoc :contains("' + $('#breadcrumbs li:nth-last-child(2) a').text() + '")').addClass('show').addClass('current');
-      return true;
-    }
-    let currentLeaf = $('.globaltoc a.current.leaf');
-    if (currentLeaf.length == 0) {
-      currentLeaf = $('.globaltoc [href="#"].current');
-    }
-    currentLeaf.parents('li').each(function() {
-      $(this).addClass('initial').addClass('show');
-    });
-    completelyHideMenuItems();
-  }
-
-  /**
    * Completely hides the visually hidden elements
    */
   function completelyHideMenuItems() {
@@ -420,9 +349,6 @@ $(function() {
         /* The selected menu link in the globaltoc acts as the toggle button, showing on and off its subtree */
         if (regex.test(href) || isCurrent) {
           $(this).addClass(className);
-        }
-        if (isCurrent) {
-          $(this).addClass('current-toc-node');
         }
       });
     });

--- a/source/_themes/wazuh_doc_theme/layout.html
+++ b/source/_themes/wazuh_doc_theme/layout.html
@@ -105,7 +105,7 @@
     ga('send', 'pageview');
   </script>
   {% endif %}
-  
+
 </head>
 {%- endblock head %}
 <body>
@@ -142,7 +142,12 @@
                 {% block menu %}
                 {% set toctree = toctree(maxdepth=theme_globaltoc_depth|toint, collapse=theme_collapse_navigation, includehidden=theme_globaltoc_includehidden|tobool) %}
                 {% if toctree %}
-                {{ toctree }}
+                  {% set toctree = toctree.replace('toctree-l1 current', 'toctree-l1 current show') %}
+                  {% set toctree = toctree.replace('toctree-l2 current', 'toctree-l2 current show') %}
+                  {% set toctree = toctree.replace('toctree-l3 current', 'toctree-l3 current show') %}
+                  {% set toctree = toctree.replace('toctree-l4 current', 'toctree-l4 current show') %}
+                  {% set toctree = toctree.replace('reference internal" href="#"', 'reference internal current-toc-node" href="#"') %}
+                  {{ toctree }}
                 {% endif %}
                 {% endblock %}
               </nav>


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

This PR moves part of the functionality related to the sidebar menu from javascript to the template that is used during the compilation. This reduces de shifting of this element when the page is loading, which improves user experience, thus it reduces the value of Cumulative Layer Shift (CLS), the new metric of Google Analytics.

Related issue: https://github.com/wazuh/wazuh-website/issues/1373

<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).