### PR TITLE
[3.11] Fixed some errors in the redirect paths for 4.0

### DIFF
--- a/source/_static/js/redirects.js
+++ b/source/_static/js/redirects.js
@@ -346,22 +346,22 @@ redirections.push(
     {
       'target': ['3.13=>4.0', '4.0=>3.13'],
       '3.13': '/installation-guide/installing-splunk/splunk-distributed.html',
-      '4.0':  '/installation-guide/more-installation-alternatives/splunk-distributed.html',
+      '4.0':  '/installation-guide/more-installation-alternatives/splunk/splunk-distributed.html',
     },  
     {
       'target': ['3.13=>4.0', '4.0=>3.13'],
       '3.13': '/installation-guide/installing-splunk/splunk-forwarder.html',
-      '4.0':  '/installation-guide/more-installation-alternatives/splunk-forwarder.html',
+      '4.0':  '/installation-guide/more-installation-alternatives/splunk/splunk-forwarder.html',
     },  
     {
       'target': ['3.13=>4.0', '4.0=>3.13'],
       '3.13': '/installation-guide/installing-splunk/splunk-polling.html',
-      '4.0':  '/installation-guide/more-installation-alternatives/splunk-polling.html',
+      '4.0':  '/installation-guide/more-installation-alternatives/splunk/splunk-polling.html',
     },  
     {
       'target': ['3.13=>4.0', '4.0=>3.13'],
       '3.13': '/installation-guide/installing-splunk/splunk-reverse-proxy.html',
-      '4.0':  '/installation-guide/more-installation-alternatives/splunk-reverse-proxy.html',
+      '4.0':  '/installation-guide/more-installation-alternatives/splunk/splunk-reverse-proxy.html',
     },    
     {
       'target': ['3.13=>4.0', '4.0=>3.13'],
@@ -681,7 +681,7 @@ redirections.push(
     {
       'target': ['3.13=>4.0', '4.0=>3.13'],
       '3.13': '/installation-guide/installing-wazuh-agent/deployment_variables.html',
-      '4.0':  '/installation-guide/wazuh-agent/deployment_variables/deployment_variables.rst',
+      '4.0':  '/installation-guide/wazuh-agent/deployment_variables/deployment_variables.html',
     },
     {
       'target': ['3.13=>4.0', '4.0=>3.13'],


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

This PR fixes some errors in the redirect path of some of the documents that have been moved in the new release branch `4.0`.

## Checks
- [x] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

## Note to the reviewer

This PR includes changes to the `redirect.js` script that need to be included in all production branches.
