### PR TITLE
Add parallel doc generation by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ endif
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
+ALLSPHINXOPTS   = -j auto -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 


### PR DESCRIPTION
## Description

Hi team!

This PR aims to allow the generation of documents in parallel. The number of jobs/threads it set to `auto` (supported from Sphinx 1.7) to fit the CPUs of the compiling machine.

## Checks
- [X] It compiles without warnings (related with the compilation itself).

Regards,
Nico
