### PR TITLE
localfile: add multiline-regex and continue from last read line

### DIFF
--- a/source/user-manual/reference/ossec-conf/localfile.rst
+++ b/source/user-manual/reference/ossec-conf/localfile.rst
@@ -31,6 +31,8 @@ Options
 - `age`_
 - `exclude`_
 - `reconnect_time`_
+- `multiline`_
+
 
 location
 ^^^^^^^^
@@ -454,6 +456,47 @@ Defines the interval of reconnection attempts when the Windows Event Channel ser
 .. note::
 
     This option only applies when the ``log_format`` is ``eventchannel``.
+
+multiline
+^^^^^^^^^
+
++--------------------+------------------------------+
+| **Default value**  | n/a                          |
++--------------------+------------------------------+
+| **Allowed values** | Any `PCRE2 regular expression<../../ruleset/ruleset-xml-syntax/regex.html>`_ |
++--------------------+------------------------------+
+
+The attributes below are optional.
+
++-------------+---------------------------------------+--------------+---------------+
+| Attribute   |              Description              | Value range  | Default value |
++=============+=======================================+==============+===============+
+| **match**   | allows to set how regex will handle   |   start      |    start      |
+|             | regex match                           +--------------+               |
+|             |                                       |   end        |               |
+|             |                                       +--------------+               |
+|             |                                       |   all        |               |
++-------------+---------------------------------------+--------------+---------------+
+| **replace** | allows to replace newline character   |   space      |    start      |
+|             | with other one                        +--------------+               |
+|             |                                       |   tab        |               |
+|             |                                       +--------------+               |
+|             |                                       |   none       |               |
++-------------+---------------------------------------+--------------+---------------+
+
+.. note::
+    This option only applies when the ``log_format`` is ``syslog``.
+
+For example, we may want to read a Python traceback output as one single log, replacing newline with spaces
+
+.. code-block:: xml
+
+  <localfile>
+      <log_format>syslog</log_format>
+      <location>/var/logs/my_python_app.log</location>
+      <multiline replace="space">^Traceback</multiline>
+   </localfile>
+
 
 Configuration examples
 ----------------------

--- a/source/user-manual/reference/ossec-conf/localfile.rst
+++ b/source/user-manual/reference/ossec-conf/localfile.rst
@@ -140,17 +140,33 @@ Prevents a command from being executed in less time than the specified time (in 
 only-future-events
 ^^^^^^^^^^^^^^^^^^
 
+
 Set it to *no* to collect events generated since Wazuh agent was stopped.
 
-By default, when Wazuh starts it will only read all log content from a given Windows Event Channel since the agent started.
-
-This feature is only compatible with `eventchannel` log format.
+By default, when Wazuh starts it will only read all log content since the agent started.
 
 +--------------------+-----------+
 | **Default value**  | yes       |
 +--------------------+-----------+
 | **Allowed values** | yes or no |
 +--------------------+-----------+
+
+The attributes below are optional.
+
++-------------+---------------------------------------+--------------+---------------+
+| Attribute   |              Description              | Value range  | Default value |
++=============+=======================================+==============+===============+
+|**max-size** | Allows to skip reading old events     |              |               |
+|             | from the last read if the length of   |  0 to 100MB  |     10KB      |
+|             | them exceeds a certain value in bytes.|              |               |
+|             |                                       |              |               |
+|             | Positive number followed by B, KB     |              |               |
+|             | and MB units are supported            |              |               |
+|             |                                       |              |               |
+|             | .. versionadded:: 4.1.0               |              |               |
++-------------+---------------------------------------+--------------+---------------+
+
+
 
 query
 ^^^^^
@@ -306,6 +322,8 @@ Set the format of the log to be read. **field is required**
 |                    | multi-line-regex   | Used to monitor applications that log variable amount lines with variable length per event.      |
 |                    |                    |                                                                                                  |
 |                    |                    | The behavior depends on `multiline_regex`_ option.                                               |
+|                    |                    |                                                                                                  |
+|                    |                    | .. versionadded:: 4.1.0                                                                          |
 +--------------------+--------------------+--------------------------------------------------------------------------------------------------+
 
 .. warning::

--- a/source/user-manual/reference/ossec-conf/localfile.rst
+++ b/source/user-manual/reference/ossec-conf/localfile.rst
@@ -31,7 +31,7 @@ Options
 - `age`_
 - `exclude`_
 - `reconnect_time`_
-- `multiline`_
+- `multiline_regex`_
 
 
 location
@@ -302,6 +302,10 @@ Set the format of the log to be read. **field is required**
 |                    |                    | may be multiple timestamps in the final event.                                                   |
 |                    |                    |                                                                                                  |
 |                    |                    | The format for this value is: <log_format>multi-line: NUMBER</log_format>                        |
++                    +--------------------+--------------------------------------------------------------------------------------------------+
+|                    | multi-line-regex   | Used to monitor applications that log variable amount lines with variable length per event.      |
+|                    |                    |                                                                                                  |
+|                    |                    | The behavior depends on `multiline_regex`_ option.                                               |
 +--------------------+--------------------+--------------------------------------------------------------------------------------------------+
 
 .. warning::
@@ -457,14 +461,17 @@ Defines the interval of reconnection attempts when the Windows Event Channel ser
 
     This option only applies when the ``log_format`` is ``eventchannel``.
 
-multiline
-^^^^^^^^^
+multiline_regex
+^^^^^^^^^^^^^^^
+.. versionadded:: 4.1.0
 
-+--------------------+------------------------------+
-| **Default value**  | n/a                          |
-+--------------------+------------------------------+
-| **Allowed values** | Any `PCRE2 regular expression<../../ruleset/ruleset-xml-syntax/regex.html>`_ |
-+--------------------+------------------------------+
+This specifies a regular expression, match criteria and replace option for logs with a variable amount of lines.
+
++--------------------+--------------------------------------------------------------------------------------------+
+| **Default value**  | n/a                                                                                        |
++--------------------+--------------------------------------------------------------------------------------------+
+| **Allowed values** | Any `PCRE2 regular expression <../../ruleset/ruleset-xml-syntax/regex.html#pcre2-syntax>`_ |
++--------------------+--------------------------------------------------------------------------------------------+
 
 The attributes below are optional.
 
@@ -477,24 +484,32 @@ The attributes below are optional.
 |             |                                       +--------------+               |
 |             |                                       |   all        |               |
 +-------------+---------------------------------------+--------------+---------------+
-| **replace** | allows to replace newline character   |   space      |    start      |
-|             | with other one                        +--------------+               |
+| **replace** | allows to replace newline character   |   space      |  no-replace   |
+|             | with another one                      +--------------+               |
+|             |                                       |   wspace     |               |
+|             |                                       +--------------+               |
 |             |                                       |   tab        |               |
 |             |                                       +--------------+               |
 |             |                                       |   none       |               |
 +-------------+---------------------------------------+--------------+---------------+
+| **timeout** | allows to set max waiting time in     |   1 to 120   |      3        |
+|             | seconds to receive a new line         |              |               |
++-------------+---------------------------------------+--------------+---------------+
 
 .. note::
-    This option only applies when the ``log_format`` is ``syslog``.
+    This option only applies when the `log_format`_ is ``multi-line-regex``.
 
-For example, we may want to read a Python traceback output as one single log, replacing newline with spaces
+.. note::
+    The value of ``timeout`` attribute cannot be bigger than the value of the `age`_ option.
+
+For example, we may want to read a Python Traceback output as one single log, replacing newline with spaces
 
 .. code-block:: xml
 
   <localfile>
       <log_format>syslog</log_format>
       <location>/var/logs/my_python_app.log</location>
-      <multiline replace="space">^Traceback</multiline>
+      <multiline replace="wspace">^Traceback</multiline>
    </localfile>
 
 

--- a/source/user-manual/reference/ossec-conf/localfile.rst
+++ b/source/user-manual/reference/ossec-conf/localfile.rst
@@ -140,10 +140,10 @@ Prevents a command from being executed in less time than the specified time (in 
 only-future-events
 ^^^^^^^^^^^^^^^^^^
 
-
-Set it to *no* to collect events generated since ``ossec-logcollector`` was stopped.
+It allows to read new log content since ``ossec-logcollector`` was stopped.
 
 By default, when ``ossec-logcollector`` starts it will only read all log content since it was started.
+Set it to no to collect events generated since ``ossec-logcollector`` was stopped.
 
 +--------------------+-----------+
 | **Default value**  | yes       |
@@ -498,13 +498,13 @@ The attributes below are optional.
 +-------------+---------------------------------------+--------------+---------------+
 | Attribute   |              Description              | Value range  | Default value |
 +=============+=======================================+==============+===============+
-| **match**   | allows to set how regex will handle   |   start      |    start      |
+| **match**   | Allows to set how regex will handle   |   start      |    start      |
 |             | regex match.                          +--------------+               |
 |             |                                       |   end        |               |
 |             |                                       +--------------+               |
 |             |                                       |   all        |               |
 +-------------+---------------------------------------+--------------+---------------+
-| **replace** | allows to replace or remove           |  no-replace  |  no-replace   |
+| **replace** | Allows to replace or remove           |  no-replace  |  no-replace   |
 |             | end-of-line.                          +--------------+               |
 |             |                                       |   wspace     |               |
 |             |                                       +--------------+               |
@@ -512,7 +512,7 @@ The attributes below are optional.
 |             |                                       +--------------+               |
 |             |                                       |   none       |               |
 +-------------+---------------------------------------+--------------+---------------+
-| **timeout** | allows to set max waiting time in     |   1 to 120   |      5        |
+| **timeout** | Allows to set max waiting time in     |   1 to 120   |      5        |
 |             | seconds to receive a new line         |              |               |
 +-------------+---------------------------------------+--------------+---------------+
 
@@ -521,6 +521,23 @@ The attributes below are optional.
 
 .. note::
     The value of ``timeout`` attribute cannot be bigger than the value of the `age`_ option.
+
+The behavior of the ``match`` attribute is as follows
+
++-------------+-------------------------------------------------------------------------+
+| Match       |                       Description                                       |
++=============+=========================================================================+
+| **start**   | Group as one event the content between two lines that matches the regex.|
+|             |                                                                         |
+|             | The grouped event does not include the last matching line.              |
++-------------+-------------------------------------------------------------------------+
+|  **end**    | Group as one event the content until a line that matches the regex.     |
++-------------+-------------------------------------------------------------------------+
+|  **all**    | Group as one event the content until whole event match the regex.       |
++-------------+-------------------------------------------------------------------------+
+
+.. note::
+    ``start`` and ``end`` value for ``match`` attribute try to match the regex with a single line.
 
 For example, we may want to read a Python Traceback output as one single log, replacing newline with spaces
 

--- a/source/user-manual/reference/ossec-conf/localfile.rst
+++ b/source/user-manual/reference/ossec-conf/localfile.rst
@@ -141,9 +141,9 @@ only-future-events
 ^^^^^^^^^^^^^^^^^^
 
 
-Set it to *no* to collect events generated since Wazuh agent was stopped.
+Set it to *no* to collect events generated since ``ossec-logcollector`` was stopped.
 
-By default, when Wazuh starts it will only read all log content since the agent started.
+By default, when ``ossec-logcollector`` starts it will only read all log content since it was started.
 
 +--------------------+-----------+
 | **Default value**  | yes       |
@@ -157,15 +157,17 @@ The attributes below are optional.
 | Attribute   |              Description              | Value range  | Default value |
 +=============+=======================================+==============+===============+
 |**max-size** | Allows to skip reading old events     |              |               |
-|             | from the last read if the length of   |  0 to 100MB  |     10KB      |
+|             | from the last read if the length of   |  0 to 2GB    |     10MB      |
 |             | them exceeds a certain value in bytes.|              |               |
 |             |                                       |              |               |
-|             | Positive number followed by B, KB     |              |               |
-|             | and MB units are supported            |              |               |
+|             | Positive number followed by B, KB, MB |              |               |
+|             | and GB units are supported            |              |               |
 |             |                                       |              |               |
-|             | .. versionadded:: 4.1.0               |              |               |
+|             | .. versionadded:: 4.2.0               |              |               |
 +-------------+---------------------------------------+--------------+---------------+
 
+.. note::
+  If the log rotates while ``ossec-logcollector`` was stopped and ``only-future-events`` was set to ``no``, it will start reading from the beginning of the log. 
 
 
 query
@@ -323,7 +325,7 @@ Set the format of the log to be read. **field is required**
 |                    |                    |                                                                                                  |
 |                    |                    | The behavior depends on `multiline_regex`_ option.                                               |
 |                    |                    |                                                                                                  |
-|                    |                    | .. versionadded:: 4.1.0                                                                          |
+|                    |                    | .. versionadded:: 4.2.0                                                                          |
 +--------------------+--------------------+--------------------------------------------------------------------------------------------------+
 
 .. warning::
@@ -481,7 +483,7 @@ Defines the interval of reconnection attempts when the Windows Event Channel ser
 
 multiline_regex
 ^^^^^^^^^^^^^^^
-.. versionadded:: 4.1.0
+.. versionadded:: 4.2.0
 
 This specifies a regular expression, match criteria and replace option for logs with a variable amount of lines.
 
@@ -497,20 +499,20 @@ The attributes below are optional.
 | Attribute   |              Description              | Value range  | Default value |
 +=============+=======================================+==============+===============+
 | **match**   | allows to set how regex will handle   |   start      |    start      |
-|             | regex match                           +--------------+               |
+|             | regex match.                          +--------------+               |
 |             |                                       |   end        |               |
 |             |                                       +--------------+               |
 |             |                                       |   all        |               |
 +-------------+---------------------------------------+--------------+---------------+
-| **replace** | allows to replace newline character   |   space      |  no-replace   |
-|             | with another one                      +--------------+               |
+| **replace** | allows to replace or remove           |  no-replace  |  no-replace   |
+|             | end-of-line.                          +--------------+               |
 |             |                                       |   wspace     |               |
 |             |                                       +--------------+               |
 |             |                                       |   tab        |               |
 |             |                                       +--------------+               |
 |             |                                       |   none       |               |
 +-------------+---------------------------------------+--------------+---------------+
-| **timeout** | allows to set max waiting time in     |   1 to 120   |      3        |
+| **timeout** | allows to set max waiting time in     |   1 to 120   |      5        |
 |             | seconds to receive a new line         |              |               |
 +-------------+---------------------------------------+--------------+---------------+
 


### PR DESCRIPTION
|Related issue|
|---|
|wazuh/wazuh#5652|
|wazuh/wazuh#3368|
|wazuh/wazuh#6890|
## Description

Hi team! This PR aims to add documentation to new features regarding to `localfile` 

- New value `multi-line-regex` for `log_format`, and related option `multiline_regex`  that allows collecting logs with multiples and variables lines.
- Allowing to continue from last read line in a log by setting `only_future_events` for all `log_format`

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 

Regards,
Nico
