### PR TITLE
Updating documentation with agent's disconnection time settings

### DIFF
--- a/source/user-manual/agents/agent-life-cycle.rst
+++ b/source/user-manual/agents/agent-life-cycle.rst
@@ -25,7 +25,7 @@ Agent status
 - **Never connected:** The agent has been registered but has not yet connected to the manager.
 - **Pending.** The authentication process is pending: The manager has received a request for connection from the agent but has not received anything else. This may indicate a firewall issue. The agent will be in this state one time in its life cycle.
 - **Active:** The agent has successfully connected and can now communicate with the manager.
-- **Disconnected:** The manager will consider the agent disconnected if it does not receive any ``keep alive`` messages from the agent within 30 minutes.
+- **Disconnected:** The manager will consider the agent disconnected if it does not receive any ``keep alive`` messages within :ref:`agents_disconnection_time<reference_agents_disconnection_time>` (20s default time).
 
 Removed agent
 -------------

--- a/source/user-manual/reference/ossec-conf/global.rst
+++ b/source/user-manual/reference/ossec-conf/global.rst
@@ -450,7 +450,7 @@ agents_disconnection_time
 
 .. versionadded:: 4.1.0
 
-This sets the time since the last keepalive of an agent to consider it as disconnected.
+This sets the time after which the manager considers an agent as disconnected since its last keepalive.
 
 +-------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
 | **Default value**       | 20s                                                                                                                               |
@@ -471,9 +471,8 @@ agents_disconnection_alert_time
 
 .. versionadded:: 4.1.0
 
-This sets the time since an agent is considered disconnected to trigger an alert.
-Like this time is added to the :ref:`agents_disconnection_time<reference_agents_disconnection_time>` parameter, the minimun time frame to produce an alert is 2m and 20s.
-Also consider that the daemon :doc:`monitord<../../reference/daemons/ossec-monitord>` checks the status of the agents evey two minutes, so even when the neccesary time to trigeer the alert has passed, it's neccesary to wait this scan to begin.
+This sets the time after which an alert is generated since an agent was considered as disconnected.
+As this time is after an agent is considered as disconnected, the minimum time frame to produce an alert taking the default values is 2m and 20s.
 
 +-------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
 | **Default value**       | 2m                                                                                                                                |

--- a/source/user-manual/reference/ossec-conf/global.rst
+++ b/source/user-manual/reference/ossec-conf/global.rst
@@ -43,6 +43,8 @@ Options
 - `geoipdb`_
 - `rotate_interval`_
 - `max_output_size`_
+- `agents_disconnection_time`_
+- `agents_disconnection_alert_time`_
 
 alerts_log
 ^^^^^^^^^^
@@ -390,7 +392,7 @@ This option sets the interval between file rotation. The range of possible value
 +-------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
 | **Default value**       | 0 (disabled)                                                                                                                      |
 +-------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
-| **Allowed values**      | A positive number that should ends with character indicating a time unit, such as, s (seconds), m (minutes), h (hours), d (days). |
+| **Allowed values**      | A positive number that should end with a character indicating a time unit, such as: s (seconds), m (minutes), h (hours), d (days) |
 +-------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
 
 .. note::
@@ -441,6 +443,50 @@ Example:
 
   <queue_size>16384</queue_size>
 
+.. _reference_agents_disconnection_time:
+
+agents_disconnection_time
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. versionadded:: 4.1.0
+
+This sets the time since the last keepalive of an agent to consider it as disconnected.
+
++-------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
+| **Default value**       | 20s                                                                                                                               |
++-------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
+| **Allowed values**      | A positive number that should end with a character indicating a time unit, such as: s (seconds), m (minutes), h (hours), d (days) |
++-------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
+
+Example:
+
+.. code-block:: xml
+
+  <agents_disconnection_time>1m</agents_disconnection_time>
+
+.. _reference_agents_disconnection_alert_time:
+
+agents_disconnection_alert_time
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. versionadded:: 4.1.0
+
+This sets the time since an agent is considered disconnected to trigger an alert.
+Like this time is added to the :ref:`agents_disconnection_time<reference_agents_disconnection_time>` parameter, the minimun time frame to produce an alert is 2m and 20s.
+Also consider that the daemon :doc:`monitord<../../reference/daemons/ossec-monitord>` checks the status of the agents evey two minutes, so even when the neccesary time to trigeer the alert has passed, it's neccesary to wait this scan to begin.
+
++-------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
+| **Default value**       | 2m                                                                                                                                |
++-------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
+| **Allowed values**      | A positive number that should end with a character indicating a time unit, such as: s (seconds), m (minutes), h (hours), d (days) |
++-------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
+
+Example:
+
+.. code-block:: xml
+
+  <agents_disconnection_alert_time>1h</agents_disconnection_alert_time>
+
 Default configuration
 ---------------------
 
@@ -456,4 +502,6 @@ Default configuration
       <email_from>ossecm@example.wazuh.com</email_from>
       <email_to>recipient@example.wazuh.com</email_to>
       <email_maxperhour>12</email_maxperhour>
+      <agents_disconnection_time>20s</agents_disconnection_time>
+      <agents_disconnection_alert_time>2m</agents_disconnection_alert_time>
     </global>


### PR DESCRIPTION
## Description
Two new global settings are added in wazuh/wazuh#6310. They configure the time to consider an agent disconnected and the corresponding time to generate an alert.

This PR adds both of them to the **global** XML section reference section, and _agents_disconnection_time_ is mentioned in agent's life cycle.

 ## Checks
- [x] It compiles without warnings.
- [ ] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 