### PR TITLE
Update message format documentation for AES (3.12)

### DIFF
--- a/source/development/message-format.rst
+++ b/source/development/message-format.rst
@@ -266,9 +266,13 @@ The encryption system uses a constant initialization vector and a key:
 
 **Initialization vector**
 
-    8-byte hexadecimal array::
+    8-byte hexadecimal array for Blowfish method::
 
         <IV> = FE DC BA 98 76 54 32 10
+
+    8-byte hexadecimal array for AES method::
+
+        <IV> = FE DC BA 09 87 65 43 21
 
 **Encryption key**
 


### PR DESCRIPTION
Update message format documentation for AES

|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/6265|

In AES the IV is different than in Blowfish. ([aes_op.c](https://github.com/wazuh/wazuh/blob/v3.5.0/src/os_crypto/aes/aes_op.c#L26))

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

## Checks
- [ ] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

## Note to the reviewer

This PR includes changes to the `redirect.js` script that need to be included in all production branches.
