### PR TITLE
Corrected allow values content of groups section of ossec-conf integration section

### DIFF
--- a/source/user-manual/reference/ossec-conf/integration.rst
+++ b/source/user-manual/reference/ossec-conf/integration.rst
@@ -91,11 +91,11 @@ group
 
 This filters alerts by rule group. For the VirusTotal integration, only rules from the `syscheck` group are available.
 
-+--------------------+-------------------------------------------------+
-| **Default value**  | n/a                                             |
-+--------------------+-------------------------------------------------+
-| **Allowed values** | Any rule group or comma-separated rule groups.  |
-+--------------------+-------------------------------------------------+
++--------------------+------------------------------------------------------------+
+| **Default value**  | n/a                                                        |
++--------------------+------------------------------------------------------------+
+| **Allowed values** | Any rule group or vertical bar-separated rule groups.      |
++--------------------+------------------------------------------------------------+
 
 
 event_location


### PR DESCRIPTION
Hello team,

I've corrected the allow values content of groups section as asked to at https://github.com/wazuh/wazuh-documentation/issues/2660

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description
Corrected allow values content of the section groups of the ossec-conf integration section of 3.3
<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->
Best regards,

Juan Carlos