### PR TITLE
Restructure of the step-by-step installation guide for Elasticsearch multi-node cluster (Elastic Stack)

### DIFF
--- a/source/_templates/installations/basic/elastic/common/disabling_repositories_explanation.rst
+++ b/source/_templates/installations/basic/elastic/common/disabling_repositories_explanation.rst
@@ -2,9 +2,9 @@
 
 In the installation guide, we described how to install and configure Wazuh and also how to install and configure Elastic Stack for its use with Wazuh. At Wazuh we have complete control of when a new Wazuh version is going to be released, but we don't have control over when a new Elasticsearch version is going to be released.
 
-The current Wazuh Kibana plugin has been tested in Kibana version 7.8.0. Each time a new version of the Elastic Stack is released we conduct a complete set of testing to ensure the correct behavior of our Wazuh Kibana plugin. After testing is done and any necessary adjustments have been performed we release a new version of the Wazuh Kibana plugin that is compatible with the new Filebeat/Elasticsearch/Kibana version.
+The current Wazuh Kibana plugin has been tested in Kibana version 7.8.0. Each time a new version of the Elastic Stack is released we conduct a complete set of testing to ensure the correct behavior of our Wazuh Kibana plugin. After testing is done and any necessary adjustments have been performed, we release a new version of the Wazuh Kibana plugin that is compatible with the new Filebeat/Elasticsearch/Kibana version.
 
-If the repository is still enabled when Elastic releases a new version, the new Filebeat version would be installed on your system forcing the upgrade of Elasticsearch and Kibana.  If there is an accidental Filebeat (and consequently Kibana and Elasticsearch) upgrade, it's possible that the Wazuh Kibana plugin could become incompatible.
+If the repository is still enabled when Elastic releases a new version, the new Filebeat version would be installed on your system forcing the upgrade of Elasticsearch and Kibana.  If there is an accidental Filebeat (and consequently Kibana and Elasticsearch) upgrade, it is possible that the Wazuh Kibana plugin could become incompatible.
 
 In order to anticipate and avoid this situation, it is recommended to disable the Elasticsearch repository in the following way:
 

--- a/source/_templates/installations/basic/elastic/common/elastic-multi-node/configure_elasticsearch_initial_node.rst
+++ b/source/_templates/installations/basic/elastic/common/elastic-multi-node/configure_elasticsearch_initial_node.rst
@@ -1,0 +1,32 @@
+.. Copyright (C) 2020 Wazuh, Inc.
+
+.. code-block:: console
+
+  # curl -so /etc/elasticsearch/elasticsearch.yml https://raw.githubusercontent.com/wazuh/wazuh/new-documentation-templates/extensions/basic/elasticsearch/elasticsearch_cluster_initial_node.yml
+
+The file ``/etc/elasticsearch/elasticsearch.yml`` has to be edited:
+
+.. code-block:: yaml
+
+  network.host: <elasticsearch_ip>
+  node.name: elasticsearch-1
+  cluster.name: elasticsearch_cluster
+  cluster.initial_master_nodes:
+          - elasticsearch-1
+          - elasticsearch-2
+          - elasticsearch-3
+  discovery.seed_hosts:
+          - <elasticsearch_ip_node1>
+          - <elasticsearch_ip_node2>
+          - <elasticsearch_ip_node3>
+
+Depending on the node type, some parameters may vary between nodes. ``cluster.initial_master_nodes`` and ``discovery.seed_hosts`` are lists of all the master-eligible nodes in the cluster. The parameter ``node.master: false`` must be included in every Elasticsearch node that will not be configured as master.
+
+Values to be replaced:
+
+- ``<elasticsearch_ip>``: the host's IP. E.g.: ``10.0.0.2``. The value ``0.0.0.0`` is an acceptable IP address and will bind to all network interfaces.
+- ``<elasticsearch_ip_nodeX>`` Elasticsearch cluster master-eligible nodes IP. E.g.: ``10.0.0.3``.
+
+For more information, please see `important discovery and cluster formation settings <https://www.elastic.co/guide/en/elasticsearch/reference/7.6/discovery-settings.html#discovery-settings>`_.
+
+.. End of include file

--- a/source/_templates/installations/basic/elastic/common/elastic-multi-node/configure_elasticsearch_subsequent_nodes.rst
+++ b/source/_templates/installations/basic/elastic/common/elastic-multi-node/configure_elasticsearch_subsequent_nodes.rst
@@ -1,0 +1,33 @@
+.. Copyright (C) 2020 Wazuh, Inc.
+
+.. code-block:: console
+
+  # curl -so /etc/elasticsearch/elasticsearch.yml https://raw.githubusercontent.com/wazuh/wazuh/new-documentation-templates/extensions/basic/elasticsearch/elasticsearch_cluster_subsequent_nodes.yml
+
+The file ``/etc/elasticsearch/elasticsearch.yml`` has to be edited:
+
+.. code-block:: yaml
+
+  network.host: <elasticsearch_ip>
+  node.name: <elasticsearch-X>
+  cluster.name: elasticsearch_cluster
+  cluster.initial_master_nodes:
+          - elasticsearch-1
+          - elasticsearch-2
+          - elasticsearch-3
+  discovery.seed_hosts:
+          - <elasticsearch_ip_node1>
+          - <elasticsearch_ip_node2>
+          - <elasticsearch_ip_node3>
+
+Depending on the node type, some parameters may vary between nodes. ``cluster.initial_master_nodes`` and ``discovery.seed_hosts`` are lists of all the master-eligible nodes in the cluster. The parameter ``node.master: false`` must be included in every Elasticsearch node that will not be configured as master.
+
+Values to be replaced:
+
+- ``<elasticsearch_ip>``: the host's IP. E.g.: ``10.0.0.2``. The value ``0.0.0.0`` is an acceptable IP address and will bind to all network interfaces.
+- ``<node_name>``: The node name, change the ``X`` for your node number. E.g.: ``elasticsearch-2``.
+- ``<elasticsearch_ip_nodeX>`` Elasticsearch cluster master-eligible nodes IP. E.g.: ``10.0.0.3``.
+
+For more information, please see `important discovery and cluster formation settings <https://www.elastic.co/guide/en/elasticsearch/reference/7.6/discovery-settings.html#discovery-settings>`_.
+
+.. End of include file

--- a/source/_templates/installations/basic/elastic/common/elastic-multi-node/deploy_certificates_initial_node.rst
+++ b/source/_templates/installations/basic/elastic/common/elastic-multi-node/deploy_certificates_initial_node.rst
@@ -1,0 +1,16 @@
+.. Copyright (C) 2020 Wazuh, Inc.
+
+.. code-block:: console
+
+  # unzip ~/certs.zip -d ~/certs
+  # mkdir /etc/elasticsearch/certs/ca -p
+  # cp -R ~/certs/ca/ ~/certs/elasticsearch-1/* /etc/elasticsearch/certs/
+  # mv /etc/elasticsearch/certs/elasticsearch-1.crt /etc/elasticsearch/certs/elasticsearch.crt
+  # mv /etc/elasticsearch/certs/elasticsearch-1.key /etc/elasticsearch/certs/elasticsearch.key
+  # chown -R elasticsearch: /etc/elasticsearch/certs
+  # chmod -R 500 /etc/elasticsearch/certs
+  # chmod 400 /etc/elasticsearch/certs/ca/ca.* /etc/elasticsearch/certs/elasticsearch.*
+  # rm -rf ~/certs/ ~/certs.zip
+
+
+.. End of include file

--- a/source/_templates/installations/basic/elastic/common/elastic-multi-node/deploy_certificates_subsequent_nodes.rst
+++ b/source/_templates/installations/basic/elastic/common/elastic-multi-node/deploy_certificates_subsequent_nodes.rst
@@ -1,0 +1,18 @@
+.. Copyright (C) 2020 Wazuh, Inc.
+
+
+.. code-block:: console
+
+  # unzip ~/certs.zip -d ~/certs
+  # rm ~/certs/ca/ca.key
+  # mkdir /etc/elasticsearch/certs/ca -p
+  # cp -R ~/certs/ca/ ~/certs/elasticsearch-X/* /etc/elasticsearch/certs/
+  # mv /etc/elasticsearch/certs/elasticsearch-X.crt /etc/elasticsearch/certs/elasticsearch.crt
+  # mv /etc/elasticsearch/certs/elasticsearch-X.key /etc/elasticsearch/certs/elasticsearch.key
+  # chown -R elasticsearch: /etc/elasticsearch/certs
+  # chmod -R 500 /etc/elasticsearch/certs
+  # chmod 400 /etc/elasticsearch/certs/ca/ca.* /etc/elasticsearch/certs/elasticsearch.*
+  # rm -rf ~/certs/ ~/certs.zip
+
+
+.. End of include file

--- a/source/_templates/installations/basic/elastic/common/elastic-multi-node/generate_certificates.rst
+++ b/source/_templates/installations/basic/elastic/common/elastic-multi-node/generate_certificates.rst
@@ -84,6 +84,5 @@
 
       # /usr/share/elasticsearch/bin/elasticsearch-certutil cert ca --pem --in instances.yml --keep-ca-key --out ~/certs.zip
 
-The ``cert.zip`` must be distributed across all ``instances.yml`` defined servers. This guide will assume that the file will be placed in ~/ (home user folder).
 
 .. End of include file

--- a/source/_templates/installations/wazuh/common/configure_wazuh_worker_node.rst
+++ b/source/_templates/installations/wazuh/common/configure_wazuh_worker_node.rst
@@ -7,8 +7,8 @@ Configure the cluster node by editing the following settings in the ``/var/ossec
   <cluster>
       <name>wazuh</name>
       <node_name>worker-node</node_name>
-      <key>c98b62a9b6169ac5f67dae55ae4a9088</key>
       <node_type>worker</node_type>
+      <key>c98b62a9b6169ac5f67dae55ae4a9088</key>      
       <port>1516</port>
       <bind_addr>0.0.0.0</bind_addr>
       <nodes>
@@ -21,9 +21,9 @@ Configure the cluster node by editing the following settings in the ``/var/ossec
 As shown in the example above, the following parameters have to be amended:
 
 +-------------------------------------+----------------------------------------------------------------------------------------------+
-| :ref:`node_type <cluster_node_type>`| Has to be set as ``worker``.                                                                 |
-+-------------------------------------+----------------------------------------------------------------------------------------------+
 | :ref:`node_name <cluster_node_name>`| Each node of the cluster must have a unique name.                                            |
++-------------------------------------+----------------------------------------------------------------------------------------------+
+| :ref:`node_type <cluster_node_type>`| Has to be set as ``worker``.                                                                 |
 +-------------------------------------+----------------------------------------------------------------------------------------------+
 | :ref:`key <cluster_key>`            | The key created previously for the ``master`` node. It has to be the same for all the nodes. |
 +-------------------------------------+----------------------------------------------------------------------------------------------+

--- a/source/installation-guide/basic/distributed-deployment/step-by-step-installation/elasticsearch-cluster/elasticsearch-multi-node-cluster.rst
+++ b/source/installation-guide/basic/distributed-deployment/step-by-step-installation/elasticsearch-cluster/elasticsearch-multi-node-cluster.rst
@@ -13,17 +13,33 @@ This document will explain how to install the Elastic Stack components in a mult
 .. note:: Root user privileges are necessary to execute all the commands described below.
 
 
+
 Installing Elasticsearch
 ------------------------
 
-Elasticsearch is a highly scalable full-text search and analytics engine. For more information, please see `Elasticsearch <https://www.elastic.co/products/elasticsearch>`_.
+Elasticsearch is a highly scalable full-text search and analytics engine. For more information, please see `Elasticsearch <https://www.elastic.co/products/elasticsearch>`_. For resilience in case Elasticsearch nodes become unavailable, it is recommended to have an odd number of master eligible nodes, please take this into consideration when deciding the configuration of your Elasticsearch cluster.
 
-The Elasticsearch configuration section has steps that must be done in all the hosts where Elasticsearch will be installed. But some of them only need to be done in the Elasticsearch master node. The labels [*All*] or [*Master*]  at the beginning of the step will indicate whether the steps must be done in all nodes or in a master node. In case of having two or more [*Master*] nodes, the steps must be done in just one of them.
+The installation process for a multi-node cluster will be explained in three parts. The first one refers to the configuration of the initial node, in which the certificates that will be deployed to the subsequent nodes are generated. 
+
+The second part will explain how to configure the remaining nodes of the cluster. Finally, the third part provides instructions for initializing the Elasticsearch cluster and verifying that everything is working properly.  
+
+
+**Initial node**
+****************
+
+The following instructions are meant to be performed on the **first** Elasticsearch node to be configured.  
+
+
+Prerequisites
+~~~~~~~~~~~~~
+
+.. include:: ../../../../../_templates/installations/basic/before_installation_elastic.rst
+
 
 Adding the Elastic Stack repository
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-[*All*] The addition of Elastic Stack repository must be done in all Elasticsearch cluster nodes.
+The addition of Elastic Stack repository must be done in all Elasticsearch cluster nodes.
 
 .. tabs::
 
@@ -51,7 +67,7 @@ Adding the Elastic Stack repository
 Elasticsearch installation and configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-#. [*All*] Install the Elasticsearch package:
+Install the Elasticsearch package:
 
     .. tabs::
 
@@ -76,28 +92,120 @@ Elasticsearch installation and configuration
 
 
 
-#. [*All*] Once Elasticsearch is installed it has to be configured by downloading and editing the file ``/etc/elasticsearch/elasticsearch.yml`` as follows:
+Once Elasticsearch is installed it has to be configured by downloading and editing the file ``/etc/elasticsearch/elasticsearch.yml`` as follows:
 
-    .. include:: ../../../../../_templates/installations/basic/elastic/common/elastic-multi-node/configure_elasticsearch.rst
+.. include:: ../../../../../_templates/installations/basic/elastic/common/elastic-multi-node/configure_elasticsearch_initial_node.rst
+
 
 Certificates creation and deployment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-#. [*Master*] This step implies the selection of the Wazuh cluster installation type. Choose between ``Wazuh single-node cluster``, if having only one Wazuh server, and ``Wazuh multi-node cluster`` in case of having two or more Wazuh servers.
+#.  This step implies the selection of the Wazuh cluster installation type. Choose between ``Wazuh single-node cluster``, if having only one Wazuh server, and ``Wazuh multi-node cluster`` in case of having two or more Wazuh servers.
 
     .. include:: ../../../../../_templates/installations/basic/elastic/common/elastic-multi-node/generate_certificates.rst
 
-#. [*All*] The next step is to create the directory ``/etc/elasticsearch/certs``, and then copy the certificate authorities, the certificate and the key there. The ``X`` must be replaced according to the defined data in ``instances.yml`` file:
+#. Copy ``certs.tar`` to all the servers of the distributed deployment. This can be done by using, for example,  ``scp.`` This guide will assume that the file will be placed in ~/ (home user folder).
 
-    .. include:: ../../../../../_templates/installations/basic/elastic/common/elastic-multi-node/deploy_certificates.rst
+#.  The next step is to create the directory ``/etc/elasticsearch/certs``, and then copy the certificate authorities, the certificate and the key there. 
 
-#. [*All*] Enable and start the Elasticsearch service:
+    .. include:: ../../../../../_templates/installations/basic/elastic/common/elastic-multi-node/deploy_certificates_initial_node.rst
+
+#. Enable and start the Elasticsearch service:
 
     .. include:: ../../../../../_templates/installations/basic/elastic/common/enable_elasticsearch.rst
 
-#. [*Master*] Generate credentials for all the Elastic Stack pre-built roles and users:
 
-    .. include:: ../../../../../_templates/installations/basic/elastic/common/generate_elastic_credentials.rst
+**Subsequent nodes**
+********************
+
+The following steps **should be executed in each of the subsequent nodes** of the Elasticsearch cluster. 
+
+
+Prerequisites
+~~~~~~~~~~~~~
+
+.. include:: ../../../../../_templates/installations/basic/before_installation_elastic.rst
+
+
+Adding the Elastic Stack repository
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The addition of Elastic Stack repository must be done in all Elasticsearch cluster nodes.
+
+.. tabs::
+
+
+  .. group-tab:: Yum
+
+
+    .. include:: ../../../../../_templates/installations/basic/elastic/yum/add_repository.rst
+
+
+
+  .. group-tab:: APT
+
+
+    .. include:: ../../../../../_templates/installations/basic/elastic/deb/add_repository.rst
+
+
+
+  .. group-tab:: ZYpp
+
+
+    .. include:: ../../../../../_templates/installations/basic/elastic/zypp/add_repository.rst
+
+
+Elasticsearch installation and configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+#. Install the Elasticsearch package:
+
+  .. tabs::
+
+    .. group-tab:: Yum
+
+
+      .. include:: ../../../../../_templates/installations/basic/elastic/yum/install_elasticsearch.rst
+
+
+
+    .. group-tab:: APT
+
+
+      .. include:: ../../../../../_templates/installations/basic/elastic/deb/install_elasticsearch.rst
+
+
+
+    .. group-tab:: ZYpp
+
+
+      .. include:: ../../../../../_templates/installations/basic/elastic/zypp/install_elasticsearch.rst
+
+
+#. Once Elasticsearch is installed it has to be configured by downloading and editing the file ``/etc/elasticsearch/elasticsearch.yml`` as follows:
+
+.. include:: ../../../../../_templates/installations/basic/elastic/common/elastic-multi-node/configure_elasticsearch_subsequent_nodes.rst
+
+Certificates deployment
+~~~~~~~~~~~~~~~~~~~~~~~
+
+
+#.  The next step is to create the directory ``/etc/elasticsearch/certs``, and then copy the certificate authorities, the certificate and the key there. The ``X`` must be replaced according to the defined data in ``instances.yml`` file:
+
+    .. include:: ../../../../../_templates/installations/basic/elastic/common/elastic-multi-node/deploy_certificates_subsequent_nodes.rst
+
+#.  Enable and start the Elasticsearch service:
+
+    .. include:: ../../../../../_templates/installations/basic/elastic/common/enable_elasticsearch.rst
+
+
+**Initializing the cluster**
+****************************
+
+Once the installation process is done in all the servers of the Elasticsearch cluster, run the following command on the **initial node** to generate credentials for all the Elastic Stack pre-built roles and users: 
+
+.. include:: ../../../../../_templates/installations/basic/elastic/common/generate_elastic_credentials.rst
+
 
 Disabling repositories
 ----------------------

--- a/source/installation-guide/open-distro/distributed-deployment/step-by-step-installation/kibana/index.rst
+++ b/source/installation-guide/open-distro/distributed-deployment/step-by-step-installation/kibana/index.rst
@@ -12,6 +12,8 @@ Kibana is a flexible and intuitive web interface for mining and visualizing the 
 
 It is recommended to install Kibana on the same server as Elasticsearch, but it is not required. The following Kibana installation may vary depending on whether Kibana will be installed in the same server as Elasticsearch or not.
 
+.. note:: Root user privileges are required to run all the commands described below.
+
 Prerequisites
 ~~~~~~~~~~~~~
 

--- a/source/installation-guide/open-distro/distributed-deployment/step-by-step-installation/kibana/index.rst
+++ b/source/installation-guide/open-distro/distributed-deployment/step-by-step-installation/kibana/index.rst
@@ -75,7 +75,7 @@ Kibana installation and configuration
     .. code-block:: console
 
         # cd /usr/share/kibana
-        # sudo -u kibana /usr/share/kibana/bin/kibana-plugin install https://packages-dev.wazuh.com/trash/app/kibana/wazuhapp-4.0.0_7.8.0.zip
+        # sudo -u kibana bin/kibana-plugin install https://packages-dev.wazuh.com/trash/app/kibana/wazuhapp-4.0.0_7.8.0.zip
 
 #. The next step involves the certificates placement. It will vary depending on whether Kibana will be installed in the same server as Elasticsearch or in a different one:
 


### PR DESCRIPTION
## Description

Restructure of the step-by-step installation guide for Elasticsearch multi-node cluster (Elastic Stack). The new approach of the guide changes "All nodes, master and all but master" into "Initial and Subsequent nodes", by doing this the instructions are simpler for users and the ambiguity between master in the installation and Elasticsearch eligible master is removed. 

The new guide approach includes templates and specific instructions for the initial and the subsequent nodes.   

This pull request also includes some changes in other sections of the installation guide like removing an unnecessary path, adding a missing note that root privileges are required and changing the order of the instructions regarding a file in order to match the actual configuration file. 

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).


