### PR TITLE
Updated instructions regarding service starting on manager and linux …

### DIFF
--- a/source/learning-wazuh/build-lab/install-linux-agents.rst
+++ b/source/learning-wazuh/build-lab/install-linux-agents.rst
@@ -40,12 +40,13 @@ Add the Wazuh yum repository
 Install and connect Wazuh agent to Manager
 ------------------------------------------
 
-Install the Wazuh agent software
+Install and start the Wazuh agent software
 
   .. code-block:: console
 
     # WAZUH_MANAGER="172.30.0.10" WAZUH_REGISTRATION_PASSWORD="please123" \
     WAZUH_PROTOCOL="tcp" yum -y install wazuh-agent
+    # systemctl start wazuh-agent
 
 Verify the agent has properly connected:
 

--- a/source/learning-wazuh/build-lab/install-wazuh-manager.rst
+++ b/source/learning-wazuh/build-lab/install-wazuh-manager.rst
@@ -39,12 +39,12 @@ The first step to setting up the manager is to add the Wazuh repository:
 Install and set up Wazuh server
 --------------------------------
 
-Install the Wazuh manager software and confirm it is running:
+Install the Wazuh manager software and start its service:
 
   .. code-block:: console
 
     # yum -y install wazuh-manager
-    # systemctl status wazuh-manager
+    # systemctl start wazuh-manager
 
 Configure Wazuh manager to allow self registration of new agents with authentication:
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description
This PR updates the instructions of learning-wazuh to reflect that both the Wazuh Manager and the Linux Agents do not automatically start now when installed.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
