### PR TITLE
Updating the description of the settings modified for monitord

### DIFF
--- a/source/user-manual/reference/internal-options.rst
+++ b/source/user-manual/reference/internal-options.rst
@@ -729,6 +729,10 @@ Monitord
 +----------------------------------+---------------+--------------------------------------------------------------------+
 |  **monitord.delete_old_agents**  | Description   | Number of minutes before deleting an old disconnected agent.       |
 |                                  |               |                                                                    |
+|                                  |               | This setting is added to the                                       |
+|                                  |               | :ref:`disconnection time<reference_agents_disconnection_time>`     |
+|                                  |               | before comparing with the agent's last keepalive.                  |
+|                                  |               |                                                                    |
 |                                  |               | .. versionadded:: 3.8.0                                            |
 +                                  +---------------+--------------------------------------------------------------------+
 |                                  | Default value | 0                                                                  |

--- a/source/user-manual/reference/ossec-conf/global.rst
+++ b/source/user-manual/reference/ossec-conf/global.rst
@@ -451,6 +451,7 @@ agents_disconnection_time
 .. versionadded:: 4.1.0
 
 This sets the time after which the manager considers an agent as disconnected since its last keepalive.
+It has to be greater than 20s.
 
 +-------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
 | **Default value**       | 20s                                                                                                                               |
@@ -471,7 +472,7 @@ agents_disconnection_alert_time
 
 .. versionadded:: 4.1.0
 
-This sets the time after which an alert is generated since an agent was considered as disconnected.
+This sets the time after which an alert is generated since an agent was considered as disconnected. It has to be greater than 2m.
 As this time is after an agent is considered as disconnected, the minimum time frame to produce an alert taking the default values is 2m and 20s.
 
 +-------------------------+-----------------------------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
## Description

This PR updates the description of the following settings, according to the new implementation [5887](https://github.com/wazuh/wazuh/issues/5887) and Closes #3116:
- _agents_disconnection_time_: adding minimum value
- _agents_disconnection_alert_time_: adding minimum value
- _monitord.delete_old_agents_: the internal calculation is explained, because now this time is added to the agent's disconnection time

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 