### PR TITLE
Add raw token info in API - Getting started and remove v4 string from API requests

### DIFF
--- a/source/user-manual/api/examples.rst
+++ b/source/user-manual/api/examples.rst
@@ -16,7 +16,7 @@ cURL is a command-line tool for sending http/https requests and commands. It is 
 
 .. code-block:: console
 
-    # curl -k -X GET "https://localhost:55000/" -H  "Authorization: Bearer $TOKEN"
+    # curl -k -X GET "https://localhost:55000/" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
 
 .. code-block:: json
     :class: output
@@ -36,7 +36,7 @@ cURL is a command-line tool for sending http/https requests and commands. It is 
 
 .. code-block:: console
 
-    # curl -k -X PUT "https://localhost:55000/manager/api/config?pretty=true" -H  "Authorization: Bearer $TOKEN" -H  "Content-Type: application/json" -d "{\"cache\":{\"enabled\":true,\"time\":0.75}}"
+    # curl -k -X PUT "https://localhost:55000/manager/api/config?pretty=true" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>" -H  "Content-Type: application/json" -d "{\"cache\":{\"enabled\":true,\"time\":0.75}}"
 
 .. code-block:: json
     :class: output
@@ -58,7 +58,7 @@ cURL is a command-line tool for sending http/https requests and commands. It is 
 
 .. code-block:: console
 
-    # curl -k -X POST "https://localhost:55000/security/users" -H  "Authorization: Bearer $TOKEN" -H  "Content-Type: application/json" -d "{\"username\":\"test_user\",\"password\":\"Test_user1\"}"
+    # curl -k -X POST "https://localhost:55000/security/users" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>" -H  "Content-Type: application/json" -d "{\"username\":\"test_user\",\"password\":\"Test_user1\"}"
 
 .. code-block:: json
     :class: output
@@ -83,7 +83,7 @@ cURL is a command-line tool for sending http/https requests and commands. It is 
 
 .. code-block:: console
 
-    # curl -k -X DELETE "https://localhost:55000/groups?pretty=true" -H  "Authorization: Bearer $TOKEN"
+    # curl -k -X DELETE "https://localhost:55000/groups?pretty=true" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
 
 .. code-block:: json
     :class: output

--- a/source/user-manual/api/examples.rst
+++ b/source/user-manual/api/examples.rst
@@ -138,7 +138,6 @@ Code:
     protocol = 'https'
     host = 'API_IP'
     port = 'API_PORT'
-    version = 'v4'
     user = 'wazuh'
     password = 'wazuh'
 
@@ -156,7 +155,7 @@ Code:
             raise Exception(f"Error obtaining response: {request_result.json()}")
 
     # Variables
-    base_url = f"{protocol}://{host}:{port}/{version}"
+    base_url = f"{protocol}://{host}:{port}"
     login_url = f"{base_url}/security/user/authenticate"
     basic_auth = f"{user}:{password}".encode()
     headers = {'Authorization': f'Basic {b64encode(basic_auth).decode()}'}
@@ -230,12 +229,11 @@ Code:
     $protocol = "https"
     $host_name = "API_IP"
     $port = "API_PORT"
-    $version = "v4"
     $username = "wazuh"
     $password = "wazuh"
 
     # Variables
-    $base_url = $protocol + "://" + $host_name + ":" + $port + "/" + $version
+    $base_url = $protocol + "://" + $host_name + ":" + $port
     $login_url = $base_url + "/security/user/authenticate"
     $endpoint_url = $base_url + $endpoint
     $base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(("{0}:{1}" -f $username, $password)))

--- a/source/user-manual/api/examples.rst
+++ b/source/user-manual/api/examples.rst
@@ -16,7 +16,7 @@ cURL is a command-line tool for sending http/https requests and commands. It is 
 
 .. code-block:: console
 
-    # curl -X GET "https://localhost:55000/v4/" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
+    # curl -X GET "https://localhost:55000/" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
 
 .. code-block:: json
     :class: output
@@ -36,7 +36,7 @@ cURL is a command-line tool for sending http/https requests and commands. It is 
 
 .. code-block:: console
 
-    # curl -X PUT "https://localhost:55000/v4/manager/api/config?pretty=true" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>" -H  "Content-Type: application/json" -d "{\"cache\":{\"enabled\":true,\"time\":0.75}}"
+    # curl -X PUT "https://localhost:55000/manager/api/config?pretty=true" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>" -H  "Content-Type: application/json" -d "{\"cache\":{\"enabled\":true,\"time\":0.75}}"
 
 .. code-block:: json
     :class: output
@@ -58,7 +58,7 @@ cURL is a command-line tool for sending http/https requests and commands. It is 
 
 .. code-block:: console
 
-    # curl -X POST "https://localhost:55000/v4/security/users" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>" -H  "Content-Type: application/json" -d "{\"username\":\"test_user\",\"password\":\"Test_user1\"}"
+    # curl -X POST "https://localhost:55000/security/users" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>" -H  "Content-Type: application/json" -d "{\"username\":\"test_user\",\"password\":\"Test_user1\"}"
 
 .. code-block:: json
     :class: output
@@ -83,7 +83,7 @@ cURL is a command-line tool for sending http/https requests and commands. It is 
 
 .. code-block:: console
 
-    # curl -X DELETE "https://localhost:55000/v4/groups?pretty=true" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
+    # curl -X DELETE "https://localhost:55000/groups?pretty=true" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
 
 .. code-block:: json
     :class: output

--- a/source/user-manual/api/examples.rst
+++ b/source/user-manual/api/examples.rst
@@ -16,7 +16,7 @@ cURL is a command-line tool for sending http/https requests and commands. It is 
 
 .. code-block:: console
 
-    # curl -X GET "https://localhost:55000/" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
+    # curl -k -X GET "https://localhost:55000/" -H  "Authorization: Bearer $TOKEN"
 
 .. code-block:: json
     :class: output
@@ -36,7 +36,7 @@ cURL is a command-line tool for sending http/https requests and commands. It is 
 
 .. code-block:: console
 
-    # curl -X PUT "https://localhost:55000/manager/api/config?pretty=true" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>" -H  "Content-Type: application/json" -d "{\"cache\":{\"enabled\":true,\"time\":0.75}}"
+    # curl -k -X PUT "https://localhost:55000/manager/api/config?pretty=true" -H  "Authorization: Bearer $TOKEN" -H  "Content-Type: application/json" -d "{\"cache\":{\"enabled\":true,\"time\":0.75}}"
 
 .. code-block:: json
     :class: output
@@ -58,7 +58,7 @@ cURL is a command-line tool for sending http/https requests and commands. It is 
 
 .. code-block:: console
 
-    # curl -X POST "https://localhost:55000/security/users" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>" -H  "Content-Type: application/json" -d "{\"username\":\"test_user\",\"password\":\"Test_user1\"}"
+    # curl -k -X POST "https://localhost:55000/security/users" -H  "Authorization: Bearer $TOKEN" -H  "Content-Type: application/json" -d "{\"username\":\"test_user\",\"password\":\"Test_user1\"}"
 
 .. code-block:: json
     :class: output
@@ -83,7 +83,7 @@ cURL is a command-line tool for sending http/https requests and commands. It is 
 
 .. code-block:: console
 
-    # curl -X DELETE "https://localhost:55000/groups?pretty=true" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
+    # curl -k -X DELETE "https://localhost:55000/groups?pretty=true" -H  "Authorization: Bearer $TOKEN"
 
 .. code-block:: json
     :class: output

--- a/source/user-manual/api/getting-started.rst
+++ b/source/user-manual/api/getting-started.rst
@@ -31,7 +31,7 @@ Logging into the API
 
 Wazuh API endpoints require authentication in order to be used. Therefore, all calls must include a JSON Web Token. JWT is an open standard (RFC 7519) that defines a compact and self-contained way for securely transmitting information between parties as a JSON object. Follow the steps below to log in and obtain a token in order to run any endpoint:
 
-1. Use the cURL command to log in, the API will provide a JWT token upon success. Replace <user> and <password> with yours. By default, the user is ``wazuh`` and the password is ``wazuh``. If ``SSL`` (https) is enabled in the API and it is using the default **self-signed certificates**, it will be necessary to add the parameter ``-k``. Use the ``raw`` option to get the token in a plain text format, this way, we will be able to export the token to an environment variable and make API requests in an easier way. Using ``raw=true`` is highly recommended as tokens could be long and difficult to use.
+1. Use the cURL command to log in, the API will provide a JWT token upon success. Replace <user> and <password> with yours. By default, the user is ``wazuh`` and the password is ``wazuh``. If ``SSL`` (https) is enabled in the API and it is using the default **self-signed certificates**, it will be necessary to add the parameter ``-k``. Use the ``raw`` option to get the token in a plain text format. Querying the login endpoint with ``raw=true`` is highly recommended when using cURL commands as tokens could be really long and difficult to handle otherwise. Exporting the token to an environment variable will ease the use of API requests after login.
 
     .. code-block:: console
 

--- a/source/user-manual/api/getting-started.rst
+++ b/source/user-manual/api/getting-started.rst
@@ -89,7 +89,7 @@ Logging into the API via scripts
 
 The following scripts provide API login examples using default (`false`) or plain text (`true`) `raw` parameter. They intend to bring the user closer to real use cases with Wazuh API.
 
-1. Logging in with Python and non-raw token:
+1. Logging in with Python:
 
 .. code-block:: python
 

--- a/source/user-manual/api/getting-started.rst
+++ b/source/user-manual/api/getting-started.rst
@@ -131,7 +131,7 @@ The following scripts provide API login examples using default (`false`) or plai
     response = requests.get(f"{protocol}://{host}:{port}/?pretty=true", headers=requests_headers, verify=False)
     print(response.text)
 
-    print("\nGetting /agents/summary/os:\n")
+    print("\nGetting agents status summary:\n")
 
     response = requests.get(f"{protocol}://{host}:{port}/agents/summary/status?pretty=true", headers=requests_headers, verify=False)
     print(response.text)

--- a/source/user-manual/api/getting-started.rst
+++ b/source/user-manual/api/getting-started.rst
@@ -109,7 +109,7 @@ The following scripts provide API login examples using default (`false`) or plai
     port = 55000
     user = 'wazuh'
     password = 'wazuh'
-    login_endpoint = 'security/user/authenticate?raw=false'
+    login_endpoint = 'security/user/authenticate'
 
     login_url = f"{protocol}://{host}:{port}/{login_endpoint}"
     basic_auth = f"{user}:{password}".encode()

--- a/source/user-manual/api/getting-started.rst
+++ b/source/user-manual/api/getting-started.rst
@@ -44,7 +44,7 @@ Wazuh API endpoints require authentication in order to be used. Therefore, all c
 
         <YOUR_JWT_TOKEN>
 
-    Export the token to an environment variable so API requests will be easier to make:
+    Export the token to an environment variable to use it in authorization header of future API requests:
 
     .. code-block:: console
 

--- a/source/user-manual/api/getting-started.rst
+++ b/source/user-manual/api/getting-started.rst
@@ -31,7 +31,7 @@ Logging into the API
 
 Wazuh API endpoints require authentication in order to be used. Therefore, all calls must include a JSON Web Token. JWT is an open standard (RFC 7519) that defines a compact and self-contained way for securely transmitting information between parties as a JSON object. Follow the steps below to log in and obtain a token in order to run any endpoint:
 
-1. Use the cURL command to log in, the API will provide a JWT token upon success. Replace <user> and <password> with yours. By default, the user is ``wazuh`` and the password is ``wazuh``. If ``SSL`` (https) is enabled in the API and it is using the default **self-signed certificates**, it will be necessary to add the parameter ``-k``. Use the ``raw`` option to get the token in a *plain text format*, this way, we will be able to export the token to an environment variable and make API requests in an easier way. Using ``raw=true`` is highly recommended as tokens could be long and difficult to use.
+1. Use the cURL command to log in, the API will provide a JWT token upon success. Replace <user> and <password> with yours. By default, the user is ``wazuh`` and the password is ``wazuh``. If ``SSL`` (https) is enabled in the API and it is using the default **self-signed certificates**, it will be necessary to add the parameter ``-k``. Use the ``raw`` option to get the token in a plain text format, this way, we will be able to export the token to an environment variable and make API requests in an easier way. Using ``raw=true`` is highly recommended as tokens could be long and difficult to use.
 
     .. code-block:: console
 

--- a/source/user-manual/api/getting-started.rst
+++ b/source/user-manual/api/getting-started.rst
@@ -44,6 +44,12 @@ Wazuh API endpoints require authentication in order to be used. Therefore, all c
 
         <YOUR_JWT_TOKEN>
 
+    Export the token to an environment variable so API requests will be easier to make:
+
+    .. code-block:: console
+
+        # TOKEN=$(curl -u <user>:<password> -k -X GET "https://localhost:55000/security/user/authenticate?raw=true")
+
     If you set ``raw=false`` or you leave it by default, you will get a result similar to the following. Copy the token that you will find in ``<YOUR_JWT_TOKEN>`` without the quotes.
 
     .. code-block:: none

--- a/source/user-manual/api/getting-started.rst
+++ b/source/user-manual/api/getting-started.rst
@@ -199,7 +199,7 @@ Running the script provides a result similar to the following:
 
     echo -e "\n\nEnd of the script.\n"
 
-With this script, you will get a result similar to the following:
+Running the script provides a result similar to the following:
 
 .. code-block:: console
 

--- a/source/user-manual/api/getting-started.rst
+++ b/source/user-manual/api/getting-started.rst
@@ -50,7 +50,7 @@ Wazuh API endpoints require authentication in order to be used. Therefore, all c
 
         # TOKEN=$(curl -u <user>:<password> -k -X GET "https://localhost:55000/security/user/authenticate?raw=true")
 
-    If you set ``raw=false`` or you leave it by default, you will get a result similar to the following. Copy the token that you will find in ``<YOUR_JWT_TOKEN>`` without the quotes.
+    By default (``raw=false``), the token is obtained in an ``application/json`` format. If using this option, copy the token that you will find in ``<YOUR_JWT_TOKEN>`` without the quotes.
 
     .. code-block:: none
         :class: output

--- a/source/user-manual/api/getting-started.rst
+++ b/source/user-manual/api/getting-started.rst
@@ -31,24 +31,11 @@ Logging into the API
 
 Wazuh API endpoints require authentication in order to be used. Therefore, all calls must include a JSON Web Token. JWT is an open standard (RFC 7519) that defines a compact and self-contained way for securely transmitting information between parties as a JSON object. Follow the steps below to log in and obtain a token in order to run any endpoint:
 
-1. Use the cURL command to log in, the API will provide a JWT token upon success. Replace <user> and <password> with yours. By default, the user is ``wazuh`` and the password is ``wazuh``.  If ``SSL`` (https) is enabled in the API and it is using the default **self-signed certificates**, it will be necessary to add the parameter ``-k``.
+1. Use the cURL command to log in, the API will provide a JWT token upon success. Replace <user> and <password> with yours. By default, the user is ``wazuh`` and the password is ``wazuh``. If ``SSL`` (https) is enabled in the API and it is using the default **self-signed certificates**, it will be necessary to add the parameter ``-k``. Use the ``raw`` option to get the token in a *plain text format*, this way, we will be able to export the token to an environment variable and make API requests in an easier way. Using ``raw=true`` is highly recommended as tokens could be long and difficult to use.
 
     .. code-block:: console
 
-        # curl -u <user>:<password> -X GET "https://localhost:55000/security/user/authenticate"
-
-    You will get a result similar to the following. Copy the token that you will find in ``<YOUR_JWT_TOKEN>`` without the quotes.
-
-    .. code-block:: none
-        :class: output
-
-        {"token": "<YOUR_JWT_TOKEN>"}
-
-    1.1 **Optional**. Using the ``raw`` parameter is another way to log in and get the JWT token. With the ``raw`` option, we can get the token in a plain text format, this way, we will be able to export the token to an environment variable and make API requests in an easier way.
-
-    .. code-block:: console
-
-        # curl -u <user>:<password> -X GET "https://localhost:55000/security/user/authenticate?raw=true"
+        # curl -u <user>:<password> -k -X GET "https://localhost:55000/security/user/authenticate?raw=true"
 
     You will get a result similar to the following.
 
@@ -57,17 +44,18 @@ Wazuh API endpoints require authentication in order to be used. Therefore, all c
 
         <YOUR_JWT_TOKEN>
 
-    With this parameter set to ``true``, we can export the token to an environment variable so API requests will be easier to make:
+    If you set ``raw=false`` or you leave it by default, you will get a result similar to the following. Copy the token that you will find in ``<YOUR_JWT_TOKEN>`` without the quotes.
 
-    .. code-block:: console
+    .. code-block:: none
+        :class: output
 
-        # TOKEN=$(curl -u <user>:<password> -X GET "https://localhost:55000/security/user/authenticate?raw=true")
+        {"token": "<YOUR_JWT_TOKEN>"}
 
 2. Send a *request* to confirm that everything is working as expected:
 
     .. code-block:: console
 
-        # curl -X GET "https://localhost:55000/" -H "Authorization: Bearer <YOUR_JWT_TOKEN>"
+        # curl -k -X GET "https://localhost:55000/" -H "Authorization: Bearer $TOKEN"
 
     .. code-block:: json
         :class: output
@@ -82,17 +70,12 @@ Wazuh API endpoints require authentication in order to be used. Therefore, all c
             "timestamp": "2020-05-25T07:05:00+0000"
         }
 
-    Example of an API request using the ``TOKEN`` variable defined before.
 
-    .. code-block:: console
-
-        # curl -X GET -H "Authorization: Bearer $TOKEN" "https://localhost:55000"
-
-Once we are logged in we can run any endpoint following the structure below. Please, do not forget to replace <endpoint> and <YOUR_JWT_TOKEN> with your own values.
+Once we are logged in we can run any endpoint following the structure below. Please, do not forget to replace <endpoint> with your own value. In case you are not using the environment variable, replace $TOKEN with your jwt token.
 
 .. code-block:: console
 
-    # curl -X <METHOD> "https://localhost:55000/<ENDPOINT>" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
+    # curl -k -X <METHOD> "https://localhost:55000/<ENDPOINT>" -H  "Authorization: Bearer $TOKEN"
 
 
 Basic concepts
@@ -241,7 +224,7 @@ Often when an alert fires, it is helpful to know details about the rule itself. 
 
 .. code-block:: console
 
-    # curl -X GET "https://localhost:55000/rules?rule_ids=1002&pretty=true" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
+    # curl -k -X GET "https://localhost:55000/rules?rule_ids=1002&pretty=true" -H  "Authorization: Bearer $TOKEN"
 
 .. code-block:: json
     :class: output
@@ -284,7 +267,7 @@ It can also be helpful to know what rules are available that match a specific cr
 
 .. code-block:: console
 
-    # curl -X GET "https://localhost:55000/rules?pretty=true&limit=500&search=failures&group=web&pci_dss=10.6.1" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
+    # curl -k -X GET "https://localhost:55000/rules?pretty=true&limit=500&search=failures&group=web&pci_dss=10.6.1" -H  "Authorization: Bearer $TOKEN"
 
 .. code-block:: json
     :class: output
@@ -355,7 +338,7 @@ The API can be used to show information about all monitored files by syscheck. T
 
 .. code-block:: console
 
-    # curl -X GET "https://localhost:55000/syscheck/000?pretty=true&search=.py" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
+    # curl -k -X GET "https://localhost:55000/syscheck/000?pretty=true&search=.py" -H  "Authorization: Bearer $TOKEN"
 
 .. code-block:: json
     :class: output
@@ -409,7 +392,7 @@ You can find a file using its md5/sha1 hash. In the following examples, the same
 
 .. code-block:: console
 
-    # curl -X GET "https://localhost:55000/syscheck/000?pretty=true&hash=bc929cb047b79d5c16514f2c553e6b759abfb1b8" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
+    # curl -k -X GET "https://localhost:55000/syscheck/000?pretty=true&hash=bc929cb047b79d5c16514f2c553e6b759abfb1b8" -H  "Authorization: Bearer $TOKEN"
 
 .. code-block:: json
     :class: output
@@ -444,7 +427,7 @@ You can find a file using its md5/sha1 hash. In the following examples, the same
 
 .. code-block:: console
 
-    # curl -X GET "https://localhost:55000/syscheck/000?pretty=true&hash=085c1161d814a8863562694b3819f6a5" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
+    # curl -k -X GET "https://localhost:55000/syscheck/000?pretty=true&hash=085c1161d814a8863562694b3819f6a5" -H  "Authorization: Bearer $TOKEN"
 
 .. code-block:: json
     :class: output
@@ -484,7 +467,7 @@ Some information about the manager can be retrieved using the API. Configuration
 
 .. code-block:: console
 
-    # curl -X GET "https://localhost:55000/manager/status?pretty=true" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
+    # curl -k -X GET "https://localhost:55000/manager/status?pretty=true" -H  "Authorization: Bearer $TOKEN"
 
 .. code-block:: json
     :class: output
@@ -524,7 +507,7 @@ You can even dump the manager's current configuration with the request below (re
 
 .. code-block:: console
 
-    # curl -X GET "https://localhost:55000/manager/configuration?pretty=true&section=global" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
+    # curl -k -X GET "https://localhost:55000/manager/configuration?pretty=true&section=global" -H  "Authorization: Bearer $TOKEN"
 
 .. code-block:: json
     :class: output
@@ -570,7 +553,7 @@ This enumerates **active** agents:
 
 .. code-block:: console
 
-    # curl -X GET "https://localhost:55000/agents?pretty=true&offset=1&limit=1&status=never_connected" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
+    # curl -k -X GET "https://localhost:55000/agents?pretty=true&offset=1&limit=1&status=never_connected" -H  "Authorization: Bearer $TOKEN"
 
 .. code-block:: json
     :class: output
@@ -604,7 +587,7 @@ Adding an agent is now easier than ever. Simply send a request with the agent na
 
 .. code-block:: console
 
-    # curl -X POST "https://localhost:55000/agents?pretty=true" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>" -H  "Content-Type: application/json" -d "{\"name\":\"NewHost\",\"ip\":\"10.0.10.11\"}"
+    # curl -k -X POST "https://localhost:55000/agents?pretty=true" -H  "Authorization: Bearer $TOKEN" -H  "Content-Type: application/json" -d "{\"name\":\"NewHost\",\"ip\":\"10.0.10.11\"}"
 
 .. code-block:: json
     :class: output

--- a/source/user-manual/api/getting-started.rst
+++ b/source/user-manual/api/getting-started.rst
@@ -138,7 +138,7 @@ With these scripts, it will be easier to understand the two ways of logging into
 
     print("\n\nEnd of the script.\n")
 
-With this script, you will get a result similar to the following:
+Running the script provides a result similar to the following:
 
 .. code-block:: console
 

--- a/source/user-manual/api/getting-started.rst
+++ b/source/user-manual/api/getting-started.rst
@@ -35,7 +35,7 @@ Wazuh API endpoints require authentication in order to be used. Therefore, all c
 
     .. code-block:: console
 
-        # curl -u <user>:<password> -X GET "https://localhost:55000/v4/security/user/authenticate"
+        # curl -u <user>:<password> -X GET "https://localhost:55000/security/user/authenticate"
 
     You will get a result similar to the following. Copy the token that you will find in ``<YOUR_JWT_TOKEN>`` without the quotes.
 
@@ -44,11 +44,30 @@ Wazuh API endpoints require authentication in order to be used. Therefore, all c
 
         {"token": "<YOUR_JWT_TOKEN>"}
 
+    **Note:** Using the ``raw`` parameter is another way to log in and get the JWT token. With the ``raw`` option, we can get the token in a plain text format, this way, we will be able to export the token to an environment variable and make API requests in an easier way.
+
+    .. code-block:: console
+
+        # curl -u <user>:<password> -X GET "https://localhost:55000/security/user/authenticate?raw=true"
+
+    You will get a result similar to the following.
+
+    .. code-block:: none
+        :class: output
+
+        <YOUR_JWT_TOKEN>
+
+    With this parameter set to ``true``, we can export the token to an environment variable so API requests will be easier to make:
+
+    .. code-block:: console
+
+        # TOKEN=$(curl -u <user>:<password> -X GET "https://localhost:55000/security/user/authenticate?raw=true")
+
 2. Send a *request* to confirm that everything is working as expected:
 
     .. code-block:: console
 
-        curl -X GET "https://localhost:55000/v4/" -H "Authorization: Bearer <YOUR_JWT_TOKEN>"
+        # curl -X GET "https://localhost:55000/" -H "Authorization: Bearer <YOUR_JWT_TOKEN>"
 
     .. code-block:: json
         :class: output
@@ -63,11 +82,17 @@ Wazuh API endpoints require authentication in order to be used. Therefore, all c
             "timestamp": "2020-05-25T07:05:00+0000"
         }
 
+    Example of an API request using the ``TOKEN`` variable defined before.
+
+    .. code-block:: console
+
+        # curl -X GET -H "Authorization: Bearer $TOKEN" "https://localhost:55000"
+
 Once we are logged in we can run any endpoint following the structure below. Please, do not forget to replace <endpoint> and <YOUR_JWT_TOKEN> with your own values.
 
 .. code-block:: console
 
-    # curl -X <METHOD> "https://localhost:55000/v4/<ENDPOINT>" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
+    # curl -X <METHOD> "https://localhost:55000/<ENDPOINT>" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
 
 
 Basic concepts
@@ -82,8 +107,8 @@ Here are some of the basic concepts related to making API requests and understan
     +=================================================+====================================================================================================================================================================+
     | ``-X GET/POST/PUT/DELETE``                      | Specifies a custom request method to use when communicating with the HTTP server.                                                                                  |
     +-------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-    | ``http://localhost:55000/v4/<ENDPOINT>``        | The API URL to use if you are running the command on the manager itself. It will be ``http`` or ``https`` depending on whether SSL is activated in the API or not. |
-    | ``https://localhost:55000/v4/<ENDPOINT>``       |                                                                                                                                                                    |
+    | ``http://localhost:55000/<ENDPOINT>``           | The API URL to use if you are running the command on the manager itself. It will be ``http`` or ``https`` depending on whether SSL is activated in the API or not. |
+    | ``https://localhost:55000/<ENDPOINT>``          |                                                                                                                                                                    |
     +-------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------+
     | ``-H  "accept: application/json"``              | Include extra header in the request to set output type to JSON (optional).                                                                                         |
     +-------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -216,7 +241,7 @@ Often when an alert fires, it is helpful to know details about the rule itself. 
 
 .. code-block:: console
 
-    # curl -X GET "https://localhost:55000/v4/rules?rule_ids=1002&pretty=true" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
+    # curl -X GET "https://localhost:55000/rules?rule_ids=1002&pretty=true" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
 
 .. code-block:: json
     :class: output
@@ -259,7 +284,7 @@ It can also be helpful to know what rules are available that match a specific cr
 
 .. code-block:: console
 
-    # curl -X GET "https://localhost:55000/v4/rules?pretty=true&limit=500&search=failures&group=web&pci_dss=10.6.1" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
+    # curl -X GET "https://localhost:55000/rules?pretty=true&limit=500&search=failures&group=web&pci_dss=10.6.1" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
 
 .. code-block:: json
     :class: output
@@ -330,7 +355,7 @@ The API can be used to show information about all monitored files by syscheck. T
 
 .. code-block:: console
 
-    # curl -X GET "https://localhost:55000/v4/syscheck/000?pretty=true&search=.py" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
+    # curl -X GET "https://localhost:55000/syscheck/000?pretty=true&search=.py" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
 
 .. code-block:: json
     :class: output
@@ -384,7 +409,7 @@ You can find a file using its md5/sha1 hash. In the following examples, the same
 
 .. code-block:: console
 
-    # curl -X GET "https://localhost:55000/v4/syscheck/000?pretty=true&hash=bc929cb047b79d5c16514f2c553e6b759abfb1b8" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
+    # curl -X GET "https://localhost:55000/syscheck/000?pretty=true&hash=bc929cb047b79d5c16514f2c553e6b759abfb1b8" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
 
 .. code-block:: json
     :class: output
@@ -419,7 +444,7 @@ You can find a file using its md5/sha1 hash. In the following examples, the same
 
 .. code-block:: console
 
-    # curl -X GET "https://localhost:55000/v4/syscheck/000?pretty=true&hash=085c1161d814a8863562694b3819f6a5" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
+    # curl -X GET "https://localhost:55000/syscheck/000?pretty=true&hash=085c1161d814a8863562694b3819f6a5" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
 
 .. code-block:: json
     :class: output
@@ -459,7 +484,7 @@ Some information about the manager can be retrieved using the API. Configuration
 
 .. code-block:: console
 
-    # curl -X GET "https://localhost:55000/v4/manager/status?pretty=true" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
+    # curl -X GET "https://localhost:55000/manager/status?pretty=true" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
 
 .. code-block:: json
     :class: output
@@ -499,7 +524,7 @@ You can even dump the manager's current configuration with the request below (re
 
 .. code-block:: console
 
-    # curl -X GET "https://localhost:55000/v4/manager/configuration?pretty=true&section=global" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
+    # curl -X GET "https://localhost:55000/manager/configuration?pretty=true&section=global" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
 
 .. code-block:: json
     :class: output
@@ -545,7 +570,7 @@ This enumerates **active** agents:
 
 .. code-block:: console
 
-    # curl -X GET "https://localhost:55000/v4/agents?pretty=true&offset=1&limit=1&status=never_connected" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
+    # curl -X GET "https://localhost:55000/agents?pretty=true&offset=1&limit=1&status=never_connected" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
 
 .. code-block:: json
     :class: output
@@ -579,7 +604,7 @@ Adding an agent is now easier than ever. Simply send a request with the agent na
 
 .. code-block:: console
 
-    # curl -X POST "https://localhost:55000/v4/agents?pretty=true" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>" -H  "Content-Type: application/json" -d "{\"name\":\"NewHost\",\"ip\":\"10.0.10.11\"}"
+    # curl -X POST "https://localhost:55000/agents?pretty=true" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>" -H  "Content-Type: application/json" -d "{\"name\":\"NewHost\",\"ip\":\"10.0.10.11\"}"
 
 .. code-block:: json
     :class: output

--- a/source/user-manual/api/getting-started.rst
+++ b/source/user-manual/api/getting-started.rst
@@ -120,7 +120,7 @@ The following scripts provide API login examples using default (`false`) or plai
     response = requests.get(login_url, headers=login_headers, verify=False)
     token = json.loads(response.content.decode())['token']
 
-    # new authorization with the token we got
+    # New authorization header with the JWT token we got
     requests_headers = {'Content-Type': 'application/json',
                         'Authorization': f'Bearer {token}'}
 

--- a/source/user-manual/api/getting-started.rst
+++ b/source/user-manual/api/getting-started.rst
@@ -77,7 +77,7 @@ Wazuh API endpoints require authentication in order to be used. Therefore, all c
         }
 
 
-Once we are logged in we can run any endpoint following the structure below. Please, do not forget to replace <endpoint> with your own value. In case you are not using the environment variable, replace $TOKEN with your jwt token.
+Once logged in, it is possible to run any endpoint following the structure below. Please, do not forget to replace <endpoint> with your own value. In case you are not using the environment variable, replace $TOKEN with your jwt token.
 
 .. code-block:: console
 

--- a/source/user-manual/api/getting-started.rst
+++ b/source/user-manual/api/getting-started.rst
@@ -33,17 +33,6 @@ Wazuh API endpoints require authentication in order to be used. Therefore, all c
 
 1. Use the cURL command to log in, the API will provide a JWT token upon success. Replace <user> and <password> with yours. By default, the user is ``wazuh`` and the password is ``wazuh``. If ``SSL`` (https) is enabled in the API and it is using the default **self-signed certificates**, it will be necessary to add the parameter ``-k``. Use the ``raw`` option to get the token in a plain text format. Querying the login endpoint with ``raw=true`` is highly recommended when using cURL commands as tokens could be really long and difficult to handle otherwise. Exporting the token to an environment variable will ease the use of API requests after login.
 
-    .. code-block:: console
-
-        # curl -u <user>:<password> -k -X GET "https://localhost:55000/security/user/authenticate?raw=true"
-
-    You will get a result similar to the following.
-
-    .. code-block:: none
-        :class: output
-
-        <YOUR_JWT_TOKEN>
-
     Export the token to an environment variable to use it in authorization header of future API requests:
 
     .. code-block:: console
@@ -119,6 +108,7 @@ The following scripts provide API login examples using default (`false`) or plai
     print("\nLogin request ...\n")
     response = requests.get(login_url, headers=login_headers, verify=False)
     token = json.loads(response.content.decode())['token']
+    print(token)
 
     # New authorization header with the JWT token we got
     requests_headers = {'Content-Type': 'application/json',
@@ -144,12 +134,13 @@ Running the script provides a result similar to the following:
 
     # root@wazuh-master:/# python3 login_script.py
 
-    - Getting token ...
+    Login request ...
 
+    eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNTk3ODI4OTQ3LCJleHAiOjE1OTc4NjQ5NDcsInN1YiI6IndhenVoIiwicmJhY19wb2xpY2llcyI6eyJhZ2VudDpjcmVhdGUiOnsiKjoqOioiOiJhbGxvdyJ9LCJncm91cDpjcmVhdGUiOnsiKjoqOioiOiJhbGxvdyJ9LCJhZ2VudDpyZWFkIjp7ImFnZW50OmlkOioiOiJhbGxvdyIsImFnZW50Omdyb3VwOioiOiJhbGxvdyJ9LCJhZ2VudDpkZWxldGUiOnsiYWdlbnQ6aWQ6KiI6ImFsbG93IiwiYWdlbnQ6Z3JvdXA6KiI6ImFsbG93In0sImFnZW50Om1vZGlmeV9ncm91cCI6eyJhZ2VudDppZDoqIjoiYWxsb3ciLCJhZ2VudDpncm91cDoqIjoiYWxsb3cifSwiYWdlbnQ6cmVzdGFydCI6eyJhZ2VudDppZDoqIjoiYWxsb3ciLCJhZ2VudDpncm91cDoqIjoiYWxsb3cifSwiYWdlbnQ6dXBncmFkZSI6eyJhZ2VudDppZDoqIjoiYWxsb3ciLCJhZ2VudDpncm91cDoqIjoiYWxsb3cifSwiZ3JvdXA6cmVhZCI6eyJncm91cDppZDoqIjoiYWxsb3cifSwiZ3JvdXA6ZGVsZXRlIjp7Imdyb3VwOmlkOioiOiJhbGxvdyJ9LCJncm91cDp1cGRhdGVfY29uZmlnIjp7Imdyb3VwOmlkOioiOiJhbGxvdyJ9LCJncm91cDptb2RpZnlfYXNzaWdubWVudHMiOnsiZ3JvdXA6aWQ6KiI6ImFsbG93In0sImFjdGl2ZS1yZXNwb25zZTpjb21tYW5kIjp7ImFnZW50OmlkOioiOiJhbGxvdyJ9LCJzZWN1cml0eTpjcmVhdGUiOnsiKjoqOioiOiJhbGxvdyJ9LCJzZWN1cml0eTpjcmVhdGVfdXNlciI6eyIqOio6KiI6ImFsbG93In0sInNlY3VyaXR5OnJlYWRfY29uZmlnIjp7Iio6KjoqIjoiYWxsb3cifSwic2VjdXJpdHk6dXBkYXRlX2NvbmZpZyI6eyIqOio6KiI6ImFsbG93In0sInNlY3VyaXR5OnJldm9rZSI6eyIqOio6KiI6ImFsbG93In0sInNlY3VyaXR5OnJlYWQiOnsicm9sZTppZDoqIjoiYWxsb3ciLCJwb2xpY3k6aWQ6KiI6ImFsbG93IiwidXNlcjppZDoqIjoiYWxsb3cifSwic2VjdXJpdHk6dXBkYXRlIjp7InJvbGU6aWQ6KiI6ImFsbG93IiwicG9saWN5OmlkOioiOiJhbGxvdyIsInVzZXI6aWQ6KiI6ImFsbG93In0sInNlY3VyaXR5OmRlbGV0ZSI6eyJyb2xlOmlkOioiOiJhbGxvdyIsInBvbGljeTppZDoqIjoiYWxsb3ciLCJ1c2VyOmlkOioiOiJhbGxvdyJ9LCJjbHVzdGVyOnN0YXR1cyI6eyIqOio6KiI6ImFsbG93In0sIm1hbmFnZXI6cmVhZCI6eyIqOio6KiI6ImFsbG93In0sIm1hbmFnZXI6cmVhZF9hcGlfY29uZmlnIjp7Iio6KjoqIjoiYWxsb3cifSwibWFuYWdlcjp1cGRhdGVfYXBpX2NvbmZpZyI6eyIqOio6KiI6ImFsbG93In0sIm1hbmFnZXI6dXBsb2FkX2ZpbGUiOnsiKjoqOioiOiJhbGxvdyJ9LCJtYW5hZ2VyOnJlc3RhcnQiOnsiKjoqOioiOiJhbGxvdyJ9LCJtYW5hZ2VyOmRlbGV0ZV9maWxlIjp7Iio6KjoqIjoiYWxsb3ciLCJmaWxlOnBhdGg6KiI6ImFsbG93In0sIm1hbmFnZXI6cmVhZF9maWxlIjp7ImZpbGU6cGF0aDoqIjoiYWxsb3cifSwiY2x1c3RlcjpkZWxldGVfZmlsZSI6eyJub2RlOmlkOioiOiJhbGxvdyIsIm5vZGU6aWQ6KiZmaWxlOnBhdGg6KiI6ImFsbG93In0sImNsdXN0ZXI6cmVhZF9hcGlfY29uZmlnIjp7Im5vZGU6aWQ6KiI6ImFsbG93In0sImNsdXN0ZXI6cmVhZCI6eyJub2RlOmlkOioiOiJhbGxvdyJ9LCJjbHVzdGVyOnVwZGF0ZV9hcGlfY29uZmlnIjp7Im5vZGU6aWQ6KiI6ImFsbG93In0sImNsdXN0ZXI6cmVzdGFydCI6eyJub2RlOmlkOioiOiJhbGxvdyJ9LCJjbHVzdGVyOnVwbG9hZF9maWxlIjp7Im5vZGU6aWQ6KiI6ImFsbG93In0sImNsdXN0ZXI6cmVhZF9maWxlIjp7Im5vZGU6aWQ6KiZmaWxlOnBhdGg6KiI6ImFsbG93In0sImNpc2NhdDpyZWFkIjp7ImFnZW50OmlkOioiOiJhbGxvdyJ9LCJkZWNvZGVyczpyZWFkIjp7ImRlY29kZXI6ZmlsZToqIjoiYWxsb3cifSwibGlzdHM6cmVhZCI6eyJsaXN0OnBhdGg6KiI6ImFsbG93In0sInJ1bGVzOnJlYWQiOnsicnVsZTpmaWxlOioiOiJhbGxvdyJ9LCJtaXRyZTpyZWFkIjp7Iio6KjoqIjoiYWxsb3cifSwic2NhOnJlYWQiOnsiYWdlbnQ6aWQ6KiI6ImFsbG93In0sInN5c2NoZWNrOmNsZWFyIjp7ImFnZW50OmlkOioiOiJhbGxvdyJ9LCJzeXNjaGVjazpyZWFkIjp7ImFnZW50OmlkOioiOiJhbGxvdyJ9LCJzeXNjaGVjazpydW4iOnsiYWdlbnQ6aWQ6KiI6ImFsbG93In0sInN5c2NvbGxlY3RvcjpyZWFkIjp7ImFnZW50OmlkOioiOiJhbGxvdyJ9LCJyYmFjX21vZGUiOiJibGFjayJ9fQ.rcn9j--_sA-Fy47mSc0R5Hts20izTtreB9WPTBILi9g
 
     - API calls with TOKEN environment variable ...
 
-    Getting default information:
+    Getting API information:
 
     {
        "title": "Wazuh API REST",
@@ -158,10 +149,10 @@ Running the script provides a result similar to the following:
        "license_name": "GPL 2.0",
        "license_url": "https://github.com/wazuh/wazuh/blob/master/LICENSE",
        "hostname": "wazuh-master",
-       "timestamp": "2020-08-18T08:35:45+0000"
+       "timestamp": "2020-08-19T09:20:02+0000"
     }
 
-    Getting /agents/summary/os:
+    Getting agents status summary:
 
     {
        "data": {

--- a/source/user-manual/api/getting-started.rst
+++ b/source/user-manual/api/getting-started.rst
@@ -87,7 +87,7 @@ Once logged in, it is possible to run any endpoint following the structure below
 Logging into the API via scripts
 --------------------------------
 
-With these scripts, it will be easier to understand the two ways of logging into the API: using `raw=true` or `raw=false`.
+The following scripts provide API login examples using default (`false`) or plain text (`true`) `raw` parameter. They intend to bring the user closer to real use cases with Wazuh API.
 
 1. Logging in with Python and non-raw token:
 

--- a/source/user-manual/api/getting-started.rst
+++ b/source/user-manual/api/getting-started.rst
@@ -126,7 +126,7 @@ The following scripts provide API login examples using default (`false`) or plai
 
     print("\n- API calls with TOKEN environment variable ...\n")
 
-    print("Getting default information:\n")
+    print("Getting API information:\n")
 
     response = requests.get(f"{protocol}://{host}:{port}/?pretty=true", headers=requests_headers, verify=False)
     print(response.text)

--- a/source/user-manual/api/getting-started.rst
+++ b/source/user-manual/api/getting-started.rst
@@ -555,11 +555,11 @@ Playing with agents
 
 Here are some commands for working with the agents.
 
-This enumerates **active** agents:
+This enumerates 2 **active** agents:
 
 .. code-block:: console
 
-    # curl -k -X GET "https://localhost:55000/agents?pretty=true&offset=1&limit=1&status=never_connected" -H  "Authorization: Bearer $TOKEN"
+    # curl -k -X GET "https://localhost:55000/agents?pretty=true&offset=1&limit=2&select=status%2Cid%2Cmanager%2Cname%2Cnode_name%2Cversion&status=active" -H  "Authorization: Bearer $TOKEN"
 
 .. code-block:: json
     :class: output
@@ -568,20 +568,23 @@ This enumerates **active** agents:
       "data": {
         "affected_items": [
           {
-            "node_name": "unknown",
-            "status": "never_connected",
-            "dateAdd": "1970-01-01T00:00:00Z",
-            "registerIP": "any",
+            "node_name": "worker2",
+            "status": "active",
+            "manager": "wazuh-worker2",
+            "version": "Wazuh v3.13.1",
+            "id": "001",
+            "name": "wazuh-agent1"
+          },
+          {
+            "node_name": "worker2",
+            "status": "active",
+            "manager": "wazuh-worker2",
+            "version": "Wazuh v3.13.1",
             "id": "002",
-            "ip": "any",
-            "name": "wazuh-agent2",
-            "group": [
-              "default",
-              "group2"
-            ]
+            "name": "wazuh-agent2"
           }
         ],
-        "total_affected_items": 10,
+        "total_affected_items": 9,
         "total_failed_items": 0,
         "failed_items": []
       },

--- a/source/user-manual/api/getting-started.rst
+++ b/source/user-manual/api/getting-started.rst
@@ -44,7 +44,7 @@ Wazuh API endpoints require authentication in order to be used. Therefore, all c
 
         {"token": "<YOUR_JWT_TOKEN>"}
 
-    **Note:** Using the ``raw`` parameter is another way to log in and get the JWT token. With the ``raw`` option, we can get the token in a plain text format, this way, we will be able to export the token to an environment variable and make API requests in an easier way.
+    1.1 **Optional**. Using the ``raw`` parameter is another way to log in and get the JWT token. With the ``raw`` option, we can get the token in a plain text format, this way, we will be able to export the token to an environment variable and make API requests in an easier way.
 
     .. code-block:: console
 

--- a/source/user-manual/api/getting-started.rst
+++ b/source/user-manual/api/getting-started.rst
@@ -116,7 +116,7 @@ The following scripts provide API login examples using default (`false`) or plai
     login_headers = {'Content-Type': 'application/json',
                      'Authorization': f'Basic {b64encode(basic_auth).decode()}'}
 
-    print("\n- Getting token ...\n")
+    print("\nLogin request ...\n")
     response = requests.get(login_url, headers=login_headers, verify=False)
     token = json.loads(response.content.decode())['token']
 

--- a/source/user-manual/api/queries.rst
+++ b/source/user-manual/api/queries.rst
@@ -32,7 +32,7 @@ For example, to filter Ubuntu agents with a version higher than 18, the followin
 
 .. code-block:: console
 
-    # curl -G --data-urlencode "q=os.name=ubuntu;os.version>18" -X GET "https://localhost:55000/agents?limit=500&pretty=true&select=id,name,os.name,os.version,os.codename,os.major" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
+    # curl -G --data-urlencode "q=os.name=ubuntu;os.version>18" -k -X GET "https://localhost:55000/agents?limit=500&pretty=true&select=id,name,os.name,os.version,os.codename,os.major" -H  "Authorization: Bearer $TOKEN"
 
 .. code-block:: json
     :class: output
@@ -132,7 +132,7 @@ The same field can be used multiple times to get a more accurate result. For exa
 
 .. code-block:: console
 
-    # curl -G --data-urlencode "q=os.name=ubuntu;os.version>18;os.version<18.04.4" -X GET "https://localhost:55000/agents?limit=500&pretty=true&select=id,name,os.name,os.version,os.codename,os.major" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
+    # curl -G --data-urlencode "q=os.name=ubuntu;os.version>18;os.version<18.04.4" -k -X GET "https://localhost:55000/agents?limit=500&pretty=true&select=id,name,os.name,os.version,os.codename,os.major" -H  "Authorization: Bearer $TOKEN"
 
 .. code-block:: json
     :class: output
@@ -172,7 +172,7 @@ An example of using the OR (``,``) operator and LIKE AS (``~``) can be filtering
 
 .. code-block:: console
 
-    # curl -G --data-urlencode "q=os.name~centos,os.name~windows" -X GET "https://localhost:55000/agents?limit=500&pretty=true&select=id,name,os.name,os.version,os.codename,os.major" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
+    # curl -G --data-urlencode "q=os.name~centos,os.name~windows" -k -X GET "https://localhost:55000/agents?limit=500&pretty=true&select=id,name,os.name,os.version,os.codename,os.major" -H  "Authorization: Bearer $TOKEN"
 
 .. code-block:: json
     :class: output
@@ -201,7 +201,7 @@ Getting the ubuntu agents with id other than 0 and lower than 4, whose name cont
 
 .. code-block:: console
 
-    # curl -G --data-urlencode "q=id!=0;id<4;name~waz;(os.major=16,os.major=18)" -X GET "https://localhost:55000/agents?limit=500&pretty=true&select=id,name,os.name,os.version,os.codename,os.major" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
+    # curl -G --data-urlencode "q=id!=0;id<4;name~waz;(os.major=16,os.major=18)" -k -X GET "https://localhost:55000/agents?limit=500&pretty=true&select=id,name,os.name,os.version,os.codename,os.major" -H  "Authorization: Bearer $TOKEN"
 
 .. code-block:: json
     :class: output

--- a/source/user-manual/api/queries.rst
+++ b/source/user-manual/api/queries.rst
@@ -32,7 +32,7 @@ For example, to filter Ubuntu agents with a version higher than 18, the followin
 
 .. code-block:: console
 
-    # curl -G --data-urlencode "q=os.name=ubuntu;os.version>18" -X GET "https://localhost:55000/v4/agents?limit=500&pretty=true&select=id,name,os.name,os.version,os.codename,os.major" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
+    # curl -G --data-urlencode "q=os.name=ubuntu;os.version>18" -X GET "https://localhost:55000/agents?limit=500&pretty=true&select=id,name,os.name,os.version,os.codename,os.major" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
 
 .. code-block:: json
     :class: output
@@ -132,7 +132,7 @@ The same field can be used multiple times to get a more accurate result. For exa
 
 .. code-block:: console
 
-    # curl -G --data-urlencode "q=os.name=ubuntu;os.version>18;os.version<18.04.4" -X GET "https://localhost:55000/v4/agents?limit=500&pretty=true&select=id,name,os.name,os.version,os.codename,os.major" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
+    # curl -G --data-urlencode "q=os.name=ubuntu;os.version>18;os.version<18.04.4" -X GET "https://localhost:55000/agents?limit=500&pretty=true&select=id,name,os.name,os.version,os.codename,os.major" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
 
 .. code-block:: json
     :class: output
@@ -172,7 +172,7 @@ An example of using the OR (``,``) operator and LIKE AS (``~``) can be filtering
 
 .. code-block:: console
 
-    # curl -G --data-urlencode "q=os.name~centos,os.name~windows" -X GET "https://localhost:55000/v4/agents?limit=500&pretty=true&select=id,name,os.name,os.version,os.codename,os.major" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
+    # curl -G --data-urlencode "q=os.name~centos,os.name~windows" -X GET "https://localhost:55000/agents?limit=500&pretty=true&select=id,name,os.name,os.version,os.codename,os.major" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
 
 .. code-block:: json
     :class: output
@@ -201,7 +201,7 @@ Getting the ubuntu agents with id other than 0 and lower than 4, whose name cont
 
 .. code-block:: console
 
-    # curl -G --data-urlencode "q=id!=0;id<4;name~waz;(os.major=16,os.major=18)" -X GET "https://localhost:55000/v4/agents?limit=500&pretty=true&select=id,name,os.name,os.version,os.codename,os.major" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
+    # curl -G --data-urlencode "q=id!=0;id<4;name~waz;(os.major=16,os.major=18)" -X GET "https://localhost:55000/agents?limit=500&pretty=true&select=id,name,os.name,os.version,os.codename,os.major" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
 
 .. code-block:: json
     :class: output

--- a/source/user-manual/api/queries.rst
+++ b/source/user-manual/api/queries.rst
@@ -32,7 +32,7 @@ For example, to filter Ubuntu agents with a version higher than 18, the followin
 
 .. code-block:: console
 
-    # curl -G --data-urlencode "q=os.name=ubuntu;os.version>18" -k -X GET "https://localhost:55000/agents?limit=500&pretty=true&select=id,name,os.name,os.version,os.codename,os.major" -H  "Authorization: Bearer $TOKEN"
+    # curl -G --data-urlencode "q=os.name=ubuntu;os.version>18" -k -X GET "https://localhost:55000/agents?limit=500&pretty=true&select=id,name,os.name,os.version,os.codename,os.major" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
 
 .. code-block:: json
     :class: output
@@ -132,7 +132,7 @@ The same field can be used multiple times to get a more accurate result. For exa
 
 .. code-block:: console
 
-    # curl -G --data-urlencode "q=os.name=ubuntu;os.version>18;os.version<18.04.4" -k -X GET "https://localhost:55000/agents?limit=500&pretty=true&select=id,name,os.name,os.version,os.codename,os.major" -H  "Authorization: Bearer $TOKEN"
+    # curl -G --data-urlencode "q=os.name=ubuntu;os.version>18;os.version<18.04.4" -k -X GET "https://localhost:55000/agents?limit=500&pretty=true&select=id,name,os.name,os.version,os.codename,os.major" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
 
 .. code-block:: json
     :class: output
@@ -172,7 +172,7 @@ An example of using the OR (``,``) operator and LIKE AS (``~``) can be filtering
 
 .. code-block:: console
 
-    # curl -G --data-urlencode "q=os.name~centos,os.name~windows" -k -X GET "https://localhost:55000/agents?limit=500&pretty=true&select=id,name,os.name,os.version,os.codename,os.major" -H  "Authorization: Bearer $TOKEN"
+    # curl -G --data-urlencode "q=os.name~centos,os.name~windows" -k -X GET "https://localhost:55000/agents?limit=500&pretty=true&select=id,name,os.name,os.version,os.codename,os.major" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
 
 .. code-block:: json
     :class: output
@@ -201,7 +201,7 @@ Getting the ubuntu agents with id other than 0 and lower than 4, whose name cont
 
 .. code-block:: console
 
-    # curl -G --data-urlencode "q=id!=0;id<4;name~waz;(os.major=16,os.major=18)" -k -X GET "https://localhost:55000/agents?limit=500&pretty=true&select=id,name,os.name,os.version,os.codename,os.major" -H  "Authorization: Bearer $TOKEN"
+    # curl -G --data-urlencode "q=id!=0;id<4;name~waz;(os.major=16,os.major=18)" -k -X GET "https://localhost:55000/agents?limit=500&pretty=true&select=id,name,os.name,os.version,os.codename,os.major" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
 
 .. code-block:: json
     :class: output

--- a/source/user-manual/api/rbac/configuration.rst
+++ b/source/user-manual/api/rbac/configuration.rst
@@ -12,7 +12,7 @@ You can modify the RBAC mode (as explained in the :ref:`How it works <api_rbac_h
 
 .. code-block:: console
 
-    # curl -k -X PUT "https://localhost:55000/security/config?pretty=true" -H "Authorization: Bearer $TOKEN" -d "{\"rbac_mode\":\"<DESIRED_RBAC_MODE>\"}"
+    # curl -k -X PUT "https://localhost:55000/security/config?pretty=true" -H "Authorization: Bearer <YOUR_JWT_TOKEN>" -d "{\"rbac_mode\":\"<DESIRED_RBAC_MODE>\"}"
 
 .. code-block:: json
     :class: output
@@ -54,7 +54,7 @@ The request would be as follows:
 
 .. code-block:: console
 
-    # curl -k -X POST "https://localhost:55000/security/policies?pretty=true" -H  "Authorization: Bearer $TOKEN" -d "{\"name\":\"customer_x_agents\",\"policy\":{\"actions\":[\"agent:read\"],\"resources\":[\"agent:id:001\",\"agent:id:002\",\"agent:id:003\",\"agent:id:004\"],\"effect\":\"allow\"}}" -k
+    # curl -k -X POST "https://localhost:55000/security/policies?pretty=true" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>" -d "{\"name\":\"customer_x_agents\",\"policy\":{\"actions\":[\"agent:read\"],\"resources\":[\"agent:id:001\",\"agent:id:002\",\"agent:id:003\",\"agent:id:004\"],\"effect\":\"allow\"}}" -k
 
 With this policy, we have established that it is allowed to read information related to agents 001, 002, 003 and 004. We can create more policies to our liking as long as they are not repeated. We may also change this policy at any time to, for example, add new agents.
 
@@ -119,7 +119,7 @@ The request with the information showed above would look like this:
 
 .. code-block:: console
 
-    # curl -k -X POST "https://localhost:55000/security/roles?pretty=true" -H  "Authorization: Bearer $TOKEN" -d "{\"name\":\"sales-team\",\"rule\":{\"MATCH\":{\"definition\":\"sales-team\"}}}"
+    # curl -k -X POST "https://localhost:55000/security/roles?pretty=true" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>" -d "{\"name\":\"sales-team\",\"rule\":{\"MATCH\":{\"definition\":\"sales-team\"}}}"
 
 The response body would be this. Remember that the ID is needed to link policies to this role.
 
@@ -159,7 +159,7 @@ In our example the *role_id* would be ``8`` (the ID of "sales-team" role) and th
 
 .. code-block:: console
 
-    # curl -k -X POST "https://localhost:55000/security/roles/8/policies?policy_ids=12&pretty=true" -H  "Authorization: Bearer $TOKEN"
+    # curl -k -X POST "https://localhost:55000/security/roles/8/policies?policy_ids=12&pretty=true" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
 
 .. code-block:: json
     :class: output
@@ -200,7 +200,7 @@ Following the previous examples, we are going to link the user "sales-member-1" 
 
 .. code-block:: console
 
-    # curl -k -X POST "https://localhost:55000/security/users/sales-member-1/roles?role_ids=8&pretty=true" -H  "Authorization: Bearer $TOKEN"
+    # curl -k -X POST "https://localhost:55000/security/users/sales-member-1/roles?role_ids=8&pretty=true" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
 
 .. code-block:: json
     :class: output

--- a/source/user-manual/api/rbac/configuration.rst
+++ b/source/user-manual/api/rbac/configuration.rst
@@ -12,7 +12,7 @@ You can modify the RBAC mode (as explained in the :ref:`How it works <api_rbac_h
 
 .. code-block:: console
 
-    # curl -X PUT "https://localhost:55000/v4/security/config?pretty=true" -H "Authorization: Bearer <YOUR_JWT_TOKEN>" -d "{\"rbac_mode\":\"<DESIRED_RBAC_MODE>\"}"
+    # curl -X PUT "https://localhost:55000/security/config?pretty=true" -H "Authorization: Bearer <YOUR_JWT_TOKEN>" -d "{\"rbac_mode\":\"<DESIRED_RBAC_MODE>\"}"
 
 .. code-block:: json
     :class: output
@@ -54,7 +54,7 @@ The request would be as follows:
 
 .. code-block:: console
 
-    # curl -X POST "https://localhost:55000/v4/security/policies?pretty=true" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>" -d "{\"name\":\"customer_x_agents\",\"policy\":{\"actions\":[\"agent:read\"],\"resources\":[\"agent:id:001\",\"agent:id:002\",\"agent:id:003\",\"agent:id:004\"],\"effect\":\"allow\"}}" -k
+    # curl -X POST "https://localhost:55000/security/policies?pretty=true" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>" -d "{\"name\":\"customer_x_agents\",\"policy\":{\"actions\":[\"agent:read\"],\"resources\":[\"agent:id:001\",\"agent:id:002\",\"agent:id:003\",\"agent:id:004\"],\"effect\":\"allow\"}}" -k
 
 With this policy, we have established that it is allowed to read information related to agents 001, 002, 003 and 004. We can create more policies to our liking as long as they are not repeated. We may also change this policy at any time to, for example, add new agents.
 
@@ -119,7 +119,7 @@ The request with the information showed above would look like this:
 
 .. code-block:: console
 
-    # curl -X POST "https://localhost:55000/v4/security/roles?pretty=true" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>" -d "{\"name\":\"sales-team\",\"rule\":{\"MATCH\":{\"definition\":\"sales-team\"}}}"
+    # curl -X POST "https://localhost:55000/security/roles?pretty=true" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>" -d "{\"name\":\"sales-team\",\"rule\":{\"MATCH\":{\"definition\":\"sales-team\"}}}"
 
 The response body would be this. Remember that the ID is needed to link policies to this role.
 
@@ -159,7 +159,7 @@ In our example the *role_id* would be ``8`` (the ID of "sales-team" role) and th
 
 .. code-block:: console
 
-    # curl -X POST "https://localhost:55000/v4/security/roles/8/policies?policy_ids=12&pretty=true" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
+    # curl -X POST "https://localhost:55000/security/roles/8/policies?policy_ids=12&pretty=true" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
 
 .. code-block:: json
     :class: output
@@ -200,7 +200,7 @@ Following the previous examples, we are going to link the user "sales-member-1" 
 
 .. code-block:: console
 
-    # curl -X POST "https://localhost:55000/v4/security/users/sales-member-1/roles?role_ids=8&pretty=true" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
+    # curl -X POST "https://localhost:55000/security/users/sales-member-1/roles?role_ids=8&pretty=true" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
 
 .. code-block:: json
     :class: output

--- a/source/user-manual/api/rbac/configuration.rst
+++ b/source/user-manual/api/rbac/configuration.rst
@@ -12,7 +12,7 @@ You can modify the RBAC mode (as explained in the :ref:`How it works <api_rbac_h
 
 .. code-block:: console
 
-    # curl -X PUT "https://localhost:55000/security/config?pretty=true" -H "Authorization: Bearer <YOUR_JWT_TOKEN>" -d "{\"rbac_mode\":\"<DESIRED_RBAC_MODE>\"}"
+    # curl -k -X PUT "https://localhost:55000/security/config?pretty=true" -H "Authorization: Bearer $TOKEN" -d "{\"rbac_mode\":\"<DESIRED_RBAC_MODE>\"}"
 
 .. code-block:: json
     :class: output
@@ -54,7 +54,7 @@ The request would be as follows:
 
 .. code-block:: console
 
-    # curl -X POST "https://localhost:55000/security/policies?pretty=true" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>" -d "{\"name\":\"customer_x_agents\",\"policy\":{\"actions\":[\"agent:read\"],\"resources\":[\"agent:id:001\",\"agent:id:002\",\"agent:id:003\",\"agent:id:004\"],\"effect\":\"allow\"}}" -k
+    # curl -k -X POST "https://localhost:55000/security/policies?pretty=true" -H  "Authorization: Bearer $TOKEN" -d "{\"name\":\"customer_x_agents\",\"policy\":{\"actions\":[\"agent:read\"],\"resources\":[\"agent:id:001\",\"agent:id:002\",\"agent:id:003\",\"agent:id:004\"],\"effect\":\"allow\"}}" -k
 
 With this policy, we have established that it is allowed to read information related to agents 001, 002, 003 and 004. We can create more policies to our liking as long as they are not repeated. We may also change this policy at any time to, for example, add new agents.
 
@@ -119,7 +119,7 @@ The request with the information showed above would look like this:
 
 .. code-block:: console
 
-    # curl -X POST "https://localhost:55000/security/roles?pretty=true" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>" -d "{\"name\":\"sales-team\",\"rule\":{\"MATCH\":{\"definition\":\"sales-team\"}}}"
+    # curl -k -X POST "https://localhost:55000/security/roles?pretty=true" -H  "Authorization: Bearer $TOKEN" -d "{\"name\":\"sales-team\",\"rule\":{\"MATCH\":{\"definition\":\"sales-team\"}}}"
 
 The response body would be this. Remember that the ID is needed to link policies to this role.
 
@@ -159,7 +159,7 @@ In our example the *role_id* would be ``8`` (the ID of "sales-team" role) and th
 
 .. code-block:: console
 
-    # curl -X POST "https://localhost:55000/security/roles/8/policies?policy_ids=12&pretty=true" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
+    # curl -k -X POST "https://localhost:55000/security/roles/8/policies?policy_ids=12&pretty=true" -H  "Authorization: Bearer $TOKEN"
 
 .. code-block:: json
     :class: output
@@ -200,7 +200,7 @@ Following the previous examples, we are going to link the user "sales-member-1" 
 
 .. code-block:: console
 
-    # curl -X POST "https://localhost:55000/security/users/sales-member-1/roles?role_ids=8&pretty=true" -H  "Authorization: Bearer <YOUR_JWT_TOKEN>"
+    # curl -k -X POST "https://localhost:55000/security/users/sales-member-1/roles?role_ids=8&pretty=true" -H  "Authorization: Bearer $TOKEN"
 
 .. code-block:: json
     :class: output


### PR DESCRIPTION
**Related issue**
https://github.com/wazuh/wazuh/issues/5708

Hi team,

In this PR, I have added `raw` parameter information into the API - Getting started documentation. An example of how we use this parameter in order to make easier API requests is included.

I have also removed the `v4` string from API request examples (this is related to a different issue, https://github.com/wazuh/wazuh/issues/5629)