### PR TITLE
[3.4] Correctly ignore theme's min files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ package-lock.json
 package.json
 source/_static/css/*.min.css
 source/_static/js/*.min.js
+!source/_static/js/bootstrap.min.js
+!source/_static/js/popper.min.js
+!source/_static/css/fontawesome.min.css


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

This PRs makes this branch correctly ignore the files *.min.js and *.min.css which are generated by our theme during compilation. On the other hand, it allows to keep the 3rd party *.min.* files required by our theme.