### PR TITLE
2205 open distro installation sandra branch

### DIFF
--- a/source/_templates/installations/elastic/common/copy_certificates_filebeat.rst
+++ b/source/_templates/installations/elastic/common/copy_certificates_filebeat.rst
@@ -1,6 +1,6 @@
 .. Copyright (C) 2020 Wazuh, Inc.
 
-During the Elasticsearch installation, the ``certs.tar`` file was created. The file must be copied into the Wazuh server host, for example, using ``scp``. This guide assumes that the file is placed in ~/ (home user folder):
+During the Elasticsearch installation, the ``certs.tar`` file was created. The file must be copied into the Wazuh server host, for example, using ``scp``. This guide assumes that the file is placed in the root home folder (``~/``):
 
 .. code-block:: console
 

--- a/source/installation-guide/open-distro/distributed-deployment/unattended/index.rst
+++ b/source/installation-guide/open-distro/distributed-deployment/unattended/index.rst
@@ -11,7 +11,7 @@ The unattended installation method consists of two scripts that will automatize 
 
 - **Wazuh cluster:** the script will install the Wazuh manager, the Wazuh API and Filebeat on its OSS version.
 
-It is highly recommended to first install Open Distro for Elasticsearch, since the certificates needed for securitizing the communication are created during its installation. 
+It is highly recommended to first install Open Distro for Elasticsearch, since the certificates needed for securing the communication are created during its installation. 
 
 .. toctree::
     :maxdepth: 1

--- a/source/installation-guide/open-distro/distributed-deployment/unattended/unattended-elasticsearch-cluster-installation.rst
+++ b/source/installation-guide/open-distro/distributed-deployment/unattended/unattended-elasticsearch-cluster-installation.rst
@@ -260,8 +260,8 @@ Run the script:
 
 The following values must be replaced:
 
-  - ``kibana_IP``: The IP of Kibana. The value 0.0.0.0 will accept all the available IPs of the host.
-  - ``elasticsearch_IP``: The IP of Elasticsearch. The value 0.0.0.0 will accept all the available IPs of the host.
+  - ``kibana_IP``: The IP of Kibana. 
+  - ``elasticsearch_IP``: The IP of Elasticsearch. 
   - ``wazuh_IP``: The IP of the Wazuh server.
   
 

--- a/source/installation-guide/open-distro/distributed-deployment/unattended/unattended-elasticsearch-cluster-installation.rst
+++ b/source/installation-guide/open-distro/distributed-deployment/unattended/unattended-elasticsearch-cluster-installation.rst
@@ -51,7 +51,7 @@ Download the script and the configuration file. After downloading them, configur
 
     **Configure the installation** 
       
-      Edit the ``config.yml`` file to specify the IP you want the Elasticsearch service to bind to. If you set it to ``0.0.0.0`` it will bind to all the availables IPs. 
+      Edit the ``config.yml`` file to specify the IP you want the Elasticsearch service to bind to. 
 
       .. code-block:: yaml
         :emphasize-lines: 4, 14

--- a/source/installation-guide/open-distro/distributed-deployment/unattended/unattended-elasticsearch-cluster-installation.rst
+++ b/source/installation-guide/open-distro/distributed-deployment/unattended/unattended-elasticsearch-cluster-installation.rst
@@ -24,7 +24,7 @@ The script allows installing both Elasticsearch and Kibana. They can be installe
 +-------------------------------+---------------------------------------------------------------------------------------------------------------+
 | -eip / --elasticsearch-ip     | Indicates the IP of Elasticsearch. It can be set to ``0.0.0.0`` which will bind all the availables IPs        |
 +-------------------------------+---------------------------------------------------------------------------------------------------------------+
-| -wip / --wazuh-ip             | Indicates the IP of Wazuh                                                                                    |
+| -wip / --wazuh-ip             | Indicates the IP of Wazuh                                                                                     |
 +-------------------------------+---------------------------------------------------------------------------------------------------------------+
 | -c / --create-certificates    | Generates the certificates for all the nodes indicated on the configuration file (only for multi-node mode)   |
 +-------------------------------+---------------------------------------------------------------------------------------------------------------+

--- a/source/installation-guide/open-distro/distributed-deployment/unattended/unattended-elasticsearch-cluster-installation.rst
+++ b/source/installation-guide/open-distro/distributed-deployment/unattended/unattended-elasticsearch-cluster-installation.rst
@@ -24,7 +24,7 @@ The script allows installing both Elasticsearch and Kibana. They can be installe
 +-------------------------------+---------------------------------------------------------------------------------------------------------------+
 | -eip / --elasticsearch-ip     | Indicates the IP of Elasticsearch. It can be set to ``0.0.0.0`` which will bind all the availables IPs        |
 +-------------------------------+---------------------------------------------------------------------------------------------------------------+
-| -wip / --wazuh-ip             | Indicates the IP of Wazuh.                                                                                    |
+| -wip / --wazuh-ip             | Indicates the IP of Wazuh                                                                                    |
 +-------------------------------+---------------------------------------------------------------------------------------------------------------+
 | -c / --create-certificates    | Generates the certificates for all the nodes indicated on the configuration file (only for multi-node mode)   |
 +-------------------------------+---------------------------------------------------------------------------------------------------------------+
@@ -50,6 +50,8 @@ Download the script and the configuration file. After downloading them, configur
           # curl -so ~/config.yml https://raw.githubusercontent.com/wazuh/wazuh/new-documentation-templates/extensions/unattended-installation/distributed/templates/config.yml
 
     **Configure the installation** 
+      
+      Edit the ``config.yml`` file to specify the IP you want the Elasticsearch service to bind to. If you set it to ``0.0.0.0`` it will bind to all the availables IPs. 
 
       .. code-block:: yaml
         :emphasize-lines: 4, 14
@@ -78,10 +80,6 @@ Download the script and the configuration file. After downloading them, configur
           - name: filebeat
             dn: CN=filebeat,OU=Docu,O=Wazuh,L=California,C=US
 
-
-      The highlighted lines indicates the values that must be replaced. These values are: 
-
-        - ``<elasticsearch_ip>``: Elasticsearch IP.
 
       In case of having more than one Wazuh server, there can be added as much nodes for their certificates creation as needed, changing the ``name`` of the certificate and the ``CN`` value. This should be indicated on the ``Clients certificates`` section: 
 
@@ -168,7 +166,7 @@ Download the script and the configuration file. After downloading them, configur
         ## Wazuh master configuration
         url: https://<wazuh_master_server_IP>   
 
-      The highlighted lines indicates the values that must be replaced. These values are: 
+      The highlighted lines indicates the values that must be replaced in the ``config.yml``. These values are: 
 
         - ``<elasticsearch_ip>``: Elasticsearch IP.
         - ``<node_name>``: Name of the node
@@ -210,7 +208,7 @@ After the installation of Elasticsearch, some steps must be done manually. Choos
 
     Once Elasticsearch is installed, the script will start the services automatically. The certificates will be placed at ``/etc/elasticsearch/certs/certs.tar``. This file must be copied into the :ref:`Wazuh server <unattended_distributed_wazuh>` to extract the certificates needed.
 
-    In case that Kibana was installed in a different server, the certs.tr file should be also copied into its server to extract the :ref:`corresponding certificates <configure_kibana_unattended>`.
+    In case that Kibana was installed in a different server, the ``certs.tar`` file should be also copied into its server to extract the :ref:`corresponding certificates <configure_kibana_unattended>`.
 
 
   .. group-tab:: Multi-node

--- a/source/installation-guide/open-distro/distributed-deployment/unattended/unattended-elasticsearch-cluster-installation.rst
+++ b/source/installation-guide/open-distro/distributed-deployment/unattended/unattended-elasticsearch-cluster-installation.rst
@@ -53,6 +53,8 @@ Download the script and the configuration file. After downloading them, configur
       
       Edit the ``config.yml`` file to specify the IP you want the Elasticsearch service to bind to. 
 
+      .. note:: In order to create valid certificates for the communication between the various components of Wazuh and the Elastic Stack, external IPs must be used.
+
       .. code-block:: yaml
         :emphasize-lines: 4, 14
 

--- a/source/installation-guide/open-distro/distributed-deployment/unattended/unattended-wazuh-cluster-installation.rst
+++ b/source/installation-guide/open-distro/distributed-deployment/unattended/unattended-wazuh-cluster-installation.rst
@@ -20,7 +20,7 @@ Download the script:
     # curl -so ~/wazuh-server-installation.sh https://raw.githubusercontent.com/wazuh/wazuh/new-documentation-templates/extensions/unattended-installation/distributed/wazuh-server-installation.sh 
     
 
-Filebeat needs to be configured by adding the Elasticsearch nodes IPs in order to connect with them. Choose between single-node or multi-node depending on the type of installation. The following commands assume that the script has been downloaded in the home directory ( ``~/`` ):
+Filebeat needs to be configured by adding the Elasticsearch nodes IPs in order to connect with them. Choose between single-node or multi-node depending on the type of installation. The following commands assume that the script has been downloaded in the root home directory ( ``~/`` ):
 
 .. tabs::
 


### PR DESCRIPTION
##  Description

General improvements including: 

-  Added a note that external IPs must be used to generate valid certificates.

- Removed the suggestion of 0.0.0.0 for the elastic-stack-installation.sh because the configuration then placed in kibana.yml did not allow it to find elasticsearch.

- Clarification that the installation guide is referring the root home folder.

- I specified that the configuration changes must be done the in config.yml file and did some minor format changes.

- Changed securitazing, which is a financial term, to securing.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->


