### PR TITLE
Fix incorrect default value of ossec_syscheck_directories_2 in documentation

### DIFF
--- a/source/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-agent-class.rst
+++ b/source/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-agent-class.rst
@@ -449,7 +449,7 @@ $ossec_syscheck_report_changes_directories_1
 $ossec_syscheck_directories_2
   List of directories to be monitored. The directories should be comma-separated
 
-  `Default '/etc,/usr/bin,/usr/sbin'`
+  `Default '/bin,/sbin,/boot'`
 
 $ossec_syscheck_realtime_directories_2
   This will enable real-time/continuous monitoring on directories listed on `ossec_syscheck_directories_2`. Real time only works with directories, not individual files.


### PR DESCRIPTION
Seeing both ossec_syscheck_directories_1 and ossec_syscheck_directories_2 with the same value in documentation is very confusing.
You can check true default value on https://github.com/wazuh/wazuh-puppet/blob/51fe0e9f99b2c56bc49d936ebfdb884f5bbcbe6a/manifests/params_agent.pp#L221

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

## Checks
- [ ] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

## Note to the reviewer

This PR includes changes to the `redirect.js` script that need to be included in all production branches.
