### PR TITLE
Clarified that the Kibana IP address must be specified to generate the corresponding certificate. 

### DIFF
--- a/source/_templates/installations/elastic/common/elastic-multi-node/generate_certificates.rst
+++ b/source/_templates/installations/elastic/common/elastic-multi-node/generate_certificates.rst
@@ -30,23 +30,28 @@
         # curl -so ~/searchguard/search-guard.yml https://raw.githubusercontent.com/wazuh/wazuh-documentation/4.0/resources/open-distro/searchguard/multi-node/search-guard.yml
 
 
-      After downloading the configuration file in ``~/searchguard/search-guard.yml``, replace the values ``<elasticsearch_X_IP>`` with the corresponding Elasticsearch's IPs. More than one IP can be specified (one entry per line):
+      After downloading the configuration file in ``~/searchguard/search-guard.yml``, replace the values ``<elasticsearch_X_IP>`` and ``<kibana_ip>``  with the corresponding IP addresses. More than one IP can be specified (one entry per line):
 
         .. code-block:: yaml
 
+          # Nodes certificates
           nodes:
             - name: node-1
-            dn: CN=node-1,OU=Docu,O=Wazuh,L=California,C=US
-            ip:
-              - <elasticsearch_X_IP>
+              dn: CN=node-1,OU=Docu,O=Wazuh,L=California,C=US
+              ip:
+                - <elasticsearch_1_IP>
             - name: node-2
-            dn: CN=node-2,OU=Docu,O=Wazuh,L=California,C=US
-            ip:
-              - <elasticsearch_X_IP>
+              dn: CN=node-2,OU=Docu,O=Wazuh,L=California,C=US
+              ip:
+                - <elasticsearch_2_IP>
             - name: node-3
-            dn: CN=node-3,OU=Docu,O=Wazuh,L=California,C=US
-            ip:
-              - <elasticsearch_X_IP>
+              dn: CN=node-3,OU=Docu,O=Wazuh,L=California,C=US
+              ip:
+                - <elasticsearch_3_IP>
+            - name: kibana
+              dn: CN=kibana,OU=Docu,O=Wazuh,L=California,C=US      
+              ip:
+                - <kibana_ip>   
 
     .. group-tab:: Wazuh multi-node cluster
 
@@ -55,25 +60,31 @@
         # curl -so ~/searchguard/search-guard.yml https://raw.githubusercontent.com/wazuh/wazuh-documentation/4.0/resources/open-distro/searchguard/multi-node/search-guard-multi-node.yml
 
 
-      After downloading the configuration file, replace the values ``<elasticsearch_X_IP>`` with the corresponding Elasticsearch's IPs in the file ``~/searchguard/search-guard.yml``. More than one IP can be specified (one entry per line):
+      After downloading the configuration file, replace the values ``<elasticsearch_X_IP>`` and ``<kibana_ip>``  with the corresponding IP addresses in the file ``~/searchguard/search-guard.yml``. More than one IP can be specified (one entry per line):
 
         .. code-block:: yaml
 
+          # Nodes certificates
           nodes:
             - name: node-1
-            dn: CN=node-1,OU=Docu,O=Wazuh,L=California,C=US
-            ip:
-              - <elasticsearch_X_IP>
+              dn: CN=node-1,OU=Docu,O=Wazuh,L=California,C=US
+              ip:
+                - <elasticsearch_1_IP>
             - name: node-2
-            dn: CN=node-2,OU=Docu,O=Wazuh,L=California,C=US
-            ip:
-              - <elasticsearch_X_IP>
+              dn: CN=node-2,OU=Docu,O=Wazuh,L=California,C=US
+              ip:
+                - <elasticsearch_2_IP>
             - name: node-3
-            dn: CN=node-3,OU=Docu,O=Wazuh,L=California,C=US
-            ip:
-              - <elasticsearch_X_IP>
+              dn: CN=node-3,OU=Docu,O=Wazuh,L=California,C=US
+              ip:
+                - <elasticsearch_3_IP>
+            - name: kibana
+              dn: CN=kibana,OU=Docu,O=Wazuh,L=California,C=US      
+              ip:
+                - <kibana_ip>   
 
-      There should as many ``filebeat-X`` sections as Wazuh servers will be involved in the installation:
+
+      There should as many ``filebeat-X`` sections as Wazuh servers in the installation:
 
         .. code-block:: yaml
 

--- a/source/_templates/installations/elastic/common/elastic-single-node/generate_deploy_certificates.rst
+++ b/source/_templates/installations/elastic/common/elastic-single-node/generate_deploy_certificates.rst
@@ -30,15 +30,20 @@
         # curl -so ~/searchguard/search-guard.yml https://raw.githubusercontent.com/wazuh/wazuh-documentation/4.0/resources/open-distro/searchguard/single-node/search-guard.yml
 
 
-      After downloading the configuration file in ``~/searchguard/search-guard.yml``, replace the value ``<elasticsearch_IP>`` with the corresponding Elasticsearch's IP. More than one IP can be specified (one entry per line):
+      After downloading the configuration file in ``~/searchguard/search-guard.yml``, replace the values ``<elasticsearch_IP>`` and ``<kibana_ip>``  with the corresponding IP addresses. More than one IP can be specified (one entry per line):
 
         .. code-block:: yaml
 
+          # Nodes certificates
           nodes:
             - name: elasticsearch
-            dn: CN=node-1,OU=Docu,O=Wazuh,L=California,C=US
-            ip:
-              - <elasticsearch_IP>
+              dn: CN=node-1,OU=Docu,O=Wazuh,L=California,C=US
+              ip:
+                - <elasticsearch_IP>
+            - name: kibana
+              dn: CN=kibana,OU=Docu,O=Wazuh,L=California,C=US     
+              ip:
+                - <kibana_ip>    
 
     .. group-tab:: Wazuh multi-node cluster
 
@@ -47,15 +52,20 @@
         # curl -so ~/searchguard/search-guard.yml https://raw.githubusercontent.com/wazuh/wazuh-documentation/4.0/resources/open-distro/searchguard/single-node/search-guard-multi-node.yml
 
 
-      After downloading the configuration file, replace the value ``<elasticsearch_IP>`` with the corresponding Elasticsearch's IP in the file ``~/searchguard/search-guard.yml``. More than one IP can be specified (one entry per line):
+      After downloading the configuration file, replace the value ``<elasticsearch_IP>`` and ``<kibana_ip>``  with the corresponding IP addresses in the file ``~/searchguard/search-guard.yml``. More than one IP can be specified (one entry per line):
 
         .. code-block:: yaml
 
+          # Nodes certificates
           nodes:
             - name: elasticsearch
-            dn: CN=node-1,OU=Docu,O=Wazuh,L=California,C=US
-            ip:
-              - <elasticsearch_IP>
+              dn: CN=node-1,OU=Docu,O=Wazuh,L=California,C=US
+              ip: 
+                - <elasticsearch_IP>
+            - name: kibana
+              dn: CN=kibana,OU=Docu,O=Wazuh,L=California,C=US     
+              ip:
+                - <kibana_ip> 
 
       There should be as many ``filebeat-X`` sections as Wazuh servers in the installation:
 


### PR DESCRIPTION


## Description

Modified the templates examples and clarified that the Kibana IP address must be specified to generate the corresponding certificate.  

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).


