### PR TITLE
Moved CA configuration to upgrade module

### DIFF
--- a/source/user-manual/agents/remote-upgrading/install-custom-wpk.rst
+++ b/source/user-manual/agents/remote-upgrading/install-custom-wpk.rst
@@ -22,10 +22,13 @@ You have two options to perform this action:
 
     .. code-block:: xml
 
-        <active-response>
-          <ca_store>/var/ossec/etc/wpk_root.pem</ca_store>
-          <ca_store>/path/to/certificate</ca_store>
-        </active-response>
+        <agent-upgrade>
+            <ca_verification>
+                <enabled>yes</enabled>
+                <ca_store>/var/ossec/etc/wpk_root.pem</ca_store>
+                <ca_store>/path/to/certificate</ca_store>
+            </ca_verification>
+        </agent-upgrade>
 
 
 2. Run the upgrade

--- a/source/user-manual/reference/ossec-conf/active-response.rst
+++ b/source/user-manual/reference/ossec-conf/active-response.rst
@@ -34,8 +34,6 @@ Agent side
 ^^^^^^^^^^
 
 - `repeated_offenders`_
-- `ca_store`_
-- `ca_verification`_
 
 disabled
 ^^^^^^^^
@@ -165,28 +163,6 @@ Sets timeouts in minutes for repeat offenders. This is a comma-separated list of
 .. warning::
     This option must be configured directly in the **ossec.conf** file of the agent, even when using a manager/agent setup with centralized configuration of other settings via **agent.conf**. Apart from that, it has to be defined in the upper ``<active-response>`` section found in the configuration file.
 
-ca_store
-^^^^^^^^
-
-Indicates the path to the root CA certificate. The agent needs the certificate with which the WPK was signed in order to be updated.
-
-+--------------------+-----------------------------+
-| **Default value**  | wpk_root.pem                |
-+--------------------+-----------------------------+
-| **Allowed values** | Path to root CA certificate |
-+--------------------+-----------------------------+
-
-ca_verification
-^^^^^^^^^^^^^^^
-
-This option enables or disables the WPK validation using the root CA certificate. If this parameter is set to ``no`` the agent will accept any WPK package coming from the manager.
-
-+--------------------+-----------------------------+
-| **Default value**  | yes                         |
-+--------------------+-----------------------------+
-| **Allowed values** | yes, no                     |
-+--------------------+-----------------------------+
-
 Sample Configuration
 --------------------
 
@@ -207,7 +183,5 @@ Sample Configuration
     <!-- On the agent side -->
     <active-response>
       <disabled>no</disabled>
-      <ca_store>/var/ossec/etc/wpk_root.pem</ca_store>
-      <ca_verification>yes</ca_verification>
       <repeated_offenders>1,5,10</repeated_offenders>
     </active-response>

--- a/source/user-manual/reference/ossec-conf/agent-upgrade.rst
+++ b/source/user-manual/reference/ossec-conf/agent-upgrade.rst
@@ -144,6 +144,8 @@ Maximum time allowed between successive notifications. Can use second, minute an
 ca_verification
 ^^^^^^^^^^^^^^^
 
+.. versionadded:: 4.1.0
+
 Configuration block to specify CA certificates to validate WPK files.
 
 +---------------------------+--------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------+

--- a/source/user-manual/reference/ossec-conf/agent-upgrade.rst
+++ b/source/user-manual/reference/ossec-conf/agent-upgrade.rst
@@ -38,6 +38,7 @@ Agent side
 - `notification_wait_start`_
 - `notification_wait_factor`_
 - `notification_wait_max`_
+- `ca_verification`_
 
 .. note:: On the agent side, this module can be disabled and doing so will block remote upgrading of that agent.
 
@@ -140,6 +141,26 @@ Maximum time allowed between successive notifications. Can use second, minute an
 +--------------------+--------------------------------------------------------------------------------------------------------------------------+
 
 
+ca_verification
+^^^^^^^^^^^^^^^
+
+Configuration block to specify CA certificates to validate WPK files.
+
++---------------------------+--------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|                           | This option enables or disables the WPK validation using the root CA certificate. If this parameter is set to ``no`` the agent will accept any WPK package coming from the manager.  |
+|                           +--------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|  **enabled**              | **Default value**  | yes                                                                                                                                                             |
+|                           +--------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|                           | **Allowed values** | yes, no                                                                                                                                                         |
++---------------------------+--------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|                           | Indicates the path to the root CA certificate. The agent needs the certificate with which the WPK was signed in order to be updated.                                                 |
+|                           +--------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|  **ca_store**             | **Default value**  | wpk_root.pem                                                                                                                                                    |
+|                           +--------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|                           | **Allowed values** | Path to root CA certificate                                                                                                                                     |
++---------------------------+--------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+
 Sample Configuration
 --------------------
 
@@ -159,4 +180,8 @@ Sample Configuration
       <notification_wait_start>60s</notification_wait_start>
       <notification_wait_factor>4</notification_wait_factor>
       <notification_wait_max>2h</notification_wait_max>
+      <ca_verification>
+        <enabled>yes</enabled>
+        <ca_store>/var/ossec/etc/wpk_root.pem</ca_store>
+      </ca_verification>
     </agent-upgrade>

--- a/source/user-manual/reference/statistics-files/ossec-analysisd-state.rst
+++ b/source/user-manual/reference/statistics-files/ossec-analysisd-state.rst
@@ -93,6 +93,12 @@ Below there is an example of the content of the file:
     # Hostinfo queue size
     hostinfo_queue_size='16384'
 
+    # Upgrade module message queue
+    upgrade_queue_usage='0.01'
+
+    # Upgrade module message queue size
+    upgrade_queue_size='16384'
+
     # Event queue
     event_queue_usage='0.53'
 


### PR DESCRIPTION
## Description

Now, the `agent-upgrade` module executes all the WPK commands in the agent insted of `execd`.

It was necessary to move the CA certificates configuration from the `active-response` section to the `agent-upgrade` section since now they are managed by this module.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
