### PR TITLE
removed / before URL of debian offline update config

### DIFF
--- a/source/user-manual/capabilities/vulnerability-detection/offline_update.rst
+++ b/source/user-manual/capabilities/vulnerability-detection/offline_update.rst
@@ -125,7 +125,7 @@ In order to update the vulnerability feeds from an alternative repository, the c
 
     <provider name="debian">
         <enabled>yes</enabled>
-        <url>/http://local_repo/security_tracker_local.json</url>
+        <url>http://local_repo/security_tracker_local.json</url>
         <update_interval>1h</update_interval>
     </provider>
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description
I noticed there was an unnecessary `/` character for the configuration example in the offline update section of the vulnerability detector.


## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

