### PR TITLE
Changed core paths according to the new Wazuh naming standard

### DIFF
--- a/source/development/message-format.rst
+++ b/source/development/message-format.rst
@@ -48,7 +48,7 @@ The string in *log* is the input for decoders defined in XML format or plugin de
 Standard OSSEC event
 --------------------
 
-OSSEC events are transmitted between software components of the same machine, using the local datagram socket at ``/var/ossec/queue/ossec/queue``. For instance:
+OSSEC events are transmitted between software components of the same machine, using the local datagram socket at ``/var/ossec/queue/sockets/queue``. For instance:
 
 - Log events from *Logcollector* to *Agent daemon*.
 - File integrity monitoring events from *Syscheck* to *Agent daemon*.

--- a/source/learning-wazuh/survive-flood.rst
+++ b/source/learning-wazuh/survive-flood.rst
@@ -135,7 +135,7 @@ Generate a log flood on linux-agent
         #!/bin/bash
         for i in {1..10000}
         do
-          echo -n "1:floodtest:Feb  3 03:08:47 linux-agent centos: fatal firehose $i" | ncat -Uu /var/ossec/queue/ossec/queue
+          echo -n "1:floodtest:Feb  3 03:08:47 linux-agent centos: fatal firehose $i" | ncat -Uu /var/ossec/queue/sockets/queue
           echo -n "."
         done
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->
I have replaced `queue/ossec/` by `queue/sockets/`. There was not any reference to `logs/ossec/` (folder for the rotated logs).
This Pull Request closes #3233 

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
