### PR TITLE
Add logtest documentation: API and RBAC references

### DIFF
--- a/source/user-manual/api/getting-started.rst
+++ b/source/user-manual/api/getting-started.rst
@@ -543,8 +543,6 @@ It can also be helpful to know which rules matching a specific criteria are avai
 Testing rules and decoders
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-REVISAR ESTO
-
 With the Wazuh API, it is possible to start a wazuh-logtest session or use an already started session and test and verify custom or default rules and decoders. With the following request, a logtest session is created and the rules and decoders that match with the given log are shown. The predecoding phase is also shown, among other information.
 
 .. code-block:: console

--- a/source/user-manual/api/getting-started.rst
+++ b/source/user-manual/api/getting-started.rst
@@ -540,6 +540,71 @@ It can also be helpful to know which rules matching a specific criteria are avai
 
 
 
+Testing rules and decoders
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+REVISAR ESTO
+
+With the Wazuh API, it is possible to start a wazuh-logtest session or use an already started session and test and verify custom or default rules and decoders. With the following request, a logtest session is created and the rules and decoders that match with the given log are shown. The predecoding phase is also shown, among other information.
+
+.. code-block:: console
+
+    # curl -k -X PUT "https://localhost:55000/logtest" -H  "Authorization: Bearer $TOKEN" -H  "Content-Type: application/json" -d "{\"event\":\"Jun 29 15:54:13 focal multipathd[557]: sdb: failed to get sysfs uid: No data available\",\"log_format\":\"syslog\",\"location\":\"user->/var/log/syslog\"}"
+
+
+.. code-block:: json
+    :class: output
+
+    {
+      "error": 0,
+      "data": {
+        "token": "bc3ca27a",
+        "messages": [
+          "WARNING: (7309): 'null' is not a valid token",
+          "INFO: (7202): Session initialized with token 'bc3ca27a'"
+        ],
+        "output": {
+          "timestamp": "2020-10-15T09:40:53.630+0000",
+          "rule": {
+            "level": 0,
+            "description": "FreeIPA messages grouped",
+            "id": "82202",
+            "firedtimes": 1,
+            "mail": false,
+            "groups": [
+              "freeipa"
+            ]
+          },
+          "agent": {
+            "id": "000",
+            "name": "wazuh-master"
+          },
+          "manager": {
+            "name": "wazuh-master"
+          },
+          "id": "1602754853.1000774",
+          "cluster": {
+            "name": "wazuh",
+            "node": "master-node"
+          },
+          "full_log": "Jun 29 15:54:13 focal multipathd[557]: sdb: failed to get sysfs uid: No data available",
+          "predecoder": {
+            "program_name": "multipathd",
+            "timestamp": "Jun 29 15:54:13",
+            "hostname": "focal"
+          },
+          "decoder": {
+            "name": "freeipa"
+          },
+          "location": "user->/var/log/syslog"
+        },
+        "alert": false,
+        "codemsg": 1
+      }
+    }
+
+
+
 Mining the file integrity monitoring database of an agent
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/source/user-manual/api/getting-started.rst
+++ b/source/user-manual/api/getting-started.rst
@@ -543,7 +543,7 @@ It can also be helpful to know which rules matching a specific criteria are avai
 Testing rules and decoders
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-With the Wazuh API, it is possible to start a wazuh-logtest session or use an already started session and test and verify custom or default rules and decoders. With the following request, a logtest session is created and the rules and decoders that match with the given log are shown. The predecoding phase is also shown, among other information.
+With the Wazuh API, it is possible to start a **wazuh-logtest** session or use an already started session to test and verify custom or default rules and decoders. With the following request, a logtest session is created and the rules and decoders that match with the given log are shown. The predecoding phase is also shown, among other information.
 
 .. code-block:: console
 
@@ -885,4 +885,3 @@ Adding an agent is now easier than ever. Simply send a request with the agent na
 Conclusion
 ^^^^^^^^^^
 The provided examples should help appreciate the potential of the Wazuh API. Remember to check out the :ref:`reference <api_reference>` document to discover all the available API requests.
-

--- a/source/user-manual/api/index.rst
+++ b/source/user-manual/api/index.rst
@@ -15,6 +15,7 @@ Here is a list of the Wazuh API capabilities:
 * Syscheck control and search
 * MITRE attacks and CISCAT overview
 * Ruleset information
+* Testing and verification of rules and decoders
 * Syscollector information
 * Access restriction and security (RBAC)
 * API management (HTTPS, configuration)

--- a/source/user-manual/api/rbac/reference.rst
+++ b/source/user-manual/api/rbac/reference.rst
@@ -72,6 +72,9 @@ This reference also contains a set of default roles and policies that can be imm
     - `Lists`_
         - `lists:read`_
 
+    - `Logtest`_
+        - `logtest:run`_
+
     - `Manager`_
         - `manager:delete_file`_
         - `manager:read_api_config`_
@@ -426,6 +429,14 @@ lists:read
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 - :api-ref:`GET /lists <operation/api.controllers.lists_controller.get_lists>` (`list:path`_)
 - :api-ref:`GET /lists/files <operation/api.controllers.lists_controller.get_lists_files>` (`list:path`_)
+
+
+Logtest
+^^^^^^^^^^^^^^^
+logtest:run
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+- :api-ref:`PUT /logtest <operation/api.controllers.logtest_controller.run_logtest_tool>` (`*:*`_)
+- :api-ref:`DELETE /logtest/sessions/{token} <operation/api.controllers.logtest_controller.end_logtest_session>` (`*:*`_)
 
 
 Manager


### PR DESCRIPTION
Hi team,

This PR is part of https://github.com/wazuh/wazuh/issues/5337. In this PR, I have added some examples of the new PUT logtest API endpoint to the getting started part of the API documentation. I have also included the new rbac logtest reference.