### PR TITLE
Updated the help messages of the package generators

### DIFF
--- a/source/development/packaging/generate-aix-package.rst
+++ b/source/development/packaging/generate-aix-package.rst
@@ -33,7 +33,7 @@ Execute the ``generate_wazuh_packages.sh`` script, with the different options yo
 
   Usage: ./generate_wazuh_packages.sh [OPTIONS]
 
-      -b, --branch <branch>               Select Git branch or tag e.g.
+      -b, --branch <branch>               Select Git branch or tag e.g. |WAZUH_LATEST_MINOR|
       -e, --environment                   Install all the packages necessaries to build the RPM package
       -s, --store  <rpm_directory>        Directory to store the resulting RPM package. By default: /tmp/build
       -p, --install-path <rpm_home>       Installation path for the package. By default: /var

--- a/source/development/packaging/generate-deb-package.rst
+++ b/source/development/packaging/generate-deb-package.rst
@@ -31,16 +31,19 @@ Execute the ``generate_debian_package.sh`` script, with the different options yo
   :class: output
 
   Usage: ./generate_debian_package.sh [OPTIONS]
-
-      -b, --branch <branch>     [Required] Select Git branch [master]. By default: master.
+  
+      -b, --branch <branch>     [Required] Select Git branch []. By default: master.
       -t, --target <target>     [Required] Target package to build: manager, api or agent.
-      -a, --architecture <arch> [Optional] Target architecture of the package amd64 or i386. By default: amd64
-      -j, --jobs <number>       [Optional] Change number of parallel jobs when compiling the manager or agent. By default: 4.
+      -a, --architecture <arch> [Optional] Target architecture of the package [amd64/i386/ppc64le/arm64/armhf].
+      -j, --jobs <number>       [Optional] Change number of parallel jobs when compiling the manager or agent. By default: 2.
       -r, --revision <rev>      [Optional] Package revision. By default: 1.
-      -s, --store <path>        [Optional] Set the directory where the package will be stored. By default, an output folder will be created.
+      -s, --store <path>        [Optional] Set the destination path of package. By default, an output folder will be created.
       -p, --path <path>         [Optional] Installation path for the package. By default: /var/ossec.
       -d, --debug               [Optional] Build the binaries with debug symbols. By default: no.
       -c, --checksum <path>     [Optional] Generate checksum on the desired path (by default, if no path is specified it will be generated on the same directory than the package).
+      --dont-build-docker   [Optional] Locally built docker image will be used instead of generating a new one.
+      --sources <path>          [Optional] Absolute path containing wazuh source code. This option will use local source code instead of downloading it from GitHub.
+      --dev                     [Optional] Use the SPECS files stored in the host instead of downloading them from GitHub.
       -h, --help                Show this help.
 
 Below, you will find some examples of how to build a DEB package.

--- a/source/development/packaging/generate-hpux-package.rst
+++ b/source/development/packaging/generate-hpux-package.rst
@@ -34,13 +34,13 @@ Execute the ``generate_wazuh_packages.sh`` script, with the different options yo
 
   Usage: ./generate_wazuh_packages.sh [OPTIONS]
 
-      -e Install all the packages necessaries to build the TAR package"
-      -b <branch> Select Git branch. Example v3.5.0"
-      -s <tar_directory> Directory to store the resulting tar package. By default, an output folder will be created."
-      -p <tar_home> Installation path for the package. By default: /var"
-      -c, --checksum Compute the SHA512 checksum of the TAR package."
-      -d <path_to_depot>, --depot Change the path to depothelper package (by default current path)."
-      -h Shows this help"
+      -e Install all the packages necessaries to build the TAR package
+      -b <branch> Select Git branch. Example v3.5.0
+      -s <tar_directory> Directory to store the resulting tar package. By default, an output folder will be created.
+      -p <tar_home> Installation path for the package. By default: /var
+      -c, --checksum Compute the SHA512 checksum of the TAR package.
+      -d <path_to_depot>, --depot Change the path to depothelper package (by default current path).
+      -h Shows this help
 
 Below, you will find an example of how to build HPUX packages.
 

--- a/source/development/packaging/generate-hpux-package.rst
+++ b/source/development/packaging/generate-hpux-package.rst
@@ -34,13 +34,13 @@ Execute the ``generate_wazuh_packages.sh`` script, with the different options yo
 
   Usage: ./generate_wazuh_packages.sh [OPTIONS]
 
-      -e Install all the packages necessaries to build the TAR package
-      -b <branch> Select Git branch. Example v|WAZUH_LATEST|
-      -s <tar_directory> Directory to store the resulting tar package. By default, an output folder will be created.
-      -p <tar_home> Installation path for the package. By default: /var
-      -c,  --checksum Compute the SHA512 checksum of the TAR package.
-      -d <path_to_depot>, --depot Change the path to depothelper package (by default current path).
-      -h Shows this help
+      -e Install all the packages necessaries to build the TAR package"
+      -b <branch> Select Git branch. Example v3.5.0"
+      -s <tar_directory> Directory to store the resulting tar package. By default, an output folder will be created."
+      -p <tar_home> Installation path for the package. By default: /var"
+      -c, --checksum Compute the SHA512 checksum of the TAR package."
+      -d <path_to_depot>, --depot Change the path to depothelper package (by default current path)."
+      -h Shows this help"
 
 Below, you will find an example of how to build HPUX packages.
 

--- a/source/development/packaging/generate-osx-package.rst
+++ b/source/development/packaging/generate-osx-package.rst
@@ -34,9 +34,9 @@ Execute the ``generate_wazuh_packages.sh`` script, with the different options yo
   :class: output
 
   Usage: ./generate_wazuh_packages.sh [OPTIONS]
-
-  Build options:
-      -b, --branch <branch>         [Required] Select Git branch or tag e.g.
+  
+    Build options:
+      -b, --branch <branch>         [Required] Select Git branch or tag e.g. 
       -s, --store-path <path>       [Optional] Set the destination absolute path of package.
       -j, --jobs <number>           [Optional] Number of parallel jobs when compiling.
       -r, --revision <rev>          [Optional] Package revision that append to version e.g. x.x.x-rev
@@ -44,8 +44,8 @@ Execute the ``generate_wazuh_packages.sh`` script, with the different options yo
       -h, --help                    [  Util  ] Show this help.
       -i, --install-deps            [  Util  ] Install build dependencies (Packages).
       -x, --install-xcode           [  Util  ] Install X-Code and brew. Can't be executed as root.
-
-  Signing options:
+  
+    Signing options:
       --keychain                    [Optional] Keychain where the Certificates are installed.
       --keychain-password           [Optional] Password of the keychain.
       --application-certificate     [Optional] Apple Developer ID certificate name to sign Apps and binaries.

--- a/source/development/packaging/generate-ova.rst
+++ b/source/development/packaging/generate-ova.rst
@@ -32,13 +32,16 @@ Execute the ``generate_ova.sh`` script, with the different options you desire.
 .. code-block:: none
   :class: output
 
-  OPTIONS:
-       -b, --build            [Required] Build the OVA and OVF.
-       -v, --version          [Required] Version of wazuh to install on VM.
-       -e, --elastic-version  [Required] Elastic version to download inside VM.
-       -r, --repository       [Required] Status of the packages [stable/unstable]
-       -c, --clean            [Optional] Clean the local machine.
-       -h, --help             [  Util  ] Show this help.
+  Usage: ./generate_ova.sh [OPTIONS]
+  
+    -b, --build            [Required] Build the OVA and OVF.
+    -v, --version          [Required] Version of wazuh to install on VM.
+    -e, --elastic-version  [Required] Elastic version to download inside VM.
+    -r, --repository       [Required] Status of the packages [stable/unstable]
+    -d, --directory        [Optional] Where will be installed manager. Default /var/ossec
+    -s, --store <path>     [Optional] Set the destination absolute path of package.
+    -c, --checksum <path>  [Optional] Generate checksum.
+    -h, --help             [  Util  ] Show this help.
 
 The options for the repository indicates whether the packages used to install Wazuh are the production ones or not.
 

--- a/source/development/packaging/generate-rpm-package.rst
+++ b/source/development/packaging/generate-rpm-package.rst
@@ -31,18 +31,23 @@ Execute the ``generate_rpm_package.sh`` script, with the different options you d
   :class: output
 
   Usage: ./generate_rpm_package.sh [OPTIONS]
-
-      -b, --branch <branch>     [Required] Select Git branch or tag e.g. master
-      -t, --target <target>     [Required] Target package to build [manager/api/agent].
-      -a, --architecture <arch> [Optional] Target architecture of the package [x86_64/i386].
-      -r, --revision <rev>      [Optional] Package revision that append to version e.g. x.x.x-rev
-      -l, --legacy              [Optional] Build package for CentOS 5.
-      -s, --store <path>        [Optional] Set the destination path of package.
-      -j, --jobs <number>       [Optional] Number of parallel jobs when compiling.
-      -p, --path <path>         [Optional] Installation path for the package. By default: /var.
-      -d, --debug               [Optional] Build the binaries with debug symbols and create debuginfo packages. By default: no.
-      -c, --checksum <path>     [Optional] Generate checksum on the desired path (by default, if no path is specified it will be generated on the same directory than the package).
-      -h, --help                Show this help.
+  
+      -b, --branch <branch>        [Required] Select Git branch or tag e.g. master
+      -t, --target <target>        [Required] Target package to build [manager/api/agent].
+      -a, --architecture <arch>    [Optional] Target architecture of the package [x86_64/i386/ppc64le/aarch64/armv7hl].
+      -r, --revision <rev>         [Optional] Package revision that append to version e.g. x.x.x-rev
+      -l, --legacy                 [Optional] Build package for CentOS 5.
+      -s, --store <path>           [Optional] Set the destination path of package. By default, an output folder will be created.
+      -j, --jobs <number>          [Optional] Number of parallel jobs when compiling.
+      -p, --path <path>            [Optional] Installation path for the package. By default: /var/ossec.
+      -d, --debug                  [Optional] Build the binaries with debug symbols and create debuginfo packages. By default: no.
+      -c, --checksum <path>        [Optional] Generate checksum on the desired path (by default, if no path is specified it will be generated on the same directory than the package).
+      --dont-build-docker      [Optional] Locally built docker image will be used instead of generating a new one.
+      --sources <path>             [Optional] Absolute path containing wazuh source code. This option will use local source code instead of downloading it from GitHub.
+      --packages-branch <branch>   [Optional] Select Git branch or tag from wazuh-packages repository. e.g master
+      --dev                        [Optional] Use the SPECS files stored in the host instead of downloading them from GitHub.
+      --src                        [Optional] Generate the source package in the destination directory.
+      -h, --help                   Show this help.
 
 Below, you will find some examples of how to build an RPM package.
 

--- a/source/development/packaging/generate-sol-package.rst
+++ b/source/development/packaging/generate-sol-package.rst
@@ -32,14 +32,13 @@ Execute the ``generate_wazuh_packages.sh`` script to build the package. Here you
  :class: output
 
  Usage: ./generate_wazuh_packages.sh [OPTIONS]
-
+ 
      -b, --branch <branch>               Select Git branch or tag e.g. master.
      -e, --environment                   Install all the packages necessaries to build the pkg package.
      -s, --store  <pkg_directory>        Directory to store the resulting pkg package. By default, an output folder will be created.
      -p, --install-path <pkg_home>       Installation path for the package. By default: /var.
      -c, --checksum                      Compute the SHA512 checksum of the pkg package.
      -h, --help                          Shows this help.
-
 
 Below, you will find an example of how to build a Solaris package.
 

--- a/source/development/packaging/generate-wazuh-kibana-app.rst
+++ b/source/development/packaging/generate-wazuh-kibana-app.rst
@@ -31,9 +31,9 @@ Execute the ``generate_wazuh_app.sh`` script, with the different options you des
   :class: output
 
   Usage: ./generate_wazuh_app.sh [OPTIONS]
-
-      -b, --branch <branch>     [Required] Select Git branch or tag e.g.v|WAZUH_LATEST|-|ELASTICSEARCH_LATEST|
-      -s, --store <path>        [Optional] Set the destination path of package, by defauly wazuhapp/output/
+  
+      -b, --branch <branch>     [Required] Select Git branch or tag e.g. 3.8-6.7 or v3.7.2-6.5.4
+      -s, --store <path>        [Optional] Set the destination path of package, by defauly /tmp/wazuh-app.
       -r, --revision <rev>      [Optional] Package revision that append to version e.g. x.x.x-rev
       -c, --checksum <path>     [Optional] Generate checksum
       -h, --help                Show this help.

--- a/source/development/packaging/generate-wazuh-splunk-app.rst
+++ b/source/development/packaging/generate-wazuh-splunk-app.rst
@@ -31,11 +31,11 @@ Execute the ``generate_wazuh_splunk_app.sh`` script, with the different options 
   :class: output
 
   Usage: ./generate_wazuh_splunk_app.sh [OPTIONS]
-
-      -b, --branch <branch>     [Required] Select Git branch or tag e.g. v|WAZUH_LATEST|-|SPLUNK_LATEST|
-      -s, --store <directory>   [Optional] Destination directory by default splunkapp/output
-      -r, --revision            [Optional] Package revision that append to version e.g. x.x.x-y.y.y-rev
-      -c, --checksum  <path>    [Optional] Generate checksum
+  
+      -b, --branch <branch>     [Required] Select Git branch or tag e.g. 3.8 or v3.8.1-7.2.3
+      -s, --store <directory>   [Optional] Destination directory by default /home/vagrant/wazuh-wazuh-packages-26460eb/splunkapp/output
+      -r, --revision            [Optional] Package revision that append to version e.g. x.x.x-y.y.y_rev
+      -c, --checksum <path>     [Optional] Generate checksum
       -h, --help                Show this help.
 
 Below, you will find some examples of how to build Wazuh Splunk App packages.

--- a/source/development/packaging/generate-windows-package.rst
+++ b/source/development/packaging/generate-windows-package.rst
@@ -41,13 +41,13 @@ image with all the necessary tools to compile and obtain the Windows agent compi
   :class: output
 
   Usage: ./generate_compiled_windows_agent.sh [OPTIONS]
-
-      -b, --branch <branch>     [Required] Select Git branch [${BRANCH}]. By default: master."
-      -j, --jobs <number>       [Optional] Change number of parallel jobs when compiling the Windows agent. By default: 4."
-      -r, --revision <rev>      [Optional] Package revision. By default: 1."
-      -s, --store <path>        [Optional] Set the directory where the package will be stored. By default the current path."
-      -d, --debug               [Optional] Build the binaries with debug symbols. By default: no."
-      -h, --help                Show this help."
+  
+      -b, --branch <branch>     [Required] Select Git branch [master]. By default: master.
+      -j, --jobs <number>       [Optional] Change number of parallel jobs when compiling the Windows agent. By default: 4.
+      -r, --revision <rev>      [Optional] Package revision. By default: 1.
+      -s, --store <path>        [Optional] Set the directory where the package will be stored. By default the current path.
+      -d, --debug               [Optional] Build the binaries with debug symbols. By default: no.
+      -h, --help                Show this help.
 
 Below, you will find an example of how to build a compiled Windows agent.
 

--- a/source/development/packaging/generate-wpk-package.rst
+++ b/source/development/packaging/generate-wpk-package.rst
@@ -33,16 +33,17 @@ Execute the ``generate_wpk_package.sh`` script, with the different options you d
   :class: output
 
   Usage: ./generate_wpk_package.sh [OPTIONS]
-
+  
       -t,   --target-system <target>              [Required] Select target wpk to build [linux/windows]
-      -b,   --branch <branch>                     [Required] Select Git branch or tag e.g.
+      -b,   --branch <branch>                     [Required] Select Git branch or tag e.g. 
       -d,   --destination <path>                  [Required] Set the destination path of package.
-      -k,   --key-dir <path>                      [Required] Set the WPK key path to sign package.
+      -k,   --key-dir <arch>                      [Required] Set the WPK key path to sign package.
       -a,   --architecture <arch>                 [Optional] Target architecture of the package [x86_64].
       -j,   --jobs <number>                       [Optional] Number of parallel jobs when compiling.
       -pd,  --package-directory <directory>       [Required for windows] Package name to pack on wpk.
+      -p,   --path <path>                         [Optional] Installation path for the package. By default: /var.
       -o,   --output <name>                       [Required] Name to the output package.
-      -c,   --checksum <path>                     [Optional] Generate checksum
+      -c,   --checksum                            [Optional] Generate checksum
       -h,   --help                                Show this help.
 
 To use this tool, the previously required :ref:`certificate <create-wpk-key>` and the key must be in the same directory.


### PR DESCRIPTION
## Description

With this PR I've updated one by one all the help messages from the scripts of the wazuh-packages repository.
As mentioned in issue #2783 the messages were missing current options and some had wrongly replaced version texts.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

This PR solves issue #2783 