### PR TITLE
Added -icl option to OD commands

### DIFF
--- a/source/user-manual/elasticsearch/elastic_tuning.rst
+++ b/source/user-manual/elasticsearch/elastic_tuning.rst
@@ -29,7 +29,7 @@ In order to improve security, it is highly recommended to change Elasticsearch's
         .. code-block:: console
 
           # cd /usr/share/elasticsearch/plugins/opendistro_security/tools/
-          # ./securityadmin.sh -backup <backup-directory> -nhnv -cacert /etc/elasticsearch/certs/root-ca.pem -cert /etc/elasticsearch/certs/admin.pem -key /etc/elasticsearch/certs/admin.key -h <elasticsearch_ip>
+          # ./securityadmin.sh -backup <backup-directory> -nhnv -cacert /etc/elasticsearch/certs/root-ca.pem -cert /etc/elasticsearch/certs/admin.pem -key /etc/elasticsearch/certs/admin.key -icl -h <elasticsearch_ip>
 
     
     #. To generate a new password hash, Open Distro for Elasticsearch offers an utility called ``hash.sh`` located at ``/usr/share/elasticsearch/plugins/opendistro_security/tools``. Replace ``<new-password>`` with the chosen new password and generate a hash for it using the ``hash.sh`` utility:
@@ -57,7 +57,7 @@ In order to improve security, it is highly recommended to change Elasticsearch's
         .. code-block:: console
 
           # cd /usr/share/elasticsearch/plugins/opendistro_security/tools/
-          # ./securityadmin.sh -f <backup-directory>/internal_users.yml -t internalusers -nhnv -cacert /etc/elasticsearch/certs/root-ca.pem -cert /etc/elasticsearch/certs/admin.pem -key /etc/elasticsearch/certs/admin.key -h <elasticsearch_ip>
+          # ./securityadmin.sh -f <backup-directory>/internal_users.yml -t internalusers -nhnv -cacert /etc/elasticsearch/certs/root-ca.pem -cert /etc/elasticsearch/certs/admin.pem -key /etc/elasticsearch/certs/admin.key -icl -h <elasticsearch_ip>
 
     #. Remove files from your ``<backup-directory>``.
 


### PR DESCRIPTION
Hello team!

This PR closes #3241 
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

When the password is changed in a distributed environment using ODFE the cluster name must be given to run the `securityadmin` script.

I've added the `-icl` option, this way, the script will ignore the cluster name and it will not be needed to simplify the configuration of the command.
<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

Regards,

David