### PR TITLE
Clarification about the Elasticsearch cluster initialization

### DIFF
--- a/source/installation-guide/more-installation-alternatives/elastic-stack/distributed-deployment/unattended/unattended-elasticsearch-cluster-installation.rst
+++ b/source/installation-guide/more-installation-alternatives/elastic-stack/distributed-deployment/unattended/unattended-elasticsearch-cluster-installation.rst
@@ -211,7 +211,7 @@ Download the script and the configuration file. After downloading them, configur
     
     **Cluster initialization**
 
-      After stating all the nodes, run the following commands to generate the passwords.
+      Once the installation process is done in all the servers of the Elasticsearch cluster, run the following command on the **initial node** to generate credentials for all the Elastic Stack pre-built roles and users:
 
       .. include:: ../../../../../_templates/installations/basic/elastic/common/generate_elastic_credentials.rst        
 

--- a/source/installation-guide/open-distro/distributed-deployment/unattended/unattended-elasticsearch-cluster-installation.rst
+++ b/source/installation-guide/open-distro/distributed-deployment/unattended/unattended-elasticsearch-cluster-installation.rst
@@ -193,7 +193,7 @@ Download the script and the configuration file. After downloading them, configur
 
     **Cluster initialization**
 
-      Once all the nodes on the cluster have been started, run the ``securityadmin`` script to load the new certificates information and start the cluster. To run this command, the value ``<elasticsearch_IP>`` must be replaced by the Elasticsearch installation IP:
+      Once all the nodes on the cluster have been started, run the ``securityadmin`` script  on the **initial node** to load the new certificates information and start the cluster. To run this command, the value ``<elasticsearch_IP>`` must be replaced by the Elasticsearch installation IP:
 
       .. code-block:: console
 


### PR DESCRIPTION

## Description

Clarified that the Elasticsearch cluster initialization must be done on the initial node. 

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

