### PR TITLE
[4.0] Fixed the spacing in the stylesheet for the pages that use ReDoc

### DIFF
--- a/source/_static/css/custom-redoc.css
+++ b/source/_static/css/custom-redoc.css
@@ -96,9 +96,17 @@ redoc[spec-url] .sc-bMVAic.llQIcF.btn-close.collapsed::before {
   transition: all ease .4s;
 }
 
-
 .loading redoc[spec-url] {
 	/* display:none; */
+}
+
+redoc[spec-url] .cncswi {
+	padding: 10px 0px 0px;
+}
+
+redoc[spec-url] .cncswi .TPAYK {
+	padding-top: 0;
+	padding-bottom: 0;
 }
 
 redoc[spec-url] .bmRLPL a {
@@ -374,7 +382,7 @@ redoc[spec-url] .gsaTRZ > button {
   font-family: 'Open Sans', sans-serif;
 }
 
-redoc[spec-url] table {
+redoc[spec-url] table:not(.security-details) {
   display: block;
   width: 100%;
   overflow-x: auto;
@@ -531,15 +539,41 @@ redoc[spec-url] .scrollbar-container [role="menuitem"]:focus {
 	font-size: 0.7rem;
 }
 
+redoc[spec-url] .TPAYK.api-info {
+	padding-top: 30px;
+}
+
+redoc[spec-url] .WxWXp {
+	line-height: 1.1em;
+}
+
 @media (max-width: 499px){
 	redoc[spec-url] td.sc-kgoBCf.kGwPhO {
     max-width: 290px;
 	}
 }
+
 @media (max-width: 767px){
-	redoc[spec-url] .TPAYK,
+	redoc[spec-url] .TPAYK {
+    padding: 30px 15px;
+	}
+	
+	redoc[spec-url] .eVtsEQ {
+		padding: 0 15px;
+	}
+	
+	redoc[spec-url] .kBiOhJ {
+		margin-top: 1.5em;
+	}
+	
 	redoc[spec-url] .celZWI {
-    padding: 15px;
+		padding: 30px 15px 20px;
+	}
+}
+
+@media (max-width: 75rem){
+	redoc[spec-url] .TPAYK {
+		padding: 20px 40px 40px;
 	}
 }
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

Related issue: https://github.com/wazuh/wazuh-website/issues/1489

This PR reduces the vertical spacing in the style for ReDoc.
Before:
![imagen](https://user-images.githubusercontent.com/13232723/97537570-4a3ea700-19bf-11eb-8449-a4345be7ad6c.png)

After:
![imagen](https://user-images.githubusercontent.com/13232723/97537336-f207a500-19be-11eb-8c03-97b7f8b11940.png)

## Checks
- [x] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
