### PR TITLE
Update wazuh-container.rst

### DIFF
--- a/source/docker/wazuh-container.rst
+++ b/source/docker/wazuh-container.rst
@@ -175,9 +175,9 @@ These are the steps to deploy a production grade Wazuh cluster using the "Open D
         - SSL_CERTIFICATE=/etc/filebeat/filebeat.pem
         - SSL_KEY=/etc/filebeat/filebeat.key
       volumes:
-        - ./ssl_certs/root-ca.pem:/etc/filebeat/root-ca.pem
-        - ./ssl_certs/filebeat.pem:/etc/filebeat/filebeat.pem
-        - ./ssl_certs/filebeat.key:/etc/filebeat/filebeat.key
+        - ./production_cluster/ssl_certs/root-ca.pem:/etc/filebeat/root-ca.pem
+        - ./production_cluster/ssl_certs/filebeat.pem:/etc/filebeat/filebeat.pem
+        - ./production_cluster/ssl_certs/filebeat.key:/etc/filebeat/filebeat.key
 
   2.4 Setup SSL certificates for Kibana
 


### PR DESCRIPTION
Update 2.4 volumes to link to the proper folder.

## Description

Wazuh-container section 2.4 linked to a subfolder ssl_keys of production_cluster instead of starting with production_cluster like the other steps

## Checks
- [ N/A] It compiles without warnings.
- [ X] Spelling and grammar. 
- [ X] Used impersonal speech. 
- [ X] Used uppercase only on nouns. 
- [ N/A] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
