### PR TITLE
Added instructions to inject the Wazuh template to Elasticsearch

### DIFF
--- a/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-elastic-stack.rst
+++ b/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-elastic-stack.rst
@@ -208,7 +208,7 @@ The following steps needs to be run in the Wazuh server or servers in case of Wa
 
     .. include:: ../../_templates/installations/basic/elastic/common/enable_filebeat.rst
 
-#. Upload the new Wazuh template to Elasticsearch. This step can be omited in Wazuh single-node installations:
+#. Upload the new Wazuh template to Elasticsearch. This step can be omitted in Wazuh single-node installations:
 
   .. code-block:: console
 

--- a/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-elastic-stack.rst
+++ b/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-elastic-stack.rst
@@ -208,6 +208,12 @@ The following steps needs to be run in the Wazuh server or servers in case of Wa
 
     .. include:: ../../_templates/installations/basic/elastic/common/enable_filebeat.rst
 
+#. Upload the new Wazuh template to Elasticsearch. This step can be omited in Wazuh single-node installations:
+
+  .. code-block:: console
+
+    # filebeat setup --index-management -E output.logstash.enabled=false
+
 
 Upgrading Kibana
 ----------------

--- a/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-open-distro.rst
+++ b/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-open-distro.rst
@@ -265,6 +265,12 @@ Upgrading Filebeat
 
     .. include:: ../../_templates/installations/basic/elastic/common/enable_filebeat.rst
 
+#. Upload the new Wazuh template to Elasticsearch. This step can be omited in Wazuh single-node installations:
+
+  .. code-block:: console
+
+    # filebeat setup --index-management -E output.logstash.enabled=false    
+
 Upgrading Kibana
 ----------------
 

--- a/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-open-distro.rst
+++ b/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-open-distro.rst
@@ -265,7 +265,7 @@ Upgrading Filebeat
 
     .. include:: ../../_templates/installations/basic/elastic/common/enable_filebeat.rst
 
-#. Upload the new Wazuh template to Elasticsearch. This step can be omited in Wazuh single-node installations:
+#. Upload the new Wazuh template to Elasticsearch. This step can be omitted in Wazuh single-node installations:
 
   .. code-block:: console
 


### PR DESCRIPTION
Hello team!

This issue closes #3202 
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

I've done several upgrade tests, and in Filebeat multinode installation, the Wazuh template is not injected after Filebeat startup.

I've added the step needed to inject the template.

<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

Regards,

David