### PR TITLE
Fixed the URL of the link to endpoint in the API reference page (api-ref)

### DIFF
--- a/source/_static/js/style.js
+++ b/source/_static/js/style.js
@@ -14,13 +14,10 @@ $(function() {
   if ( useApiRedoc ) {
     /* Change DOMAIN in href */
     const domainReplacePattern = 'https://DOMAIN';
-    let currentReleasePath = window.location.hostname;
-    if ( window.location.pathname.split('/')[1] === version ) {
-      currentReleasePath += '/'+version;
-    }
+    const url_root = $('[data-url_root]').data('url_root');
     $('[href^="'+domainReplacePattern+'/"]').each(function() {
       const oldHref = $(this).attr('href');
-      $(this).attr('href', oldHref.replace(domainReplacePattern, 'https://'+currentReleasePath));
+      $(this).attr('href', oldHref.replace(domainReplacePattern+'/', url_root));
       $(this).attr('target', '_blank');
     });
   }


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

Fixed the custom role `:api-ref:` that creates the link to an endpoint in the API reference page to make it compatible with any domain and port used (for development purposes). 
For example, in the case that the endpoint with the hash `my-hash` exists, including a link to this endpoint in a .rst file using 
```rst
:api-ref:`my-hash`
```
will work for production, where it will link to `https://documentation.wazuh.com/4.0/user-manual/api/reference.html#my-hash`,
as well as for development URLs, like this one: `http://localhost:8000/user-manual/api/reference.html#my-hash`

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
