### PR TITLE
Adding minor limits for the agents_disconnection_time and agents_disc…

### DIFF
--- a/source/user-manual/agents/agent-life-cycle.rst
+++ b/source/user-manual/agents/agent-life-cycle.rst
@@ -23,7 +23,7 @@ Agent status
 ------------
 
 - **Never connected:** The agent has been registered but has not yet connected to the manager.
-- **Pending.** The authentication process is pending: The manager has received a request for connection from the agent but has not received anything else. This may indicate a firewall issue. The agent will be in this state one time in its life cycle.
+- **Pending.** The authentication process is pending: The manager has received a request for connection from the agent but has not received anything else. This may indicate a firewall issue. The agent will be in this state one time in its life cycle after each startup.
 - **Active:** The agent has successfully connected and can now communicate with the manager.
 - **Disconnected:** The manager will consider the agent disconnected if it does not receive any ``keep alive`` messages within :ref:`agents_disconnection_time<reference_agents_disconnection_time>` (20s default time).
 

--- a/source/user-manual/reference/internal-options.rst
+++ b/source/user-manual/reference/internal-options.rst
@@ -729,9 +729,9 @@ Monitord
 +----------------------------------+---------------+--------------------------------------------------------------------+
 |  **monitord.delete_old_agents**  | Description   | Number of minutes before deleting an old disconnected agent.       |
 |                                  |               |                                                                    |
-|                                  |               | This setting is added to the                                       |
-|                                  |               | :ref:`disconnection time<reference_agents_disconnection_time>`     |
-|                                  |               | before comparing with the agent's last keepalive.                  |
+|                                  |               | This is a time-lapse after the agent is considered as              |
+|                                  |               | disconnected because of the                                        |
+|                                  |               | :ref:`disconnection time<reference_agents_disconnection_time>`.    |
 |                                  |               |                                                                    |
 |                                  |               | .. versionadded:: 3.8.0                                            |
 +                                  +---------------+--------------------------------------------------------------------+

--- a/source/user-manual/reference/ossec-conf/global.rst
+++ b/source/user-manual/reference/ossec-conf/global.rst
@@ -451,13 +451,12 @@ agents_disconnection_time
 .. versionadded:: 4.1.0
 
 This sets the time after which the manager considers an agent as disconnected since its last keepalive.
-It has to be greater than 20s.
 
-+-------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
-| **Default value**       | 20s                                                                                                                               |
-+-------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
-| **Allowed values**      | A positive number that should end with a character indicating a time unit, such as: s (seconds), m (minutes), h (hours), d (days) |
-+-------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
++-------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| **Default value**       | 20s                                                                                                                                                           |
++-------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| **Allowed values**      | A positive number that should end with a character indicating a time unit, such as: s (seconds), m (minutes), h (hours), d (days). The minimum allowed is 1s. |
++-------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 Example:
 
@@ -472,14 +471,14 @@ agents_disconnection_alert_time
 
 .. versionadded:: 4.1.0
 
-This sets the time after which an alert is generated since an agent was considered as disconnected. It has to be greater than 2m.
-As this time is after an agent is considered as disconnected, the minimum time frame to produce an alert taking the default values is 2m and 20s.
+This sets the time after which an alert is generated since an agent was considered as disconnected.
+As this is a time-lapse after an agent is considered as disconnected because of the :ref:`disconnection time<reference_agents_disconnection_time>`, the minimum time frame to produce an alert taking the default values is 2m and 20s.
 
-+-------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
-| **Default value**       | 2m                                                                                                                                |
-+-------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
-| **Allowed values**      | A positive number that should end with a character indicating a time unit, such as: s (seconds), m (minutes), h (hours), d (days) |
-+-------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
++-------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| **Default value**       | 2m                                                                                                                                                                                                                                            |
++-------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| **Allowed values**      | A positive number that should end with a character indicating a time unit, such as: s (seconds), m (minutes), h (hours), d (days). The minimum allowed is 0s in order to generate an alert as soon as an agent is considered as disconnected. |
++-------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 Example:
 


### PR DESCRIPTION
## Description

This pull request includes all the necessary to document the minor limits for the new settings introduced as part of the epic: **[Agents' status management improvement based on new monitord settings](https://github.com/wazuh/wazuh/issues/5887)**

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 