### PR TITLE
Add environment variables to syscheck documentation

### DIFF
--- a/source/user-manual/capabilities/file-integrity/fim-configuration.rst
+++ b/source/user-manual/capabilities/file-integrity/fim-configuration.rst
@@ -40,6 +40,40 @@ To configure syscheck, a list of files and directories must be identified. The `
     <directories check_all="yes">/root/users.txt,/bsd,/root/db.html</directories>
   </syscheck>
 
+Syscheck can monitor directories/file that contain commas by scaping them.
+
+.. code-block:: xml
+
+  <syscheck>
+    <directories check_all="yes">/comma\,folder</directories>
+  </syscheck>
+
+With this configuration, the folder ``/comma,folder`` will be monitored.
+
+.. versionadded:: 4.0
+
+Environment variables can be used to configure syscheck in Linux and Windows.
+
+.. code-block:: xml
+
+  <syscheck>
+    <directories check_all="yes">$DIRECTORY</directories>
+  </syscheck>
+
+Under UNIX based systems, the variable must be added to the file ``/etc/ossec-init.conf`` if wazuh is restarted using systemd.
+If wazuh is restarted using the ``ossec-control`` binary the variable must be owned by the root user.
+
+.. code-block:: xml
+
+  <syscheck>
+    <directories check_all="yes">%CommonProgramFiles%</directories>
+  </syscheck>
+
+Under Windows, be sure that the variable is a system environment variable.
+
+.. note::
+  Wazuh runs as a 32 bit application, so the previous environment variable will be replaced by ``C:\Program Files (x86)\Common Files``. In order to specifically monitor ``C:\Program Files\Common Files``, the associate environment variable is: ``%CommonProgramW6432%``.
+
 Configuring scheduled scans
 ---------------------------
 

--- a/source/user-manual/capabilities/file-integrity/fim-configuration.rst
+++ b/source/user-manual/capabilities/file-integrity/fim-configuration.rst
@@ -50,7 +50,7 @@ Environment variables can be used to configure syscheck in Linux and Windows.
     <directories check_all="yes">$DIRECTORY</directories>
   </syscheck>
 
-On UNIX based systems, the variable must be added to the file ``/etc/ossec-init.conf`` if wazuh is restarted using systemd. On the other hand, if wazuh is restarted using the ``ossec-control`` binary, the variable must be owned by the root user.
+On UNIX based systems, the variable must be added to the file ``/etc/ossec-init.conf`` if Wazuh is restarted using systemd. On the other hand, if Wazuh is restarted using the ``ossec-control`` binary, the variable must be owned by the root user.
 You can specify multiple paths in a variable by separating them using ``:``.
 
 .. code-block:: xml

--- a/source/user-manual/capabilities/file-integrity/fim-configuration.rst
+++ b/source/user-manual/capabilities/file-integrity/fim-configuration.rst
@@ -40,16 +40,6 @@ To configure syscheck, a list of files and directories must be identified. The `
     <directories check_all="yes">/root/users.txt,/bsd,/root/db.html</directories>
   </syscheck>
 
-Syscheck can monitor directories/files that contain commas by scaping them.
-
-.. code-block:: xml
-
-  <syscheck>
-    <directories check_all="yes">/comma\,folder</directories>
-  </syscheck>
-
-With this configuration, the folder ``/comma,folder`` will be monitored.
-
 .. versionadded:: 4.0
 
 Environment variables can be used to configure syscheck in Linux and Windows.
@@ -60,8 +50,9 @@ Environment variables can be used to configure syscheck in Linux and Windows.
     <directories check_all="yes">$DIRECTORY</directories>
   </syscheck>
 
-Under UNIX based systems, the variable must be added to the file ``/etc/ossec-init.conf`` if wazuh is restarted using systemd.
+In UNIX based systems, the variable must be added to the file ``/etc/ossec-init.conf`` if wazuh is restarted using systemd.
 If wazuh is restarted using the ``ossec-control`` binary the variable must be owned by the root user.
+You can specify multiple paths in a variable by separating them using ``:``.
 
 .. code-block:: xml
 
@@ -69,7 +60,8 @@ If wazuh is restarted using the ``ossec-control`` binary the variable must be ow
     <directories check_all="yes">%CommonProgramFiles%</directories>
   </syscheck>
 
-Under Windows, be sure that the variable is a system environment variable.
+On Windows, be sure that the variable is a system environment variable.
+A variable can contain multiple paths using ``;`` to separate them.
 
 .. note::
   Wazuh runs as a 32 bit application, so the previous environment variable will be replaced by ``C:\Program Files (x86)\Common Files``. In order to specifically monitor ``C:\Program Files\Common Files``, the associate environment variable is: ``%CommonProgramW6432%``.

--- a/source/user-manual/capabilities/file-integrity/fim-configuration.rst
+++ b/source/user-manual/capabilities/file-integrity/fim-configuration.rst
@@ -50,8 +50,7 @@ Environment variables can be used to configure syscheck in Linux and Windows.
     <directories check_all="yes">$DIRECTORY</directories>
   </syscheck>
 
-In UNIX based systems, the variable must be added to the file ``/etc/ossec-init.conf`` if wazuh is restarted using systemd.
-If wazuh is restarted using the ``ossec-control`` binary the variable must be owned by the root user.
+On UNIX based systems, the variable must be added to the file ``/etc/ossec-init.conf`` if wazuh is restarted using systemd. On the other hand, if wazuh is restarted using the ``ossec-control`` binary, the variable must be owned by the root user.
 You can specify multiple paths in a variable by separating them using ``:``.
 
 .. code-block:: xml
@@ -60,8 +59,7 @@ You can specify multiple paths in a variable by separating them using ``:``.
     <directories check_all="yes">%CommonProgramFiles%</directories>
   </syscheck>
 
-On Windows, be sure that the variable is a system environment variable.
-A variable can contain multiple paths using ``;`` to separate them.
+On Windows, only system environment variables can be used. You can add multiple directories to the same variable by separating them using ``;``
 
 .. note::
   Wazuh runs as a 32 bit application, so the previous environment variable will be replaced by ``C:\Program Files (x86)\Common Files``. In order to specifically monitor ``C:\Program Files\Common Files``, the associate environment variable is: ``%CommonProgramW6432%``.

--- a/source/user-manual/capabilities/file-integrity/fim-configuration.rst
+++ b/source/user-manual/capabilities/file-integrity/fim-configuration.rst
@@ -40,7 +40,7 @@ To configure syscheck, a list of files and directories must be identified. The `
     <directories check_all="yes">/root/users.txt,/bsd,/root/db.html</directories>
   </syscheck>
 
-Syscheck can monitor directories/file that contain commas by scaping them.
+Syscheck can monitor directories/files that contain commas by scaping them.
 
 .. code-block:: xml
 

--- a/source/user-manual/reference/ossec-conf/syscheck.rst
+++ b/source/user-manual/reference/ossec-conf/syscheck.rst
@@ -54,7 +54,7 @@ Use this option to add or remove directories to be monitored. The directories mu
 
 All files and subdirectories within the noted directories will also be monitored.
 
-Drive letters without directories are not valid. At a minimum the '.' should be included (``D:\.``).
+Drive letters without directories are valid (``D:``).
 
 This is to be set on the system to be monitored (or in the ``agent.conf``, if appropriate).
 
@@ -64,6 +64,10 @@ There exists a limit in the number of directories that can be written in one lin
 | **Default value**  | /etc,/usr/bin,/usr/sbin,/bin,/sbin |
 +--------------------+------------------------------------+
 | **Allowed values** | Any directory                      |
++                    +                                    +
+|                    | .. versionadded:: 4.0              |
++                    +                                    +
+|                    | Any environment variable           |
 +--------------------+------------------------------------+
 
 Attributes:

--- a/source/user-manual/reference/ossec-conf/syscheck.rst
+++ b/source/user-manual/reference/ossec-conf/syscheck.rst
@@ -54,7 +54,7 @@ Use this option to add or remove directories to be monitored. The directories mu
 
 All files and subdirectories within the noted directories will also be monitored.
 
-Drive letters without directories are valid (``D:``).
+Drive letters without directories are valid. It's possible to configure them by removing the last backslash, for example ``D:``.
 
 This is to be set on the system to be monitored (or in the ``agent.conf``, if appropriate).
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description
Hi team.

As mentioned in #2433, syscheck now supports Linux environment variables and this new feature needs to be added to the documentation.

Kind regards.

<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 


