### PR TITLE
try to fix the absence of tools.jar in Fedora if the java version in …

### DIFF
--- a/resources/open-distro/unattended-installation/all-in-one-installation.sh
+++ b/resources/open-distro/unattended-installation/all-in-one-installation.sh
@@ -83,6 +83,10 @@ installPrerequisites() {
     if [ ${sys_type} == "yum" ]; then
         eval "yum install curl unzip wget libcap -y -q ${debug}"
         eval "yum install java-11-openjdk-devel -y -q ${debug}"
+        jv_temp=$(java -version 2>&1 | grep -o -m1 '1.8.0' )
+        if [ "${jv_temp}" == "1.8.0" ]; then
+            eval "yum install java-openjdk-devel -y -q ${debug}"
+        fi
         if [ "$?" != 0 ]; then
             os=$(cat /etc/os-release > /dev/null 2>&1 | awk -F"ID=" '/ID=/{print $2; exit}' | tr -d \")
             if [ -z "${os}" ]; then


### PR DESCRIPTION
Hi,
I have tried to install on a Fedora 32 with java 8 installed before.
I have used all-in-one-installation.sh
The rpms related to java on my system before the installation was:

_[root@localhost ~]# rpm -qa | grep java
tzdata-java-2019c-3.fc32.noarch
javapackages-filesystem-5.3.0-9.fc32.noarch
**java-1.8.0-openjdk-headless-1.8.0.242.b08-1.fc32.x86_64**
abrt-java-connector-1.1.4-1.fc32.x86_64_

The installation failed in this way:

_[root@localhost ~]# curl -so ~/all-in-one-installation.sh https://raw.githubusercontent.com/wazuh/wazuh-documentation/4.0/resources/open-distro/unattended-installation/all-in-one-installation.sh && bash ~/all-in-one-installation.sh -i
Health-check ignored.
Installing all necessary utilities for the installation...
Done
Adding the Wazuh repository...
Done
Installing the Wazuh manager...
Done
Wazuh-manager started
Installing Open Distro for Elasticsearch...
Done
Configuring Elasticsearch...
Certificates created
**Elasticsearch could not be started.**_

Looking in the script, I have found that, in case of running with Java 1.8, the creation of the symbolic link is correct [line 239]. The original file, tools.jar, is present on the system only if the package java-openjdk-devel is installed.

I have fix my installation with this commit and I have retried on the previous snapshot of the VM:

_[root@localhost ~]# curl -so ~/all-in-one-installation.sh https://raw.githubusercontent.com/rossonet/wazuh-documentation/develop/resources/open-distro/unattended-installation/all-in-one-installation.sh && bash ~/all-in-one-installation.sh -i
Health-check ignored.
Installing all necessary utilities for the installation...
Done
Adding the Wazuh repository...
Done
Installing the Wazuh manager...
Done
Wazuh-manager started
Installing Open Distro for Elasticsearch...
Done
Configuring Elasticsearch...
Certificates created
Elasticsearch started
Initializing Elasticsearch...
Done
Installing Filebeat...
Filebeat started
Done
Installing Open Distro for Kibana...
Kibana started
Done
Checking the installation...
Elasticsearch installation succeeded.
Filebeat installation succeeded.
Initializing Kibana (this may take a while)
.............
Installation finished

You can access the web interface https://<kibana_ip>. The credentials are admin:admin_

Thanks

A.




