### PR TITLE
Update Puppet and Ansible. Remove old references

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -414,9 +414,9 @@ def customReplacements(app, docname, source):
 custom_replacements = {
     "|CURRENT_MAJOR|" : "4.x",
     "|WAZUH_LATEST|" : "4.0.4",
-    "|WAZUH_LATEST_ANSIBLE|" : "4.0.0",
+    "|WAZUH_LATEST_ANSIBLE|" : "4.0.4",
     "|WAZUH_LATEST_KUBERNETES|" : "4.0.4",
-    "|WAZUH_LATEST_PUPPET|" : "4.0.0",
+    "|WAZUH_LATEST_PUPPET|" : "4.0.4",
     "|WAZUH_LATEST_OVA|" : "4.0.4",
     "|WAZUH_LATEST_DOCKER|" : "4.0.4",
     "|OPEN_DISTRO_LATEST|" : "1.11.0",

--- a/source/deploying-with-ansible/guide/install-ansible.rst
+++ b/source/deploying-with-ansible/guide/install-ansible.rst
@@ -374,7 +374,7 @@ From Ansible server.
 .. code-block:: console
 
 	ansible@ansible:~$ cd /etc/ansible/roles/
-	ansible@ansible:/etc/ansible/roles$ sudo git clone --branch v|WAZUH_LATEST_ANSIBLE|_|ELASTICSEARCH_LATEST_ANSIBLE| https://github.com/wazuh/wazuh-ansible.git
+	ansible@ansible:/etc/ansible/roles$ sudo git clone --branch v|WAZUH_LATEST_ANSIBLE| https://github.com/wazuh/wazuh-ansible.git
 	ansible@ansible:/etc/ansible/roles$ ls
 
 .. code-block:: none

--- a/source/deploying-with-ansible/guide/install-wazuh-manager.rst
+++ b/source/deploying-with-ansible/guide/install-wazuh-manager.rst
@@ -232,19 +232,6 @@ We can check the status of our new services in our Wazuh server.
 	   Loaded: loaded (/etc/systemd/system/wazuh-manager.service; enabled; vendor preset: disabled)
 	   Active: active (running) since jue 2018-09-13 12:36:52 CEST; 35min ago
 
-- Wazuh API.
-
-.. code-block:: console
-
-	[root@localhost centos]# systemctl status wazuh-api
-
-.. code-block:: none
-	:class: output
-
-	● wazuh-api.service - Wazuh API daemon
-	   Loaded: loaded (/etc/systemd/system/wazuh-api.service; enabled; vendor preset: disabled)
-	   Active: active (running) since jue 2018-09-13 12:36:54 CEST; 36min ago
-
 - Filebeat.
 
 .. code-block:: none

--- a/source/deploying-with-ansible/roles/index.rst
+++ b/source/deploying-with-ansible/roles/index.rst
@@ -5,12 +5,12 @@
 Roles
 ======
 
-You can use these roles to deploy Elastic Stack components, Wazuh API, Wazuh Manager and Wazuh Agents, first clone our `GitHub repository <https://github.com/wazuh/wazuh-ansible>`_ directly to your Ansible roles folder:
+You can use these roles to deploy Elastic Stack components, Wazuh Manager and Wazuh Agents, first clone our `GitHub repository <https://github.com/wazuh/wazuh-ansible>`_ directly to your Ansible roles folder:
 
   .. code-block:: yaml
 
     $ cd /etc/ansible/roles
-    $ git clone https://github.com/wazuh/wazuh-ansible.git .
+    $ git clone --branch v|WAZUH_LATEST_ANSIBLE| https://github.com/wazuh/wazuh-ansible.git
 
 Below we explain briefly how to use these roles, please check out `Ansible Playbooks <http://docs.ansible.com/ansible/playbooks.html>`_ for more information.
 

--- a/source/deploying-with-puppet/wazuh-puppet-module/index.rst
+++ b/source/deploying-with-puppet/wazuh-puppet-module/index.rst
@@ -24,14 +24,14 @@ Download and install the Wazuh module from Puppet Forge:
     Notice: Installing -- do not interrupt ...
     /etc/puppet/modules
     └─┬ wazuh-wazuh (v|WAZUH_LATEST_PUPPET|)
-      ├── puppet-nodejs (v7.0.0)
-      ├── puppet-selinux (v1.6.1)
-      ├── puppetlabs-apt (v6.3.0)
-      ├─┬ puppetlabs-concat (v5.3.0)
-      │ └── puppetlabs-translate (v1.2.0)
-      ├── puppetlabs-firewall (v1.15.1)
-      ├── puppetlabs-stdlib (v5.2.0)
-      └── stahnma-epel (v1.3.1)
+      ├── puppet-nodejs (v7.0.1)
+      ├── puppet-selinux (v3.2.0)
+      ├── puppetlabs-apt (v7.7.0)
+      ├── puppetlabs-concat (v6.3.0)
+      ├── puppetlabs-firewall (v2.7.0)
+      ├── puppetlabs-powershell (v2.3.0)
+      └── puppetlabs-stdlib (v6.5.0)
+
 
 This module installs and configures Wazuh agent and manager.
 


### PR DESCRIPTION
Hi team,

This PR bumps Ansible and Puppet versions and adds a specific release selector on the Ansible and Puppet clone command.
This PR removes opendistro version for Ansible and Puppet Clone commands.
This PR removes references to old `wazuh-api` service.



_-JP_