### PR TITLE
Remove old Wazuh-api service references

### DIFF
--- a/source/installation-guide/compatibility_matrix/index.rst
+++ b/source/installation-guide/compatibility_matrix/index.rst
@@ -117,7 +117,7 @@ API and Kibana app
 
 The Wazuh app for Kibana requires compatibility between two different products:
 
-  - With the **Wazuh API**, which comes installed by default. It requires the same ``major.minor`` version.
+  - With the **Wazuh manager**, it requires the same ``major.minor`` version.
   - With the **Elastic Stack**, it's only compatible with the exact same version.
 
 +-----------------------------------+------------------------------------+
@@ -163,7 +163,7 @@ API and Splunk app
 
 The Splunk app for Wazuh requires compatibility between two different products:
 
-  - With the **Wazuh API**, which comes installed by default. It requires the same ``major.minor`` version.
+  - With the **Wazuh manager**, it requires the same ``major.minor`` version.
   - With **Splunk**, it's only compatible with the exact same version.
 
 +---------------------------------+---------------------------+

--- a/source/installation-guide/compatibility_matrix/index.rst
+++ b/source/installation-guide/compatibility_matrix/index.rst
@@ -99,7 +99,7 @@ In this table, you can check our supported OS list where the Wazuh agent can be 
 Product compatibility
 ---------------------
 
-When using the full stack of Wazuh software (that means, ``wazuh-manager``, ``wazuh-agent``, ``wazuh-api`` and ``wazuh-app``), there are different compatibility requirements in order to make everything work properly.
+When using the full stack of Wazuh software (that means, ``wazuh-manager``, ``wazuh-agent`` and ``wazuh-app``), there are different compatibility requirements in order to make everything work properly.
 
 Manager and agents
 ^^^^^^^^^^^^^^^^^^
@@ -111,18 +111,13 @@ The compatibility between Wazuh agent and Wazuh manager is guaranteed when the W
 
     The Wazuh manager is also compatible with **OSSEC agents**, but keep in mind that not all the capabilities will be available for them.
 
-Manager and API
-^^^^^^^^^^^^^^^
-
-The API requires the same ``major.minor`` version as the Wazuh manager in order to be compatible.
-
 
 API and Kibana app
 ^^^^^^^^^^^^^^^^^^
 
 The Wazuh app for Kibana requires compatibility between two different products:
 
-  - With the **Wazuh API**, it requires the same ``major.minor`` version.
+  - With the **Wazuh API**, which comes installed by default. It requires the same ``major.minor`` version.
   - With the **Elastic Stack**, it's only compatible with the exact same version.
 
 +-----------------------------------+------------------------------------+
@@ -168,7 +163,7 @@ API and Splunk app
 
 The Splunk app for Wazuh requires compatibility between two different products:
 
-  - With the **Wazuh API**, it requires the same ``major.minor`` version.
+  - With the **Wazuh API**, which comes installed by default. It requires the same ``major.minor`` version.
   - With **Splunk**, it's only compatible with the exact same version.
 
 +---------------------------------+---------------------------+

--- a/source/installation-guide/installing-wazuh-manager/linux/amazon/wazuh_server_packages_amazon.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/amazon/wazuh_server_packages_amazon.rst
@@ -56,22 +56,8 @@ Once the process is complete, you can check the service status with:
 
 The Wazuh API will be installed along the Wazuh manager by default. No extra steps or requirements are needed to install it.
 
-To check the API service status use the following command:
-
-  * For Systemd:
-
-    .. code-block:: console
-
-      # systemctl status wazuh-api
-
-  * For SysV Init:
-
-    .. code-block:: console
-
-      # service wazuh-api status
-
 .. note::
-    Check out the section :ref:`RESTful API <api>` for more information on how to set up and use Wazuh API.
+    Check out the section :ref:`Wazuh API <api>` for more information on how to set up and use Wazuh API.
 
 **Optional:** Disable the Wazuh repository.
 
@@ -173,7 +159,7 @@ To uninstall the Wazuh manager and Wazuh API:
 
     .. code-block:: console
 
-      # yum remove wazuh-manager wazuh-api
+      # yum remove wazuh-manager
 
 There are files marked as configuration files. Due to this designation, the package manager doesn't remove those files from the filesystem. The complete files removal action is a user responsibility. It can be done by removing the folder ``/var/ossec``.
 

--- a/source/installation-guide/installing-wazuh-manager/linux/amazon/wazuh_server_sources_amazon.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/amazon/wazuh_server_sources_amazon.rst
@@ -98,21 +98,7 @@ Installing Wazuh manager
 
 The Wazuh API will be installed along the Wazuh manager by default. No extra steps or requirements are needed to install it.
 
-To check the API service status use the following command:
-
-  * For Systemd:
-
-    .. code-block:: console
-
-      # systemctl status wazuh-api
-
-  * For SysV Init:
-
-    .. code-block:: console
-
-      # service wazuh-api status
-
-.. note:: Check out the section :ref:`RESTful API <api>` for more information on how to set up and use Wazuh API.
+.. note:: Check out the section :ref:`Wazuh API <api>` for more information on how to set up and use Wazuh API.
 
 Installing Filebeat
 -------------------
@@ -142,7 +128,6 @@ Stop the service:
   .. code-block:: console
 
     # service wazuh-manager stop 2> /dev/null
-    # service wazuh-api stop 2> /dev/null
 
 Stop the daemon:
 

--- a/source/installation-guide/installing-wazuh-manager/linux/centos/wazuh_server_packages_centos.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/centos/wazuh_server_packages_centos.rst
@@ -56,22 +56,8 @@ Once the process is complete, you can check the service status with:
 
 The Wazuh API will be installed along the Wazuh manager by default. No extra steps or requirements are needed to install it.
 
-To check the API service status use the following command:
-
-  * For Systemd:
-
-    .. code-block:: console
-
-      # systemctl status wazuh-api
-
-  * For SysV Init:
-
-    .. code-block:: console
-
-      # service wazuh-api status
-
 .. note::
-    Check out the section :doc:`RESTful API <../../../../user-manual/api/index>` for more information on how to set up and use Wazuh API.
+    Check out the section :ref:`Wazuh API <api>` for more information on how to set up and use Wazuh API.
 
 **Optional:** Disable the Wazuh repository.
 
@@ -173,7 +159,7 @@ To uninstall the Wazuh manager and Wazuh API:
 
     .. code-block:: console
 
-      # yum remove wazuh-manager wazuh-api
+      # yum remove wazuh-manager
 
 There are files marked as configuration files. Due to this designation, the package manager doesn't remove those files from the filesystem. The complete files removal action is a user responsibility. It can be done by removing the folder ``/var/ossec``.
 

--- a/source/installation-guide/installing-wazuh-manager/linux/centos/wazuh_server_sources_centos.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/centos/wazuh_server_sources_centos.rst
@@ -98,21 +98,7 @@ Installing Wazuh manager
 
 The Wazuh API will be installed along the Wazuh manager by default. No extra steps or requirements are needed to install it.
 
-To check the API service status use the following command:
-
-  * For Systemd:
-
-    .. code-block:: console
-
-      # systemctl status wazuh-api
-
-  * For SysV Init:
-
-    .. code-block:: console
-
-      # service wazuh-api status
-
-.. note:: Check out the section :doc:`RESTful API <../../../../user-manual/api/index>` for more information on how to set up and use Wazuh API.
+.. note:: Check out the section :ref:`Wazuh API <api>` for more information on how to set up and use Wazuh API.
 
 Installing Filebeat
 -------------------
@@ -142,7 +128,6 @@ Stop the service:
   .. code-block:: console
 
     # service wazuh-manager stop 2> /dev/null
-    # service wazuh-api stop 2> /dev/null
 
 Stop the daemon:
 

--- a/source/installation-guide/installing-wazuh-manager/linux/debian/wazuh_server_packages_deb.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/debian/wazuh_server_packages_deb.rst
@@ -66,22 +66,8 @@ Once the process is completed, you can check the service status with:
 
 The Wazuh API will be installed along the Wazuh manager by default. No extra steps or requirements are needed to install it.
 
-To check the API service status use the following command:
-
-  * For Systemd:
-
-    .. code-block:: console
-
-      # systemctl status wazuh-api
-
-  * For SysV Init:
-
-    .. code-block:: console
-
-      # service wazuh-api status
-
 .. note::
-    Check out the section :doc:`RESTful API <../../../../user-manual/api/index>` for more information on how to set up and use Wazuh API.
+    Check out the section :ref:`Wazuh API <api>` for more information on how to set up and use Wazuh API.
 
 **Optional:** Disable the Wazuh repository.
 
@@ -97,7 +83,6 @@ To check the API service status use the following command:
   .. code-block:: console
 
     # echo "wazuh-manager hold" | sudo dpkg --set-selections
-    # echo "wazuh-api hold" | sudo dpkg --set-selections
 
 .. _wazuh_server_packages_deb_filebeat:
 
@@ -174,13 +159,13 @@ To uninstall the Wazuh manager and Wazuh API:
 
     .. code-block:: console
 
-      # apt-get remove wazuh-manager wazuh-api
+      # apt-get remove wazuh-manager
 
 There are files marked as configuration files. Due to this designation, the package manager doesn't remove those files from the filesystem. The complete files removal action can be done using the following command:
 
     .. code-block:: console
 
-      # apt-get remove --purge wazuh-manager wazuh-api
+      # apt-get remove --purge wazuh-manager
 
 To uninstall filebeat:
 

--- a/source/installation-guide/installing-wazuh-manager/linux/debian/wazuh_server_sources_deb.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/debian/wazuh_server_sources_deb.rst
@@ -100,21 +100,7 @@ Installing Wazuh manager
 
 The Wazuh API will be installed along the Wazuh manager by default. No extra steps or requirements are needed to install it.
 
-To check the API service status use the following command:
-
-  * For Systemd:
-
-    .. code-block:: console
-
-      # systemctl status wazuh-api
-
-  * For SysV Init:
-
-    .. code-block:: console
-
-      # service wazuh-api status
-
-.. note:: Check out the section :doc:`RESTful API <../../../../user-manual/api/index>` for more information on how to set up and use Wazuh API.
+.. note:: Check out the section :ref:`Wazuh API <api>` for more information on how to set up and use Wazuh API.
 
 Installing Filebeat
 -------------------
@@ -144,7 +130,6 @@ Stop the service:
   .. code-block:: console
 
     # service wazuh-manager stop 2> /dev/null
-    # service wazuh-api stop 2> /dev/null
 
 Stop the daemon:
 

--- a/source/installation-guide/installing-wazuh-manager/linux/fedora/wazuh_server_packages_fedora.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/fedora/wazuh_server_packages_fedora.rst
@@ -60,22 +60,8 @@ Once the process is complete, you can check the service status with:
 
 The Wazuh API will be installed along the Wazuh manager by default. No extra steps or requirements are needed to install it.
 
-To check the API service status use the following command:
-
-  * For Systemd:
-
-    .. code-block:: console
-
-      # systemctl status wazuh-api
-
-  * For SysV Init:
-
-    .. code-block:: console
-
-      # service wazuh-api status
-
 .. note::
-    Check out the section :doc:`RESTful API <../../../../user-manual/api/index>` for more information on how to set up and use Wazuh API.
+    Check out the section :ref:`Wazuh API <api>` for more information on how to set up and use Wazuh API.
 
 **Optional:** Disable the Wazuh repository.
 
@@ -177,7 +163,7 @@ To uninstall the Wazuh manager and Wazuh API:
 
   .. code-block:: console
 
-    # dnf remove wazuh-manager wazuh-api
+    # dnf remove wazuh-manager
 
 There are files marked as configuration files. Due to this designation, the package manager doesn't remove those files from the filesystem. The complete files removal action is a user responsibility. It can be done by removing the folder ``/var/ossec``.
 

--- a/source/installation-guide/installing-wazuh-manager/linux/fedora/wazuh_server_sources_fedora.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/fedora/wazuh_server_sources_fedora.rst
@@ -98,21 +98,7 @@ Installing Wazuh manager
 
 The Wazuh API will be installed along the Wazuh manager by default. No extra steps or requirements are needed to install it.
 
-To check the API service status use the following command:
-
-  * For Systemd:
-
-    .. code-block:: console
-
-      # systemctl status wazuh-api
-
-  * For SysV Init:
-
-    .. code-block:: console
-
-      # service wazuh-api status
-
-.. note:: Check out the section :doc:`RESTful API <../../../../user-manual/api/index>` for more information on how to set up and use Wazuh API.
+.. note:: Check out the section :ref:`Wazuh API <api>` for more information on how to set up and use Wazuh API.
 
 Installing Filebeat
 -------------------
@@ -142,7 +128,6 @@ Stop the service:
   .. code-block:: console
 
     # service wazuh-manager stop 2> /dev/null
-    # service wazuh-api stop 2> /dev/null
 
 Stop the daemon:
 

--- a/source/installation-guide/installing-wazuh-manager/linux/opensuse/wazuh_server_packages_opensuse.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/opensuse/wazuh_server_packages_opensuse.rst
@@ -57,22 +57,8 @@ Once the process is complete, you can check the service status with:
 
 The Wazuh API will be installed along the Wazuh manager by default. No extra steps or requirements are needed to install it.
 
-To check the API service status use the following command:
-
-  * For Systemd:
-
-    .. code-block:: console
-
-      # systemctl status wazuh-api
-
-  * For SysV Init:
-
-    .. code-block:: console
-
-      # service wazuh-api status
-
 .. note::
-    Check out the section :doc:`RESTful API <../../../../user-manual/api/index>` for more information on how to set up and use Wazuh API.
+    Check out the section :ref:`Wazuh API <api>` for more information on how to set up and use Wazuh API.
 
 **Optional:** Disable the Wazuh repository.
 
@@ -165,7 +151,7 @@ Filebeat is the tool on the Wazuh server that securely forwards alerts and archi
 Next steps
 ----------
 
-Once you have installed the manager, API and Filebeat, you are ready to install :ref:`Elastic Stack <installation_elastic>`.
+Once you have installed the manager and Filebeat, you are ready to install :ref:`Elastic Stack <installation_elastic>`.
 
 Uninstall
 ---------
@@ -174,7 +160,7 @@ To uninstall the Wazuh manager and Wazuh API:
 
     .. code-block:: console
 
-      # zypper remove wazuh-manager wazuh-api
+      # zypper remove wazuh-manager
 
 There are files marked as configuration files. Due to this designation, the package manager doesn't remove those files from the filesystem. The complete files removal action is a user responsibility. It can be done by removing the folder ``/var/ossec``.
 

--- a/source/installation-guide/installing-wazuh-manager/linux/opensuse/wazuh_server_sources_opensuse.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/opensuse/wazuh_server_sources_opensuse.rst
@@ -104,15 +104,15 @@ To check the API service status use the following command:
 
     .. code-block:: console
 
-      # systemctl status wazuh-api
+      # systemctl status wazuh-manager
 
   * For SysV Init:
 
     .. code-block:: console
 
-      # service wazuh-api status
+      # service wazuh-manager status
 
-.. note:: Check out the section :doc:`RESTful API <../../../../user-manual/api/index>` for more information on how to set up and use Wazuh API.
+.. note:: Check out the section :ref:`Wazuh API <api>` for more information on how to set up and use Wazuh API.
 
 Installing Filebeat
 -------------------
@@ -142,7 +142,6 @@ Stop the service:
   .. code-block:: console
 
     # service wazuh-manager stop 2> /dev/null
-    # service wazuh-api stop 2> /dev/null
 
 Stop the daemon:
 

--- a/source/installation-guide/installing-wazuh-manager/linux/opensuse/wazuh_server_sources_opensuse.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/opensuse/wazuh_server_sources_opensuse.rst
@@ -98,20 +98,6 @@ Installing Wazuh manager
 
 The Wazuh API will be installed along the Wazuh manager by default. No extra steps or requirements are needed to install it.
 
-To check the API service status use the following command:
-
-  * For Systemd:
-
-    .. code-block:: console
-
-      # systemctl status wazuh-manager
-
-  * For SysV Init:
-
-    .. code-block:: console
-
-      # service wazuh-manager status
-
 .. note:: Check out the section :ref:`Wazuh API <api>` for more information on how to set up and use Wazuh API.
 
 Installing Filebeat

--- a/source/installation-guide/installing-wazuh-manager/linux/oracle/wazuh_server_packages_oracle.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/oracle/wazuh_server_packages_oracle.rst
@@ -57,22 +57,8 @@ Once the process is complete, you can check the service status with:
 
 The Wazuh API will be installed along the Wazuh manager by default. No extra steps or requirements are needed to install it.
 
-To check the API service status use the following command:
-
-  * For Systemd:
-
-    .. code-block:: console
-
-      # systemctl status wazuh-api
-
-  * For SysV Init:
-
-    .. code-block:: console
-
-      # service wazuh-api status
-
 .. note::
-    Check out the section :doc:`RESTful API <../../../../user-manual/api/index>` for more information on how to set up and use Wazuh API.
+    Check out the section :ref:`Wazuh API <api>` for more information on how to set up and use Wazuh API.
 
 **Optional:** Disable the Wazuh repository.
 
@@ -174,7 +160,7 @@ To uninstall the Wazuh manager and Wazuh API:
 
     .. code-block:: console
 
-      # yum remove wazuh-manager wazuh-api
+      # yum remove wazuh-manager
 
 There are files marked as configuration files. Due to this designation, the package manager doesn't remove those files from the filesystem. The complete files removal action is a user responsibility. It can be done by removing the folder ``/var/ossec``.
 

--- a/source/installation-guide/installing-wazuh-manager/linux/oracle/wazuh_server_sources_oracle.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/oracle/wazuh_server_sources_oracle.rst
@@ -98,21 +98,7 @@ Installing Wazuh manager
 
 The Wazuh API will be installed along the Wazuh manager by default. No extra steps or requirements are needed to install it.
 
-To check the API service status use the following command:
-
-  * For Systemd:
-
-    .. code-block:: console
-
-      # systemctl status wazuh-api
-
-  * For SysV Init:
-
-    .. code-block:: console
-
-      # service wazuh-api status
-
-.. note:: Check out the section :doc:`RESTful API <../../../../user-manual/api/index>` for more information on how to set up and use Wazuh API.
+.. note:: Check out the section :ref:`Wazuh API <api>` for more information on how to set up and use Wazuh API.
 
 Installing Filebeat
 -------------------
@@ -142,7 +128,6 @@ Stop the service:
   .. code-block:: console
 
     # service wazuh-manager stop 2> /dev/null
-    # service wazuh-api stop 2> /dev/null
 
 Stop the daemon:
 

--- a/source/installation-guide/installing-wazuh-manager/linux/rhel/wazuh_server_packages_rhel.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/rhel/wazuh_server_packages_rhel.rst
@@ -56,22 +56,8 @@ Once the process is complete, you can check the service status with:
 
 The Wazuh API will be installed along the Wazuh manager by default. No extra steps or requirements are needed to install it.
 
-To check the API service status use the following command:
-
-  * For Systemd:
-
-    .. code-block:: console
-
-      # systemctl status wazuh-api
-
-  * For SysV Init:
-
-    .. code-block:: console
-
-      # service wazuh-api status
-
 .. note::
-    Check out the section :doc:`RESTful API <../../../../user-manual/api/index>` for more information on how to set up and use Wazuh API.
+    Check out the section :ref:`Wazuh API <api>` for more information on how to set up and use Wazuh API.
 
 **Optional:** Disable the Wazuh repository.
 
@@ -173,7 +159,7 @@ To uninstall the Wazuh manager and Wazuh API:
 
     .. code-block:: console
 
-      # yum remove wazuh-manager wazuh-api
+      # yum remove wazuh-manager
 
 There are files marked as configuration files. Due to this designation, the package manager doesn't remove those files from the filesystem. The complete files removal action is a user responsibility. It can be done by removing the folder ``/var/ossec``.
 

--- a/source/installation-guide/installing-wazuh-manager/linux/rhel/wazuh_server_sources_rhel.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/rhel/wazuh_server_sources_rhel.rst
@@ -98,21 +98,7 @@ Installing Wazuh manager
 
 The Wazuh API will be installed along the Wazuh manager by default. No extra steps or requirements are needed to install it.
 
-To check the API service status use the following command:
-
-  * For Systemd:
-
-    .. code-block:: console
-
-      # systemctl status wazuh-api
-
-  * For SysV Init:
-
-    .. code-block:: console
-
-      # service wazuh-api status
-
-.. note:: Check out the section :doc:`RESTful API <../../../../user-manual/api/index>` for more information on how to set up and use Wazuh API.
+.. note:: Check out the section :ref:`Wazuh API <api>` for more information on how to set up and use Wazuh API.
 
 Installing Filebeat
 -------------------
@@ -142,7 +128,6 @@ Stop the service:
   .. code-block:: console
 
     # service wazuh-manager stop 2> /dev/null
-    # service wazuh-api stop 2> /dev/null
 
 Stop the daemon:
 

--- a/source/installation-guide/installing-wazuh-manager/linux/suse/wazuh_server_packages_suse.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/suse/wazuh_server_packages_suse.rst
@@ -57,22 +57,8 @@ Once the process is complete, you can check the service status with:
 
 The Wazuh API will be installed along the Wazuh manager by default. No extra steps or requirements are needed to install it.
 
-To check the API service status use the following command:
-
-  * For Systemd:
-
-    .. code-block:: console
-
-      # systemctl status wazuh-api
-
-  * For SysV Init:
-
-    .. code-block:: console
-
-      # service wazuh-api status
-
 .. note::
-    Check out the section :doc:`RESTful API <../../../../user-manual/api/index>` for more information on how to set up and use Wazuh API.
+    Check out the section :ref:`Wazuh API <api>` for more information on how to set up and use Wazuh API.
 
 **Optional:** Disable the Wazuh repository.
 
@@ -174,7 +160,7 @@ To uninstall the Wazuh manager and Wazuh API:
 
     .. code-block:: console
 
-      # zypper remove wazuh-manager wazuh-api
+      # zypper remove wazuh-manager
 
 There are files marked as configuration files. Due to this designation, the package manager doesn't remove those files from the filesystem. The complete files removal action is a user responsibility. It can be done by removing the folder ``/var/ossec``.
 

--- a/source/installation-guide/installing-wazuh-manager/linux/suse/wazuh_server_sources_suse.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/suse/wazuh_server_sources_suse.rst
@@ -98,21 +98,7 @@ Installing Wazuh manager
 
 The Wazuh API will be installed along the Wazuh manager by default. No extra steps or requirements are needed to install it.
 
-To check the API service status use the following command:
-
-  * For Systemd:
-
-    .. code-block:: console
-
-      # systemctl status wazuh-api
-
-  * For SysV Init:
-
-    .. code-block:: console
-
-      # service wazuh-api status
-
-.. note:: Check out the section :doc:`RESTful API <../../../../user-manual/api/index>` for more information on how to set up and use Wazuh API.
+.. note:: Check out the section :ref:`Wazuh API <api>` for more information on how to set up and use Wazuh API.
 
 Installing Filebeat
 -------------------
@@ -142,7 +128,6 @@ Stop the service:
   .. code-block:: console
 
     # service wazuh-manager stop 2> /dev/null
-    # service wazuh-api stop 2> /dev/null
 
 Stop the daemon:
 

--- a/source/installation-guide/installing-wazuh-manager/linux/ubuntu/wazuh_server_packages_ubuntu.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/ubuntu/wazuh_server_packages_ubuntu.rst
@@ -64,24 +64,10 @@ Once the process is completed, you can check the service status with:
 
 .. versionadded:: 4.0.0
 
-The Wazuh API will be installed along the Wazuh manager by default. No extra steps or requirements are needed to install it.
-
-To check the API service status use the following command:
-
-  * For Systemd:
-
-    .. code-block:: console
-
-      # systemctl status wazuh-api
-
-  * For SysV Init:
-
-    .. code-block:: console
-
-      # service wazuh-api status
+The Wazuh API will be installed along the Wazuh manager by default. No extra steps or requirements are needed to install it
 
 .. note::
-    Check out the section :doc:`RESTful API <../../../../user-manual/api/index>` for more information on how to set up and use Wazuh API.
+    Check out the section :ref:`Wazuh API <api>` for more information on how to set up and use Wazuh API.
 
 **Optional:** Disable the Wazuh repository.
 
@@ -97,7 +83,6 @@ To check the API service status use the following command:
   .. code-block:: console
 
     # echo "wazuh-manager hold" | sudo dpkg --set-selections
-    # echo "wazuh-api hold" | sudo dpkg --set-selections
 
 .. _wazuh_server_packages_ubuntu_filebeat:
 
@@ -174,13 +159,13 @@ To uninstall the Wazuh manager and Wazuh API:
 
     .. code-block:: console
 
-      # apt-get remove wazuh-manager wazuh-api
+      # apt-get remove wazuh-manager wazuh-manager
 
 There are files marked as configuration files. Due to this designation, the package manager doesn't remove those files from the filesystem. The complete files removal action can be done using the following command:
 
     .. code-block:: console
 
-      # apt-get remove --purge wazuh-manager wazuh-api
+      # apt-get remove --purge wazuh-manager wazuh-manager
 
 To uninstall filebeat:
 

--- a/source/installation-guide/installing-wazuh-manager/linux/ubuntu/wazuh_server_sources_ubuntu.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/ubuntu/wazuh_server_sources_ubuntu.rst
@@ -100,21 +100,7 @@ Installing Wazuh manager
 
 The Wazuh API will be installed along the Wazuh manager by default. No extra steps or requirements are needed to install it.
 
-To check the API service status use the following command:
-
-  * For Systemd:
-
-    .. code-block:: console
-
-      # systemctl status wazuh-api
-
-  * For SysV Init:
-
-    .. code-block:: console
-
-      # service wazuh-api status
-
-.. note:: Check out the section :doc:`RESTful API <../../../../user-manual/api/index>` for more information on how to set up and use Wazuh API.
+.. note:: Check out the section :ref:`Wazuh API <api>` for more information on how to set up and use Wazuh API.
 
 Installing Filebeat
 -------------------
@@ -144,7 +130,6 @@ Stop the service:
   .. code-block:: console
 
     # service wazuh-manager stop 2> /dev/null
-    # service wazuh-api stop 2> /dev/null
 
 Stop the daemon:
 

--- a/source/installation-guide/securing_api.rst
+++ b/source/installation-guide/securing_api.rst
@@ -35,7 +35,7 @@ Recommended changes to securize Wazuh API
         use_ca: False
         ca: "api/configuration/ssl/ca.crt"
 
-    After setting these parameters, it will be necessary to restart the Wazuh API using the Wazuh-manager service:
+    After setting these parameters, it will be necessary to restart the Wazuh API using the ``wazuh-manager`` service:
 
       * For Systemd:
 
@@ -72,7 +72,7 @@ Recommended changes to securize Wazuh API
 
       port: 55000
 
-    After configuring these parameters, it will be necessary to restart the Wazuh API using the Wazuh-manager service.
+    After configuring these parameters, it will be necessary to restart the Wazuh API using the ``wazuh-manager`` service.
 
       * For Systemd:
 

--- a/source/installation-guide/securing_api.rst
+++ b/source/installation-guide/securing_api.rst
@@ -35,19 +35,19 @@ Recommended changes to securize Wazuh API
         use_ca: False
         ca: "api/configuration/ssl/ca.crt"
 
-    After setting these parameters, it will be necessary to restart the Wazuh API service:
+    After setting these parameters, it will be necessary to restart the Wazuh API using the Wazuh-manager service:
 
       * For Systemd:
 
         .. code-block:: console
 
-          # systemctl restart wazuh-api
+          # systemctl restart wazuh-manager
 
       * For SysV Init:
 
         .. code-block:: console
 
-          # service wazuh-api restart
+          # service wazuh-manager restart
 
 #. Change the default password of the admin users (**wazuh** and **wazuh-wui**): 
 
@@ -72,19 +72,19 @@ Recommended changes to securize Wazuh API
 
       port: 55000
 
-    After configuring these parameters, it will be necessary to restart the Wazuh API service.
+    After configuring these parameters, it will be necessary to restart the Wazuh API using the Wazuh-manager service.
 
       * For Systemd:
 
         .. code-block:: console
 
-          # systemctl restart wazuh-api
+          # systemctl restart wazuh-manager
 
       * For SysV Init:
 
         .. code-block:: console
 
-          # service wazuh-api restart
+          # service wazuh-manager restart
 
 #. Set maximum number of requests per minute:
 

--- a/source/installation-guide/virtual-machine.rst
+++ b/source/installation-guide/virtual-machine.rst
@@ -34,12 +34,11 @@ Wazuh provides a pre-built virtual machine image (OVA) that you can directly imp
   .. warning::
     By default the network interface type is bridge. The VM will try to get an IP address from the network's DHCP server. Alternatively, a static IP address can be set by configuring the proper network files on the CentOS operating system that the virtual machine is based on.
 
-4. You can start and stop wazuh-manager, wazuh-api, elasticsearch, filebeat, and kibana with the 'systemctl' command. For example:
+4. You can start and stop wazuh-manager, elasticsearch, filebeat, and kibana with the 'systemctl' command. For example:
 
     .. code-block:: console
 
       # systemctl restart wazuh-manager
-      # systemctl restart wazuh-api
       # systemctl stop elasticsearch
       # systemctl start filebeat
       # systemctl status kibana

--- a/source/learning-wazuh/build-lab/install-wazuh-manager.rst
+++ b/source/learning-wazuh/build-lab/install-wazuh-manager.rst
@@ -69,35 +69,12 @@ listener are in place:
       tcp        0      0 0.0.0.0:1514            0.0.0.0:*               LISTEN      14311/ossec-remoted
       tcp        0      0 0.0.0.0:1515            0.0.0.0:*               LISTEN      14263/ossec-authd
 
+.. versionadded:: 4.0.0
 
-Install Wazuh API
------------------
+The Wazuh API will be installed along the Wazuh manager by default. No extra steps or requirements are needed to install it.
 
-The Wazuh API provides an interface to manage and monitor the configuration and deployment status of agents.
-It is mostly used by the Wazuh Kibana plugin, but it is a general-purpose RESTful API that can be used
-from the command line via curl or via custom scripts for interacting with various
-aspects of Wazuh manager.
-
-1. Install wazuh-api package and its dependency nodejs.
-
-  .. code-block:: console
-
-	 # curl --silent --location https://rpm.nodesource.com/setup_10.x | bash -
-	 # yum -y install nodejs
-	 # yum -y install wazuh-api
-	 # systemctl status wazuh-api
-
-2. Use the API configurator script to enable SSL and set credentials for API access
-
-  .. code-block:: console
-
-	 # /var/ossec/api/scripts/configure_api.sh
-
-  Press <Enter> during configuration to take defaults, except for these cases:
-
-  - For the three "Enter pass phrase for..." prompts:  specify "keypass" each time.
-  - For "API user", enter "wazuhapiuser".
-  - For "New password", enter "wazuhlab" and then enter it again.
+.. note::
+    Check out the section :ref:`Wazuh API <api>` for more information on how to set up and use Wazuh API.
 
 
 Install Filebeat

--- a/source/learning-wazuh/vuln-detection.rst
+++ b/source/learning-wazuh/vuln-detection.rst
@@ -326,19 +326,19 @@ The results should look like this:
       [root@wazuh-manager centos]# sed -i 's/config.experimental_features  = false/config.experimental_features  = true/g' /var/ossec/api/configuration/config.js
 
 
-5. Restart the Wazuh API service:
+5. Restart the Wazuh API using the Wazuh-manager service:
 
   a. For Systemd:
 
     .. code-block:: console
 
-      # systemctl restart wazuh-api
+      # systemctl restart wazuh-manager
 
   b. For SysV Init:
 
     .. code-block:: console
 
-      # service wazuh-api restart
+      # service wazuh-manager restart
 
 
 6. Let's list the versions of curl on all of our Linux systems:
@@ -417,7 +417,7 @@ The results should look like this:
 
 
 .. note::
-  Take time to read the online documentation about the `Wazuh API <../user-manual/api/index.html>`_. It is a
+  Take time to read the online documentation about the :ref:`Wazuh API <api>` . It is a
   powerful utility that puts all sorts of data, configuration details, and
   state information at your fingertips once you know how to ask for it.
 

--- a/source/learning-wazuh/vuln-detection.rst
+++ b/source/learning-wazuh/vuln-detection.rst
@@ -326,7 +326,7 @@ The results should look like this:
 
 
 
-5. Restart the Wazuh API using the Wazuh-manager service:
+5. Restart the Wazuh API using the ``wazuh-manager`` service:
 
   a. For Systemd:
 

--- a/source/learning-wazuh/vuln-detection.rst
+++ b/source/learning-wazuh/vuln-detection.rst
@@ -319,11 +319,11 @@ The results should look like this:
 
 4. You can also use the experimental capabilities of the API to list information
    of all agents in the environment. In order to do so it is necessary to enable
-   this capability by editing the API's configuration file:
+   this capability in ``WAZUH_PATH/configuration/api.yaml``. A complete API configuration
+   guide can be found :ref:`here <api_configuration>`. Experimental capabilities
+   can be also enabled by using the following Wazuh API endpoint:
+   :ref:`PUT /manager/api/config<api_reference>`.
 
-  .. code-block:: console
-
-      [root@wazuh-manager centos]# sed -i 's/config.experimental_features  = false/config.experimental_features  = true/g' /var/ossec/api/configuration/config.js
 
 
 5. Restart the Wazuh API using the Wazuh-manager service:

--- a/source/upgrade-guide/upgrading/different_major.rst
+++ b/source/upgrade-guide/upgrading/different_major.rst
@@ -14,7 +14,6 @@ Upgrade Wazuh manager
 
   .. code-block:: console
 
-    # systemctl stop wazuh-api
     # systemctl stop wazuh-manager
 
 2. Add the new repository for Wazuh 3.x.
@@ -53,20 +52,6 @@ Upgrade Wazuh manager
 
       # apt-get update
       # apt-get install wazuh-manager
-
-4. Upgrade the API.
-
-  a) Upgrade the Wazuh API on CentOS/RHEL/Fedora:
-
-    .. code-block:: console
-
-      # yum install wazuh-api
-
-  b) Upgrade the Wazuh API on Debian/Ubuntu:
-
-    .. code-block:: console
-
-      # apt-get install wazuh-api
 
 Upgrade Wazuh agent
 -------------------
@@ -159,5 +144,4 @@ We recommend that the Wazuh repository be disabled in order to prevent accidenta
     .. code-block:: console
 
       # echo "wazuh-manager hold" | sudo dpkg --set-selections
-      # echo "wazuh-api hold" | sudo dpkg --set-selections
       # echo "wazuh-agent hold" | sudo dpkg --set-selections

--- a/source/upgrade-guide/upgrading/latest_wazuh3_minor.rst
+++ b/source/upgrade-guide/upgrading/latest_wazuh3_minor.rst
@@ -32,8 +32,8 @@ c) OpenSUSE:
 
     # sed -i "s/^enabled=0/enabled=1/" /etc/zypp/repos.d/wazuh.repo
 
-Upgrade the Wazuh manager and API
-----------------------------------
+Upgrade the Wazuh manager
+-------------------------
 
 a) CentOS/RHEL/Fedora:
 

--- a/source/upgrade-guide/upgrading/latest_wazuh3_minor.rst
+++ b/source/upgrade-guide/upgrading/latest_wazuh3_minor.rst
@@ -39,20 +39,20 @@ a) CentOS/RHEL/Fedora:
 
 .. code-block:: console
 
-    # yum upgrade wazuh-manager wazuh-api
+    # yum upgrade wazuh-manager
 
 b) Debian/Ubuntu:
 
 .. code-block:: console
 
     # apt-get update
-    # apt-get install wazuh-manager wazuh-api
+    # apt-get install wazuh-manager
 
 c) OpenSUSE:
 
 .. code-block:: console
 
-    # zypper update wazuh-manager wazuh-api
+    # zypper update wazuh-manager
 
 .. note::
   The installation of the updated packages **will automatically restart the services** for the Wazuh manager, API and agents. Your Wazuh config file will keep **unmodified**, so you'll need to manually add the settings for the new capabilities. Check the :ref:`User Manual <user_manual>` for more information.

--- a/source/upgrade-guide/upgrading/legacy/upgrading-wazuh-manager.rst
+++ b/source/upgrade-guide/upgrading/legacy/upgrading-wazuh-manager.rst
@@ -12,7 +12,6 @@ Follow these steps to update your ``Wazuh v1.x`` server to ``Wazuh v2.x``.
   .. code-block:: console
 
     # /var/ossec/bin/ossec-control stop
-    # systemctl stop wazuh-api
 
 2. **If you have a distributed architecture**, remove logstash-forwarder as it has been replaced by Filebeat:
 

--- a/source/upgrade-guide/upgrading/same_minor_or_major.rst
+++ b/source/upgrade-guide/upgrading/same_minor_or_major.rst
@@ -15,20 +15,20 @@ a) Upgrade on CentOS/RHEL/Fedora:
 
 .. code-block:: console
 
-    # yum upgrade wazuh-manager wazuh-api
+    # yum upgrade wazuh-manager
 
 b) Upgrade on Debian/Ubuntu:
 
 .. code-block:: console
 
     # apt-get update
-    # apt-get install wazuh-manager wazuh-api
+    # apt-get install wazuh-manager
 
 c) Upgrade on OpenSUSE:
 
 .. code-block:: console
 
-    # zypper update wazuh-manager wazuh-api
+    # zypper update wazuh-manager
 
 
 Upgrade the Wazuh agent

--- a/source/user-manual/api/configuration.rst
+++ b/source/user-manual/api/configuration.rst
@@ -58,7 +58,7 @@ Here are all the settings available for the `api.yaml` configuration file. For m
 
     If running a cluster, the master will NOT send its local API configuration file to the workers. Each node provides its own API, if the configuration file is changed in the master node, the user should manually update the workers API configuration in order to use the same configuration. Take care of not overwriting the IP and port in the local configuration of each worker.
 
-Make sure to restart wazuh-manager service after editing the configuration file:
+Make sure to restart the Wazuh API using wazuh-manager service after editing the configuration file:
 
   a. For Systemd:
 

--- a/source/user-manual/api/configuration.rst
+++ b/source/user-manual/api/configuration.rst
@@ -58,19 +58,19 @@ Here are all the settings available for the `api.yaml` configuration file. For m
 
     If running a cluster, the master will NOT send its local API configuration file to the workers. Each node provides its own API, if the configuration file is changed in the master node, the user should manually update the workers API configuration in order to use the same configuration. Take care of not overwriting the IP and port in the local configuration of each worker.
 
-Make sure to restart wazuh-api service after editing the configuration file:
+Make sure to restart wazuh-manager service after editing the configuration file:
 
   a. For Systemd:
 
   .. code-block:: console
 
-    # systemctl restart wazuh-api
+    # systemctl restart wazuh-manager
 
   b. For SysV Init:
 
   .. code-block:: console
 
-    # service wazuh-api restart
+    # service wazuh-manager restart
 
 Security configuration
 ----------------------
@@ -121,13 +121,13 @@ To apply changes to different settings, it is necessary to restart each API whos
 
   .. code-block:: console
 
-    # systemctl restart wazuh-api
+    # systemctl restart wazuh-manager
 
   b. For SysV Init:
 
   .. code-block:: console
 
-    # service wazuh-api restart
+    # service wazuh-manager restart
 
 Manually enable https support
 -----------------------------

--- a/source/user-manual/api/getting-started.rst
+++ b/source/user-manual/api/getting-started.rst
@@ -10,19 +10,19 @@ This guide provides the basic information you need to start using the Wazuh API.
 Starting and stopping the API
 -----------------------------
 
-The API starts at boot time. To control or check the **wazuh-api** service, use the ``systemctl`` or ``service`` command.
+The Wazuh API will be installed along the Wazuh manager by default and it will start at boot time. To control or check the **wazuh-api** use the **wazuh-manager** service with the ``systemctl`` or ``service`` command:
 
 **Systemd systems**
 
 .. code-block:: console
 
-    # systemctl start/status/stop/restart wazuh-api
+    # systemctl start/status/stop/restart wazuh-manager
 
 **SysVinit systems**
 
 .. code-block:: console
 
-    # service wazuh-api start/status/stop/restart
+    # service wazuh-manager start/status/stop/restart
 
 .. _api_log_in:
 

--- a/source/user-manual/kibana-app/troubleshooting.rst
+++ b/source/user-manual/kibana-app/troubleshooting.rst
@@ -48,13 +48,13 @@ If you are using ``systemd``, please check the status as follow:
 
 .. code-block:: console
 
-  # systemctl status wazuh-api
+  # systemctl status wazuh-manager
 
 If you are using ``SysV Init``, please check the status as follow:
 
 .. code-block:: console
 
-  # service wazuh-api status
+  # service wazuh-manager status
 
 If the Wazuh API is running, try to fetch data using the CLI from the Kibana server:
 


### PR DESCRIPTION
Hello team,

This PR is related to [#5824](https://github.com/wazuh/wazuh/pull/5868). The wazuh-api service has been merged together with wazuh-manager service here. This PR removes any reference to the old wazuh-api service.
