### PR TITLE
Fixed typo in the Command monitoring configuration section

### DIFF
--- a/source/user-manual/capabilities/command-monitoring/command-configuration.rst
+++ b/source/user-manual/capabilities/command-monitoring/command-configuration.rst
@@ -142,7 +142,7 @@ And the custom rule to alert when "uptime" is higher than two load averages:
   <rule id="100101" level="7" ignore="7200">
     <if_sid>530</if_sid>
     <match>ossec: output: 'uptime': </match>
-    <regex>load averages: 2.</regex>
+    <regex>load average: 2.</regex>
     <description>Load average reached 2..</description>
   </rule>
 


### PR DESCRIPTION


## Description

Fixed typo in the Command monitoring configuration section. 

From  `<regex>load averages: 2.</regex>` to  `<regex>load average: 2.</regex>`.   

This PR solves issue #2727. This typo was fixed in all branches from 2.1 to 4.0. 


## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).


