### PR TITLE
[4.1] Changed the style of the carousel in the index page

### DIFF
--- a/source/_static/css/style.css
+++ b/source/_static/css/style.css
@@ -556,36 +556,42 @@ header .menuweb-bar .menu-item a {
 
 #capabilities .right .screenshots .carousel-control-prev {
   position: absolute !important;
-  background-image: -webkit-gradient(linear,0 top,100% top,from(rgba(0,0,0,0.15)),to(rgba(0,0,0,0.0001)));
-  background-image: -webkit-linear-gradient(left,color-stop(rgba(0,0,0,0.15) 0),color-stop(rgba(0,0,0,0.0001) 100%));
-  background-image: -moz-linear-gradient(left,rgba(0,0,0,0.15) 0,rgba(0,0,0,0.0001) 100%);
-  background-image: linear-gradient(to right,rgba(0,0,0,0.15) 0,rgba(0,0,0,0.0001) 100%);
-  background-repeat: repeat-x;
+  background-image: none;
 }
 
 #capabilities .right .screenshots .carousel-control-prev:hover {
-  background-image: -webkit-gradient(linear,0 top,100% top,from(rgba(0,0,0,0.2)),to(rgba(0,0,0,0.0001)));
-  background-image: -webkit-linear-gradient(left,color-stop(rgba(0,0,0,0.2) 0),color-stop(rgba(0,0,0,0.0001) 100%));
-  background-image: -moz-linear-gradient(left,rgba(0,0,0,0.2) 0,rgba(0,0,0,0.0001) 100%);
-  background-image: linear-gradient(to right,rgba(0,0,0,0.2) 0,rgba(0,0,0,0.0001) 100%);
-  background-repeat: repeat-x;
+  background-image: none;
 }
 
 #capabilities .right .screenshots .carousel-control-next {
   position: absolute !important;
-  background-image: -webkit-gradient(linear,0 top,100% top,from(rgba(0,0,0,0.0001)),to(rgba(0,0,0,0.15)));
-  background-image: -webkit-linear-gradient(left,color-stop(rgba(0,0,0,0.0001) 0),color-stop(rgba(0,0,0,0.15) 100%));
-  background-image: -moz-linear-gradient(left,rgba(0,0,0,0.0001) 0,rgba(0,0,0,0.15) 100%);
-  background-image: linear-gradient(to right,rgba(0,0,0,0.0001) 0,rgba(0,0,0,0.15) 100%);
-  background-repeat: repeat-x;
+  background-image: none;
 }
 
-#capabilities .right .screenshots .carousel-control-next:hover {
-  background-image: -webkit-gradient(linear,0 top,100% top,from(rgba(0,0,0,0.0001)),to(rgba(0,0,0,0.2)));
-  background-image: -webkit-linear-gradient(left,color-stop(rgba(0,0,0,0.0001) 0),color-stop(rgba(0,0,0,0.2) 100%));
-  background-image: -moz-linear-gradient(left,rgba(0,0,0,0.0001) 0,rgba(0,0,0,0.2) 100%);
-  background-image: linear-gradient(to right,rgba(0,0,0,0.0001) 0,rgba(0,0,0,0.2) 100%);
-  background-repeat: repeat-x;
+#capabilities .carousel-control-prev .fas, 
+#capabilities .carousel-control-next .fas {
+  color: #333;
+  font-size: 2rem;
+}
+
+#capabilities .carousel-control-next,
+#capabilities .carousel-control-prev {
+	opacity: 0.1;
+}
+
+#capabilities .screenshots .carousel-control-next:focus, 
+#capabilities .screenshots .carousel-control-next:hover, 
+#capabilities .screenshots .carousel-control-prev:focus, 
+#capabilities .screenshots .carousel-control-prev:hover {
+  background-image: none;
+  opacity: 1;
+}
+
+#capabilities .screenshots #slider:hover .carousel-control-prev, 
+#capabilities .screenshots #slider:focus .carousel-control-prev,
+#capabilities .screenshots #slider:hover .carousel-control-next, 
+#capabilities .screenshots #slider:focus .carousel-control-next {
+  opacity: 0.4;
 }
 
 .deployment-types {
@@ -2390,7 +2396,7 @@ label {
 	background-color: #e8e8e8;
 }
 
-.admonition ul, .admonition ol {
+.admonition ul, .admonition ol {
   padding-top: 1rem;
   padding-right: 1rem;
   padding-bottom: 0;

--- a/source/index.rst
+++ b/source/index.rst
@@ -288,11 +288,11 @@ Wazuh is a free and open source platform for threat detection, security monitori
           </div>
 
           <a class="carousel-control-prev" href="#slider" role="button" data-slide="prev">
-            <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+            <span class="fas fa-angle-left" aria-hidden="true"></span>
             <span class="sr-only">Previous</span>
           </a>
           <a class="carousel-control-next" href="#slider" role="button" data-slide="next">
-            <span class="carousel-control-next-icon" aria-hidden="true"></span>
+            <span class="fas fa-angle-right" aria-hidden="true"></span>
             <span class="sr-only">Next</span>
           </a>
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

Slightly changed the style of the carousel located in the index page: the gradient has been removed and its buttons have been changed from white to grey.
 ![imagen](https://user-images.githubusercontent.com/13232723/105983638-50fdb880-6099-11eb-90fa-0b1e69a3a7b3.png)

Related issue: https://github.com/wazuh/wazuh-website/issues/1556

## Checks
- [x] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
