### PR TITLE
Update default value in remove_from_bucket AWS option

### DIFF
--- a/source/user-manual/reference/ossec-conf/wodle-s3.rst
+++ b/source/user-manual/reference/ossec-conf/wodle-s3.rst
@@ -118,7 +118,7 @@ remove_from_bucket
 Define if you want to remove logs from your S3 bucket after they are read by the wodle.
 
 +--------------------+---------+
-| **Default value**  | yes     |
+| **Default value**  | no      |
 +--------------------+---------+
 | **Allowed values** | yes, no |
 +--------------------+---------+


### PR DESCRIPTION
Hi team!


## Description
As we can see in this line, the `<remove_from_bucket>` option is `No` by default
https://github.com/wazuh/wazuh/blob/a834acd443b73d2daa9bed01be3e8804b5f7189e/wodles/aws/aws_s3.py#L2755-L2756

However, in the current 3.13 configuration (and all previous versions), it says the default value is `Yes`. It is already fixed in the Develop branch, but right now it could lead to confusion.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

Kind regards,
Selu.
