### PR TITLE
Improvements to the upgrade guide

### DIFF
--- a/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-elastic-stack.rst
+++ b/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-elastic-stack.rst
@@ -10,6 +10,8 @@ This section guides through the upgrade process of Elasticsearch, Filebeat and K
 .. note::
   This guide is meant for upgrades from 7.x to 7.y. The upgrade instructions for Elastic Stack versions prior to 7.0 can be found in the :ref:`Upgrading Elastic Stack from a legacy version <upgrading_elastic_stack_legacy>` section.
 
+.. note:: Root user privileges are required to execute all the commands described below.
+
 Preparing Elastic Stack
 -----------------------
 

--- a/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-elastic-stack.rst
+++ b/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-elastic-stack.rst
@@ -21,26 +21,26 @@ Preparing Elastic Stack
 #. Add the Elastic Stack repository:
 
 
-.. tabs::
+    .. tabs::
 
-  .. group-tab:: Yum
-
-
-    .. include:: ../../../../_templates/installations/basic/elastic/yum/add_repository.rst
+      .. group-tab:: YUM
 
 
-
-  .. group-tab:: APT
-
-
-    .. include:: ../../../../_templates/installations/basic/elastic/deb/add_repository.rst
+        .. include:: ../../_templates/installations/basic/elastic/yum/add_repository.rst
 
 
 
-  .. group-tab:: ZYpp
+      .. group-tab:: APT
 
 
-    .. include:: ../../../../_templates/installations/basic/elastic/zypp/add_repository.rst              
+        .. include:: ../../_templates/installations/basic/elastic/deb/add_repository.rst
+
+
+
+      .. group-tab:: ZYpp
+
+
+         .. include:: ../../_templates/installations/basic/elastic/zypp/add_repository.rst              
 
 
 #. Before the upgrade process it is important to ensure that the Wazuh repository is disabled, as it contains Filebeat packages used by Open Distro for Elasticsearch distribution, which might be accidentally installed instead of the Elastic package. In case of having enabled the Wazuh repository it can be disabled using:

--- a/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-elastic-stack.rst
+++ b/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-elastic-stack.rst
@@ -23,7 +23,7 @@ Preparing Elastic Stack
 
     .. tabs::
 
-      .. group-tab:: YUM
+      .. group-tab:: Yum
 
 
         .. include:: ../../_templates/installations/basic/elastic/yum/add_repository.rst
@@ -47,7 +47,7 @@ Preparing Elastic Stack
 
   .. tabs::
 
-    .. group-tab:: YUM
+    .. group-tab:: Yum
 
       .. code-block:: console
 
@@ -101,7 +101,7 @@ In the commands below ``127.0.0.1`` IP address is used. If Elasticsearch is boun
 
       .. tabs::
 
-        .. group-tab:: YUM
+        .. group-tab:: Yum
 
           .. code-block:: console
 
@@ -161,7 +161,7 @@ The following steps needs to be run in the Wazuh server or servers in case of Wa
 
     .. tabs::
 
-      .. group-tab:: YUM
+      .. group-tab:: Yum
 
         .. code-block:: console
 
@@ -287,7 +287,7 @@ Copy the Wazuh Kibana plugin configuration file to its new location. This step i
 
       .. tabs::
 
-        .. group-tab:: YUM
+        .. group-tab:: Yum
 
           .. code-block:: console
 
@@ -375,7 +375,7 @@ It is recommended to disable the Elastic repository to prevent an upgrade to a n
 
       .. tabs::
 
-        .. group-tab:: YUM
+        .. group-tab:: Yum
 
           .. code-block:: console
 

--- a/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-elastic-stack.rst
+++ b/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-elastic-stack.rst
@@ -18,28 +18,29 @@ Preparing Elastic Stack
     .. include:: ../../_templates/installations/basic/elastic/common/stop_kibana_filebeat.rst
 
 
-#. Enable the Elastic repository:
+#. Add the Elastic Stack repository:
 
-    .. tabs::
 
-      .. group-tab:: YUM
+.. tabs::
 
-            .. code-block:: console
+  .. group-tab:: Yum
 
-              # sed -i "s/^enabled=0/enabled=1/" /etc/yum.repos.d/elastic.repo
 
-      .. group-tab:: APT
+    .. include:: ../../../../_templates/installations/basic/elastic/yum/add_repository.rst
 
-            .. code-block:: console
 
-              # sed -i "s/#deb/deb/" /etc/apt/sources.list.d/elastic-7.x.list
-              # apt-get update
 
-      .. group-tab:: ZYpp
+  .. group-tab:: APT
 
-            .. code-block:: console
 
-              # sed -i "s/^enabled=0/enabled=1/" /etc/zypp/repos.d/elastic.repo
+    .. include:: ../../../../_templates/installations/basic/elastic/deb/add_repository.rst
+
+
+
+  .. group-tab:: ZYpp
+
+
+    .. include:: ../../../../_templates/installations/basic/elastic/zypp/add_repository.rst              
 
 
 #. Before the upgrade process it is important to ensure that the Wazuh repository is disabled, as it contains Filebeat packages used by Open Distro for Elasticsearch distribution, which might be accidentally installed instead of the Elastic package. In case of having enabled the Wazuh repository it can be disabled using:

--- a/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-elastic-stack.rst
+++ b/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-elastic-stack.rst
@@ -341,6 +341,14 @@ Copy the Wazuh Kibana plugin configuration file to its new location. This step i
       NODE_OPTIONS="--max_old_space_size=2048"
       EOF
 
+
+#. Link Kibana’s socket to privileged port 443:
+
+    .. code-block:: console
+
+      # setcap 'cap_net_bind_service=+ep' /usr/share/kibana/node/bin/node      
+
+
 #. Restart Kibana:
 
     .. include:: ../../_templates/installations/basic/elastic/common/enable_kibana.rst

--- a/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-open-distro.rst
+++ b/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-open-distro.rst
@@ -7,6 +7,8 @@ Upgrading Open Distro for Elasticsearch
 
 This section guides through the upgrade process of Elasticsearch, Filebeat and Kibana for *Open Distro for Elasticsearch* distribution. 
 
+.. note:: Root user privileges are required to execute all the commands described below.
+
 Preparing Open Distro for Elasticsearch
 ---------------------------------------
 

--- a/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-open-distro.rst
+++ b/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-open-distro.rst
@@ -21,7 +21,7 @@ Preparing Open Distro for Elasticsearch
 
     .. tabs::
 
-      .. group-tab:: YUM
+      .. group-tab:: Yum
 
         .. code-block:: console
 
@@ -44,7 +44,7 @@ Preparing Open Distro for Elasticsearch
 
     .. tabs::
 
-      .. group-tab:: YUM
+      .. group-tab:: Yum
 
         .. code-block:: console
 
@@ -75,7 +75,7 @@ Preparing Open Distro for Elasticsearch
 
     .. tabs::
 
-      .. group-tab:: YUM
+      .. group-tab:: Yum
 
         .. include:: ../../_templates/installations/basic/wazuh/yum/add_repository_aio.rst
 
@@ -132,7 +132,7 @@ In the commands below ``127.0.0.1`` IP address is used. If Elasticsearch is boun
 
       .. tabs::
 
-        .. group-tab:: YUM
+        .. group-tab:: Yum
 
           .. code-block:: console
 
@@ -201,7 +201,7 @@ Upgrading Filebeat
 
       .. tabs::
 
-        .. group-tab:: YUM
+        .. group-tab:: Yum
 
           .. code-block:: console
 
@@ -344,7 +344,7 @@ Copy the Wazuh Kibana plugin configuration file to its new location. This step i
 
       .. tabs::
 
-        .. group-tab:: YUM
+        .. group-tab:: Yum
 
           .. code-block:: console
 
@@ -441,7 +441,7 @@ It is recommended to disable the Wazuh repository to prevent an upgrade to a new
 
       .. tabs::
 
-        .. group-tab:: YUM
+        .. group-tab:: Yum
 
           .. code-block:: console
 

--- a/source/upgrade-guide/upgrading-agent.rst
+++ b/source/upgrade-guide/upgrading-agent.rst
@@ -11,7 +11,7 @@ To perform the upgrade locally, follow the instructions for the operating system
 
 .. tabs::
 
-  .. group-tab:: YUM
+  .. group-tab:: Yum
 
 
     #. If the Wazuh repository is disabled it is necessary to enable it to get the latest package:

--- a/source/upgrade-guide/upgrading-wazuh.rst
+++ b/source/upgrade-guide/upgrading-wazuh.rst
@@ -14,7 +14,7 @@ To upgrade the Wazuh manager choose the appropriate tab for the desired package 
 
 .. tabs::
 
-  .. group-tab:: YUM
+  .. group-tab:: Yum
 
     .. include:: ../_templates/installations/basic/wazuh/yum/add_repository_aio.rst
 
@@ -63,7 +63,7 @@ It is recommended to disable the Wazuh repository in order to avoid undesired up
 
 .. tabs::
 
-  .. group-tab:: YUM
+  .. group-tab:: Yum
 
     .. code-block:: console
 

--- a/source/upgrade-guide/upgrading-wazuh.rst
+++ b/source/upgrade-guide/upgrading-wazuh.rst
@@ -5,10 +5,12 @@
 Upgrading the Wazuh manager
 ===========================
 
-This section describes how to upgrade the Wazuh manager, from Wazuh 3.x to newest, which implies upgrading to the latest compatible version of Open Distro for Elasticsearch or Elastic Stack. 
+This section describes how to upgrade the Wazuh manager, from Wazuh 3.x to the latest available version, which includes upgrading to the latest compatible version of Open Distro for Elasticsearch or Elastic Stack basic licence. 
 
 .. note::
   To reduce the downtime of the servers it is recommended to upgrade the master node first
+
+.. note:: Root user privileges are required to execute all the commands described below.
 
 To upgrade the Wazuh manager choose the appropriate tab for the desired package manager:
 


### PR DESCRIPTION


## Description

Improvements to the upgrade guide including: 

- Adding the instruction to add the Elastic repository. 
- Adding the instruction to link Kibana’s socket to privileged port 443.
- Changing tab labels.
- Adding a note stating that root privileges are required.  


## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).


