### PR TITLE
Update API protocol

### DIFF
--- a/source/user-manual/agents/grouping-agents.rst
+++ b/source/user-manual/agents/grouping-agents.rst
@@ -34,7 +34,7 @@ Below are the steps to assign agents to a group with a specific configuration:
 
    .. code-block:: console
 
-      # curl -u foo:bar -X PUT "http://localhost:55000/agents/002/group/dbms?pretty"
+      # curl -u foo:bar -X PUT "https://localhost:55000/agents/002/group/dbms?pretty"
 
    An agent's group assignment can be checked using one of the following commands:
 
@@ -58,7 +58,7 @@ Below are the steps to assign agents to a group with a specific configuration:
 
    .. code-block:: console
 
-      # curl -u foo:bar -X GET "http://localhost:55000/agents/groups/dbms?pretty"
+      # curl -u foo:bar -X GET "https://localhost:55000/agents/groups/dbms?pretty"
 
 
 2. Once a group is created, its ``agent.conf`` file can be edited to include the specific configuration you wish to assign to this group. For this example, the file to be edited is located at ``/var/ossec/etc/shared/dbms/agent.conf`` and each agent belonging to this group will receive this file.
@@ -98,7 +98,7 @@ In this example, the agent 001 has been added to `webserver` and `apache` groups
 
     .. code-block:: console
 
-        # curl -u foo:bar -X PUT "http://localhost:55000/agents/001/group/webserver?pretty"
+        # curl -u foo:bar -X PUT "https://localhost:55000/agents/001/group/webserver?pretty"
 
     .. code-block:: json
         :class: output
@@ -110,7 +110,7 @@ In this example, the agent 001 has been added to `webserver` and `apache` groups
 
     .. code-block:: console
 
-        # curl -u foo:bar -X PUT "http://localhost:55000/agents/001/group/apache?pretty"
+        # curl -u foo:bar -X PUT "https://localhost:55000/agents/001/group/apache?pretty"
 
     .. code-block:: json
         :class: output
@@ -124,7 +124,7 @@ After that, we can ask the **API** about groups which an agent belongs:
 
     .. code-block:: console
 
-        # curl -u foo:bar -X GET "http://localhost:55000/agents/001?pretty"
+        # curl -u foo:bar -X GET "https://localhost:55000/agents/001?pretty"
 
     .. code-block:: json
         :emphasize-lines: 6,7,8,9,10
@@ -294,7 +294,7 @@ Finally, to check the synchronization status of the group configuration for a si
 
     .. code-block:: console
 
-        # curl -u foo:bar -X GET "http://localhost:55000/agents/001/group/is_sync?pretty"
+        # curl -u foo:bar -X GET "https://localhost:55000/agents/001/group/is_sync?pretty"
 
     .. code-block:: json
         :class: output

--- a/source/user-manual/api/examples.rst
+++ b/source/user-manual/api/examples.rst
@@ -16,7 +16,7 @@ cURL is a command-line tool for sending http/https requests and commands. It is 
 
 .. code-block:: console
 
-    # curl -u foo:bar "http://localhost:55000"
+    # curl -u foo:bar "https://localhost:55000"
 
 .. code-block:: json
     :class: output
@@ -36,7 +36,7 @@ cURL is a command-line tool for sending http/https requests and commands. It is 
 
 .. code-block:: console
 
-    # curl -u foo:bar -X PUT "http://localhost:55000/agents/new_agent"
+    # curl -u foo:bar -X PUT "https://localhost:55000/agents/new_agent"
 
 .. code-block:: json
     :class: output
@@ -54,7 +54,7 @@ cURL is a command-line tool for sending http/https requests and commands. It is 
 
 .. code-block:: console
 
-    # curl -u foo:bar -X POST -d '{"name":"NewHost","ip":"10.0.0.8"}' -H 'Content-Type:application/json' "http://localhost:55000//agents"
+    # curl -u foo:bar -X POST -d '{"name":"NewHost","ip":"10.0.0.8"}' -H 'Content-Type:application/json' "https://localhost:55000//agents"
 
 .. code-block:: json
     :class: output
@@ -72,7 +72,7 @@ cURL is a command-line tool for sending http/https requests and commands. It is 
 
 .. code-block:: console
 
-    # curl -u foo:bar -X DELETE "http://localhost:55000/rootcheck/001?pretty"
+    # curl -u foo:bar -X DELETE "https://localhost:55000/rootcheck/001?pretty"
 
 .. code-block:: json
     :class: output

--- a/source/user-manual/api/getting-started.rst
+++ b/source/user-manual/api/getting-started.rst
@@ -28,7 +28,7 @@ Use the cURL command to send a *request* to confirm that everything is working a
 
 .. code-block:: console
 
-    # curl -u foo:bar "http://localhost:55000?pretty"
+    # curl -u foo:bar "https://localhost:55000?pretty"
 
 .. code-block:: json
     :class: output
@@ -48,7 +48,7 @@ Explanation:
 
  * ``curl``: A command-line tool for sending requests and commands over HTTP and HTTPS.
  * ``-u foo:bar``: The username and password to authenticate with the API.
- * ``http://localhost:55000``: The API URL to use if you are running the command on the manager itself.
+ * ``https://localhost:55000``: The API URL to use if you are running the command on the manager itself.
  * ``?pretty``: The parameter that makes the JSON output more human-readable.
 
 Basic concepts
@@ -111,7 +111,7 @@ Often when an alert fires, it is helpful to know details about the rule itself. 
 
 .. code-block:: console
 
-    # curl -u foo:bar "http://localhost:55000/rules/1002?pretty"
+    # curl -u foo:bar "https://localhost:55000/rules/1002?pretty"
 
 .. code-block:: json
     :class: output
@@ -148,7 +148,7 @@ It can also be helpful to know what rules are available that match a specific cr
 
 .. code-block:: console
 
-    # curl -u foo:bar "http://localhost:55000/rules?group=web&pci=10.6.1&search=failures&pretty"
+    # curl -u foo:bar "https://localhost:55000/rules?group=web&pci=10.6.1&search=failures&pretty"
 
 .. code-block:: json
     :class: output
@@ -201,7 +201,7 @@ The API can be used to show information about all monitored files by syscheck. T
 
 .. code-block:: console
 
-    # curl -u foo:bar "http://localhost:55000/syscheck/000?event=modified&search=.py&pretty"
+    # curl -u foo:bar "https://localhost:55000/syscheck/000?event=modified&search=.py&pretty"
 
 .. code-block:: json
     :class: output
@@ -252,7 +252,7 @@ You can find a file using its md5/sha1 hash. In the following examples, the same
 
 .. code-block:: console
 
-    # curl -u foo:bar "http://localhost:55000/syscheck/000?pretty&hash=17f51705df5b61c53ef600fc1fcbe031e4d53c20"
+    # curl -u foo:bar "https://localhost:55000/syscheck/000?pretty&hash=17f51705df5b61c53ef600fc1fcbe031e4d53c20"
 
 .. code-block:: json
     :class: output
@@ -284,7 +284,7 @@ You can find a file using its md5/sha1 hash. In the following examples, the same
 
 .. code-block:: console
 
-    # curl -u foo:bar "http://localhost:55000/syscheck/000?pretty&hash=39b88ab3ddfaf00db53e5cf193051351"
+    # curl -u foo:bar "https://localhost:55000/syscheck/000?pretty&hash=39b88ab3ddfaf00db53e5cf193051351"
 
 .. code-block:: json
     :class: output
@@ -322,7 +322,7 @@ Rootcheck requests are very similar to the syscheck requests. In order to get al
 
 .. code-block:: console
 
-    # curl -u foo:bar "http://localhost:55000/rootcheck/000?status=outstanding&offset=10&limit=1&pretty"
+    # curl -u foo:bar "https://localhost:55000/rootcheck/000?status=outstanding&offset=10&limit=1&pretty"
 
 .. code-block:: json
     :class: output
@@ -351,7 +351,7 @@ Some information about the manager can be retrieved using the API. Configuration
 
 .. code-block:: console
 
-    # curl -u foo:bar "http://localhost:55000/manager/status?pretty"
+    # curl -u foo:bar "https://localhost:55000/manager/status?pretty"
 
 .. code-block:: json
     :class: output
@@ -377,7 +377,7 @@ You can even dump the manager's current configuration with the request below (re
 
 .. code-block:: console
 
-    # curl -u foo:bar "http://localhost:55000/manager/configuration?pretty"
+    # curl -u foo:bar "https://localhost:55000/manager/configuration?pretty"
 
 .. code-block:: json
     :class: output
@@ -409,7 +409,7 @@ This enumerates **active** agents:
 
 .. code-block:: console
 
-    # curl -u foo:bar "http://localhost:55000/agents?offset=1&limit=1&status=active&pretty"
+    # curl -u foo:bar "https://localhost:55000/agents?offset=1&limit=1&status=active&pretty"
 
 .. code-block:: json
     :class: output
@@ -453,7 +453,7 @@ Adding an agent is now easier than ever. Simply send a request with the agent na
 
 .. code-block:: console
 
-    # curl -u foo:bar -X POST -d '{"name":"NewHost","ip":"10.0.0.9"}' -H 'Content-Type:application/json' "http://localhost:55000/agents?pretty"
+    # curl -u foo:bar -X POST -d '{"name":"NewHost","ip":"10.0.0.9"}' -H 'Content-Type:application/json' "https://localhost:55000/agents?pretty"
 
 .. code-block:: json
     :class: output

--- a/source/user-manual/api/queries.rst
+++ b/source/user-manual/api/queries.rst
@@ -31,7 +31,7 @@ For example, to filter Ubuntu agents with a version higher than 12, the followin
 
 .. code-block:: console
 
-    # curl -u foo:bar -X GET "http://localhost:55000/agents?pretty&q=os.name=ubuntu;os.version>12&select=id,name,os.name,os.version,os.codename,os.major"
+    # curl -u foo:bar -X GET "https://localhost:55000/agents?pretty&q=os.name=ubuntu;os.version>12&select=id,name,os.name,os.version,os.codename,os.major"
 
 .. code-block:: json
     :class: output
@@ -69,7 +69,7 @@ The same field can be used multiple times to get a more accurate result. For exa
 
 .. code-block:: console
 
-    # curl -u foo:bar -X GET "http://localhost:55000/agents?pretty&q=os.name=ubuntu;os.version>12;os.version<18&select=id,name,os.name,os.version,os.codename,os.major"
+    # curl -u foo:bar -X GET "https://localhost:55000/agents?pretty&q=os.name=ubuntu;os.version>12;os.version<18&select=id,name,os.name,os.version,os.codename,os.major"
 
 .. code-block:: json
     :class: output
@@ -97,7 +97,7 @@ An example of using the OR operator can be filtering Ubuntu or CentOS agents:
 
 .. code-block:: console
 
-    # curl -u foo:bar -X GET "http://localhost:55000/agents?pretty&q=os.name=ubuntu,os.name=centos+linux&select=id,name,os.name,os.version,os.codename,os.major"
+    # curl -u foo:bar -X GET "https://localhost:55000/agents?pretty&q=os.name=ubuntu,os.name=centos+linux&select=id,name,os.name,os.version,os.codename,os.major"
 
 .. code-block:: json
     :class: output
@@ -145,7 +145,7 @@ Another example using the ``~`` operator is the following:
 
 .. code-block:: console
 
-    # curl -u foo:bar -X GET "http://localhost:55000/agents?pretty&q=os.name~cent"
+    # curl -u foo:bar -X GET "https://localhost:55000/agents?pretty&q=os.name~cent"
 
 .. code-block:: json
     :class: output
@@ -192,7 +192,7 @@ The following example shows how to check rootcheck events generated in a specifi
 
 .. code-block:: console
 
-    # curl -u foo:bar -X GET "http://localhost:55000/rootcheck/001?pretty&q=oldDay<3h25m&limit=2"
+    # curl -u foo:bar -X GET "https://localhost:55000/rootcheck/001?pretty&q=oldDay<3h25m&limit=2"
 
 .. code-block:: json
     :class: output
@@ -223,7 +223,7 @@ A more precise timeframe can be specified using operators ``>`` and ``<`` togeth
 
 .. code-block:: console
 
-    # curl -u foo:bar -X GET "http://localhost:55000/rootcheck/001?pretty&q=oldDay<3h30m;oldDay>3h&limit=2"
+    # curl -u foo:bar -X GET "https://localhost:55000/rootcheck/001?pretty&q=oldDay<3h30m;oldDay>3h&limit=2"
 
 .. code-block:: json
     :class: output

--- a/source/user-manual/configuring-cluster/cluster_management.rst
+++ b/source/user-manual/configuring-cluster/cluster_management.rst
@@ -23,7 +23,7 @@ This information can also be obtained using the Restful API:
 
 .. code-block:: console
 
-    # curl -u foo:bar -X GET "http://localhost:55000/cluster/nodes?pretty"
+    # curl -u foo:bar -X GET "https://localhost:55000/cluster/nodes?pretty"
 
 .. code-block:: json
     :class: output


### PR DESCRIPTION
## Description

Hi team! This PR closes #2719. It updates the protocol used in the example API urls as it is `https` by default since some months ago. 

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
