### PR TITLE
Update install-wazuh-agent.rst

### DIFF
--- a/source/deploying-with-ansible/guide/install-wazuh-agent.rst
+++ b/source/deploying-with-ansible/guide/install-wazuh-agent.rst
@@ -185,6 +185,7 @@ Our resulting file is:
 	      enable: true
 	      port: 1515
 	      ssl_agent_ca: null
+	      ssl_agent_cert: null
 	      ssl_auto_negotiate: 'no'
 
 


### PR DESCRIPTION
when instaling agents on Linux with `ssl_agent_ca` , ansible run fails with:
```
fatal: [x.x.x.x]: FAILED! => {"msg": "'dict object' has no attribute 'ssl_agent_cert'"}
```
adding `ssl_agent_cert: null` fixes the issue.

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

## Checks
- [ ] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

## Note to the reviewer

This PR includes changes to the `redirect.js` script that need to be included in all production branches.
