### PR TITLE
Fixed variable name in the Standard OSSEC message format section

### DIFF
--- a/source/development/message-format.rst
+++ b/source/development/message-format.rst
@@ -170,14 +170,14 @@ The compressed data is a byte array that must:
 So the ``<Padding>`` object is a string of 1 to 8 ``!`` symbols, so that the array resulting of appending both ``<Padding>`` and ``<CData>`` has asize multiple of 8. ::
 
     <Padding> = 1..8 "!"
-    Length(<Padding> <Block>) = 0 (mod 8)
+    Length(<Padding> <CData>) = 0 (mod 8)
 
 Encrypted data
 ++++++++++++++
 
 The padded data is encrypted using AES::
 
-    <Encrypted> = AES(<Padding> <Block>)
+    <Encrypted> = AES(<Padding> <CData>)
 
 The initialization vector and the encryption key are described in `Encryption system`_.
 


### PR DESCRIPTION


## Description

Fixed variable name. 

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).


