### PR TITLE
Removed decoders options duplicate list

### DIFF
--- a/source/user-manual/ruleset/ruleset-xml-syntax/decoders.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/decoders.rst
@@ -81,24 +81,6 @@ Before making a custom decoder, the first step should always be running the even
 Options
 -------
 
-There is many options to configure the decoders:
-
-- `decoder`_
-- `parent`_
-- `accumulate`_
-- `program_name`_
-- `prematch`_
-- `regex`_
-- `order`_
-- `fts`_
-- `ftscomment`_
-- `plugin_decoder`_
-- `use_own_name`_
-- `json_null_field`_
-- `json_array_structure`_
-- `var`_
-- `type`_
-
 decoder
 ^^^^^^^
 


### PR DESCRIPTION


## Description

Removed decoders options duplicate list. Thanks @mikykeane for reporting! 

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).


