### PR TITLE
[3.14] Fixed the option to include Release Notes in the search results

### DIFF
--- a/source/_static/js/style.js
+++ b/source/_static/js/style.js
@@ -565,7 +565,6 @@ $(function() {
     let lastResult = null;
     let splitURL = null;
     const configAdd = {childList: true};
-    const configAtt = {attributes: true, attributeOldValue: true};
     let observerResults = null;
     let observerResultList = null;
     let observerResultText = null;
@@ -600,7 +599,7 @@ $(function() {
           observerResultList = new MutationObserver(addedResult);
           observerResultList.observe(ulSearch[0], configAdd);
           observerResultText = new MutationObserver(changeResultText);
-          observerResultText.observe($('#search-results > p')[0], configAtt);
+          observerResultText.observe($('#search-results > p')[0], configAdd);
         }
       }
     };
@@ -608,7 +607,7 @@ $(function() {
     /* Replaces the result message */
     const changeResultText = function(mutationsList, observer) {
       for (i = 0; i < mutationsList.length; i++) {
-        if (mutationsList[i].type === 'attributes') {
+        if (mutationsList[i].type === 'childList') {
           observerResultText.disconnect();
           const totalResults = $('ul.search li').length;
           const excludedResults = $('ul.search li.excluded-search-result').length;


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

This PR fixes the option to include Release Notes in the search results that disappears when compiling with Sphinx 3

Related issue https://github.com/wazuh/wazuh-website/issues/1427

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).