### PR TITLE
[3.11] Fixed a bug in the style of the top bar

### DIFF
--- a/source/_static/css/style.css
+++ b/source/_static/css/style.css
@@ -3092,8 +3092,7 @@ div.highlight pre {
       }
 
       #header-default .right {
-        position: relative;
-        height: auto;
+        height: 73px;
       }
 
       .release-selector-wrapper {

--- a/source/_themes/wazuh_doc_theme/header.html
+++ b/source/_themes/wazuh_doc_theme/header.html
@@ -71,7 +71,7 @@
           </div> <!-- // #logo-title -->
         </nav>
 
-        <div class="right col-lg-9 col-12">
+        <div class="right col-12">
 
           <div id="navbarWebMenu">
 

--- a/source/_themes/wazuh_doc_theme/header.html
+++ b/source/_themes/wazuh_doc_theme/header.html
@@ -87,6 +87,8 @@
               <ul id="menu-subfooter-social-links" class="nav from-left no-bullets">
                 <li class="rrss menu-item nav-item d-inline-block"><a class="nav-link" title="Wazuh on Twitter" target="_blank" href="https://twitter.com/wazuh"><i class="fab fa-twitter"></i></a></li>
                 <li class="rrss menu-item nav-item d-inline-block"><a class="nav-link" title="Join us on Slack" href="https://wazuh.com/community/join-us-on-slack/"><i class="fab fa-slack"></i></a></li>
+                <li class="rrss menu-item nav-item d-inline-block"><a class="nav-link" title="Wazuh on Youtube" target="_blank" href="https://www.youtube.com/c/wazuhsecurity"><i class="fab fa-youtube"></i></a></li>
+                <li class="rrss menu-item nav-item d-inline-block"><a class="nav-link" title="Wazuh on LinkedIn" target="_blank" href="https://www.linkedin.com/company/wazuh"><i class="fab fa-linkedin-in"></i></a></li>
                 <li class="rrss menu-item nav-item d-inline-block"><a class="nav-link" title="Wazuh on Github" target="_blank" href="https://github.com/wazuh"><i class="fab fa-github"></i></a></li>
               </ul>
             </nav>


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

This PR fixes the position of the top menu bar and the version selector, that were affected by a bug we have recently noticed. This bug seems to affect only desktop versions of Chrome browser. 
![imagen](https://user-images.githubusercontent.com/13232723/89261226-00e3f300-d62e-11ea-86a8-ef70e9e2d1f2.png)

In addition, we have added the links to YouTube and LinkedIn.

Related issue https://github.com/wazuh/wazuh-website/issues/1426

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
