### PR TITLE
Fixed GitHub uppercase

### DIFF
--- a/source/_themes/wazuh_doc_theme/footer.html
+++ b/source/_themes/wazuh_doc_theme/footer.html
@@ -29,7 +29,7 @@
         <nav class="social-bar" role="navigation">
           <div class="subfooter-menu-bar-container">
             <ul id="menu-subfooter-social-links" class="nav from-left no-bullets">
-              <li class="rrss menu-item nav-item d-inline-block"><a class="nav-link" title="Wazuh on Github" target="_blank" href="https://github.com/wazuh"><i class="fab fa-github"></i></a></li>
+              <li class="rrss menu-item nav-item d-inline-block"><a class="nav-link" title="Wazuh on GitHub" target="_blank" href="https://github.com/wazuh"><i class="fab fa-github"></i></a></li>
               <li class="rrss menu-item nav-item d-inline-block"><a class="nav-link" title="Wazuh on Twitter" target="_blank" href="https://twitter.com/wazuh"><i class="fab fa-twitter"></i></a></li>
               <li class="rrss menu-item nav-item d-inline-block"><a class="nav-link" title="Join us on Slack" href="https://wazuh.com/community/join-us-on-slack/"><i class="fab fa-slack"></i></a></li>
             </ul>

--- a/source/_themes/wazuh_doc_theme/header.html
+++ b/source/_themes/wazuh_doc_theme/header.html
@@ -87,7 +87,7 @@
               <ul id="menu-subfooter-social-links" class="nav from-left no-bullets">
                 <li class="rrss menu-item nav-item d-inline-block"><a class="nav-link" title="Wazuh on Twitter" target="_blank" href="https://twitter.com/wazuh"><i class="fab fa-twitter"></i></a></li>
                 <li class="rrss menu-item nav-item d-inline-block"><a class="nav-link" title="Join us on Slack" href="https://wazuh.com/community/join-us-on-slack/"><i class="fab fa-slack"></i></a></li>
-                <li class="rrss menu-item nav-item d-inline-block"><a class="nav-link" title="Wazuh on Github" target="_blank" href="https://github.com/wazuh"><i class="fab fa-github"></i></a></li>
+                <li class="rrss menu-item nav-item d-inline-block"><a class="nav-link" title="Wazuh on GitHub" target="_blank" href="https://github.com/wazuh"><i class="fab fa-github"></i></a></li>
               </ul>
             </nav>
           </div>

--- a/source/migrating-from-ossec/index.rst
+++ b/source/migrating-from-ossec/index.rst
@@ -15,7 +15,7 @@ Unfortunately OSSEC users have not seen lots of new features over the last decad
 
 This is why, back in 2015, Wazuh team decided to fork the project. The result is a much more comprehensive, easy to use, reliable and scalable solution. The fork has had great adoption among the open source community, quickly becoming a broadly used solution in enterprise environments.
 
-Regarding project activity and roadmap, you can find Wazuh code in our `Github repository <https://github.com/wazuh/wazuh>`_. We believe is relevant to mention that, at the time of writing this documentation, the project has over 8,500 commits (3,000+ more than OSSEC).
+Regarding project activity and roadmap, you can find Wazuh code in our `GitHub repository <https://github.com/wazuh/wazuh>`_. We believe is relevant to mention that, at the time of writing this documentation, the project has over 8,500 commits (3,000+ more than OSSEC).
 
 Here is a brief summary of the value we added to the OSSEC project, and good reasons to upgrade your security monitoring infrastructure moving it to Wazuh:
 

--- a/source/user-manual/ruleset/contribute.rst
+++ b/source/user-manual/ruleset/contribute.rst
@@ -5,9 +5,9 @@
 Contribute to the ruleset
 ===========================
 
-If you have created new rules, decoders or rootchecks and you would like to contribute to our repository, please fork our `Github repository <https://github.com/wazuh/wazuh-ruleset>`_ and submit a pull request.
+If you have created new rules, decoders or rootchecks and you would like to contribute to our repository, please fork our `GitHub repository <https://github.com/wazuh/wazuh-ruleset>`_ and submit a pull request.
 
-If you are not familiar with Github, you can also share them through our `mailing list <https://groups.google.com/d/forum/wazuh>`_, to which you can subscribe by sending an email to ``wazuh+subscribe@googlegroups.com``. Also, do not hesitate to request new rules or rootchecks that you would like to see running in Wazuh.  Our team will do our best to make it happen.
+If you are not familiar with GitHub, you can also share them through our `mailing list <https://groups.google.com/d/forum/wazuh>`_, to which you can subscribe by sending an email to ``wazuh+subscribe@googlegroups.com``. Also, do not hesitate to request new rules or rootchecks that you would like to see running in Wazuh.  Our team will do our best to make it happen.
 
 .. note::
   In our repository you will find that most of the rules contain one or more groups called pci_dss_X. This is the PCI DSS control related to the rule. We have produced a document that can help you tag each rule with its corresponding PCI requirement: `PCI tagging <http://www.wazuh.com/resources/PCI_Tagging.pdf>`_

--- a/source/user-manual/ruleset/getting-started.rst
+++ b/source/user-manual/ruleset/getting-started.rst
@@ -22,7 +22,7 @@ In the ruleset repository you will find:
 
 Resources
 ^^^^^^^^^
-* Visit our repository to view the rules in detail at `Github Wazuh Ruleset <https://github.com/wazuh/wazuh-ruleset>`_
+* Visit our repository to view the rules in detail at `GitHub Wazuh Ruleset <https://github.com/wazuh/wazuh-ruleset>`_
 * Find a complete description of the available rules at `Wazuh Ruleset Summary <http://www.wazuh.com/resources/Wazuh_Ruleset.pdf>`_
 
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description
This PR fixes the GitHub uppercase occurrences
`Github` -> `GitHub`

<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->
