### PR TITLE
4.0 - Add resource rule to RBAC reference

### DIFF
--- a/source/user-manual/api/rbac/reference.rst
+++ b/source/user-manual/api/rbac/reference.rst
@@ -31,6 +31,7 @@ You can also find a set of default roles and policies, which you can use instead
     - `rule:file`_
     - `policy:id`_
     - `role:id`_
+    - `rule:id`_
     - `user:id`_
 
 `Actions`_
@@ -227,6 +228,15 @@ role:id
 | **Description** | Reference security role via its id |
 +-----------------+------------------------------------+
 | **Example**     | role:id:1                          |
++-----------------+------------------------------------+
+
+rule:id
+^^^^^^^
+
++-----------------+------------------------------------+
+| **Description** | Reference security rule via its id |
++-----------------+------------------------------------+
+| **Example**     | rule:id:1                          |
 +-----------------+------------------------------------+
 
 user:id
@@ -499,12 +509,15 @@ security:create
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 - POST /security/policies (`*:*`_)
 - POST /security/roles (`*:*`_)
+- POST /security/rules (`*:*`_)
 
 security:delete
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 - DELETE /security/policies (`policy:id`_)
 - DELETE /security/roles (`role:id`_)
-- DELETE /security/roles/{role_id}/policies (`user:id`_, `policy:id`_)
+- DELETE /security/rules (`rule:id`_)
+- DELETE /security/roles/{role_id}/policies (`role:id`_, `policy:id`_)
+- DELETE /security/roles/{role_id}/rules (`role:id`_, `rule:id`_)
 - DELETE /security/users (`user:id`_)
 - DELETE /security/users/{username}/roles (`user:id`_, `role:id`_)
 
@@ -516,6 +529,7 @@ security:read
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 - GET /security/policies (`policy:id`_)
 - GET /security/roles (`role:id`_)
+- GET /security/rules (`rule:id`_)
 - GET /security/users (`user:id`_)
 
 security:revoke
@@ -533,6 +547,7 @@ security:update
 - POST /security/users/{username}/roles (`user:id`_, `role:id`_)
 - PUT /security/policies/{policy_id} (`policy:id`_)
 - PUT /security/roles/{role_id} (`role:id`_)
+- PUT /security/rules/{rule_id} (`rule:id`_)
 - PUT /security/users/{username} (`user:id`_)
 
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->
Hello team, this PR adds the new `rule:id:*` security resource to the RBAC reference.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

Regards.
