### PR TITLE
Open Distro for Elasticsearch version update 

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -419,7 +419,7 @@ custom_replacements = {
     "|WAZUH_LATEST_PUPPET|" : "4.0.0",
     "|WAZUH_LATEST_OVA|" : "4.0.2",
     "|WAZUH_LATEST_DOCKER|" : "4.0.0",
-    "|OPEN_DISTRO_LATEST|" : "1.10.1",
+    "|OPEN_DISTRO_LATEST|" : "1.11.0",
     "|ELASTICSEARCH_LATEST|" : "7.9.1",
     "|ELASTICSEARCH_LATEST_OVA|" : "7.9.1",
     "|ELASTICSEARCH_LATEST_ANSIBLE|" : "7.8.0",


### PR DESCRIPTION


## Description

Open Distro for Elasticsearch version update from 1.10.1 to 1.11.0. 

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

