### PR TITLE
Add ruleset reference of PCRE2 attribute for expressions

### DIFF
--- a/source/user-manual/ruleset/ruleset-xml-syntax/decoders.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/decoders.rst
@@ -194,12 +194,12 @@ If ``program_name`` label is declared multiple times within the decoder, the fol
 
 Example:
 
-Define that the decoder is related with the ``syslogd`` process:
+Define that the decoder is related with the ``test``, ``TEST`` or equivalent (case-insensitive)  process:
 
 .. code-block:: xml
 
-  <decoder name="syslogd_decoder">
-    <program_name>syslogd</program_name>
+  <decoder name="test_decoder">
+    <program_name type="pcre2">(?i)test</program_name>
     ...
   </decoder>
 

--- a/source/user-manual/ruleset/ruleset-xml-syntax/decoders.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/decoders.rst
@@ -22,15 +22,17 @@ There are many options to configure in decoders:
 +------------------------+---------------------------------------------------------------+-------------------------------------------------------------------------------------------------+
 | `accumulate`_          | None                                                          | It allows to track events over multiple log messages.                                           |
 +------------------------+---------------------------------------------------------------+-------------------------------------------------------------------------------------------------+
-| `program_name`_        | Any program name                                              | It defines the name of the program associated with the decoder.                                 |
+| `program_name`_        | Any `regex <regex.html#regex-os-regex-syntax>`_,              | It defines the name of the program associated with the decoder.                                 |
+|                        | `sregex <regex.html#sregex-os-match-syntax>`_ or              |                                                                                                 |
+|                        | `pcre2 <regex.html#pcre2-syntax>`_ expression.                |                                                                                                 |
 +------------------------+---------------------------------------------------------------+-------------------------------------------------------------------------------------------------+
-| `prematch`_            | Any String or `Regular Expression                             | It will look for a match in the log, in case it does, the decoder will be used.                 |
-|                        | <regex.html#regex-os-regex-syntax>`_                          |                                                                                                 |
+| `prematch`_            | Any `regex <regex.html#regex-os-regex-syntax>`_ or            | It will look for a match in the log, in case it does, the decoder will be used.                 |
+|                        | `pcre2 <regex.html#pcre2-syntax>`_ expression.                |                                                                                                 |
 +------------------------+---------------------------------------------------------------+-------------------------------------------------------------------------------------------------+
-| `regex`_               | Any `Regular Expression                                       | The decoder will use this option to find fields of interest and extract them.                   |
-|                        | <regex.html#regex-os-regex-syntax>`_                          |                                                                                                 |
+| :ref:`regex_decoders`  | Any `regex <regex.html#regex-os-regex-syntax>`_ or            | The decoder will use this option to find fields of interest and extract them.                   |
+|                        | `pcre2 <regex.html#pcre2-syntax>`_ expression.                |                                                                                                 |
 +------------------------+---------------------------------------------------------------+-------------------------------------------------------------------------------------------------+
-| `order`_               | See `order table <decoders.html#order>`_                      | The values that `regex`_ will extract, will be stored in these groups.                          |
+| `order`_               | See `order table <decoders.html#order>`_                      | The values that :ref:`regex_decoders` will extract, will be stored in these groups.             |
 +------------------------+---------------------------------------------------------------+-------------------------------------------------------------------------------------------------+
 | `fts`_                 | See `fts table <decoders.html#fts>`_                          | Fist time seen.                                                                                 |
 +------------------------+---------------------------------------------------------------+-------------------------------------------------------------------------------------------------+
@@ -46,6 +48,8 @@ There are many options to configure in decoders:
 | `json_array_structure`_| String                                                        | Adds the option of deciding how an array structure from a JSON will be stored.                  |
 +------------------------+---------------------------------------------------------------+-------------------------------------------------------------------------------------------------+
 | `var`_                 | Name for the variable.                                        | Defines variables that can be reused inside the same file.                                      |
++------------------------+---------------------------------------------------------------+-------------------------------------------------------------------------------------------------+
+| `type`_                | See `type table <decoders.html#type>`_                        | It will set the type of log that the decoder is going to match.                                 |
 +------------------------+---------------------------------------------------------------+-------------------------------------------------------------------------------------------------+
 
 How it works
@@ -88,7 +92,7 @@ There is many options to configure the decoders:
 - `accumulate`_
 - `program_name`_
 - `prematch`_
-- `regex`_
+- :ref:`regex_decoders`
 - `order`_
 - `fts`_
 - `ftscomment`_
@@ -166,8 +170,27 @@ It defines the name of the program which the decoder is associated with. The pro
 +--------------------+--------------------------------------------------------------------+
 | **Default Value**  | n/a                                                                |
 +--------------------+--------------------------------------------------------------------+
-| **Allowed values** | Any `sregex expression <regex.html#sregex-os-match-syntax>`_       |
+| **Allowed values** | Any `regex <regex.html#regex-os-regex-syntax>`_,                   |
+|                    | `sregex <regex.html#sregex-os-match-syntax>`_ or                   |
+|                    | `pcre2 <regex.html#pcre2-syntax>`_ expression.                     |
 +--------------------+--------------------------------------------------------------------+
+
+The attributes below are optional.
+
++-------------+---------------------------------------+----------------+---------------+
+| Attribute   |              Description              | Value range    | Default value |
++=============+=======================================+================+===============+
+| **type**    | allows to set regular expression type |   osmatch      |    osmatch    |
+|             |                                       +----------------+               |
+|             |                                       |   osregex      |               |
+|             |                                       +----------------+               |
+|             |                                       |   pcre2        |               |
++-------------+---------------------------------------+----------------+---------------+
+
+If ``program_name`` label is declared multiple times within the decoder, the following rules apply:
+
+- The resulting value is their concatenation.
+- The resulting value of ``type`` attribute corresponds to the one specified in the last label. If it is not specified, the default value will be used.
 
 Example:
 
@@ -188,18 +211,31 @@ It attempts to find a match within the log for the string defined. It is used as
 +--------------------+--------------------------------------------------------------------+
 | **Default Value**  | n/a                                                                |
 +--------------------+--------------------------------------------------------------------+
-| **Allowed values** | Any `regex expression <regex.html#regex-os-regex-syntax>`_         |
+| **Allowed values** | Any `regex <regex.html#regex-os-regex-syntax>`_ or                 |
+|                    | `pcre2 <regex.html#pcre2-syntax>`_ expression.                     |
 +--------------------+--------------------------------------------------------------------+
 
-The attribute below is optional, it allows to discard some of the content of the entry.
+The attributes below are optional.
 
-+--------------------+--------------------+
-| Attribute          | Value              |
-+====================+====================+
-| **offset**         | after_regex        |
-+                    +                    +
-|                    | after_parent       |
-+--------------------+--------------------+
++-------------+----------------------------------------------------+----------------+---------------+
+| Attribute   |              Description                           | Value range    | Default value |
++=============+====================================================+================+===============+
+| **offset**  | allows to discard some of the content of the entry | after_regex    |               |
+|             |                                                    +----------------+               |
+|             |                                                    | after_parent   |               |
++-------------+----------------------------------------------------+----------------+---------------+
+| **type**    | allows to set regular expression type              |   osregex      |    osregex    |
+|             |                                                    +----------------+               |
+|             |                                                    |   pcre2        |               |
++-------------+----------------------------------------------------+----------------+---------------+
+
+If ``prematch`` label is declared multiple times within the decoder, the following rules apply:
+
+- The resulting value is their concatenation.
+- The resulting value of ``type`` attribute corresponds to the one specified in the last label. If it is not specified, the default value will be used.
+
+
+.. _regex_decoders:
 
 regex
 ^^^^^
@@ -217,22 +253,32 @@ An example is this regex that matches any numeral:
 +--------------------+--------------------------------------------------------------------+
 | **Default Value**  | n/a                                                                |
 +--------------------+--------------------------------------------------------------------+
-| **Allowed values** | Any `regex expression <regex.html#regex-os-regex-syntax>`_         |
+| **Allowed values** | Any `regex <regex.html#regex-os-regex-syntax>`_ or                 |
+|                    | `pcre2 <regex.html#pcre2-syntax>`_ expression.                     |
 +--------------------+--------------------------------------------------------------------+
 
 When using the ``regex`` label it is mandatory to define an ``order`` label as well. Besides, ``regex`` label requires a ``prematch`` or a ``program_name`` label defined on the same decoder or a ``parent`` with a ``prematch`` or a ``program_name defined`` label defined on it.
 
-The attribute below is optional. It allows to discard some of the content of the entry.
+The attributes below are optional.
 
-+--------------------+--------------------+
-| Attribute          | Value              |
-+====================+====================+
-| **offset**         | after_regex        |
-+                    +                    +
-|                    | after_parent       |
-+                    +                    +
-|                    | after_prematch     |
-+--------------------+--------------------+
++-------------+----------------------------------------------------+----------------+---------------+
+| Attribute   |              Description                           | Value range    | Default value |
++=============+====================================================+================+===============+
+| **offset**  | allows to discard some of the content of the entry | after_regex    |               |
+|             |                                                    +----------------+               |
+|             |                                                    | after_parent   |               |
+|             |                                                    +----------------+               |
+|             |                                                    | after_prematch |               |
++-------------+----------------------------------------------------+----------------+---------------+
+| **type**    | allows to set regular expression type              |   osregex      |    osregex    |
+|             |                                                    +----------------+               |
+|             |                                                    |   pcre2        |               |
++-------------+----------------------------------------------------+----------------+---------------+
+
+If ``regex`` label is declared multiple times within the decoder, the following rules apply:
+
+- The resulting value is their concatenation.
+- The resulting value of ``type`` attribute corresponds to the one specified in the last label. If it is not specified, the default value will be used.
 
 Example:
 
@@ -457,10 +503,32 @@ Example:
       <order>syscall</order>
     </decoder>
 
+.. _type:
+
 type
 ^^^^
 
 It sets the type of log that the decoder is going to match.
+
++--------------------+------------------+
+| **Default Value**  | syslog           |
++--------------------+------------------+
+| **Allowed values** | firewall         |
++                    +------------------+
+|                    | ids              |
++                    +------------------+
+|                    | web-log          |
++                    +------------------+
+|                    | syslog           |
++                    +------------------+
+|                    | squid            |
++                    +------------------+
+|                    | windows          |
++                    +------------------+
+|                    | host-information |
++                    +------------------+
+|                    | ossec            |
++--------------------+------------------+
 
 Example:
 

--- a/source/user-manual/ruleset/ruleset-xml-syntax/regex.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/regex.rst
@@ -111,49 +111,37 @@ PCRE2 syntax
 
 **Perl Compatible Regular Expressions (PCRE)** tries to match Perl syntax and semantics as closely as it can.
 
-It provides features like recursive patterns, named capture, look-ahead and look-behind assertions, non-capturing groups, non-greedy quantifiers, Unicode character properties, extended syntax for characters and character classes, multi-line matching, and many other.
-
-For more details please refer to the `PCRE Syntax documentation <https://www.pcre.org/current/doc/html/pcre2syntax.html>`_.
+It provides features like recursive patterns, look-ahead and look-behind assertions, non-capturing groups, non-greedy quantifiers, extended syntax for characters and character classes, and many other. For more details please refer to the `PCRE Syntax documentation <https://www.pcre.org/current/doc/html/pcre2syntax.html>`_.
 
 .. topic:: Supported expressions
 
-  +-------------+--------------------------------------------------------------+
-  | Expressions | Actions                                                      |
-  +=============+==============================================================+
-  | \.          | Any character except newline                                 |
-  +-------------+--------------------------------------------------------------+  
-  | \\d         | Any decimal digit                                            |
-  +-------------+--------------------------------------------------------------+
-  | \\D         | Any character that is not a decimal digit                    |
-  +-------------+--------------------------------------------------------------+
-  | \\h         | Any horizontal white space character                         |
-  +-------------+--------------------------------------------------------------+
-  | \\H         | Any character that is not a horizontal white space character |
-  +-------------+--------------------------------------------------------------+
-  | \\s         | Any white space character                                    |
-  +-------------+--------------------------------------------------------------+
-  | \\S         | Any character that is not a white space character            |
-  +-------------+--------------------------------------------------------------+
-  | \\v         | Any vertical white space character                           |
-  +-------------+--------------------------------------------------------------+
-  | \\V         | Any character that is not a vertical white space character   |
-  +-------------+--------------------------------------------------------------+
-  | \\w         | Any "word" character                                         |
-  +-------------+--------------------------------------------------------------+
-  | \\W         | Any "non-word" character                                     |
-  +-------------+--------------------------------------------------------------+
+  +-------------+----------------------------------------------------------------------------+
+  | Expressions | Actions                                                                    |
+  +=============+============================================================================+
+  | \.          | Any character except newline                                               |
+  +-------------+----------------------------------------------------------------------------+
+  | \\d         | Any decimal digit, equal to [0-9]                                          |
+  +-------------+----------------------------------------------------------------------------+
+  | \\D         | Any character that is not a decimal digit, equal to [^0-9]                 |
+  +-------------+----------------------------------------------------------------------------+
+  | \\h         | Any horizontal white space character                                       |
+  +-------------+----------------------------------------------------------------------------+
+  | \\H         | Any character that is not a horizontal white space character               |
+  +-------------+----------------------------------------------------------------------------+
+  | \\s         | Any white space character, equal to [\\t\\r\\n\\f]                         |
+  +-------------+----------------------------------------------------------------------------+
+  | \\S         | Any character that is not a white space character, equal to [^\\t\\r\\n\\f]|
+  +-------------+----------------------------------------------------------------------------+
+  | \\w         | Any "word" character                                                       |
+  +-------------+----------------------------------------------------------------------------+
+  | \\W         | Any "non-word" character                                                   |
+  +-------------+----------------------------------------------------------------------------+
 
 .. topic:: Characters escaping
 
   +-------------+------------------------------------------------------+
   | Expressions | Actions                                              |
   +=============+======================================================+
-  | \\a         | Alarm, that is, the BEL character (hex 07)           |
-  +-------------+------------------------------------------------------+
-  | \\cx        | "control-x", where x is any ASCII printing character |
-  +-------------+------------------------------------------------------+
-  | \\e         | Escape (hex 1B)                                      |         
-  +-------------+------------------------------------------------------+
   | \\f         | Form feed (hex 0C)                                   |
   +-------------+------------------------------------------------------+
   | \\n         | Newline (hex 0A)                                     |

--- a/source/user-manual/ruleset/ruleset-xml-syntax/regex.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/regex.rst
@@ -7,7 +7,7 @@ Regular Expression Syntax
 
 **Regular expressions** or ``regex`` are sequences of characters that define a pattern.
 
-There are two types of regular expressions: regex (*OS_Regex*) and sregex (*OS_Match*).
+There are three types of regular expressions: regex (*OS_Regex*), sregex (*OS_Match*) and PCRE2.
 
 .. _os_regex_syntax:
 
@@ -105,3 +105,106 @@ following special characters.
   +-------------+--------------------------------------------------+
   | !           | To negate the expression                         |
   +-------------+--------------------------------------------------+
+
+PCRE2 syntax
+-----------------------------
+
+**Perl Compatible Regular Expressions (PCRE)** tries to match Perl syntax and semantics as closely as it can.
+
+It provides features like recursive patterns, named capture, look-ahead and look-behind assertions, non-capturing groups, non-greedy quantifiers, Unicode character properties, extended syntax for characters and character classes, multi-line matching, and many other.
+
+For more details please refer to the `PCRE Syntax documentation <https://www.pcre.org/current/doc/html/pcre2syntax.html>`_.
+
+.. topic:: Supported expressions
+
+  +-------------+--------------------------------------------------------------+
+  | Expressions | Actions                                                      |
+  +=============+==============================================================+
+  | \.          | Any character except newline                                 |
+  +-------------+--------------------------------------------------------------+  
+  | \\d         | Any decimal digit                                            |
+  +-------------+--------------------------------------------------------------+
+  | \\D         | Any character that is not a decimal digit                    |
+  +-------------+--------------------------------------------------------------+
+  | \\h         | Any horizontal white space character                         |
+  +-------------+--------------------------------------------------------------+
+  | \\H         | Any character that is not a horizontal white space character |
+  +-------------+--------------------------------------------------------------+
+  | \\s         | Any white space character                                    |
+  +-------------+--------------------------------------------------------------+
+  | \\S         | Any character that is not a white space character            |
+  +-------------+--------------------------------------------------------------+
+  | \\v         | Any vertical white space character                           |
+  +-------------+--------------------------------------------------------------+
+  | \\V         | Any character that is not a vertical white space character   |
+  +-------------+--------------------------------------------------------------+
+  | \\w         | Any "word" character                                         |
+  +-------------+--------------------------------------------------------------+
+  | \\W         | Any "non-word" character                                     |
+  +-------------+--------------------------------------------------------------+
+
+.. topic:: Characters escaping
+
+  +-------------+------------------------------------------------------+
+  | Expressions | Actions                                              |
+  +=============+======================================================+
+  | \\a         | Alarm, that is, the BEL character (hex 07)           |
+  +-------------+------------------------------------------------------+
+  | \\cx        | "control-x", where x is any ASCII printing character |
+  +-------------+------------------------------------------------------+
+  | \\e         | Escape (hex 1B)                                      |         
+  +-------------+------------------------------------------------------+
+  | \\f         | Form feed (hex 0C)                                   |
+  +-------------+------------------------------------------------------+
+  | \\n         | Newline (hex 0A)                                     |
+  +-------------+------------------------------------------------------+
+  | \\r         | Carriage return (hex 0D)                             |
+  +-------------+------------------------------------------------------+
+  | \\t         | Tab (hex 09)                                         |
+  +-------------+------------------------------------------------------+
+  | \\0dd       | Character with octal code 0dd                        |
+  +-------------+------------------------------------------------------+
+  | \\o{ddd..}  | Character with octal code ddd..                      |
+  +-------------+------------------------------------------------------+
+  | \\xhh       | Character with hex code hh                           |
+  +-------------+------------------------------------------------------+
+  | \\x{hh..}   | Character with hex code hh..                         |
+  +-------------+------------------------------------------------------+
+
+.. topic:: Quantifiers
+
+  +------------+----------------------------------------+
+  | Expressions| Actions                                |
+  +============+========================================+
+  | ?          | 0 or 1, greedy                         |
+  +------------+----------------------------------------+
+  | ?+         | 0 or 1, possessive                     |
+  +------------+----------------------------------------+
+  | ??         | 0 or 1, lazy                           |
+  +------------+----------------------------------------+
+  | \*         | 0 or more, greedy                      |
+  +------------+----------------------------------------+
+  | \*+        | 0 or more, possessive                  |
+  +------------+----------------------------------------+
+  | \*?        | 0 or more, lazy                        |
+  +------------+----------------------------------------+
+  | \+         | 1 or more, greedy                      |
+  +------------+----------------------------------------+
+  | ++         | 1 or more, possessive                  |
+  +------------+----------------------------------------+
+  | +?         | 1 or more, lazy                        |
+  +------------+----------------------------------------+
+  | {n}        | Exactly n                              |
+  +------------+----------------------------------------+
+  | {n,m}      | At least n, no more than m, greedy     |
+  +------------+----------------------------------------+
+  | {n,m}+     | At least n, no more than m, possessive |
+  +------------+----------------------------------------+
+  | {n,m}?     | At least n, no more than m, lazy       |
+  +------------+----------------------------------------+
+  | {n,}       | n or more, greedy                      |
+  +------------+----------------------------------------+
+  | {n,}+      | n or more, possessive                  |
+  +------------+----------------------------------------+
+  | {n,}?      | n or more, lazy                        |
+  +------------+----------------------------------------+

--- a/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
@@ -20,57 +20,65 @@ The **xml labels** used to configure ``rules`` are listed here.
 +=========================+===============================================================+======================================================================================================+
 | `rule`_                 | See `table <rules.html#rule>`_ below.                         | Its starts a new rule and its defining options.                                                      |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
-| `match`_                | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | It will attempt to find a match in the log, deciding if the rule should be triggered.                |
+| `match`_                | Any `regular expression <regex.html>`_.                       | It will attempt to find a match in the log using `sregex <regex.html#sregex-os-match-syntax>`_  by   |
+|                         |                                                               | default, deciding if the rule should be triggered.                                                   |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
-| :ref:`regex_rules`      | Any `regex <regex.html#regex-os-regex-syntax>`_ or            | It does the same as ``match`` but in *regex* or *pcre2* instead of *sregex*.                         |
-|                         | `pcre2 <regex.html#pcre2-syntax>`_ expression.                |                                                                                                      |
+| :ref:`regex_rules`      | Any `regular expression <regex.html>`_.                       | It does the same as ``match``, but with `regex <regex.html#regex-os-regex-syntax>`_ as default.      |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
 | `decoded_as`_           | Any decoder's name.                                           | It will match with logs that have been decoded by a specific decoder.                                |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
 | `category`_             | Any `type <decoders.html#type>`_.                             | It will match with logs whose decoder's `type <decoders.html#type>`_ concur.                         |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
-| `field`_                | Name and `regex <regex.html#regex-os-regex-syntax>`_ or       | It will compare a field extracted by the decoder in `order <decoders.html#order>`_ with a specific   |
-|                         | `pcre2 <regex.html#pcre2-syntax>`_ expression.                | value.                                                                                               |
+| `field`_                | Name and any `regular expression <regex.html>`_.              | It will compare a field extracted by the decoder in `order <decoders.html#order>`_ with a            |
+|                         |                                                               | regular expression.                                                                                  |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
 | `srcip`_                | Any IP address.                                               | It will compare the IP address with the IP decoded as ``srcip``. Use "!" to negate it.               |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
 | `dstip`_                | Any IP address.                                               | It will compare the IP address with the IP decoded as ``dstip``. Use "!" to negate it.               |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
-| `srcport`_              | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | It will compare a sregex representing a port with a string decoded as ``srcport``.                   |
+| `srcport`_              | Any `regular expression <regex.html>`_.                       | It will compare a regular expression representing a port with a value decoded as ``srcport``.        |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
-| `dstport`_              | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | It will compare a sregex representing a port with a string decoded as ``dstport``.                   |
+| `dstport`_              | Any `regular expression <regex.html>`_.                       | It will compare a regular expression representing a port with a value decoded as ``dstport``.        |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
-| `data`_                 | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | Any string that is decoded into the ``data`` field.                                                  |
+| `data`_                 | Any `regular expression <regex.html>`_.                       | It will compare a regular expression representing a data with a value decoded as  ``data``.          |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
-| `extra_data`_           | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | It will compare a sregex representing a extra data with a string decoded as ``extra_data``.          |
+| `extra_data`_           | Any `regular expression <regex.html>`_.                       | It will compare a regular expression representing a extra data with a value decoded                  |
+|                         |                                                               | as ``extra_data``.                                                                                   |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
-| `user`_                 | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | It will compare a sregex representing a username with a string decoded as ``user``.                  |
+| `user`_                 | Any `regular expression <regex.html>`_.                       | It will compare a regular expression representing a user with a value decoded as ``user``.           |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
-| `system_name`_          | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | Any string that is decoded into the ``system_name`` field.                                           |
+| `system_name`_          | Any `regular expression <regex.html>`_.                       | It will compare a regular expression representing a system name with a value decoded                 |
+|                         |                                                               | as ``system_name``.                                                                                  |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
-| `program_name`_         | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | It compares it with the program_name obtained in the pre-decoding phase.                             |
+| `program_name`_         | Any `regular expression <regex.html>`_.                       | It will compare a regular expression representing a program name with a value pre-decoded            |
+|                         |                                                               | as ``program_name``.                                                                                 |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
-| `protocol`_             | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | Any string that is decoded into the ``protocol`` field.                                              |
+| `protocol`_             | Any `regular expression <regex.html>`_.                       | It will compare a regular expression representing a protocol with a value decoded as ``protocol``.   |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
-| `hostname`_             | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | It compares it with the hostname obtained in the pre-decoding phase.                                 |
+| `hostname`_             | Any `regular expression <regex.html>`_.                       | It will compare a regular expression representing a hostname with a value pre-decoded                |
+|                         |                                                               | as ``hostname``.                                                                                     |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
 | `time`_                 | Any time range. e.g. (hh:mm-hh:mm)                            | It checks if the event was generated during that time range.                                         |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
 | `weekday`_              | monday - sunday, weekdays, weekends                           | It checks whether the event was generated during certain weekdays.                                   |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
-| `id`_                   | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | It will look for a match with the field decoded as ``ID``                                            |
+| `id`_                   | Any `regular expression <regex.html>`_.                       | It will compare a regular expression representing an ID with a value decoded as ``id``               |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
-| `url`_                  | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | It will look for a match with the field decoded as ``url``                                           |
+| `url`_                  | Any `regular expression <regex.html>`_.                       | It will compare a regular expression representing a URL with a value decoded as ``url``              |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
-| `location`_             | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | It compares it with the location obtained in the pre-decoding phase.                                 |
+| `location`_             | Any `regular expression <regex.html>`_.                       | It will compare a regular expression representing a location with a value pre-decoded                |
+|                         |                                                               | as ``location``.                                                                                     |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
-| `action`_               | Any String.                                                   | It will compare it with the field decoded as ``action``.                                             |
+| `action`_               | Any String or `regular expression <regex.html>`_.             | It will compare a string or regular expression representing an action with a value decoded           |
+|                         |                                                               | as ``action``.                                                                                       |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
-| `status`_               | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | Any string that is decoded into the ``status`` field.                                                |
+| `status`_               | Any `regular expression <regex.html>`_.                       | It will compare a regular expression representing a status with a value decoded as ``status``.       |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
-| `srcgeoip`_             | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | Any string that is decoded into the ``srcgeoip`` field.                                              |
+| `srcgeoip`_             | Any `regular expression <regex.html>`_.                       | It will compare a regular expression representing a GeoIP source with a value decoded                |
+|                         |                                                               | as ``srcgeoip``.                                                                                     |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
-| `dstgeoip`_             | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | Any string that is decoded into the ``dstgeoip`` field.                                              |
+| `dstgeoip`_             | Any `regular expression <regex.html>`_.                       | It will compare a regular expression representing a GeoIP destination with a value decoded           |
+|                         |                                                               | as ``dstgeoip``.                                                                                     |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
 | `if_sid`_               | A rule ID.                                                    | It works similar to parent decoder. It will match if that rule ID has previously matched.            |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
@@ -242,11 +250,13 @@ match
 ^^^^^
 Used as a requisite to trigger the rule, will search for a match in the log event.
 
-+--------------------+-----------------------------------------------------------------+
-| **Default Value**  | n/a                                                             |
-+--------------------+-----------------------------------------------------------------+
-| **Allowed values** | Any `sregex expression <regex.html#sregex-os-match-syntax>`_    |
-+--------------------+-----------------------------------------------------------------+
++--------------------+---------------------------------------------------------------+
+| **Default Value**  | n/a                                                           |
++--------------------+---------------------------------------------------------------+
+| **Allowed values** | Any `regex <regex.html#regex-os-regex-syntax>`_,              |
+|                    | `sregex <regex.html#sregex-os-match-syntax>`_ or              |
+|                    | `pcre2 <regex.html#pcre2-syntax>`_ expression.                |
++--------------------+---------------------------------------------------------------+
 
 Example:
 
@@ -269,6 +279,12 @@ The attributes below are optional.
 |             |                                         +-------------+               |
 |             |                                         |     yes     |               |
 +-------------+-----------------------------------------+-------------+---------------+
+| **type**    | allows to set regular expression type   |   osmatch   |    osmatch    |
+|             |                                         +-------------+               |
+|             |                                         |   osregex   |               |
+|             |                                         +-------------+               |
+|             |                                         |   pcre2     |               |
++-------------+-----------------------------------------+-------------+---------------+
 
 If ``match`` label is declared multiple times within the rule, the following rules apply:
 
@@ -285,7 +301,8 @@ Used as a requisite to trigger the rule, will search for a match in the log even
 +--------------------+---------------------------------------------------------------+
 | **Default Value**  | n/a                                                           |
 +--------------------+---------------------------------------------------------------+
-| **Allowed values** | Any `regex <regex.html#regex-os-regex-syntax>`_ or            |
+| **Allowed values** | Any `regex <regex.html#regex-os-regex-syntax>`_,              |
+|                    | `sregex <regex.html#sregex-os-match-syntax>`_ or              |
 |                    | `pcre2 <regex.html#pcre2-syntax>`_ expression.                |
 +--------------------+---------------------------------------------------------------+
 
@@ -312,6 +329,8 @@ The attributes below are optional.
 |             |                                         |     yes     |               |
 +-------------+-----------------------------------------+-------------+---------------+
 | **type**    | allows to set regular expression type   |   osregex   |    osregex    |
+|             |                                         +-------------+               |
+|             |                                         |   osmatch   |               |
 |             |                                         +-------------+               |
 |             |                                         |   pcre2     |               |
 +-------------+-----------------------------------------+-------------+---------------+
@@ -374,12 +393,22 @@ field
 
 Used as a requisite to trigger the rule. It will check for a match in the content of a field extracted by the decoder.
 
-+--------------------+-----------------------------------------------------------+
-| **name**           | Specifies the name of the field extracted by the decoder. |
-+--------------------+-----------------------------------------------------------+
-| **Allowed values** | Any `regex <regex.html#regex-os-regex-syntax>`_ or        |
-|                    | `pcre2 <regex.html#pcre2-syntax>`_ expression.            |
-+--------------------+-----------------------------------------------------------+
++--------------------+---------------------------------------------------------------+
+| **Default Value**  | n/a                                                           |
++--------------------+---------------------------------------------------------------+
+| **Allowed values** | Any `regex <regex.html#regex-os-regex-syntax>`_,              |
+|                    | `sregex <regex.html#sregex-os-match-syntax>`_ or              |
+|                    | `pcre2 <regex.html#pcre2-syntax>`_ expression.                |
++--------------------+---------------------------------------------------------------+
+
+The attributes below are mandatory.
+
++-------------+-----------------------------------------+-------------+---------------+
+| Attribute   |              Description                | Value range | Default value |
++=============+=========================================+=============+===============+
+|  **name**   | specifies the name of the field         |     n/a     |       n/a     |
+|             | extracted by the decoder.               |             |               |
++-------------+-----------------------------------------+-------------+---------------+
 
 Example:
 
@@ -404,6 +433,8 @@ The attributes below are optional.
 |             |                                         |     yes     |               |
 +-------------+-----------------------------------------+-------------+---------------+
 | **type**    | allows to set regular expression type   |   osregex   |    osregex    |
+|             |                                         +-------------+               |
+|             |                                         |   osmatch   |               |
 |             |                                         +-------------+               |
 |             |                                         |   pcre2     |               |
 +-------------+-----------------------------------------+-------------+---------------+
@@ -489,11 +520,13 @@ srcport
 
 Used as a requisite to trigger the rule. It will check the source port (decoded as ``srcport``).
 
-+--------------------+------------------------------------------------------------------+
-| **Default Value**  | n/a                                                              |
-+--------------------+------------------------------------------------------------------+
-| **Allowed values** | Any `sregex expression <regex.html#sregex-os-match-syntax>`_     |
-+--------------------+------------------------------------------------------------------+
++--------------------+---------------------------------------------------------------+
+| **Default Value**  | n/a                                                           |
++--------------------+---------------------------------------------------------------+
+| **Allowed values** | Any `regex <regex.html#regex-os-regex-syntax>`_,              |
+|                    | `sregex <regex.html#sregex-os-match-syntax>`_ or              |
+|                    | `pcre2 <regex.html#pcre2-syntax>`_ expression.                |
++--------------------+---------------------------------------------------------------+
 
 The attributes below are optional.
 
@@ -503,6 +536,12 @@ The attributes below are optional.
 | **negate**  | allows to negate the regular expression |     no      |       no      |
 |             |                                         +-------------+               |
 |             |                                         |     yes     |               |
++-------------+-----------------------------------------+-------------+---------------+
+| **type**    | allows to set regular expression type   |   osmatch   |    osmatch    |
+|             |                                         +-------------+               |
+|             |                                         |   osregex   |               |
+|             |                                         +-------------+               |
+|             |                                         |   pcre2     |               |
 +-------------+-----------------------------------------+-------------+---------------+
 
 If ``srcport`` label is declared multiple times within the rule, the following rules apply:
@@ -515,11 +554,13 @@ dstport
 
 Used as a requisite to trigger the rule. It will check the destination port (decoded as ``dstport``).
 
-+--------------------+------------------------------------------------------------------+
-| **Default Value**  | n/a                                                              |
-+--------------------+------------------------------------------------------------------+
-| **Allowed values** | Any `sregex expression <regex.html#sregex-os-match-syntax>`_     |
-+--------------------+------------------------------------------------------------------+
++--------------------+---------------------------------------------------------------+
+| **Default Value**  | n/a                                                           |
++--------------------+---------------------------------------------------------------+
+| **Allowed values** | Any `regex <regex.html#regex-os-regex-syntax>`_,              |
+|                    | `sregex <regex.html#sregex-os-match-syntax>`_ or              |
+|                    | `pcre2 <regex.html#pcre2-syntax>`_ expression.                |
++--------------------+---------------------------------------------------------------+
 
 The attributes below are optional.
 
@@ -529,6 +570,12 @@ The attributes below are optional.
 | **negate**  | allows to negate the regular expression |     no      |       no      |
 |             |                                         +-------------+               |
 |             |                                         |     yes     |               |
++-------------+-----------------------------------------+-------------+---------------+
+| **type**    | allows to set regular expression type   |   osmatch   |    osmatch    |
+|             |                                         +-------------+               |
+|             |                                         |   osregex   |               |
+|             |                                         +-------------+               |
+|             |                                         |   pcre2     |               |
 +-------------+-----------------------------------------+-------------+---------------+
 
 If ``dstport`` label is declared multiple times within the rule, the following rules apply:
@@ -539,13 +586,15 @@ If ``dstport`` label is declared multiple times within the rule, the following r
 data
 ^^^^
 
-Any string that is decoded into the ``data`` field.
+Used as a requisite to trigger the rule. It will check the data (decoded as ``data``).
 
-+--------------------+-----------------------------------------------------------------+
-| **Default Value**  | n/a                                                             |
-+--------------------+-----------------------------------------------------------------+
-| **Allowed values** | Any `sregex expression <regex.html#sregex-os-match-syntax>`_    |
-+--------------------+-----------------------------------------------------------------+
++--------------------+---------------------------------------------------------------+
+| **Default Value**  | n/a                                                           |
++--------------------+---------------------------------------------------------------+
+| **Allowed values** | Any `regex <regex.html#regex-os-regex-syntax>`_,              |
+|                    | `sregex <regex.html#sregex-os-match-syntax>`_ or              |
+|                    | `pcre2 <regex.html#pcre2-syntax>`_ expression.                |
++--------------------+---------------------------------------------------------------+
 
 The attributes below are optional.
 
@@ -555,6 +604,12 @@ The attributes below are optional.
 | **negate**  | allows to negate the regular expression |     no      |       no      |
 |             |                                         +-------------+               |
 |             |                                         |     yes     |               |
++-------------+-----------------------------------------+-------------+---------------+
+| **type**    | allows to set regular expression type   |   osmatch   |    osmatch    |
+|             |                                         +-------------+               |
+|             |                                         |   osregex   |               |
+|             |                                         +-------------+               |
+|             |                                         |   pcre2     |               |
 +-------------+-----------------------------------------+-------------+---------------+
 
 If ``data`` label is declared multiple times within the rule, the following rules apply:
@@ -567,11 +622,13 @@ extra_data
 
 Used as a requisite to trigger the rule. It will compare any string with the one decoded into the extra_data field.
 
-+--------------------+-------------+
-| **Default Value**  | n/a         |
-+--------------------+-------------+
-| **Allowed values** | Any string. |
-+--------------------+-------------+
++--------------------+---------------------------------------------------------------+
+| **Default Value**  | n/a                                                           |
++--------------------+---------------------------------------------------------------+
+| **Allowed values** | Any `regex <regex.html#regex-os-regex-syntax>`_,              |
+|                    | `sregex <regex.html#sregex-os-match-syntax>`_ or              |
+|                    | `pcre2 <regex.html#pcre2-syntax>`_ expression.                |
++--------------------+---------------------------------------------------------------+
 
 Example:
 
@@ -594,6 +651,12 @@ The attributes below are optional.
 |             |                                         +-------------+               |
 |             |                                         |     yes     |               |
 +-------------+-----------------------------------------+-------------+---------------+
+| **type**    | allows to set regular expression type   |   osmatch   |    osmatch    |
+|             |                                         +-------------+               |
+|             |                                         |   osregex   |               |
+|             |                                         +-------------+               |
+|             |                                         |   pcre2     |               |
++-------------+-----------------------------------------+-------------+---------------+
 
 If ``extra_data`` label is declared multiple times within the rule, the following rules apply:
 
@@ -605,12 +668,13 @@ user
 
 Used as a requisite to trigger the rule. It will check the username (decoded as ``user``).
 
-+--------------------+------------------------------------------------------------------+
-| **Default Value**  | n/a                                                              |
-+--------------------+------------------------------------------------------------------+
-| **Allowed values** | Any `sregex expression <regex.html#sregex-os-match-syntax>`_     |
-+--------------------+------------------------------------------------------------------+
-
++--------------------+---------------------------------------------------------------+
+| **Default Value**  | n/a                                                           |
++--------------------+---------------------------------------------------------------+
+| **Allowed values** | Any `regex <regex.html#regex-os-regex-syntax>`_,              |
+|                    | `sregex <regex.html#sregex-os-match-syntax>`_ or              |
+|                    | `pcre2 <regex.html#pcre2-syntax>`_ expression.                |
++--------------------+---------------------------------------------------------------+
 
 Example:
 
@@ -633,6 +697,12 @@ The attributes below are optional.
 |             |                                         +-------------+               |
 |             |                                         |     yes     |               |
 +-------------+-----------------------------------------+-------------+---------------+
+| **type**    | allows to set regular expression type   |   osmatch   |    osmatch    |
+|             |                                         +-------------+               |
+|             |                                         |   osregex   |               |
+|             |                                         +-------------+               |
+|             |                                         |   pcre2     |               |
++-------------+-----------------------------------------+-------------+---------------+
 
 If ``user`` label is declared multiple times within the rule, the following rules apply:
 
@@ -642,13 +712,15 @@ If ``user`` label is declared multiple times within the rule, the following rule
 system_name
 ^^^^^^^^^^^^
 
-Any string that is decoded into the ``system_name`` field.
+Used as a requisite to trigger the rule. It will check the system name (decoded as ``system_name``).
 
-+--------------------+------------------------------------------------------------------+
-| **Default Value**  | n/a                                                              |
-+--------------------+------------------------------------------------------------------+
-| **Allowed values** | Any `sregex expression <regex.html#sregex-os-match-syntax>`_     |
-+--------------------+------------------------------------------------------------------+
++--------------------+---------------------------------------------------------------+
+| **Default Value**  | n/a                                                           |
++--------------------+---------------------------------------------------------------+
+| **Allowed values** | Any `regex <regex.html#regex-os-regex-syntax>`_,              |
+|                    | `sregex <regex.html#sregex-os-match-syntax>`_ or              |
+|                    | `pcre2 <regex.html#pcre2-syntax>`_ expression.                |
++--------------------+---------------------------------------------------------------+
 
 The attributes below are optional.
 
@@ -658,6 +730,12 @@ The attributes below are optional.
 | **negate**  | allows to negate the regular expression |     no      |       no      |
 |             |                                         +-------------+               |
 |             |                                         |     yes     |               |
++-------------+-----------------------------------------+-------------+---------------+
+| **type**    | allows to set regular expression type   |   osmatch   |    osmatch    |
+|             |                                         +-------------+               |
+|             |                                         |   osregex   |               |
+|             |                                         +-------------+               |
+|             |                                         |   pcre2     |               |
 +-------------+-----------------------------------------+-------------+---------------+
 
 If ``system_name`` label is declared multiple times within the rule, the following rules apply:
@@ -670,11 +748,13 @@ program_name
 
 Used as a requisite to trigger the rule. The program's name is decoded from syslog process name.
 
-+--------------------+------------------------------------------------------------------+
-| **Default Value**  | n/a                                                              |
-+--------------------+------------------------------------------------------------------+
-| **Allowed values** | Any `sregex expression <regex.html#sregex-os-match-syntax>`_     |
-+--------------------+------------------------------------------------------------------+
++--------------------+---------------------------------------------------------------+
+| **Default Value**  | n/a                                                           |
++--------------------+---------------------------------------------------------------+
+| **Allowed values** | Any `regex <regex.html#regex-os-regex-syntax>`_,              |
+|                    | `sregex <regex.html#sregex-os-match-syntax>`_ or              |
+|                    | `pcre2 <regex.html#pcre2-syntax>`_ expression.                |
++--------------------+---------------------------------------------------------------+
 
 Example:
 
@@ -698,6 +778,12 @@ The attributes below are optional.
 |             |                                         +-------------+               |
 |             |                                         |     yes     |               |
 +-------------+-----------------------------------------+-------------+---------------+
+| **type**    | allows to set regular expression type   |   osmatch   |    osmatch    |
+|             |                                         +-------------+               |
+|             |                                         |   osregex   |               |
+|             |                                         +-------------+               |
+|             |                                         |   pcre2     |               |
++-------------+-----------------------------------------+-------------+---------------+
 
 If ``program_name`` label is declared multiple times within the rule, the following rules apply:
 
@@ -707,13 +793,15 @@ If ``program_name`` label is declared multiple times within the rule, the follow
 protocol
 ^^^^^^^^
 
-Any string that is decoded into the ``protocol`` field.
+Used as a requisite to trigger the rule. It will check the protocol (decoded as ``protocol``).
 
-+--------------------+------------------------------------------------------------------+
-| **Default Value**  | n/a                                                              |
-+--------------------+------------------------------------------------------------------+
-| **Allowed values** | Any `sregex expression <regex.html#sregex-os-match-syntax>`_     |
-+--------------------+------------------------------------------------------------------+
++--------------------+---------------------------------------------------------------+
+| **Default Value**  | n/a                                                           |
++--------------------+---------------------------------------------------------------+
+| **Allowed values** | Any `regex <regex.html#regex-os-regex-syntax>`_,              |
+|                    | `sregex <regex.html#sregex-os-match-syntax>`_ or              |
+|                    | `pcre2 <regex.html#pcre2-syntax>`_ expression.                |
++--------------------+---------------------------------------------------------------+
 
 The attributes below are optional.
 
@@ -723,6 +811,12 @@ The attributes below are optional.
 | **negate**  | allows to negate the regular expression |     no      |       no      |
 |             |                                         +-------------+               |
 |             |                                         |     yes     |               |
++-------------+-----------------------------------------+-------------+---------------+
+| **type**    | allows to set regular expression type   |   osmatch   |    osmatch    |
+|             |                                         +-------------+               |
+|             |                                         |   osregex   |               |
+|             |                                         +-------------+               |
+|             |                                         |   pcre2     |               |
 +-------------+-----------------------------------------+-------------+---------------+
 
 If ``protocol`` label is declared multiple times within the rule, the following rules apply:
@@ -735,11 +829,13 @@ hostname
 
 Used as a requisite to trigger the rule. Any hostname (decoded as the syslog hostname) or log file.
 
-+--------------------+------------------------------------------------------------------+
-| **Default Value**  | n/a                                                              |
-+--------------------+------------------------------------------------------------------+
-| **Allowed values** | Any `sregex expression <regex.html#sregex-os-match-syntax>`_     |
-+--------------------+------------------------------------------------------------------+
++--------------------+---------------------------------------------------------------+
+| **Default Value**  | n/a                                                           |
++--------------------+---------------------------------------------------------------+
+| **Allowed values** | Any `regex <regex.html#regex-os-regex-syntax>`_,              |
+|                    | `sregex <regex.html#sregex-os-match-syntax>`_ or              |
+|                    | `pcre2 <regex.html#pcre2-syntax>`_ expression.                |
++--------------------+---------------------------------------------------------------+
 
 Example:
 
@@ -761,6 +857,12 @@ The attributes below are optional.
 | **negate**  | allows to negate the regular expression |     no      |       no      |
 |             |                                         +-------------+               |
 |             |                                         |     yes     |               |
++-------------+-----------------------------------------+-------------+---------------+
+| **type**    | allows to set regular expression type   |   osmatch   |    osmatch    |
+|             |                                         +-------------+               |
+|             |                                         |   osregex   |               |
+|             |                                         +-------------+               |
+|             |                                         |   pcre2     |               |
 +-------------+-----------------------------------------+-------------+---------------+
 
 If ``hostname`` label is declared multiple times within the rule, the following rules apply:
@@ -821,13 +923,13 @@ id
 
 Used as a requisite to trigger the rule. It will check any ID (decoded as the ID).
 
-+--------------------+------------------------------------------------------------------+
-| **Default Value**  | n/a                                                              |
-+--------------------+------------------------------------------------------------------+
-| **Allowed values** | Any `sregex expression <regex.html#sregex-os-match-syntax>`_     |
-+--------------------+------------------------------------------------------------------+
-
-
++--------------------+---------------------------------------------------------------+
+| **Default Value**  | n/a                                                           |
++--------------------+---------------------------------------------------------------+
+| **Allowed values** | Any `regex <regex.html#regex-os-regex-syntax>`_,              |
+|                    | `sregex <regex.html#sregex-os-match-syntax>`_ or              |
+|                    | `pcre2 <regex.html#pcre2-syntax>`_ expression.                |
++--------------------+---------------------------------------------------------------+
 
 Example:
 
@@ -850,6 +952,12 @@ The attributes below are optional.
 |             |                                         +-------------+               |
 |             |                                         |     yes     |               |
 +-------------+-----------------------------------------+-------------+---------------+
+| **type**    | allows to set regular expression type   |   osmatch   |    osmatch    |
+|             |                                         +-------------+               |
+|             |                                         |   osregex   |               |
+|             |                                         +-------------+               |
+|             |                                         |   pcre2     |               |
++-------------+-----------------------------------------+-------------+---------------+
 
 If ``id`` label is declared multiple times within the rule, the following rules apply:
 
@@ -861,11 +969,13 @@ url
 
 Used as a requisite to trigger the rule. It will check any URL (decoded as the URL).
 
-+--------------------+------------------------------------------------------------------+
-| **Default Value**  | n/a                                                              |
-+--------------------+------------------------------------------------------------------+
-| **Allowed values** | Any `sregex expression <regex.html#sregex-os-match-syntax>`_     |
-+--------------------+------------------------------------------------------------------+
++--------------------+---------------------------------------------------------------+
+| **Default Value**  | n/a                                                           |
++--------------------+---------------------------------------------------------------+
+| **Allowed values** | Any `regex <regex.html#regex-os-regex-syntax>`_,              |
+|                    | `sregex <regex.html#sregex-os-match-syntax>`_ or              |
+|                    | `pcre2 <regex.html#pcre2-syntax>`_ expression.                |
++--------------------+---------------------------------------------------------------+
 
 Example:
 
@@ -889,6 +999,12 @@ The attributes below are optional.
 |             |                                         +-------------+               |
 |             |                                         |     yes     |               |
 +-------------+-----------------------------------------+-------------+---------------+
+| **type**    | allows to set regular expression type   |   osmatch   |    osmatch    |
+|             |                                         +-------------+               |
+|             |                                         |   osregex   |               |
+|             |                                         +-------------+               |
+|             |                                         |   pcre2     |               |
++-------------+-----------------------------------------+-------------+---------------+
 
 If ``url`` label is declared multiple times within the rule, the following rules apply:
 
@@ -902,11 +1018,13 @@ location
 
 Used as a requisite to trigger the rule. It will check the content of the field location and trying to find a match.
 
-+--------------------+------------------------------------------------------------------+
-| **Default Value**  | n/a                                                              |
-+--------------------+------------------------------------------------------------------+
-| **Allowed values** | Any `sregex expression <regex.html#sregex-os-match-syntax>`_     |
-+--------------------+------------------------------------------------------------------+
++--------------------+---------------------------------------------------------------+
+| **Default Value**  | n/a                                                           |
++--------------------+---------------------------------------------------------------+
+| **Allowed values** | Any `regex <regex.html#regex-os-regex-syntax>`_,              |
+|                    | `sregex <regex.html#sregex-os-match-syntax>`_ or              |
+|                    | `pcre2 <regex.html#pcre2-syntax>`_ expression.                |
++--------------------+---------------------------------------------------------------+
 
 The location identifies the origin of the input. If the event comes from an agent, its name and registered IP (as it was added) is appended to the location.
 
@@ -969,6 +1087,12 @@ The attributes below are optional.
 |             |                                         +-------------+               |
 |             |                                         |     yes     |               |
 +-------------+-----------------------------------------+-------------+---------------+
+| **type**    | allows to set regular expression type   |   osmatch   |    osmatch    |
+|             |                                         +-------------+               |
+|             |                                         |   osregex   |               |
+|             |                                         +-------------+               |
+|             |                                         |   pcre2     |               |
++-------------+-----------------------------------------+-------------+---------------+
 
 If ``location`` label is declared multiple times within the rule, the following rules apply:
 
@@ -980,11 +1104,13 @@ action
 
 Used as a requisite to trigger the rule. It will check any action (decoded as the ACTION).
 
-+--------------------+----------------------+
-| **Default Value**  | n/a                  |
-+--------------------+----------------------+
-| **Allowed values** | Any String.          |
-+--------------------+----------------------+
++--------------------+---------------------------------------------------------------+
+| **Default Value**  | n/a                                                           |
++--------------------+---------------------------------------------------------------+
+| **Allowed values** | Any `regex <regex.html#regex-os-regex-syntax>`_,              |
+|                    | `sregex <regex.html#sregex-os-match-syntax>`_ or              |
+|                    | `pcre2 <regex.html#pcre2-syntax>`_ expression.                |
++--------------------+---------------------------------------------------------------+
 
 Example:
 
@@ -1007,6 +1133,17 @@ The attributes below are optional.
 |             |                                         +-------------+               |
 |             |                                         |     yes     |               |
 +-------------+-----------------------------------------+-------------+---------------+
+| **type**    | allows to set regular expression type   |   osmatch   |       n/a     |
+|             |                                         +-------------+               |
+|             |                                         |   osregex   |               |
+|             |                                         +-------------+               |
+|             |                                         |   pcre2     |               |
++-------------+-----------------------------------------+-------------+---------------+
+
+.. note::
+
+   By default and backward compatibility, ``action`` field try to match any string, 
+   but there is not such ``string`` value for ``type`` attribute.  In order to achieve this ``type`` attribute must be omitted.
 
 If ``action`` label is declared multiple times within the rule, the following rules apply:
 
@@ -1018,11 +1155,13 @@ status
 
 Checks the actual status of an event.
 
-+--------------------+-----------------------------------------------------------------+
-| **Default Value**  | n/a                                                             |
-+--------------------+-----------------------------------------------------------------+
-| **Allowed values** | Any `sregex expression <regex.html#sregex-os-match-syntax>`_    |
-+--------------------+-----------------------------------------------------------------+
++--------------------+---------------------------------------------------------------+
+| **Default Value**  | n/a                                                           |
++--------------------+---------------------------------------------------------------+
+| **Allowed values** | Any `regex <regex.html#regex-os-regex-syntax>`_,              |
+|                    | `sregex <regex.html#sregex-os-match-syntax>`_ or              |
+|                    | `pcre2 <regex.html#pcre2-syntax>`_ expression.                |
++--------------------+---------------------------------------------------------------+
 
 Example:
 
@@ -1044,6 +1183,12 @@ The attributes below are optional.
 |             |                                         +-------------+               |
 |             |                                         |     yes     |               |
 +-------------+-----------------------------------------+-------------+---------------+
+| **type**    | allows to set regular expression type   |   osmatch   |    osmatch    |
+|             |                                         +-------------+               |
+|             |                                         |   osregex   |               |
+|             |                                         +-------------+               |
+|             |                                         |   pcre2     |               |
++-------------+-----------------------------------------+-------------+---------------+
 
 If ``status`` label is declared multiple times within the rule, the following rules apply:
 
@@ -1053,13 +1198,15 @@ If ``status`` label is declared multiple times within the rule, the following ru
 srcgeoip
 ^^^^^^^^
 
-Any string that is decoded into the ``srcgeoip`` field.
+Used as a requisite to trigger the rule. It will check the GeoIP source (decoded as ``srcgeoip``).
 
-+--------------------+-----------------------------------------------------------------+
-| **Default Value**  | n/a                                                             |
-+--------------------+-----------------------------------------------------------------+
-| **Allowed values** | Any `sregex expression <regex.html#sregex-os-match-syntax>`_    |
-+--------------------+-----------------------------------------------------------------+
++--------------------+---------------------------------------------------------------+
+| **Default Value**  | n/a                                                           |
++--------------------+---------------------------------------------------------------+
+| **Allowed values** | Any `regex <regex.html#regex-os-regex-syntax>`_,              |
+|                    | `sregex <regex.html#sregex-os-match-syntax>`_ or              |
+|                    | `pcre2 <regex.html#pcre2-syntax>`_ expression.                |
++--------------------+---------------------------------------------------------------+
 
 The attributes below are optional.
 
@@ -1069,6 +1216,12 @@ The attributes below are optional.
 | **negate**  | allows to negate the regular expression |     no      |       no      |
 |             |                                         +-------------+               |
 |             |                                         |     yes     |               |
++-------------+-----------------------------------------+-------------+---------------+
+| **type**    | allows to set regular expression type   |   osmatch   |    osmatch    |
+|             |                                         +-------------+               |
+|             |                                         |   osregex   |               |
+|             |                                         +-------------+               |
+|             |                                         |   pcre2     |               |
 +-------------+-----------------------------------------+-------------+---------------+
 
 If ``srcgeoip`` label is declared multiple times within the rule, the following rules apply:
@@ -1079,13 +1232,15 @@ If ``srcgeoip`` label is declared multiple times within the rule, the following 
 dstgeoip
 ^^^^^^^^
 
-Any string that is decoded into the ``dstgeoip`` field.
+Used as a requisite to trigger the rule. It will check the GeoIP destination (decoded as ``dstgeoip``).
 
-+--------------------+-----------------------------------------------------------------+
-| **Default Value**  | n/a                                                             |
-+--------------------+-----------------------------------------------------------------+
-| **Allowed values** | Any `sregex expression <regex.html#sregex-os-match-syntax>`_    |
-+--------------------+-----------------------------------------------------------------+
++--------------------+---------------------------------------------------------------+
+| **Default Value**  | n/a                                                           |
++--------------------+---------------------------------------------------------------+
+| **Allowed values** | Any `regex <regex.html#regex-os-regex-syntax>`_,              |
+|                    | `sregex <regex.html#sregex-os-match-syntax>`_ or              |
+|                    | `pcre2 <regex.html#pcre2-syntax>`_ expression.                |
++--------------------+---------------------------------------------------------------+
 
 The attributes below are optional.
 
@@ -1095,6 +1250,12 @@ The attributes below are optional.
 | **negate**  | allows to negate the regular expression |     no      |       no      |
 |             |                                         +-------------+               |
 |             |                                         |     yes     |               |
++-------------+-----------------------------------------+-------------+---------------+
+| **type**    | allows to set regular expression type   |   osmatch   |    osmatch    |
+|             |                                         +-------------+               |
+|             |                                         |   osregex   |               |
+|             |                                         +-------------+               |
+|             |                                         |   pcre2     |               |
 +-------------+-----------------------------------------+-------------+---------------+
 
 If ``dstgeoip`` label is declared multiple times within the rule, the following rules apply:

--- a/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
@@ -401,13 +401,23 @@ Used as a requisite to trigger the rule. It will check for a match in the conten
 |                    | `pcre2 <regex.html#pcre2-syntax>`_ expression.                |
 +--------------------+---------------------------------------------------------------+
 
-The attributes below are mandatory.
+Below is the list of attributes.
 
 +-------------+-----------------------------------------+-------------+---------------+
 | Attribute   |              Description                | Value range | Default value |
 +=============+=========================================+=============+===============+
 |  **name**   | specifies the name of the field         |     n/a     |       n/a     |
 |             | extracted by the decoder.               |             |               |
++-------------+-----------------------------------------+-------------+---------------+
+| **negate**  | allows to negate the regular expression |     no      |       no      |
+|             |                                         +-------------+               |
+|             |                                         |     yes     |               |
++-------------+-----------------------------------------+-------------+---------------+
+| **type**    | allows to set regular expression type   |   osregex   |    osregex    |
+|             |                                         +-------------+               |
+|             |                                         |   osmatch   |               |
+|             |                                         +-------------+               |
+|             |                                         |   pcre2     |               |
 +-------------+-----------------------------------------+-------------+---------------+
 
 Example:
@@ -422,22 +432,6 @@ Example:
       </rule>
 
 This rule, groups events decoded from json that belong to an integration called `VirusTotal <../../capabilities/virustotal-scan/index.html>`_. It checks the field decoded as ``integration`` and if its content is ``virustotal`` the rule is triggered.
-
-The attributes below are optional.
-
-+-------------+-----------------------------------------+-------------+---------------+
-| Attribute   |              Description                | Value range | Default value |
-+=============+=========================================+=============+===============+
-| **negate**  | allows to negate the regular expression |     no      |       no      |
-|             |                                         +-------------+               |
-|             |                                         |     yes     |               |
-+-------------+-----------------------------------------+-------------+---------------+
-| **type**    | allows to set regular expression type   |   osregex   |    osregex    |
-|             |                                         +-------------+               |
-|             |                                         |   osmatch   |               |
-|             |                                         +-------------+               |
-|             |                                         |   pcre2     |               |
-+-------------+-----------------------------------------+-------------+---------------+
 
 srcip
 ^^^^^
@@ -1154,7 +1148,7 @@ The attributes below are optional.
 
 .. note::
 
-   Use ``type`` attribute only for regular expression match. It must be omitted if ``action`` field try to match a string. 
+   Use ``type`` attribute only for regular expression match. It must be omitted if ``action`` field try to match a string.
 
 If ``action`` label is declared multiple times within the rule, the following rules apply:
 

--- a/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
@@ -22,14 +22,15 @@ The **xml labels** used to configure ``rules`` are listed here.
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
 | `match`_                | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | It will attempt to find a match in the log, deciding if the rule should be triggered.                |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
-| `regex`_                | Any `regex expression <regex.html#regex-os-regex-syntax>`_.   | It does the same as ``match`` but in *regex* instead of *sregex*.                                    |
+| :ref:`regex_rules`      | Any `regex <regex.html#regex-os-regex-syntax>`_ or            | It does the same as ``match`` but in *regex* or *pcre2* instead of *sregex*.                         |
+|                         | `pcre2 <regex.html#pcre2-syntax>`_ expression.                |                                                                                                      |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
 | `decoded_as`_           | Any decoder's name.                                           | It will match with logs that have been decoded by a specific decoder.                                |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
-| `category`_             | ossec, ids, syslog, firewall, web-log, squid or windows.      | It will match with logs whose decoder's `type <decoders.html#decoder>`_ concur.                      |
+| `category`_             | Any `type <decoders.html#type>`_.                             | It will match with logs whose decoder's `type <decoders.html#type>`_ concur.                         |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
-| `field`_                | Name and `sregex <regex.html#sregex-os-match-syntax>`_        | It will compare a field extracted by the decoder in `order <decoders.html#order>`_ with a specific   |
-|                         |                                                               | value.                                                                                               |
+| `field`_                | Name and `regex <regex.html#regex-os-regex-syntax>`_ or       | It will compare a field extracted by the decoder in `order <decoders.html#order>`_ with a specific   |
+|                         | `pcre2 <regex.html#pcre2-syntax>`_ expression.                | value.                                                                                               |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
 | `srcip`_                | Any IP address.                                               | It will compare the IP address with the IP decoded as ``srcip``. Use "!" to negate it.               |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
@@ -39,11 +40,17 @@ The **xml labels** used to configure ``rules`` are listed here.
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
 | `dstport`_              | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | It will compare a sregex representing a port with a string decoded as ``dstport``.                   |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
+| `data`_                 | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | Any string that is decoded into the ``data`` field.                                                  |
++-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
 | `extra_data`_           | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | It will compare a sregex representing a extra data with a string decoded as ``extra_data``.          |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
 | `user`_                 | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | It will compare a sregex representing a username with a string decoded as ``user``.                  |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
+| `system_name`_          | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | Any string that is decoded into the ``system_name`` field.                                           |
++-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
 | `program_name`_         | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | It compares it with the program_name obtained in the pre-decoding phase.                             |
++-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
+| `protocol`_             | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | Any string that is decoded into the ``protocol`` field.                                              |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
 | `hostname`_             | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | It compares it with the hostname obtained in the pre-decoding phase.                                 |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
@@ -59,13 +66,7 @@ The **xml labels** used to configure ``rules`` are listed here.
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
 | `action`_               | Any String.                                                   | It will compare it with the field decoded as ``action``.                                             |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
-| `protocol`_             | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | Any string that is decoded into the ``protocol`` field.                                              |
-+-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
-| `data`_                 | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | Any string that is decoded into the ``data`` field.                                                  |
-+-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
 | `status`_               | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | Any string that is decoded into the ``status`` field.                                                |
-+-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
-| `system_name`_          | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | Any string that is decoded into the ``system_name`` field.                                           |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
 | `srcgeoip`_             | Any `sregex <regex.html#sregex-os-match-syntax>`_.            | Any string that is decoded into the ``srcgeoip`` field.                                              |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
@@ -259,13 +260,22 @@ Example:
 
 If the rule matches the ``id`` 100200 and the log contains the ``Queue flood!`` phrase in it, rule activates and triggers a level 3 alert.
 
-The attribute below is optional, it allows to negate the expressions.
+The attributes below are optional.
 
-+--------------------+--------------------+--------------------+
-| Attribute          | Value range        | Default value      |
-+====================+====================+====================+
-| **negate**         | yes  or  no        | no                 |
-+--------------------+--------------------+--------------------+
++-------------+-----------------------------------------+-------------+---------------+
+| Attribute   |              Description                | Value range | Default value |
++=============+=========================================+=============+===============+
+| **negate**  | allows to negate the regular expression |     no      |       no      |
+|             |                                         +-------------+               |
+|             |                                         |     yes     |               |
++-------------+-----------------------------------------+-------------+---------------+
+
+If ``match`` label is declared multiple times within the rule, the following rules apply:
+
+- The resulting value is their concatenation.
+- The resulting value of an attribute corresponds to the one specified in the last label. If it is not specified, the default value will be used.
+
+.. _regex_rules:
 
 regex
 ^^^^^
@@ -275,7 +285,8 @@ Used as a requisite to trigger the rule, will search for a match in the log even
 +--------------------+---------------------------------------------------------------+
 | **Default Value**  | n/a                                                           |
 +--------------------+---------------------------------------------------------------+
-| **Allowed values** | Any `regex expression <regex.html#regex-os-regex-syntax>`_    |
+| **Allowed values** | Any `regex <regex.html#regex-os-regex-syntax>`_ or            |
+|                    | `pcre2 <regex.html#pcre2-syntax>`_ expression.                |
 +--------------------+---------------------------------------------------------------+
 
 Example:
@@ -291,13 +302,24 @@ Example:
 
 If the rule matches the ``ìd`` 100500 and the event contains any valid IP, the rule is triggered and generates a level 3 alert.
 
-The attribute below is optional, it allows to negate the expressions.
+The attributes below are optional.
 
-+--------------------+--------------------+--------------------+
-| Attribute          | Value range        | Default value      |
-+====================+====================+====================+
-| **negate**         | yes  or  no        | no                 |
-+--------------------+--------------------+--------------------+
++-------------+-----------------------------------------+-------------+---------------+
+| Attribute   |              Description                | Value range | Default value |
++=============+=========================================+=============+===============+
+| **negate**  | allows to negate the regular expression |     no      |       no      |
+|             |                                         +-------------+               |
+|             |                                         |     yes     |               |
++-------------+-----------------------------------------+-------------+---------------+
+| **type**    | allows to set regular expression type   |   osregex   |    osregex    |
+|             |                                         +-------------+               |
+|             |                                         |   pcre2     |               |
++-------------+-----------------------------------------+-------------+---------------+
+
+If ``regex`` label is declared multiple times within the rule, the following rules apply:
+
+- The resulting value is their concatenation.
+- The resulting value of an attribute corresponds to the one specified in the last label. If it is not specified, the default value will be used.
 
 decoded_as
 ^^^^^^^^^^
@@ -326,13 +348,13 @@ category
 ^^^^^^^^
 
 
-Used as a requisite to trigger the rule. It will be triggered if the ``decoder`` included that log in said category. The main categories are: ids, syslog, firewall, web-log, squid or windows.
+Used as a requisite to trigger the rule. It will be triggered if the ``decoder`` included that log in said category.
 
-+--------------------+--------------+
-| **Default Value**  | n/a          |
-+--------------------+--------------+
-| **Allowed values** | Any category |
-+--------------------+--------------+
++--------------------+----------------------------------+
+| **Default Value**  | n/a                              |
++--------------------+----------------------------------+
+| **Allowed values** | Any `type <decoders.html#type>`_ |
++--------------------+----------------------------------+
 
 
 
@@ -352,11 +374,12 @@ field
 
 Used as a requisite to trigger the rule. It will check for a match in the content of a field extracted by the decoder.
 
-+--------------------+-----------------------------------------------------------------+
-| **name**           | Specifies the name of the field extracted by the decoder.       |
-+--------------------+-----------------------------------------------------------------+
-| **Allowed values** | Any `regex expression <regex.html#regex-os-regex-syntax>`_      |
-+--------------------+-----------------------------------------------------------------+
++--------------------+-----------------------------------------------------------+
+| **name**           | Specifies the name of the field extracted by the decoder. |
++--------------------+-----------------------------------------------------------+
+| **Allowed values** | Any `regex <regex.html#regex-os-regex-syntax>`_ or        |
+|                    | `pcre2 <regex.html#pcre2-syntax>`_ expression.            |
++--------------------+-----------------------------------------------------------+
 
 Example:
 
@@ -371,13 +394,19 @@ Example:
 
 This rule, groups events decoded from json that belong to an integration called `VirusTotal <../../capabilities/virustotal-scan/index.html>`_. It checks the field decoded as ``integration`` and if its content is ``virustotal`` the rule is triggered.
 
-The attribute below is optional, it allows to negate the expressions.
+The attributes below are optional.
 
-+--------------------+--------------------+--------------------+
-| Attribute          | Value range        | Default value      |
-+====================+====================+====================+
-| **negate**         | yes  or  no        | no                 |
-+--------------------+--------------------+--------------------+
++-------------+-----------------------------------------+-------------+---------------+
+| Attribute   |              Description                | Value range | Default value |
++=============+=========================================+=============+===============+
+| **negate**  | allows to negate the regular expression |     no      |       no      |
+|             |                                         +-------------+               |
+|             |                                         |     yes     |               |
++-------------+-----------------------------------------+-------------+---------------+
+| **type**    | allows to set regular expression type   |   osregex   |    osregex    |
+|             |                                         +-------------+               |
+|             |                                         |   pcre2     |               |
++-------------+-----------------------------------------+-------------+---------------+
 
 srcip
 ^^^^^
@@ -402,13 +431,20 @@ Example:
 
 This rule will trigger when that exact ``scrip`` has been decoded.
 
-The attribute below is optional, it allows to negate the expressions.
+The attributes below are optional.
 
-+--------------------+--------------------+--------------------+
-| Attribute          | Value range        | Default value      |
-+====================+====================+====================+
-| **negate**         | yes  or  no        | no                 |
-+--------------------+--------------------+--------------------+
++-------------+-----------------------------------------+-------------+---------------+
+| Attribute   |              Description                | Value range | Default value |
++=============+=========================================+=============+===============+
+| **negate**  | allows to negate the regular expression |     no      |       no      |
+|             |                                         +-------------+               |
+|             |                                         |     yes     |               |
++-------------+-----------------------------------------+-------------+---------------+
+
+If ``srcip`` label is declared multiple times within the rule, the following rules apply:
+
+- The resulting value is their concatenation.
+- The resulting value of an attribute corresponds to the one specified in the last label. If it is not specified, the default value will be used.
 
 dstip
 ^^^^^
@@ -433,13 +469,72 @@ Example:
 
 This rule will trigger when an ``dstip`` different from ``198.168.41.30`` is detected.
 
-The attribute below is optional, it allows to negate the expressions.
+The attributes below are optional.
 
-+--------------------+--------------------+--------------------+
-| Attribute          | Value range        | Default value      |
-+====================+====================+====================+
-| **negate**         | yes  or  no        | no                 |
-+--------------------+--------------------+--------------------+
++-------------+-----------------------------------------+-------------+---------------+
+| Attribute   |              Description                | Value range | Default value |
++=============+=========================================+=============+===============+
+| **negate**  | allows to negate the regular expression |     no      |       no      |
+|             |                                         +-------------+               |
+|             |                                         |     yes     |               |
++-------------+-----------------------------------------+-------------+---------------+
+
+If ``dstip`` label is declared multiple times within the rule, the following rules apply:
+
+- The resulting value is their concatenation.
+- The resulting value of an attribute corresponds to the one specified in the last label. If it is not specified, the default value will be used.
+
+srcport
+^^^^^^^
+
+Used as a requisite to trigger the rule. It will check the source port (decoded as ``srcport``).
+
++--------------------+------------------------------------------------------------------+
+| **Default Value**  | n/a                                                              |
++--------------------+------------------------------------------------------------------+
+| **Allowed values** | Any `sregex expression <regex.html#sregex-os-match-syntax>`_     |
++--------------------+------------------------------------------------------------------+
+
+The attributes below are optional.
+
++-------------+-----------------------------------------+-------------+---------------+
+| Attribute   |              Description                | Value range | Default value |
++=============+=========================================+=============+===============+
+| **negate**  | allows to negate the regular expression |     no      |       no      |
+|             |                                         +-------------+               |
+|             |                                         |     yes     |               |
++-------------+-----------------------------------------+-------------+---------------+
+
+If ``srcport`` label is declared multiple times within the rule, the following rules apply:
+
+- The resulting value is their concatenation.
+- The resulting value of an attribute corresponds to the one specified in the last label. If it is not specified, the default value will be used.
+
+dstport
+^^^^^^^
+
+Used as a requisite to trigger the rule. It will check the destination port (decoded as ``dstport``).
+
++--------------------+------------------------------------------------------------------+
+| **Default Value**  | n/a                                                              |
++--------------------+------------------------------------------------------------------+
+| **Allowed values** | Any `sregex expression <regex.html#sregex-os-match-syntax>`_     |
++--------------------+------------------------------------------------------------------+
+
+The attributes below are optional.
+
++-------------+-----------------------------------------+-------------+---------------+
+| Attribute   |              Description                | Value range | Default value |
++=============+=========================================+=============+===============+
+| **negate**  | allows to negate the regular expression |     no      |       no      |
+|             |                                         +-------------+               |
+|             |                                         |     yes     |               |
++-------------+-----------------------------------------+-------------+---------------+
+
+If ``dstport`` label is declared multiple times within the rule, the following rules apply:
+
+- The resulting value is their concatenation.
+- The resulting value of an attribute corresponds to the one specified in the last label. If it is not specified, the default value will be used.
 
 data
 ^^^^
@@ -452,13 +547,20 @@ Any string that is decoded into the ``data`` field.
 | **Allowed values** | Any `sregex expression <regex.html#sregex-os-match-syntax>`_    |
 +--------------------+-----------------------------------------------------------------+
 
-The attribute below is optional, it allows to negate the expressions.
+The attributes below are optional.
 
-+--------------------+--------------------+--------------------+
-| Attribute          | Value range        | Default value      |
-+====================+====================+====================+
-| **negate**         | yes  or  no        | no                 |
-+--------------------+--------------------+--------------------+
++-------------+-----------------------------------------+-------------+---------------+
+| Attribute   |              Description                | Value range | Default value |
++=============+=========================================+=============+===============+
+| **negate**  | allows to negate the regular expression |     no      |       no      |
+|             |                                         +-------------+               |
+|             |                                         |     yes     |               |
++-------------+-----------------------------------------+-------------+---------------+
+
+If ``data`` label is declared multiple times within the rule, the following rules apply:
+
+- The resulting value is their concatenation.
+- The resulting value of an attribute corresponds to the one specified in the last label. If it is not specified, the default value will be used.
 
 extra_data
 ^^^^^^^^^^
@@ -483,13 +585,20 @@ Example:
 
 This rule will trigger when the log belongs to ``windows`` category and the decoded field ``extra_data`` is: ``Symantec AntiVirus``
 
-The attribute below is optional, it allows to negate the expressions.
+The attributes below are optional.
 
-+--------------------+--------------------+--------------------+
-| Attribute          | Value range        | Default value      |
-+====================+====================+====================+
-| **negate**         | yes  or  no        | no                 |
-+--------------------+--------------------+--------------------+
++-------------+-----------------------------------------+-------------+---------------+
+| Attribute   |              Description                | Value range | Default value |
++=============+=========================================+=============+===============+
+| **negate**  | allows to negate the regular expression |     no      |       no      |
+|             |                                         +-------------+               |
+|             |                                         |     yes     |               |
++-------------+-----------------------------------------+-------------+---------------+
+
+If ``extra_data`` label is declared multiple times within the rule, the following rules apply:
+
+- The resulting value is their concatenation.
+- The resulting value of an attribute corresponds to the one specified in the last label. If it is not specified, the default value will be used.
 
 user
 ^^^^
@@ -515,13 +624,20 @@ Example:
 
 This rule will trigger when a user different from ``root`` or ``wazuh`` successfully login into the system.
 
-The attribute below is optional, it allows to negate the expressions.
+The attributes below are optional.
 
-+--------------------+--------------------+--------------------+
-| Attribute          | Value range        | Default value      |
-+====================+====================+====================+
-| **negate**         | yes  or  no        | no                 |
-+--------------------+--------------------+--------------------+
++-------------+-----------------------------------------+-------------+---------------+
+| Attribute   |              Description                | Value range | Default value |
++=============+=========================================+=============+===============+
+| **negate**  | allows to negate the regular expression |     no      |       no      |
+|             |                                         +-------------+               |
+|             |                                         |     yes     |               |
++-------------+-----------------------------------------+-------------+---------------+
+
+If ``user`` label is declared multiple times within the rule, the following rules apply:
+
+- The resulting value is their concatenation.
+- The resulting value of an attribute corresponds to the one specified in the last label. If it is not specified, the default value will be used.
 
 system_name
 ^^^^^^^^^^^^
@@ -534,13 +650,20 @@ Any string that is decoded into the ``system_name`` field.
 | **Allowed values** | Any `sregex expression <regex.html#sregex-os-match-syntax>`_     |
 +--------------------+------------------------------------------------------------------+
 
-The attribute below is optional, it allows to negate the expressions.
+The attributes below are optional.
 
-+--------------------+--------------------+--------------------+
-| Attribute          | Value range        | Default value      |
-+====================+====================+====================+
-| **negate**         | yes  or  no        | no                 |
-+--------------------+--------------------+--------------------+
++-------------+-----------------------------------------+-------------+---------------+
+| Attribute   |              Description                | Value range | Default value |
++=============+=========================================+=============+===============+
+| **negate**  | allows to negate the regular expression |     no      |       no      |
+|             |                                         +-------------+               |
+|             |                                         |     yes     |               |
++-------------+-----------------------------------------+-------------+---------------+
+
+If ``system_name`` label is declared multiple times within the rule, the following rules apply:
+
+- The resulting value is their concatenation.
+- The resulting value of an attribute corresponds to the one specified in the last label. If it is not specified, the default value will be used.
 
 program_name
 ^^^^^^^^^^^^
@@ -566,13 +689,20 @@ Example:
 
 The rule will trigger when the program Syslogd restarted.
 
-The attribute below is optional, it allows to negate the expressions.
+The attributes below are optional.
 
-+--------------------+--------------------+--------------------+
-| Attribute          | Value range        | Default value      |
-+====================+====================+====================+
-| **negate**         | yes  or  no        | no                 |
-+--------------------+--------------------+--------------------+
++-------------+-----------------------------------------+-------------+---------------+
+| Attribute   |              Description                | Value range | Default value |
++=============+=========================================+=============+===============+
+| **negate**  | allows to negate the regular expression |     no      |       no      |
+|             |                                         +-------------+               |
+|             |                                         |     yes     |               |
++-------------+-----------------------------------------+-------------+---------------+
+
+If ``program_name`` label is declared multiple times within the rule, the following rules apply:
+
+- The resulting value is their concatenation.
+- The resulting value of an attribute corresponds to the one specified in the last label. If it is not specified, the default value will be used.
 
 protocol
 ^^^^^^^^
@@ -585,51 +715,20 @@ Any string that is decoded into the ``protocol`` field.
 | **Allowed values** | Any `sregex expression <regex.html#sregex-os-match-syntax>`_     |
 +--------------------+------------------------------------------------------------------+
 
-The attribute below is optional, it allows to negate the expressions.
+The attributes below are optional.
 
-+--------------------+--------------------+--------------------+
-| Attribute          | Value range        | Default value      |
-+====================+====================+====================+
-| **negate**         | yes  or  no        | no                 |
-+--------------------+--------------------+--------------------+
++-------------+-----------------------------------------+-------------+---------------+
+| Attribute   |              Description                | Value range | Default value |
++=============+=========================================+=============+===============+
+| **negate**  | allows to negate the regular expression |     no      |       no      |
+|             |                                         +-------------+               |
+|             |                                         |     yes     |               |
++-------------+-----------------------------------------+-------------+---------------+
 
-srcport
-^^^^^^^
+If ``protocol`` label is declared multiple times within the rule, the following rules apply:
 
-Used as a requisite to trigger the rule. It will check the source port (decoded as ``srcport``).
-
-+--------------------+------------------------------------------------------------------+
-| **Default Value**  | n/a                                                              |
-+--------------------+------------------------------------------------------------------+
-| **Allowed values** | Any `sregex expression <regex.html#sregex-os-match-syntax>`_     |
-+--------------------+------------------------------------------------------------------+
-
-The attribute below is optional, it allows to negate the expressions.
-
-+--------------------+--------------------+--------------------+
-| Attribute          | Value range        | Default value      |
-+====================+====================+====================+
-| **negate**         | yes  or  no        | no                 |
-+--------------------+--------------------+--------------------+
-
-dstport
-^^^^^^^
-
-Used as a requisite to trigger the rule. It will check the destination port (decoded as ``dstport``).
-
-+--------------------+------------------------------------------------------------------+
-| **Default Value**  | n/a                                                              |
-+--------------------+------------------------------------------------------------------+
-| **Allowed values** | Any `sregex expression <regex.html#sregex-os-match-syntax>`_     |
-+--------------------+------------------------------------------------------------------+
-
-The attribute below is optional, it allows to negate the expressions.
-
-+--------------------+--------------------+--------------------+
-| Attribute          | Value range        | Default value      |
-+====================+====================+====================+
-| **negate**         | yes  or  no        | no                 |
-+--------------------+--------------------+--------------------+
+- The resulting value is their concatenation.
+- The resulting value of an attribute corresponds to the one specified in the last label. If it is not specified, the default value will be used.
 
 hostname
 ^^^^^^^^
@@ -654,13 +753,20 @@ Example:
 
 This rule will group rules for ``Yum logs`` when something is either being installed, updated or erased.
 
-The attribute below is optional, it allows to negate the expressions.
+The attributes below are optional.
 
-+--------------------+--------------------+--------------------+
-| Attribute          | Value range        | Default value      |
-+====================+====================+====================+
-| **negate**         | yes  or  no        | no                 |
-+--------------------+--------------------+--------------------+
++-------------+-----------------------------------------+-------------+---------------+
+| Attribute   |              Description                | Value range | Default value |
++=============+=========================================+=============+===============+
+| **negate**  | allows to negate the regular expression |     no      |       no      |
+|             |                                         +-------------+               |
+|             |                                         |     yes     |               |
++-------------+-----------------------------------------+-------------+---------------+
+
+If ``hostname`` label is declared multiple times within the rule, the following rules apply:
+
+- The resulting value is their concatenation.
+- The resulting value of an attribute corresponds to the one specified in the last label. If it is not specified, the default value will be used.
 
 time
 ^^^^
@@ -735,13 +841,20 @@ Example:
 
 This rule will group the logs whose decoded ID is usb.
 
-The attribute below is optional, it allows to negate the expressions.
+The attributes below are optional.
 
-+--------------------+--------------------+--------------------+
-| Attribute          | Value range        | Default value      |
-+====================+====================+====================+
-| **negate**         | yes  or  no        | no                 |
-+--------------------+--------------------+--------------------+
++-------------+-----------------------------------------+-------------+---------------+
+| Attribute   |              Description                | Value range | Default value |
++=============+=========================================+=============+===============+
+| **negate**  | allows to negate the regular expression |     no      |       no      |
+|             |                                         +-------------+               |
+|             |                                         |     yes     |               |
++-------------+-----------------------------------------+-------------+---------------+
+
+If ``id`` label is declared multiple times within the rule, the following rules apply:
+
+- The resulting value is their concatenation.
+- The resulting value of an attribute corresponds to the one specified in the last label. If it is not specified, the default value will be used.
 
 url
 ^^^
@@ -767,13 +880,20 @@ Example:
 
 This rule is a child from a level 5 rule ``31101`` and becomes a level 0 rule when it confirms that the extensions are nothing to worry about.
 
-The attribute below is optional, it allows to negate the expressions.
+The attributes below are optional.
 
-+--------------------+--------------------+--------------------+
-| Attribute          | Value range        | Default value      |
-+====================+====================+====================+
-| **negate**         | yes  or  no        | no                 |
-+--------------------+--------------------+--------------------+
++-------------+-----------------------------------------+-------------+---------------+
+| Attribute   |              Description                | Value range | Default value |
++=============+=========================================+=============+===============+
+| **negate**  | allows to negate the regular expression |     no      |       no      |
+|             |                                         +-------------+               |
+|             |                                         |     yes     |               |
++-------------+-----------------------------------------+-------------+---------------+
+
+If ``url`` label is declared multiple times within the rule, the following rules apply:
+
+- The resulting value is their concatenation.
+- The resulting value of an attribute corresponds to the one specified in the last label. If it is not specified, the default value will be used.
 
 location
 ^^^^^^^^
@@ -840,13 +960,20 @@ Example:
 
 This rule, groups logs that come from ``osquery`` location. Triggering a level 3 alert for it.
 
-The attribute below is optional, it allows to negate the expressions.
+The attributes below are optional.
 
-+--------------------+--------------------+--------------------+
-| Attribute          | Value range        | Default value      |
-+====================+====================+====================+
-| **negate**         | yes  or  no        | no                 |
-+--------------------+--------------------+--------------------+
++-------------+-----------------------------------------+-------------+---------------+
+| Attribute   |              Description                | Value range | Default value |
++=============+=========================================+=============+===============+
+| **negate**  | allows to negate the regular expression |     no      |       no      |
+|             |                                         +-------------+               |
+|             |                                         |     yes     |               |
++-------------+-----------------------------------------+-------------+---------------+
+
+If ``location`` label is declared multiple times within the rule, the following rules apply:
+
+- The resulting value is their concatenation.
+- The resulting value of an attribute corresponds to the one specified in the last label. If it is not specified, the default value will be used.
 
 action
 ^^^^^^
@@ -871,13 +998,109 @@ Example:
 
 This rule will trigger a level 4 alert when the decoded action from Netscreen is ``warning``.
 
-The attribute below is optional, it allows to negate the expressions.
+The attributes below are optional.
 
-+--------------------+--------------------+--------------------+
-| Attribute          | Value range        | Default value      |
-+====================+====================+====================+
-| **negate**         | yes  or  no        | no                 |
-+--------------------+--------------------+--------------------+
++-------------+-----------------------------------------+-------------+---------------+
+| Attribute   |              Description                | Value range | Default value |
++=============+=========================================+=============+===============+
+| **negate**  | allows to negate the regular expression |     no      |       no      |
+|             |                                         +-------------+               |
+|             |                                         |     yes     |               |
++-------------+-----------------------------------------+-------------+---------------+
+
+If ``action`` label is declared multiple times within the rule, the following rules apply:
+
+- The resulting value is their concatenation.
+- The resulting value of an attribute corresponds to the one specified in the last label. If it is not specified, the default value will be used.
+
+status
+^^^^^^
+
+Checks the actual status of an event.
+
++--------------------+-----------------------------------------------------------------+
+| **Default Value**  | n/a                                                             |
++--------------------+-----------------------------------------------------------------+
+| **Allowed values** | Any `sregex expression <regex.html#sregex-os-match-syntax>`_    |
++--------------------+-----------------------------------------------------------------+
+
+Example:
+
+  .. code-block:: xml
+
+      <rule id="213" level="7">
+        <if_sid>210</if_sid>
+        <status>aborted</status>
+        <description>Remote upgrade could not be launched. Error: $(error).</description>
+        <group>upgrade,upgrade_failure,</group>
+      </rule>
+
+The attributes below are optional.
+
++-------------+-----------------------------------------+-------------+---------------+
+| Attribute   |              Description                | Value range | Default value |
++=============+=========================================+=============+===============+
+| **negate**  | allows to negate the regular expression |     no      |       no      |
+|             |                                         +-------------+               |
+|             |                                         |     yes     |               |
++-------------+-----------------------------------------+-------------+---------------+
+
+If ``status`` label is declared multiple times within the rule, the following rules apply:
+
+- The resulting value is their concatenation.
+- The resulting value of an attribute corresponds to the one specified in the last label. If it is not specified, the default value will be used.
+
+srcgeoip
+^^^^^^^^
+
+Any string that is decoded into the ``srcgeoip`` field.
+
++--------------------+-----------------------------------------------------------------+
+| **Default Value**  | n/a                                                             |
++--------------------+-----------------------------------------------------------------+
+| **Allowed values** | Any `sregex expression <regex.html#sregex-os-match-syntax>`_    |
++--------------------+-----------------------------------------------------------------+
+
+The attributes below are optional.
+
++-------------+-----------------------------------------+-------------+---------------+
+| Attribute   |              Description                | Value range | Default value |
++=============+=========================================+=============+===============+
+| **negate**  | allows to negate the regular expression |     no      |       no      |
+|             |                                         +-------------+               |
+|             |                                         |     yes     |               |
++-------------+-----------------------------------------+-------------+---------------+
+
+If ``srcgeoip`` label is declared multiple times within the rule, the following rules apply:
+
+- The resulting value is their concatenation.
+- The resulting value of an attribute corresponds to the one specified in the last label. If it is not specified, the default value will be used.
+
+dstgeoip
+^^^^^^^^
+
+Any string that is decoded into the ``dstgeoip`` field.
+
++--------------------+-----------------------------------------------------------------+
+| **Default Value**  | n/a                                                             |
++--------------------+-----------------------------------------------------------------+
+| **Allowed values** | Any `sregex expression <regex.html#sregex-os-match-syntax>`_    |
++--------------------+-----------------------------------------------------------------+
+
+The attributes below are optional.
+
++-------------+-----------------------------------------+-------------+---------------+
+| Attribute   |              Description                | Value range | Default value |
++=============+=========================================+=============+===============+
+| **negate**  | allows to negate the regular expression |     no      |       no      |
+|             |                                         +-------------+               |
+|             |                                         |     yes     |               |
++-------------+-----------------------------------------+-------------+---------------+
+
+If ``dstgeoip`` label is declared multiple times within the rule, the following rules apply:
+
+- The resulting value is their concatenation.
+- The resulting value of an attribute corresponds to the one specified in the last label. If it is not specified, the default value will be used.
 
 if_sid
 ^^^^^^
@@ -1600,25 +1823,6 @@ This option is used in conjunction with ``frequency`` and ``timeframe``.
 | **Example of use** | <different_url />  |
 +--------------------+--------------------+
 
-srcgeoip
-^^^^^^^^
-
-Any string that is decoded into the ``srcgeoip`` field.
-
-+--------------------+-----------------------------------------------------------------+
-| **Default Value**  | n/a                                                             |
-+--------------------+-----------------------------------------------------------------+
-| **Allowed values** | Any `sregex expression <regex.html#sregex-os-match-syntax>`_    |
-+--------------------+-----------------------------------------------------------------+
-
-The attribute below is optional, it allows to negate the expressions.
-
-+--------------------+--------------------+--------------------+
-| Attribute          | Value range        | Default value      |
-+====================+====================+====================+
-| **negate**         | yes  or  no        | no                 |
-+--------------------+--------------------+--------------------+
-
 same_srcgeoip
 ^^^^^^^^^^^^^
 
@@ -1656,25 +1860,6 @@ Example:
 
   That rule filters when the same ``user`` tries to open file ``/home`` but returns an error, on a different ``ip`` and using the same ``port``.
 
-dstgeoip
-^^^^^^^^
-
-Any string that is decoded into the ``dstgeoip`` field.
-
-+--------------------+-----------------------------------------------------------------+
-| **Default Value**  | n/a                                                             |
-+--------------------+-----------------------------------------------------------------+
-| **Allowed values** | Any `sregex expression <regex.html#sregex-os-match-syntax>`_    |
-+--------------------+-----------------------------------------------------------------+
-
-The attribute below is optional, it allows to negate the expressions.
-
-+--------------------+--------------------+--------------------+
-| Attribute          | Value range        | Default value      |
-+====================+====================+====================+
-| **negate**         | yes  or  no        | no                 |
-+--------------------+--------------------+--------------------+
-
 same_dstgeoip
 ^^^^^^^^^^^^^
 
@@ -1702,7 +1887,7 @@ This option is used in conjunction with ``frequency`` and ``timeframe``.
 description
 ^^^^^^^^^^^
 
-Specifies a human-readable description to the rule in order to provide context to each alert regarding the nature of the events matched by it. This field is required.
+Specifies a human-readable description to the rule in order to provide context to each alert regarding the nature of the events matched by it.
 
 +--------------------+------------+
 | **Default Value**  | n/a        |
@@ -1736,6 +1921,9 @@ Example:
       <options>no_log</options>
     </rule>
 
+If ``description`` label is declared multiple times within the rule, the following rules apply:
+
+- The resulting value is their concatenation.
 
 list
 ^^^^
@@ -1902,36 +2090,6 @@ It's a very useful label to keep the rules ordered.
 +--------------------+------------+
 | **Allowed values** | Any String |
 +--------------------+------------+
-
-status
-^^^^^^
-
-Checks the actual status of an event.
-
-+--------------------+----------------------------------------------+
-| **Default Value**  | n/a                                          |
-+--------------------+----------------------------------------------+
-| **Allowed values** | started, aborted, succeded, failed, lost...  |
-+--------------------+----------------------------------------------+
-
-Example:
-
-  .. code-block:: xml
-
-      <rule id="213" level="7">
-        <if_sid>210</if_sid>
-        <status>aborted</status>
-        <description>Remote upgrade could not be launched. Error: $(error).</description>
-        <group>upgrade,upgrade_failure,</group>
-      </rule>
-
-The attribute below is optional, it allows to negate the expressions.
-
-+--------------------+--------------------+--------------------+
-| Attribute          | Value range        | Default value      |
-+====================+====================+====================+
-| **negate**         | yes  or  no        | no                 |
-+--------------------+--------------------+--------------------+
 
 mitre
 ^^^^^

--- a/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
@@ -528,6 +528,18 @@ Used as a requisite to trigger the rule. It will check the source port (decoded 
 |                    | `pcre2 <regex.html#pcre2-syntax>`_ expression.                |
 +--------------------+---------------------------------------------------------------+
 
+Example:
+
+  .. code-block:: xml
+
+      <rule id="100110" level="5">
+          <if_sid>100100<if_sid>
+          <srcport type="pcre2">^5000[0-7]$</srcport>
+          <description>Source port $(srcport) is detected.</description>
+      </rule>
+
+This rule will trigger when ``srcport`` is in the range of 50000 to 50007.
+
 The attributes below are optional.
 
 +-------------+-----------------------------------------+-------------+---------------+
@@ -1118,11 +1130,11 @@ Example:
 
       <rule id="4502" level="4">
         <if_sid>4500</if_sid>
-        <action>warning</action>
+        <action type="osregex">warning|WARN</action>
         <description>Netscreen warning message.</description>
       </rule>
 
-This rule will trigger a level 4 alert when the decoded action from Netscreen is ``warning``.
+This rule will trigger a level 4 alert when the decoded action from Netscreen is ``warning`` or ``WARN``.
 
 The attributes below are optional.
 
@@ -1133,7 +1145,7 @@ The attributes below are optional.
 |             |                                         +-------------+               |
 |             |                                         |     yes     |               |
 +-------------+-----------------------------------------+-------------+---------------+
-| **type**    | allows to set regular expression type   |   osmatch   |       n/a     |
+| **type**    | allows to set regular expression type   |   osmatch   |    string     |
 |             |                                         +-------------+               |
 |             |                                         |   osregex   |               |
 |             |                                         +-------------+               |
@@ -1142,8 +1154,7 @@ The attributes below are optional.
 
 .. note::
 
-   By default and backward compatibility, ``action`` field try to match any string, 
-   but there is not such ``string`` value for ``type`` attribute.  In order to achieve this ``type`` attribute must be omitted.
+   Use ``type`` attribute only for regular expression match. It must be omitted if ``action`` field try to match a string. 
 
 If ``action`` label is declared multiple times within the rule, the following rules apply:
 


### PR DESCRIPTION
Closes #2907 

## Description

Hi team!
This PR aims to add information regarding to PCRE2 regex type and support for the three(`osregex`, `osmatch` and `pcre2`) regex types to almost all fields and options related to regex. This consist in the next changes

Rules syntax: 
- [X] Affected options/fields
  - [X] regex
  - [X] field
  - [X] match
  - [X] action
  - [X] extra_data
  - [X] hostname
  - [X] id
  - [X] location
  - [X] match
  - [X] program_name
  - [X] protocol
  - [X] user
  - [X] url
  - [X] srcport
  - [X] dstport
  - [X] status
  - [X] system_name
  - [X] data
  - [X] srcgeoip
  - [X] dstgeoip
- [X] Tasks
  - [X] Update value to `Any regular expression` and description at index table for affected options/fields
  - [X] Add `type` as optional attribute for options/fields section, with their value range an default value
  - [X] Check that all references to regular expressions types are correct
  - [X] Add example(s)

Decoders syntax: 
- [X] Affected options/fields
  - [X] prematch
  - [X] regex
  - [X] program_name
- [X] Tasks
  - [X] Update value to `Any regular expression` and description at index table for affected options/fields
  - [X] Add `type` as optional attribute for options/fields section, with their value range an default value
  - [X] Check that all references to regular expressions types are correct
  - [X] Add example(s)

Regular expression syntax:
-  [X] Add PCRE2 heading with brief and link to their own documentation
-  [X] Add samples of new features bring by PCRE2 compared with osregex and osmatch

Other fixes:
-  [X] Rules: Fix links to `regex` option and Regular Expression Syntax page
-  [X] Rules: Add notes about regex concatenation
-  [x] Rules: Add information about attributes(`negate` and `type`) behavior in regex concatenation
-  [X] Rules: Arrange options information according to index
-  [X] Rules: `category` option: fix link to `type` (decoders), making reference to their value range.
-  [X] Rules: Change `name` to an attribute table (mandatory) in `field` option
-  [X] Decoders: `type` option: add to index, add table with all supported values, add ref for external links

## Checks
- [X] It compiles without warnings.
- [X] Spelling and grammar. 
- [X] Used impersonal speech. 
- [X] Used uppercase only on nouns. 
- [X] All links works as expected 

Regards,
Nico