### PR TITLE
Fixed broken code block in the Audit configuration section

### DIFF
--- a/source/user-manual/capabilities/system-calls-monitoring/audit-configuration.rst
+++ b/source/user-manual/capabilities/system-calls-monitoring/audit-configuration.rst
@@ -78,12 +78,13 @@ Editing ossec.conf
 ~~~~~~~~~~~~~~~~~~
 Wazuh must be aware of the events detected by Audit. So, it is needs to be configured to read the audit log file:
 
-.. code-block: xml
+.. code-block:: xml
 
     <localfile>
       <log_format>audit</log_format>
       <location>/var/log/audit/audit.log</location>
     </localfile>
+
 
 Restarting Wazuh
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Description

By fixing the broken code block the missing information in the Audit configuration section is restored. This PR solves issue #3311. 

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).


