### PR TITLE
Documentation update after ossec-init.conf removal

### DIFF
--- a/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-agent/index.rst
+++ b/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-agent/index.rst
@@ -86,7 +86,7 @@ Installing Wazuh agent from sources
 
        <h2>Uninstall</h2>
 
-    To uninstall Wazuh agent, set the right installation path for ``WAZUH_HOME``:
+    To uninstall Wazuh agent, set WAZUH_HOME with the current installation path:
 
     .. code-block:: console
 
@@ -104,7 +104,7 @@ Installing Wazuh agent from sources
 
      # $WAZUH_HOME/bin/wazuh-control stop 2> /dev/null
 
-    Remove installation folder:
+    Remove the installation folder and all its content:
 
     .. code-block:: console
 
@@ -264,7 +264,7 @@ Installing Wazuh agent from sources
 
         <h2>Uninstall</h2>
 
-    To uninstall Wazuh agent, set the right installation path for ``WAZUH_HOME``:
+    To uninstall Wazuh agent, set WAZUH_HOME with the current installation path:
 
     .. code-block:: console
 
@@ -282,7 +282,7 @@ Installing Wazuh agent from sources
 
      # $WAZUH_HOME/bin/wazuh-control stop 2> /dev/null
 
-    Remove installation folder:
+    Remove the installation folder and all its content:
 
     .. code-block:: console
 
@@ -382,7 +382,7 @@ Installing Wazuh agent from sources
 
         <h2>Uninstall</h2>
 
-    To uninstall Wazuh agent, set the right installation path for ``WAZUH_HOME``:
+    To uninstall Wazuh agent, set WAZUH_HOME with the current installation path:
 
     .. code-block:: console
 
@@ -400,7 +400,7 @@ Installing Wazuh agent from sources
 
      # $WAZUH_HOME/bin/wazuh-control stop 2> /dev/null
 
-    Remove installation folder:
+    Remove the installation folder and all its content:
 
     .. code-block:: console
 
@@ -503,7 +503,7 @@ Installing Wazuh agent from sources
 
        <h2>Uninstall</h2>
 
-    To uninstall Wazuh agent, set the right installation path for ``WAZUH_HOME``:
+    To uninstall Wazuh agent, set WAZUH_HOME with the current installation path:
 
     .. code-block:: console
 
@@ -521,7 +521,7 @@ Installing Wazuh agent from sources
 
      # $WAZUH_HOME/bin/wazuh-control stop 2> /dev/null
 
-    Remove installation folder:
+    Remove the installation folder and all its content:
 
     .. code-block:: console
 
@@ -620,7 +620,7 @@ Installing Wazuh agent from sources
 
            <h2>Uninstall</h2>
 
-        To uninstall Wazuh agent, set the right installation path for ``WAZUH_HOME``:
+        To uninstall Wazuh agent, set WAZUH_HOME with the current installation path:
 
         .. code-block:: console
 
@@ -638,7 +638,7 @@ Installing Wazuh agent from sources
 
          # $WAZUH_HOME/bin/wazuh-control stop 2> /dev/null
 
-        Remove installation folder:
+        Remove the installation folder and all its content:
 
         .. code-block:: console
 
@@ -755,7 +755,7 @@ Installing Wazuh agent from sources
 
            <h2>Uninstall</h2>
 
-        To uninstall Wazuh agent, set the right installation path for ``WAZUH_HOME``:
+        To uninstall Wazuh agent, set WAZUH_HOME with the current installation path:
 
         .. code-block:: console
 
@@ -773,7 +773,7 @@ Installing Wazuh agent from sources
 
          # $WAZUH_HOME/bin/wazuh-control stop 2> /dev/null
 
-        Remove installation folder:
+        Remove the installation folder and all its content:
 
         .. code-block:: console
 

--- a/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-agent/index.rst
+++ b/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-agent/index.rst
@@ -15,10 +15,10 @@ Installing Wazuh agent from sources
     .. note:: All the commands described below need to be executed with root user privileges. Since Wazuh 3.5 it is necessary to have internet connection when following this process.
 
     1. Install development tools and compilers. In Linux this can easily be done using your distribution's package manager:
-       
+
      .. tabs::
 
-      .. tab:: Yum   
+      .. tab:: Yum
 
         .. code-block:: console
 
@@ -39,15 +39,15 @@ Installing Wazuh agent from sources
         .. code-block:: console
 
          # zypper install make gcc policycoreutils-python automake autoconf libtool
-        
+
         .. note:: For Suse 11, it is possible that some of the tools are not found in the package manager, in that case you can add the following official repository:
 
         .. code-block:: console
 
-         # zypper addrepo http://download.opensuse.org/distribution/11.4/repo/oss/ oss 
+         # zypper addrepo http://download.opensuse.org/distribution/11.4/repo/oss/ oss
 
- 
-      
+
+
 
     2. Download and extract the latest version:
 
@@ -85,13 +85,12 @@ Installing Wazuh agent from sources
     .. raw:: html
 
        <h2>Uninstall</h2>
-    
-    To uninstall Wazuh agent:
+
+    To uninstall Wazuh agent, set the right installation path for ``WAZUH_HOME``:
 
     .. code-block:: console
 
-      # OSSEC_INIT="/etc/ossec-init.conf"
-      # . $OSSEC_INIT 2> /dev/null
+      # WAZUH_HOME="/WAZUH/INSTALLATION/PATH"
 
     Stop the service:
 
@@ -103,13 +102,13 @@ Installing Wazuh agent from sources
 
     .. code-block:: console
 
-     # $DIRECTORY/bin/wazuh-control stop 2> /dev/null
+     # $WAZUH_HOME/bin/wazuh-control stop 2> /dev/null
 
-    Remove files and service artifacts:
+    Remove installation folder:
 
     .. code-block:: console
 
-     # rm -rf $DIRECTORY $OSSEC_INIT
+     # rm -rf $WAZUH_HOME
 
     Delete the service:
 
@@ -135,13 +134,13 @@ Installing Wazuh agent from sources
      # userdel ossecm 2> /dev/null
      # userdel ossecr 2> /dev/null
      # groupdel ossec 2> /dev/null
- 
-      
-  
+
+
+
   .. group-tab:: Windows
 
     .. note:: The following procedure has been tested on Ubuntu 16.04 and other Debian based distributions and may work with other Debian/Ubuntu versions as well.
- 
+
     1. Set up the Ubuntu build environment. Install these dependencies to build the Windows Wazuh agent installer on Ubuntu:
 
      .. code-block:: console
@@ -204,8 +203,8 @@ Installing Wazuh agent from sources
         <h2>Uninstall</h2>
 
     To uninstall the agent, the original MSI file will be needed to perform the unattended process:
-    
-    .. code-block:: console 
+
+    .. code-block:: console
 
       msiexec.exe /x wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_WINDOWS|.msi /qn
 
@@ -265,12 +264,11 @@ Installing Wazuh agent from sources
 
         <h2>Uninstall</h2>
 
-    To uninstall Wazuh agent:
+    To uninstall Wazuh agent, set the right installation path for ``WAZUH_HOME``:
 
     .. code-block:: console
 
-      # OSSEC_INIT="/etc/ossec-init.conf"
-      # . $OSSEC_INIT 2> /dev/null
+      # WAZUH_HOME="/WAZUH/INSTALLATION/PATH"
 
     Stop the service:
 
@@ -282,13 +280,13 @@ Installing Wazuh agent from sources
 
     .. code-block:: console
 
-     # $DIRECTORY/bin/wazuh-control stop 2> /dev/null
+     # $WAZUH_HOME/bin/wazuh-control stop 2> /dev/null
 
-    Remove files and service artifacts:
+    Remove installation folder:
 
     .. code-block:: console
 
-     # rm -rf $DIRECTORY $OSSEC_INIT
+     # rm -rf $WAZUH_HOME
 
     Delete the service:
 
@@ -304,7 +302,7 @@ Installing Wazuh agent from sources
      # dscl . -delete "/Users/ossecm" > /dev/null 2>&1
      # dscl . -delete "/Users/ossecr" > /dev/null 2>&1
      # dscl . -delete "/Groups/ossec" > /dev/null 2>&1
-    
+
 
 
 
@@ -384,12 +382,11 @@ Installing Wazuh agent from sources
 
         <h2>Uninstall</h2>
 
-    To uninstall Wazuh agent:
+    To uninstall Wazuh agent, set the right installation path for ``WAZUH_HOME``:
 
     .. code-block:: console
 
-      # OSSEC_INIT="/etc/ossec-init.conf"
-      # . $OSSEC_INIT 2> /dev/null
+      # WAZUH_HOME="/WAZUH/INSTALLATION/PATH"
 
     Stop the service:
 
@@ -401,13 +398,13 @@ Installing Wazuh agent from sources
 
     .. code-block:: console
 
-     # $DIRECTORY/bin/wazuh-control stop 2> /dev/null
+     # $WAZUH_HOME/bin/wazuh-control stop 2> /dev/null
 
-    Remove files and service artifacts:
+    Remove installation folder:
 
     .. code-block:: console
 
-     # rm -rf $DIRECTORY $OSSEC_INIT
+     # rm -rf $WAZUH_HOME
 
     Delete the service:
 
@@ -431,7 +428,7 @@ Installing Wazuh agent from sources
     .. note:: All the commands described below need to be executed with root user privileges. Since Wazuh 3.5 it is necessary to have internet connection when following this process.
 
     1. Install development tools and compilers.
-   
+
      1.1 Download the ``depothelper-2.10-hppa_32-11.31.depot`` file.
 
       .. code-block:: console
@@ -504,14 +501,13 @@ Installing Wazuh agent from sources
 
     .. raw:: html
 
-       <h2>Uninstall</h2> 
+       <h2>Uninstall</h2>
 
-    To uninstall Wazuh agent:
+    To uninstall Wazuh agent, set the right installation path for ``WAZUH_HOME``:
 
     .. code-block:: console
 
-      # OSSEC_INIT="/etc/ossec-init.conf"
-      # . $OSSEC_INIT 2> /dev/null
+      # WAZUH_HOME="/WAZUH/INSTALLATION/PATH"
 
     Stop the service:
 
@@ -523,13 +519,13 @@ Installing Wazuh agent from sources
 
     .. code-block:: console
 
-     # $DIRECTORY/bin/wazuh-control stop 2> /dev/null
+     # $WAZUH_HOME/bin/wazuh-control stop 2> /dev/null
 
-    Remove files and service artifacts:
+    Remove installation folder:
 
     .. code-block:: console
 
-     # rm -rf $DIRECTORY $OSSEC_INIT
+     # rm -rf $WAZUH_HOME
 
     Delete the service:
 
@@ -558,8 +554,8 @@ Installing Wazuh agent from sources
     .. tabs::
 
       .. tab:: Solaris 11
-        
-       
+
+
         .. note:: All the commands described below need to be executed with root user privileges. Since Wazuh 3.5 it is necessary to have internet connection when following this process.
 
         1. Install development tools and compilers.
@@ -591,7 +587,7 @@ Installing Wazuh agent from sources
           # git clone -b v|WAZUH_LATEST| https://github.com/wazuh/wazuh.git
 
          .. note:: If you can't download the file due to an Open SSL error, then you should copy the directory with the scp utility.
- 
+
         3. Run the ``install.sh`` script. This will run a wizard that will guide you through the installation process using the Wazuh sources:
 
          .. code-block:: console
@@ -619,17 +615,16 @@ Installing Wazuh agent from sources
 
         Now that the agent is installed, the next step is to register and configure it to communicate with the manager. For more information about this process, please visit the document: :ref:`user manual<register_agents>`.
 
- 
+
         .. raw:: html
 
-           <h2>Uninstall</h2> 
-        
-        To uninstall Wazuh agent:
+           <h2>Uninstall</h2>
+
+        To uninstall Wazuh agent, set the right installation path for ``WAZUH_HOME``:
 
         .. code-block:: console
 
-         # OSSEC_INIT="/etc/ossec-init.conf"
-         # . $OSSEC_INIT 2> /dev/null
+         # WAZUH_HOME="/WAZUH/INSTALLATION/PATH"
 
         Stop the service:
 
@@ -641,13 +636,13 @@ Installing Wazuh agent from sources
 
         .. code-block:: console
 
-         # $DIRECTORY/bin/wazuh-control stop 2> /dev/null
+         # $WAZUH_HOME/bin/wazuh-control stop 2> /dev/null
 
-        Remove files and service artifacts:
+        Remove installation folder:
 
         .. code-block:: console
 
-         # rm -rf $DIRECTORY $OSSEC_INIT
+         # rm -rf $WAZUH_HOME
 
         Delete the service:
 
@@ -666,7 +661,7 @@ Installing Wazuh agent from sources
 
 
       .. tab:: Solaris 10
-          
+
         .. note:: All the commands described below need to be executed with root user privileges. Since Wazuh 3.5 it is necessary to have internet connection when following this process.
 
         1. Install development tools and compilers.
@@ -758,14 +753,13 @@ Installing Wazuh agent from sources
 
         .. raw:: html
 
-           <h2>Uninstall</h2> 
-        
-        To uninstall Wazuh agent:
+           <h2>Uninstall</h2>
+
+        To uninstall Wazuh agent, set the right installation path for ``WAZUH_HOME``:
 
         .. code-block:: console
 
-         # OSSEC_INIT="/etc/ossec-init.conf"
-         # . $OSSEC_INIT 2> /dev/null
+         # WAZUH_HOME="/WAZUH/INSTALLATION/PATH"
 
         Stop the service:
 
@@ -777,13 +771,13 @@ Installing Wazuh agent from sources
 
         .. code-block:: console
 
-         # $DIRECTORY/bin/wazuh-control stop 2> /dev/null
+         # $WAZUH_HOME/bin/wazuh-control stop 2> /dev/null
 
-        Remove files and service artifacts:
+        Remove installation folder:
 
         .. code-block:: console
 
-         # rm -rf $DIRECTORY $OSSEC_INIT
+         # rm -rf $WAZUH_HOME
 
         Delete the service:
 
@@ -798,7 +792,4 @@ Installing Wazuh agent from sources
          # userdel ossec 2> /dev/null
          # userdel ossecm 2> /dev/null
          # userdel ossecr 2> /dev/null
-         # groupdel ossec 2> /dev/null  
-
-  
-
+         # groupdel ossec 2> /dev/null

--- a/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-server/index.rst
+++ b/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-server/index.rst
@@ -141,7 +141,7 @@ Filebeat is a data shipping tool that is installed on the Wazuh server to secure
 Uninstall
 ~~~~~~~~~
 
-To uninstall Wazuh manager, set the right installation path for ``WAZUH_HOME``:
+To uninstall Wazuh manager, set WAZUH_HOME with the current installation path:
 
     .. code-block:: console
 
@@ -159,7 +159,7 @@ Stop the daemon:
 
     # $WAZUH_HOME/bin/wazuh-control stop 2> /dev/null
 
-Remove installation folder:
+Remove the installation folder and all its content:
 
   .. code-block:: console
 

--- a/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-server/index.rst
+++ b/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-server/index.rst
@@ -21,7 +21,7 @@ Installing Wazuh manager
     .. code-block:: console
 
         # yum install make gcc policycoreutils-python automake autoconf libtool
-  
+
   .. group-tab:: APT
 
 
@@ -141,12 +141,11 @@ Filebeat is a data shipping tool that is installed on the Wazuh server to secure
 Uninstall
 ~~~~~~~~~
 
-To uninstall Wazuh manager:
+To uninstall Wazuh manager, set the right installation path for ``WAZUH_HOME``:
 
     .. code-block:: console
 
-      # OSSEC_INIT="/etc/ossec-init.conf"
-      # . $OSSEC_INIT 2> /dev/null
+      # WAZUH_HOME="/WAZUH/INSTALLATION/PATH"
 
 Stop the service:
 
@@ -158,13 +157,13 @@ Stop the daemon:
 
   .. code-block:: console
 
-    # $DIRECTORY/bin/wazuh-control stop 2> /dev/null
+    # $WAZUH_HOME/bin/wazuh-control stop 2> /dev/null
 
-Remove files and service artifacts:
+Remove installation folder:
 
   .. code-block:: console
 
-    # rm -rf $DIRECTORY $OSSEC_INIT
+    # rm -rf $WAZUH_HOME
 
 Delete the service:
 

--- a/source/installation-guide/wazuh-agent/wazuh_agent_package_macos.rst
+++ b/source/installation-guide/wazuh-agent/wazuh_agent_package_macos.rst
@@ -57,12 +57,11 @@ To uninstall the agent in macOS:
 
       # /Library/Ossec/bin/wazuh-control stop
 
-#. Remove the ``/Library/Ossec/`` folder and ``ossec-init.conf`` file
+#. Remove the ``/Library/Ossec/`` folder
 
     .. code-block:: console
 
       # /bin/rm -r /Library/Ossec
-      # /bin/rm /etc/ossec-init.conf
 
 #. Stop and unload dispatcher
 
@@ -89,9 +88,3 @@ To uninstall the agent in macOS:
     .. code-block:: console
 
       # /usr/sbin/pkgutil --forget com.wazuh.pkg.wazuh-agent
-
-
-
-
-
-

--- a/source/user-manual/capabilities/file-integrity/fim-configuration.rst
+++ b/source/user-manual/capabilities/file-integrity/fim-configuration.rst
@@ -41,30 +41,6 @@ By default, syscheck scans selected directories, whose list depends on the :ref:
     <directories check_all="yes">/root/users.txt,/bsd,/root/db.html</directories>
   </syscheck>
 
-.. versionadded:: 4.0
-
-Environment variables can be used to configure syscheck in Linux and Windows.
-
-.. code-block:: xml
-
-  <syscheck>
-    <directories check_all="yes">$DIRECTORY</directories>
-  </syscheck>
-
-On UNIX based systems, the variable must be owned by the root user. Use the ``wazuh-control`` binary to restart Wazuh instead of systemd.
-You can specify multiple paths in a variable by separating them using ``:``.
-
-.. code-block:: xml
-
-  <syscheck>
-    <directories check_all="yes">%CommonProgramFiles%</directories>
-  </syscheck>
-
-On Windows, only system environment variables can be used. You can add multiple directories to the same variable by separating them using ``;``
-
-.. note::
-  Wazuh runs as a 32 bit application, so the previous environment variable will be replaced by ``C:\Program Files (x86)\Common Files``. In order to specifically monitor ``C:\Program Files\Common Files``, the associate environment variable is: ``%CommonProgramW6432%``.
-
 Configuring scheduled scans
 ---------------------------
 

--- a/source/user-manual/capabilities/file-integrity/fim-configuration.rst
+++ b/source/user-manual/capabilities/file-integrity/fim-configuration.rst
@@ -51,7 +51,7 @@ Environment variables can be used to configure syscheck in Linux and Windows.
     <directories check_all="yes">$DIRECTORY</directories>
   </syscheck>
 
-On UNIX based systems, the variable must be added to the file ``/etc/ossec-init.conf`` if Wazuh is restarted using systemd. On the other hand, if Wazuh is restarted using the ``wazuh-control`` binary, the variable must be owned by the root user.
+On UNIX based systems, the variable must be owned by the root user. Use the ``wazuh-control`` binary to restart Wazuh instead of systemd.
 You can specify multiple paths in a variable by separating them using ``:``.
 
 .. code-block:: xml

--- a/source/user-manual/reference/tools/wazuh-control.rst
+++ b/source/user-manual/reference/tools/wazuh-control.rst
@@ -12,6 +12,8 @@ The wazuh-control script is used to start, stop, configure, check on the status 
 .. note::
     We recommend to use the ``systemctl`` or ``service`` commands (depending on your OS) to **start**, **stop** or **restart** the Wazuh service. This will avoid inconsistencies between the *service* status and the *processes* status.
 
+The ``-j`` option is used for enabling JSON output format, but only in Wazuh server installations.
+
 +-------------+---------------------------------------------------------------------------------------------------------+
 | **start**   | Start the Wazuh processes.                                                                              |
 +-------------+---------------------------------------------------------------------------------------------------------+
@@ -26,6 +28,10 @@ The wazuh-control script is used to start, stop, configure, check on the status 
 |             | This option is not available on a local Wazuh installation.                                             |
 +-------------+---------------------------------------------------------------------------------------------------------+
 | **status**  | Determine which Wazuh processes are running.                                                            |
++-------------+---------------------------------------------------------------------------------------------------------+
+| **info**    | Prints the installation type, beside the Wazuh Version and Revision, in NAME="value" pairs              |
++-------------+-----------------+---------------+-----------------------------------------------------------------------+
+| **info**    |    [-v -r -t]   | Only one option at the time, prints only the value of: Version, Revision or Type      |
 +-------------+-----------------+---------------+-----------------------------------------------------------------------+
 | **enable**  |  debug          | Run all Wazuh daemons in debug mode.                                                  |
 +-------------+-----------------+---------------+-----------------------------------------------------------------------+

--- a/source/user-manual/reference/tools/wazuh-control.rst
+++ b/source/user-manual/reference/tools/wazuh-control.rst
@@ -29,9 +29,9 @@ The ``-j`` option is used for enabling JSON output format, but only in Wazuh ser
 +-------------+---------------------------------------------------------------------------------------------------------+
 | **status**  | Determine which Wazuh processes are running.                                                            |
 +-------------+---------------------------------------------------------------------------------------------------------+
-| **info**    | Prints the installation type, beside the Wazuh Version and Revision, in NAME="value" pairs              |
+| **info**    | Prints Wazuh installation type, version, and revision in environment variables format.                  |
 +-------------+-----------------+---------------+-----------------------------------------------------------------------+
-| **info**    |    [-v -r -t]   | Only one option at the time, prints only the value of: Version, Revision or Type      |
+| **info**    |    [-v -r -t]   | Only one option at the time, prints only the value of: version, revision or type.     |
 +-------------+-----------------+---------------+-----------------------------------------------------------------------+
 | **enable**  |  debug          | Run all Wazuh daemons in debug mode.                                                  |
 +-------------+-----------------+---------------+-----------------------------------------------------------------------+

--- a/source/user-manual/reference/tools/wazuh-control.rst
+++ b/source/user-manual/reference/tools/wazuh-control.rst
@@ -29,9 +29,9 @@ The ``-j`` option is used for enabling JSON output format, but only in Wazuh ser
 +-------------+---------------------------------------------------------------------------------------------------------+
 | **status**  | Determine which Wazuh processes are running.                                                            |
 +-------------+---------------------------------------------------------------------------------------------------------+
-| **info**    | Prints Wazuh installation type, version, and revision in environment variables format.                  |
+| **info**    | Prints the Wazuh installation type, version, and revision in environment variables format.              |
 +-------------+-----------------+---------------+-----------------------------------------------------------------------+
-| **info**    |    [-v -r -t]   | Only one option at the time, prints only the value of: version, revision or type.     |
+| **info**    |    [-v -r -t]   | Only one option at the time, prints the value of: version, revision or type.          |
 +-------------+-----------------+---------------+-----------------------------------------------------------------------+
 | **enable**  |  debug          | Run all Wazuh daemons in debug mode.                                                  |
 +-------------+-----------------+---------------+-----------------------------------------------------------------------+


### PR DESCRIPTION
## Description

This PR removes the references to the `ossec-init.conf` file, but leaves those in the _migrating from OSSEC_ section because the file is present in old installations.

Also, the documentation of `wazuh-control` tool is updated with the new options available.

Closes #3268.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

