### PR TITLE
 Added the instruction to start the Wazuh agent (macOS)

### DIFF
--- a/source/installation-guide/wazuh-agent/wazuh_agent_package_macos.rst
+++ b/source/installation-guide/wazuh-agent/wazuh_agent_package_macos.rst
@@ -39,6 +39,12 @@ By default, all agent files can be found at the following location: ``/Library/O
 
 Now that the agent is installed, if you did not use the deployment method, you will have to register and configure the agent to communicate with the manager. For more information about this process, please visit :ref:`user manual<register_agents>`.
 
+Finally, start the Wazuh agent:
+
+  .. code-block:: console
+
+    # sudo /Library/Ossec/bin/ossec-control start
+
 
 Uninstall
 ---------


### PR DESCRIPTION


## Description

Added the instruction to start the Wazuh agent for macOS. 

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

