### PR TITLE
Add remote commands option for api.yaml

### DIFF
--- a/source/user-manual/api/configuration.rst
+++ b/source/user-manual/api/configuration.rst
@@ -54,6 +54,15 @@ Here are all the available settings for the ``api.yaml`` configuration file. For
         block_time: 300
         max_request_per_minute: 300
 
+     remote_commands:
+        localfile:
+           enabled: yes
+           exceptions: []
+
+       wodle_command:
+          enabled: yes
+          exceptions: []
+
 .. warning::
 
     If running a cluster, the master will NOT send its local Wazuh API configuration file to the workers. Each node provides its own Wazuh API. If the configuration file is changed in the master node, the user should manually update the workers Wazuh API configuration in order to use the same one. Take care of not overwriting the IP and port in the local configuration of each worker. The Wazuh API endpoint :api-ref:`PUT /cluster/api/config <operation/api.controllers.cluster_controller.put_api_config>` can be used to change any or all of the Wazuh API configuration files in the cluster nodes.
@@ -71,6 +80,27 @@ Make sure to restart the Wazuh API using **wazuh-manager** service after editing
   .. code-block:: console
 
     # service wazuh-manager restart
+
+
+Remote commands configuration
+------------------------------
+Allow or deny the execution of remote commands through the API. When this option is disabled it is not possible to upload **ossec.conf** files with the <command> option inside the :ref:`localfile tag <reference_ossec_localfile>` as well as the :ref:`wodle "command" option <wodle_command>`.
+It is possible to add a list of exceptions in order to upload those commands through the API.
+
+.. code-block:: yaml
+
+    remote_commands:
+        localfile:
+           enabled: yes
+           exceptions: []
+
+        wodle_command:
+           enabled: yes
+           exceptions: []
+
+.. warning::
+    These settings cannot be reset to factory status via the endpoint :api-ref:`PUT /manager/api/config <operation/api.controllers.manager_controller.put_api_config>` or :api-ref:`PUT /cluster/api/config <operation/api.controllers.cluster_controller.put_api_config>`. These will keep its value before the reset.
+
 
 Security configuration
 ----------------------
@@ -262,6 +292,16 @@ access
 +------------------------+----------------------+---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | max_request_per_minute | Any positive integer | 300           | Establish a maximum number of requests the Wazuh API can handle per minute (does not include authentication requests). If the number of requests for a given minute is exceeded, all incoming requests (from any user) will be blocked for the remaining of the minute. |
 +------------------------+----------------------+---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+remote_commands (localfile and wodle "command")
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
++------------+----------------------+---------------+---------------------------------------------------------------+
+| Sub-fields | Allowed values       | Default value | Description                                                   |
++============+======================+===============+===============================================================+
+| enabled    | yes, true, no, false | true          | Enable or disable upload remote commands through the API      |
++------------+----------------------+---------------+---------------------------------------------------------------+
+| exceptions | command list         | None          | Set a list of commands allowed to be uploaded through the API |
++------------+----------------------+---------------+---------------------------------------------------------------+
 
 .. _api_security_configuration_options:
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

Hi team,

This PR is part of https://github.com/wazuh/wazuh/pull/6956. In this PR we have added the necessary documentation to make use of the new function "**remote_commands**" of the **api.yaml** file. This option allows or denies the upload of files with remote commands inside.


## Checks
- [ ] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

