### PR TITLE
Correct error in [Learning Wazuh - Survive a log flood] documentation

### DIFF
--- a/source/learning-wazuh/survive-flood.rst
+++ b/source/learning-wazuh/survive-flood.rst
@@ -191,7 +191,7 @@ See what happened according to Kibana
     :width: 100%
 
 
-5. Query Kibana for "agent_flooding".  Click **[Add]** additionally next to "rule.description" and "data.level" for readability.
+5. Query Kibana for "agent_flooding".  Click **[Add]** additionally next to "full_log" and "data.level" for readability.
 
 .. thumbnail:: ../images/learning-wazuh/labs/flood-2.png
     :title: Flood


### PR DESCRIPTION
Hi team,
This PR aims to correct an error in step 5 of these instructions: https://documentation.wazuh.com/3.13/learning-wazuh/survive-flood.html#see-what-happened-according-to-kibana.

The instructions tell us to add `rule.description` as a column, but in the screenshot we add `full_log`.

Best regards,
Sergio.
