### PR TITLE
Update documentation with the negate attribute for expressions

### DIFF
--- a/source/user-manual/ruleset/ruleset-xml-syntax/decoders.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/decoders.rst
@@ -275,6 +275,8 @@ It defines what the parenthesis groups contain and the order in which they were 
 +                    +------------+-------------------------------------------------------+
 |                    | protocol   | Protocol                                              |
 +                    +------------+-------------------------------------------------------+
+|                    | system_name| System name                                           |
++                    +------------+-------------------------------------------------------+
 |                    | id         | Event id                                              |
 +                    +------------+-------------------------------------------------------+
 |                    | url        | Url of the event                                      |
@@ -282,6 +284,8 @@ It defines what the parenthesis groups contain and the order in which they were 
 |                    | action     | Event action (deny, drop, accept, etc)                |
 +                    +------------+-------------------------------------------------------+
 |                    | status     | Event status (success, failure, etc)                  |
++                    +------------+-------------------------------------------------------+
+|                    | data       | Data                                                  |
 +                    +------------+-------------------------------------------------------+
 |                    | extra_data | Any extra data                                        |
 +--------------------+------------+-------------------------------------------------------+
@@ -314,6 +318,8 @@ It is used to designate a decoder as one in which the first time it matches the 
 +                    +------------+-------------------------------------------------------+
 |                    | protocol   | Protocol                                              |
 +                    +------------+-------------------------------------------------------+
+|                    | system_name| System name                                           |
++                    +------------+-------------------------------------------------------+
 |                    | id         | Event id                                              |
 +                    +------------+-------------------------------------------------------+
 |                    | url        | Url of the event                                      |
@@ -321,6 +327,8 @@ It is used to designate a decoder as one in which the first time it matches the 
 |                    | action     | Event action (deny, drop, accept, etc)                |
 +                    +------------+-------------------------------------------------------+
 |                    | status     | Event status (success, failure, etc)                  |
++                    +------------+-------------------------------------------------------+
+|                    | data       | Data                                                  |
 +                    +------------+-------------------------------------------------------+
 |                    | extra_data | Any extra data                                        |
 +--------------------+------------+-------------------------------------------------------+

--- a/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
@@ -245,6 +245,14 @@ Example:
 
 If the rule matches the ``id`` 100200 and the log contains the ``Queue flood!`` phrase in it, rule activates and triggers a level 3 alert.
 
+The attribute below is optional, it allows to negate the expressions.
+
++--------------------+--------------------+--------------------+
+| Attribute          | Value range        | Default value      |
++====================+====================+====================+
+| **negate**         | yes  or  no        | no                 |
++--------------------+--------------------+--------------------+
+
 regex
 ^^^^^
 
@@ -268,6 +276,14 @@ Example:
     </rule>
 
 If the rule matches the ``ìd`` 100500 and the event contains any valid IP, the rule is triggered and generates a level 3 alert.
+
+The attribute below is optional, it allows to negate the expressions.
+
++--------------------+--------------------+--------------------+
+| Attribute          | Value range        | Default value      |
++====================+====================+====================+
+| **negate**         | yes  or  no        | no                 |
++--------------------+--------------------+--------------------+
 
 decoded_as
 ^^^^^^^^^^
@@ -341,6 +357,14 @@ Example:
 
 This rule, groups events decoded from json that belong to an integration called `VirusTotal <../../capabilities/virustotal-scan/index.html>`_. It checks the field decoded as ``integration`` and if its content is ``virustotal`` the rule is triggered.
 
+The attribute below is optional, it allows to negate the expressions.
+
++--------------------+--------------------+--------------------+
+| Attribute          | Value range        | Default value      |
++====================+====================+====================+
+| **negate**         | yes  or  no        | no                 |
++--------------------+--------------------+--------------------+
+
 srcip
 ^^^^^
 
@@ -363,6 +387,14 @@ Example:
       </rule>
 
 This rule will trigger when that exact ``scrip`` has been decoded.
+
+The attribute below is optional, it allows to negate the expressions.
+
++--------------------+--------------------+--------------------+
+| Attribute          | Value range        | Default value      |
++====================+====================+====================+
+| **negate**         | yes  or  no        | no                 |
++--------------------+--------------------+--------------------+
 
 dstip
 ^^^^^
@@ -387,6 +419,13 @@ Example:
 
 This rule will trigger when an ``dstip`` different from ``198.168.41.30`` is detected.
 
+The attribute below is optional, it allows to negate the expressions.
+
++--------------------+--------------------+--------------------+
+| Attribute          | Value range        | Default value      |
++====================+====================+====================+
+| **negate**         | yes  or  no        | no                 |
++--------------------+--------------------+--------------------+
 
 data
 ^^^^
@@ -422,6 +461,14 @@ Example:
 
 This rule will trigger when the log belongs to ``windows`` category and the decoded field ``extra_data`` is: ``Symantec AntiVirus``
 
+The attribute below is optional, it allows to negate the expressions.
+
++--------------------+--------------------+--------------------+
+| Attribute          | Value range        | Default value      |
++====================+====================+====================+
+| **negate**         | yes  or  no        | no                 |
++--------------------+--------------------+--------------------+
+
 user
 ^^^^
 
@@ -445,6 +492,14 @@ Example:
       </rule>
 
 This rule will trigger when the user ``mysql`` successfully logs into the system. Being a System user it should never log in to the system.
+
+The attribute below is optional, it allows to negate the expressions.
+
++--------------------+--------------------+--------------------+
+| Attribute          | Value range        | Default value      |
++====================+====================+====================+
+| **negate**         | yes  or  no        | no                 |
++--------------------+--------------------+--------------------+
 
 system_name
 ^^^^^^^^^^^^
@@ -481,6 +536,14 @@ Example:
 
 The rule will trigger when the program Syslogd restarted.
 
+The attribute below is optional, it allows to negate the expressions.
+
++--------------------+--------------------+--------------------+
+| Attribute          | Value range        | Default value      |
++====================+====================+====================+
+| **negate**         | yes  or  no        | no                 |
++--------------------+--------------------+--------------------+
+
 protocol
 ^^^^^^^^
 
@@ -492,6 +555,13 @@ Any string that is decoded into the ``protocol`` field.
 | **Allowed values** | Any `sregex expression <regex.html#sregex-os-match-syntax>`_     |
 +--------------------+------------------------------------------------------------------+
 
+The attribute below is optional, it allows to negate the expressions.
+
++--------------------+--------------------+--------------------+
+| Attribute          | Value range        | Default value      |
++====================+====================+====================+
+| **negate**         | yes  or  no        | no                 |
++--------------------+--------------------+--------------------+
 
 hostname
 ^^^^^^^^
@@ -515,6 +585,14 @@ Example:
         </rule>
 
 This rule will group rules for ``Yum logs`` when something is either being installed, updated or erased.
+
+The attribute below is optional, it allows to negate the expressions.
+
++--------------------+--------------------+--------------------+
+| Attribute          | Value range        | Default value      |
++====================+====================+====================+
+| **negate**         | yes  or  no        | no                 |
++--------------------+--------------------+--------------------+
 
 time
 ^^^^
@@ -589,6 +667,14 @@ Example:
 
 This rule will group the logs whose decoded ID is usb.
 
+The attribute below is optional, it allows to negate the expressions.
+
++--------------------+--------------------+--------------------+
+| Attribute          | Value range        | Default value      |
++====================+====================+====================+
+| **negate**         | yes  or  no        | no                 |
++--------------------+--------------------+--------------------+
+
 url
 ^^^
 
@@ -612,6 +698,14 @@ Example:
       </rule>
 
 This rule is a child from a level 5 rule ``31101`` and becomes a level 0 rule when it confirms that the extensions are nothing to worry about.
+
+The attribute below is optional, it allows to negate the expressions.
+
++--------------------+--------------------+--------------------+
+| Attribute          | Value range        | Default value      |
++====================+====================+====================+
+| **negate**         | yes  or  no        | no                 |
++--------------------+--------------------+--------------------+
 
 location
 ^^^^^^^^
@@ -678,6 +772,14 @@ Example:
 
 This rule, groups logs that come from ``osquery`` location. Triggering a level 3 alert for it.
 
+The attribute below is optional, it allows to negate the expressions.
+
++--------------------+--------------------+--------------------+
+| Attribute          | Value range        | Default value      |
++====================+====================+====================+
+| **negate**         | yes  or  no        | no                 |
++--------------------+--------------------+--------------------+
+
 action
 ^^^^^^
 
@@ -700,6 +802,14 @@ Example:
       </rule>
 
 This rule will trigger a level 4 alert when the decoded action from Netscreen is ``warning``.
+
+The attribute below is optional, it allows to negate the expressions.
+
++--------------------+--------------------+--------------------+
+| Attribute          | Value range        | Default value      |
++====================+====================+====================+
+| **negate**         | yes  or  no        | no                 |
++--------------------+--------------------+--------------------+
 
 if_sid
 ^^^^^^

--- a/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
@@ -35,7 +35,11 @@ The **xml labels** used to configure ``rules`` are listed here.
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
 | `dstip`_                | Any IP address.                                               | It will compare the IP address with the IP decoded as ``dstip``. Use "!" to negate it.               |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
-| `extra_data`_           | Any String.                                                   | It will compare a string with the string decoded as ``extra_data``.                                  |
+| `srcport`_              | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | It will compare a sregex representing a port with a string decoded as ``srcport``.                   |
++-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
+| `dstport`_              | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | It will compare a sregex representing a port with a string decoded as ``dstport``.                   |
++-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
+| `extra_data`_           | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | It will compare a sregex representing a extra data with a string decoded as ``extra_data``.          |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
 | `user`_                 | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | It will compare a sregex representing a username with a string decoded as ``user``.                  |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
@@ -51,9 +55,21 @@ The **xml labels** used to configure ``rules`` are listed here.
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
 | `url`_                  | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | It will look for a match with the field decoded as ``url``                                           |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
-| `location`_             | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | Location identifies the origin of the input.                                                         |
+| `location`_             | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | It compares it with the location obtained in the pre-decoding phase.                                 |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
 | `action`_               | Any String.                                                   | It will compare it with the field decoded as ``action``.                                             |
++-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
+| `protocol`_             | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | Any string that is decoded into the ``protocol`` field.                                              |
++-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
+| `data`_                 | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | Any string that is decoded into the ``data`` field.                                                  |
++-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
+| `status`_               | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | Any string that is decoded into the ``status`` field.                                                |
++-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
+| `system_name`_          | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | Any string that is decoded into the ``system_name`` field.                                           |
++-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
+| `srcgeoip`_             | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | Any string that is decoded into the ``srcgeoip`` field.                                              |
++-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
+| `dstgeoip`_             | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | Any string that is decoded into the ``dstgeoip`` field.                                              |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
 | `if_sid`_               | A rule ID.                                                    | It works similar to parent decoder. It will match if that rule ID has previously matched.            |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
@@ -161,8 +177,6 @@ The **xml labels** used to configure ``rules`` are listed here.
 | `check_diff`_           | None.                                                         | Determines when the output of a command changes.                                                     |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
 | `group`_                | Any String.                                                   | Add additional groups to the alert.                                                                  |
-+-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
-| `status`_               | started, aborted, succeeded, failed, lost, etc.               | Declares the current status of a rule.                                                               |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
 | `mitre`_                | See `Mitre table <rules.html#mitre>`_ below.                  | Contains Mitre Technique IDs that fit the rule                                                       |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
@@ -438,6 +452,14 @@ Any string that is decoded into the ``data`` field.
 | **Allowed values** | Any `sregex expression <regex.html#sregex-os-match-syntax>`_    |
 +--------------------+-----------------------------------------------------------------+
 
+The attribute below is optional, it allows to negate the expressions.
+
++--------------------+--------------------+--------------------+
+| Attribute          | Value range        | Default value      |
++====================+====================+====================+
+| **negate**         | yes  or  no        | no                 |
++--------------------+--------------------+--------------------+
+
 extra_data
 ^^^^^^^^^^
 
@@ -485,13 +507,13 @@ Example:
 
   .. code-block:: xml
 
-      <rule id="140101" level="12">
-        <if_group>authentication_success</if_group>
-        <user>mysql</user>
-        <description>System user successfully logged to the system.</description>
-      </rule>
+    <rule id="140101" level="12">
+      <if_group>authentication_success</if_group>
+      <user negate="yes">wazuh|root</user>
+      <description>Unexpected user successfully logged to the system.</description>
+    </rule>
 
-This rule will trigger when the user ``mysql`` successfully logs into the system. Being a System user it should never log in to the system.
+This rule will trigger when a user different from ``root`` or ``wazuh`` successfully login into the system.
 
 The attribute below is optional, it allows to negate the expressions.
 
@@ -511,6 +533,14 @@ Any string that is decoded into the ``system_name`` field.
 +--------------------+------------------------------------------------------------------+
 | **Allowed values** | Any `sregex expression <regex.html#sregex-os-match-syntax>`_     |
 +--------------------+------------------------------------------------------------------+
+
+The attribute below is optional, it allows to negate the expressions.
+
++--------------------+--------------------+--------------------+
+| Attribute          | Value range        | Default value      |
++====================+====================+====================+
+| **negate**         | yes  or  no        | no                 |
++--------------------+--------------------+--------------------+
 
 program_name
 ^^^^^^^^^^^^
@@ -548,6 +578,44 @@ protocol
 ^^^^^^^^
 
 Any string that is decoded into the ``protocol`` field.
+
++--------------------+------------------------------------------------------------------+
+| **Default Value**  | n/a                                                              |
++--------------------+------------------------------------------------------------------+
+| **Allowed values** | Any `sregex expression <regex.html#sregex-os-match-syntax>`_     |
++--------------------+------------------------------------------------------------------+
+
+The attribute below is optional, it allows to negate the expressions.
+
++--------------------+--------------------+--------------------+
+| Attribute          | Value range        | Default value      |
++====================+====================+====================+
+| **negate**         | yes  or  no        | no                 |
++--------------------+--------------------+--------------------+
+
+srcport
+^^^^^^^
+
+Used as a requisite to trigger the rule. It will check the source port (decoded as ``srcport``).
+
++--------------------+------------------------------------------------------------------+
+| **Default Value**  | n/a                                                              |
++--------------------+------------------------------------------------------------------+
+| **Allowed values** | Any `sregex expression <regex.html#sregex-os-match-syntax>`_     |
++--------------------+------------------------------------------------------------------+
+
+The attribute below is optional, it allows to negate the expressions.
+
++--------------------+--------------------+--------------------+
+| Attribute          | Value range        | Default value      |
++====================+====================+====================+
+| **negate**         | yes  or  no        | no                 |
++--------------------+--------------------+--------------------+
+
+dstport
+^^^^^^^
+
+Used as a requisite to trigger the rule. It will check the destination port (decoded as ``dstport``).
 
 +--------------------+------------------------------------------------------------------+
 | **Default Value**  | n/a                                                              |
@@ -1532,6 +1600,25 @@ This option is used in conjunction with ``frequency`` and ``timeframe``.
 | **Example of use** | <different_url />  |
 +--------------------+--------------------+
 
+srcgeoip
+^^^^^^^^
+
+Any string that is decoded into the ``srcgeoip`` field.
+
++--------------------+-----------------------------------------------------------------+
+| **Default Value**  | n/a                                                             |
++--------------------+-----------------------------------------------------------------+
+| **Allowed values** | Any `sregex expression <regex.html#sregex-os-match-syntax>`_    |
++--------------------+-----------------------------------------------------------------+
+
+The attribute below is optional, it allows to negate the expressions.
+
++--------------------+--------------------+--------------------+
+| Attribute          | Value range        | Default value      |
++====================+====================+====================+
+| **negate**         | yes  or  no        | no                 |
++--------------------+--------------------+--------------------+
+
 same_srcgeoip
 ^^^^^^^^^^^^^
 
@@ -1568,6 +1655,25 @@ Example:
       </rule>
 
   That rule filters when the same ``user`` tries to open file ``/home`` but returns an error, on a different ``ip`` and using the same ``port``.
+
+dstgeoip
+^^^^^^^^
+
+Any string that is decoded into the ``dstgeoip`` field.
+
++--------------------+-----------------------------------------------------------------+
+| **Default Value**  | n/a                                                             |
++--------------------+-----------------------------------------------------------------+
+| **Allowed values** | Any `sregex expression <regex.html#sregex-os-match-syntax>`_    |
++--------------------+-----------------------------------------------------------------+
+
+The attribute below is optional, it allows to negate the expressions.
+
++--------------------+--------------------+--------------------+
+| Attribute          | Value range        | Default value      |
++====================+====================+====================+
+| **negate**         | yes  or  no        | no                 |
++--------------------+--------------------+--------------------+
 
 same_dstgeoip
 ^^^^^^^^^^^^^
@@ -1819,6 +1925,13 @@ Example:
         <group>upgrade,upgrade_failure,</group>
       </rule>
 
+The attribute below is optional, it allows to negate the expressions.
+
++--------------------+--------------------+--------------------+
+| Attribute          | Value range        | Default value      |
++====================+====================+====================+
+| **negate**         | yes  or  no        | no                 |
++--------------------+--------------------+--------------------+
 
 mitre
 ^^^^^


### PR DESCRIPTION
## Description

Hello team,

This PR update the ruleset reference with the negate attribute for expressions. We should add this new option to the ruleset reference documentation. We added this new option to the ruleset reference documentation.

### Changes:

- [x] action
- [x] extra_data
- [x] hostname
- [x] id
- [x] location
- [x] match
- [X] program_name
- [X] protocol
- [X] user
- [X] url
- [X] regex
- [X] field
- [X] srcip 
- [X] dstip
- [X] srcport
- [X] dstport
- [X] data
- [X] status
- [X] system_name
- [x] srcgeoip
- [x] dstgeoip

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 