### PR TITLE
Adapted the Kibana installation guide to work with the standard https port

### DIFF
--- a/source/installation-guide/basic/all-in-one-deployment/all_in_one.rst
+++ b/source/installation-guide/basic/all-in-one-deployment/all_in_one.rst
@@ -359,6 +359,12 @@ Kibana installation and configuration
         # cd /usr/share/kibana
         # sudo -u kibana /usr/share/kibana/bin/kibana-plugin install https://packages-dev.wazuh.com/trash/app/kibana/wazuhapp-4.0.0_7.8.0.zip
 
+#. Link Kibana's socket to privileged port 443:
+
+    .. code-block:: console
+
+      # setcap 'cap_net_bind_service=+ep' /usr/share/kibana/node/bin/node
+
 #. Enable and start the Kibana service:
 
     .. include:: ../../../_templates/installations/basic/elastic/common/enable_kibana.rst

--- a/source/installation-guide/basic/distributed-deployment/step-by-step-installation/kibana/index.rst
+++ b/source/installation-guide/basic/distributed-deployment/step-by-step-installation/kibana/index.rst
@@ -106,6 +106,12 @@ Kibana installation and configuration
 
         # sudo -u kibana /usr/share/kibana/bin/kibana-plugin install https://packages-dev.wazuh.com/trash/app/kibana/wazuhapp-4.0.0_7.8.0.zip
 
+#. Link Kibana's socket to privileged port 443:
+
+    .. code-block:: console
+
+      # setcap 'cap_net_bind_service=+ep' /usr/share/kibana/node/bin/node
+
 #. Enable and start the Kibana service:
 
     .. include:: ../../../../../_templates/installations/basic/elastic/common/enable_kibana.rst

--- a/source/installation-guide/basic/distributed-deployment/step-by-step-installation/kibana/index.rst
+++ b/source/installation-guide/basic/distributed-deployment/step-by-step-installation/kibana/index.rst
@@ -112,7 +112,8 @@ Kibana installation and configuration
 
     With the first access to Kibana, the browser shows a warning message stating that the certificate was not issued by a trusted authority. This can be accepted by clicking on ``Advanced options`` to add an exception or, for increased security, by importing the ``ca.crt`` previously created to the Certificate Manager of each browser that will access the Kibana interface.
 
-    .. note:: The Kibana service listens to the default port 5601. The browser address will be: ``https://<kibana_ip>:5601`` replacing <kibana_ip> by the Kibana server IP.
+    .. note:: The Kibana service listens to the default port ``443``. The browser address is: ``https://<kibana_ip>`` replacing ``<kibana_ip>`` by the Kibana server IP. The default user is ``elastic`` and the password is the one generated previously.
+
 
 Disabling repositories
 ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION


## Description

- Added the instruction to link Kibana's socket to privileged port 443 in a section of the installation guide where it was missing
- Changed default port 5601 to 443  


## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).


