### PR TITLE
Fix typo in unattended installation documentation

### DIFF
--- a/source/installation-guide/open-distro/all-in-one-deployment/unattended-installation.rst
+++ b/source/installation-guide/open-distro/all-in-one-deployment/unattended-installation.rst
@@ -20,7 +20,7 @@ Installing Wazuh
 
     # curl -so ~/all-in-one-installation.sh https://raw.githubusercontent.com/wazuh/wazuh-documentation/4.0/resources/open-distro/unattended-installation/all-in-one-installation.sh && bash ~/all-in-one-installation.sh
 
-   The script will perform an health-check to ensure that the host has enough resources to guarantee the proper performance. This can be skipped adding the option ``-i`` or ``--ignore-healthcheck`` when running the script.
+   The script will perform a health-check to ensure that the host has enough resources to guarantee the proper performance. This can be skipped adding the option ``-i`` or ``--ignore-healthcheck`` when running the script.
 
    After the execution of the script, it will show the following messages to confirm that the installation was successful:
 


### PR DESCRIPTION
Hi team,
This PR fixes a typo in this documentation page: https://documentation.wazuh.com/4.0/installation-guide/open-distro/all-in-one-deployment/unattended-installation.html.
Best regards,
Sergio.