### PR TITLE
Specify that the integrator configuration is specified in the Wazuh manager

### DIFF
--- a/source/user-manual/manager/manual-integration.rst
+++ b/source/user-manual/manager/manual-integration.rst
@@ -10,7 +10,7 @@ The **Integrator** daemon allows Wazuh to connect to external APIs and alerting 
 Configuration
 -------------
 
-The integrations are configured on the ``ossec.conf`` file which is located inside the Wazuh installation folder (``/var/ossec/etc/``). To configure an integration, add the following configuration inside the *<ossec_config>* section:
+The integrations are configured on the Wazuh manager's ``ossec.conf`` file which is located inside the Wazuh installation folder (``/var/ossec/etc/``). To configure an integration, add the following configuration inside the *<ossec_config>* section:
 
 .. code-block:: xml
 


### PR DESCRIPTION
Hi team,
I have added two words to this documentation: https://documentation.wazuh.com/3.13/user-manual/manager/manual-integration.html. The objective is to specify that the integrator configuration is added to the Wazuh manager configuration.

Regards,
Sergio.