### PR TITLE
Configuration tags normalization to Wazuh standard - Documentation changes implementation

### DIFF
--- a/source/gdpr/gdpr-IV.rst
+++ b/source/gdpr/gdpr-IV.rst
@@ -244,7 +244,7 @@ A basic configuration could be:
 
 .. code-block:: xml
 
-	<ossec_config>
+	<wazuh_config>
 	    <global>
 	        <email_notification>yes</email_notification>
 	        <email_to>data_protection_officer@test.com</email_to>
@@ -252,7 +252,7 @@ A basic configuration could be:
 	        <email_from>wazuh@test.com</email_from>
 	    </global>
 	    ...
-	</ossec_config>
+	</wazuh_config>
 
 
 Chapter IV, Article 35, Head 1

--- a/source/learning-wazuh/shellshock.rst
+++ b/source/learning-wazuh/shellshock.rst
@@ -34,7 +34,7 @@ these ``<localfile>`` sections present in the agent's ``/var/ossec/etc/ossec.con
 
     .. code-block:: xml
 
-        <ossec_config>
+        <wazuh_config>
             <localfile>
                 <log_format>apache</log_format>
                 <location>/var/log/nginx/access.log</location>
@@ -44,7 +44,7 @@ these ``<localfile>`` sections present in the agent's ``/var/ossec/etc/ossec.con
                 <log_format>apache</log_format>
                 <location>/var/log/nginx/error.log</location>
             </localfile>
-        </ossec_config>
+        </wazuh_config>
 
 Restart the wazuh agent service for this change to take effect:
 

--- a/source/migrating-from-ossec/ossec-agent.rst
+++ b/source/migrating-from-ossec/ossec-agent.rst
@@ -83,7 +83,7 @@ There have been some syntax changes, and new settings, incorporated to ``ossec.c
 
 .. code-block:: xml
 
-   <ossec_config>
+   <wazuh_config>
      <client>
        <server-ip>MANAGER_IP</server-ip>
 

--- a/source/upgrade-guide/upgrading-agent.rst
+++ b/source/upgrade-guide/upgrading-agent.rst
@@ -130,7 +130,7 @@ To perform the upgrade locally, follow the instructions for the operating system
 
   .. group-tab:: Solaris 11
 
-    The Wazuh agent upgrading process for Solaris 11 systems requires to download the latest `Solaris 11 i386 installer <https://packages.wazuh.com/|CURRENT_MAJOR|/solaris/i386/11/wazuh-agent_v|WAZUH_LATEST|-sol11-i386.pkg>`_ or `Solaris 11 sparc installer <https://packages.wazuh.com/|CURRENT_MAJOR|/solaris/sparc/11/wazuh-agent_v|WAZUH_LATEST|-sol11-sparc.pkg>`_ depending on the Solaris 11 host architecture. 
+    The Wazuh agent upgrading process for Solaris 11 systems requires to download the latest `Solaris 11 i386 installer <https://packages.wazuh.com/|CURRENT_MAJOR|/solaris/i386/11/wazuh-agent_v|WAZUH_LATEST|-sol11-i386.pkg>`_ or `Solaris 11 sparc installer <https://packages.wazuh.com/|CURRENT_MAJOR|/solaris/sparc/11/wazuh-agent_v|WAZUH_LATEST|-sol11-sparc.pkg>`_ depending on the Solaris 11 host architecture.
 
     #. Stop the Wazuh agent:
 
@@ -138,23 +138,23 @@ To perform the upgrade locally, follow the instructions for the operating system
 
           # /var/ossec/bin/ossec-control stop
 
-    
+
     #. After that, upgrade the Wazuh agent. Choose one option depending on the host architecture:
 
         * Solaris 11 i386:
 
             .. code-block:: console
-              
+
               # pkg install -g wazuh-agent_v|WAZUH_LATEST|-sol11-i386.pkg wazuh-agent
 
         * Solaris 11 sparc:
 
             .. code-block:: console
-              
+
               # pkg install -g wazuh-agent_v|WAZUH_LATEST|-sol11-sparc.pkg wazuh-agent
 
 
-    #. Start the Wazuh agent: 
+    #. Start the Wazuh agent:
 
         .. code-block:: console
 
@@ -163,7 +163,7 @@ To perform the upgrade locally, follow the instructions for the operating system
 
   .. group-tab:: Solaris 10
 
-    The Wazuh agent upgrading process for Solaris 10 systems requires to download the latest `Solaris 10 i386 installer <https://packages.wazuh.com/|CURRENT_MAJOR|/solaris/i386/10/wazuh-agent_v|WAZUH_LATEST|-sol10-i386.pkg>`_ or `Solaris 10 sparc installer <https://packages.wazuh.com/|CURRENT_MAJOR|/solaris/sparc/10/wazuh-agent_v|WAZUH_LATEST|-sol10-sparc.pkg>`_ depending on the Solaris 10 host architecture. 
+    The Wazuh agent upgrading process for Solaris 10 systems requires to download the latest `Solaris 10 i386 installer <https://packages.wazuh.com/|CURRENT_MAJOR|/solaris/i386/10/wazuh-agent_v|WAZUH_LATEST|-sol10-i386.pkg>`_ or `Solaris 10 sparc installer <https://packages.wazuh.com/|CURRENT_MAJOR|/solaris/sparc/10/wazuh-agent_v|WAZUH_LATEST|-sol10-sparc.pkg>`_ depending on the Solaris 10 host architecture.
 
     #. Stop the Wazuh agent:
 
@@ -192,13 +192,13 @@ To perform the upgrade locally, follow the instructions for the operating system
         * Solaris 10 i386:
 
             .. code-block:: console
-              
+
               # pkgadd -d wazuh-agent_v|WAZUH_LATEST|-sol10-i386.pkg wazuh-agent
 
         * Solaris 10 sparc:
 
             .. code-block:: console
-              
+
               # pkgadd -d wazuh-agent_v|WAZUH_LATEST|-sol10-sparc.pkg wazuh-agent
 
 
@@ -210,7 +210,7 @@ To perform the upgrade locally, follow the instructions for the operating system
           # chown root:ossec /var/ossec/etc/ossec.conf
 
 
-    #. Start the wazuh-agent: 
+    #. Start the wazuh-agent:
 
         .. code-block:: console
 
@@ -219,7 +219,7 @@ To perform the upgrade locally, follow the instructions for the operating system
 
   .. group-tab:: HP-UX
 
-      The Wazuh agent upgrading process for HP-UX systems requires to download the latest `HP-UX installer <https://packages.wazuh.com/|CURRENT_MAJOR|/hp-ux/wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_HPUX|-hpux-11v3-ia64.tar>`_. 
+      The Wazuh agent upgrading process for HP-UX systems requires to download the latest `HP-UX installer <https://packages.wazuh.com/|CURRENT_MAJOR|/hp-ux/wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_HPUX|-hpux-11v3-ia64.tar>`_.
 
       #. Stop the Wazuh agent:
 
@@ -253,7 +253,7 @@ To perform the upgrade locally, follow the instructions for the operating system
             # chown root:ossec /var/ossec/etc/client.keys
 
 
-      #. Start the wazuh-agent: 
+      #. Start the wazuh-agent:
 
           .. code-block:: console
 
@@ -265,11 +265,10 @@ Once the Wazuh agent is upgraded, if it still uses UDP, which was the default pr
 .. code-block:: console
   :emphasize-lines: 6
 
-  <ossec_config>
+  <wazuh_config>
     <client>
       <server>
         <address>172.16.1.17</address>
         <port>1514</port>
         <protocol>udp</protocol>
       </server>
-

--- a/source/user-manual/agents/agent-connection.rst
+++ b/source/user-manual/agents/agent-connection.rst
@@ -9,14 +9,14 @@ Before you check the agent's connection with the manager, first ensure the agent
 
 .. code-block:: xml
 
-  <ossec_config>
+  <wazuh_config>
     <client>
       <server>
         <address>10.0.0.10</address>
         <protocol>tcp</protocol>
       </server>
     </client>
-  </ossec_config>
+  </wazuh_config>
 
 This will set 10.0.0.10 as the Wazuh server. Once this is done, you will need restart the Agent:
 

--- a/source/user-manual/capabilities/log-data-collection/how-it-works.rst
+++ b/source/user-manual/capabilities/log-data-collection/how-it-works.rst
@@ -69,14 +69,14 @@ One option is for Wazuh to receive syslog logs by a custom port:
 
   .. code-block:: xml
 
-    <ossec_config>
+    <wazuh_config>
       <remote>
         <connection>syslog</connection>
         <port>513</port>
         <protocol>tcp</protocol>
         <allowed-ips>192.168.2.0/24</allowed-ips>
       </remote>
-    </ossec_config>
+    </wazuh_config>
 
 - ``<connection>syslog</connection>`` indicates that the manager will accept incoming syslog messages from across the network.
 - ``<port>513</port>`` defines the port that Wazuh will listen to retrieve the logs. The port must be free.

--- a/source/user-manual/manager/alert-threshold.rst
+++ b/source/user-manual/manager/alert-threshold.rst
@@ -5,7 +5,7 @@
 Defining an alert level threshold
 ==================================
 
-Each event collected by the Wazuh agent is transmitted to the Wazuh Manager. The Manager will assign the event a severity level depending of which rules it matches from the ruleset. By default it will only log alerts with a severity level of 3 or higher.  
+Each event collected by the Wazuh agent is transmitted to the Wazuh Manager. The Manager will assign the event a severity level depending of which rules it matches from the ruleset. By default it will only log alerts with a severity level of 3 or higher.
 
 Configuration
 -------------
@@ -14,11 +14,11 @@ The alert level threshold is configured in the ``ossec.conf`` file using the ``<
 
 .. code-block:: xml
 
-  <ossec_config>
+  <wazuh_config>
     <alerts>
         <log_alert_level>6</log_alert_level>
     </alerts>
-  </ossec_config>
+  </wazuh_config>
 
 This will set the minimum severity level that will trigger alerts that will be stored in the ``alerts.log`` and/or the ``alerts.json`` file(s).
 

--- a/source/user-manual/manager/automatic-reports.rst
+++ b/source/user-manual/manager/automatic-reports.rst
@@ -8,13 +8,13 @@ Daily reports are summaries of the alerts that were triggered each day. You can 
 
 .. code-block:: xml
 
- <ossec_config>
+ <wazuh_config>
    <reports>
        <category>syscheck</category>
        <title>Daily report: File changes</title>
        <email_to>example@test.com</email_to>
    </reports>
- </ossec_config>
+ </wazuh_config>
 
 The above configuration will send a daily report of all :ref:`syscheck <manual_file_integrity>` alerts to ``example@test.com``.
 
@@ -24,13 +24,13 @@ For example:
 
 .. code-block:: xml
 
- <ossec_config>
+ <wazuh_config>
    <reports>
        <level>10</level>
        <title>Daily report: Alerts with level higher than 10</title>
        <email_to>example@test.com</email_to>
    </reports>
- </ossec_config>
+ </wazuh_config>
 
 The above configuration will send a report with all rules that fired with a level higher than 10.
 

--- a/source/user-manual/manager/manual-email-report/index.rst
+++ b/source/user-manual/manager/manual-email-report/index.rst
@@ -37,7 +37,7 @@ In order to configure Wazuh to send email alerts, the email settings must be con
 
 .. code-block:: xml
 
-  <ossec_config>
+  <wazuh_config>
       <global>
           <email_notification>yes</email_notification>
           <email_to>me@test.com</email_to>
@@ -45,7 +45,7 @@ In order to configure Wazuh to send email alerts, the email settings must be con
           <email_from>wazuh@test.com</email_from>
       </global>
       ...
-  </ossec_config>
+  </wazuh_config>
 
 To see all of the available email configuration options, go to the :ref:`global section <reference_ossec_global>`.
 
@@ -53,12 +53,12 @@ Once the above has been configured, the ``email_alert_level`` needs to be set to
 
 .. code-block:: xml
 
-  <ossec_config>
+  <wazuh_config>
     <alerts>
         <email_alert_level>10</email_alert_level>
     </alerts>
     ...
-  </ossec_config>
+  </wazuh_config>
 
 This example will set the minimum level to 10. For more information, see the :ref:`alerts section <reference_ossec_alerts>`.
 
@@ -156,7 +156,7 @@ This example shows the email alerts capabilities. Email alerts can be sent to mu
 
 .. code-block:: xml
 
- <ossec_config>
+ <wazuh_config>
    <email_alerts>
        <email_to>alice@test.com</email_to>
        <event_location>server1|server2</event_location>
@@ -173,7 +173,7 @@ This example shows the email alerts capabilities. Email alerts can be sent to mu
        <email_to>david@test.com</email_to>
        <level>12</level>
    </email_alerts>
-  </ossec_config>
+  </wazuh_config>
 
 This configuration will send:
 

--- a/source/user-manual/manager/manual-integration.rst
+++ b/source/user-manual/manager/manual-integration.rst
@@ -10,7 +10,7 @@ The **Integrator** daemon allows Wazuh to connect to external APIs and alerting 
 Configuration
 -------------
 
-The integrations are configured on the ``ossec.conf`` file which is located inside the Wazuh installation folder (``/var/ossec/etc/``). To configure an integration, add the following configuration inside the *<ossec_config>* section:
+The integrations are configured on the ``ossec.conf`` file which is located inside the Wazuh installation folder (``/var/ossec/etc/``). To configure an integration, add the following configuration inside the *<wazuh_config>* section:
 
 .. code-block:: xml
 

--- a/source/user-manual/manager/manual-syslog-output.rst
+++ b/source/user-manual/manager/manual-syslog-output.rst
@@ -14,7 +14,7 @@ Syslog output is configured in the ``ossec.conf`` file. All of the available opt
 
 ::
 
-  <ossec_config>
+  <wazuh_config>
     <syslog_output>
       <level>9</level>
       <server>192.168.1.241</server>
@@ -23,7 +23,7 @@ Syslog output is configured in the ``ossec.conf`` file. All of the available opt
     <syslog_output>
       <server>192.168.1.240</server>
     </syslog_output>
-  </ossec_config>
+  </wazuh_config>
 
 The above configuration will send alerts to ``192.168.1.240`` and, if the alert level is higher than 9, also to ``192.168.1.241``.
 

--- a/source/user-manual/manager/remote-service.rst
+++ b/source/user-manual/manager/remote-service.rst
@@ -16,11 +16,11 @@ You can change the IP address used to listen the service with the following conf
 
 ::
 
-  <ossec_config>
+  <wazuh_config>
     <remote>
       <local_ip>10.0.0.10</local_ip>
     </remote>
-  </ossec_config>
+  </wazuh_config>
 
 This will set the manager to listen on IP address to 10.0.0.10.
 

--- a/source/user-manual/reference/ossec-conf/global.rst
+++ b/source/user-manual/reference/ossec-conf/global.rst
@@ -498,7 +498,7 @@ Default configuration
       <logall_json>no</logall_json>
       <email_notification>yes</email_notification>
       <smtp_server>smtp.example.wazuh.com</smtp_server>
-      <email_from>ossecm@example.wazuh.com</email_from>
+      <email_from>wazuh@example.wazuh.com</email_from>
       <email_to>recipient@example.wazuh.com</email_to>
       <email_maxperhour>12</email_maxperhour>
       <agents_disconnection_time>20s</agents_disconnection_time>

--- a/source/user-manual/reference/ossec-conf/index.rst
+++ b/source/user-manual/reference/ossec-conf/index.rst
@@ -7,19 +7,19 @@ Local configuration (ossec.conf)
 
 The ``ossec.conf`` file is the main configuration file on the Wazuh manager and it also plays an important role on the agents. It is located at ``/var/ossec/etc/ossec.conf`` both in the manager and agent on Linux machines. On Windows agents, we can find it at ``C:\Program Files (x86)\ossec-agent\ossec.conf``. It is recommended to back up this file before making changes on it. A configuration error may prevent Wazuh services from starting up.
 
-The ``ossec.conf`` file is in XML format and all of its configuration options are nested in their appropriate section of the file. In this file, the outermost XML tag is ``<ossec_config>``. There can be more than one ``<ossec_config>`` tag.
+The ``ossec.conf`` file is in XML format and all of its configuration options are nested in their appropriate section of the file. In this file, the outermost XML tag is ``<wazuh_config>``. There can be more than one ``<wazuh_config>`` tag.
 
 Here is an example of the proper location of the *alerts* configuration section:
 
 .. code-block:: xml
 
-    <ossec_config>
+    <wazuh_config>
         <alerts>
             <!--
             alerts options here
             -->
         </alerts>
-    </ossec_config>
+    </wazuh_config>
 
 The ``agent.conf`` file is very similar to ``ossec.conf`` but ``agent.conf`` is used to centrally distribute configuration information to agents. See more :doc:`here <../centralized-configuration>`.
 
@@ -105,7 +105,7 @@ Wazuh can be installed in two ways: as a manager by using the "server/manager" i
 | :doc:`gcp-pubsub <gcp-pubsub>`                                      | manager, agent         |
 +---------------------------------------------------------------------+------------------------+
 
-All of the above sections must be located within the top-level ``<ossec_config>`` tag. In case of adding another ``<ossec_config>`` tag, it may override the values set on the previous tag.
+All of the above sections must be located within the top-level ``<wazuh_config>`` tag. In case of adding another ``<wazuh_config>`` tag, it may override the values set on the previous tag.
 
 
 .. toctree::

--- a/source/user-manual/registering/registering-agents-troubleshooting.rst
+++ b/source/user-manual/registering/registering-agents-troubleshooting.rst
@@ -40,7 +40,7 @@ By default, the Wazuh manager attaches the Wazuh agent to the visible IP of the 
 
    .. code-block:: xml
 
-    <ossec_config>
+    <wazuh_config>
       ...
       <auth>
         ...
@@ -48,7 +48,7 @@ By default, the Wazuh manager attaches the Wazuh agent to the visible IP of the 
         ...
       </auth>
       ...
-    </ossec_config>
+    </wazuh_config>
 
    Restart the wazuh manager:
 

--- a/source/user-manual/ruleset/cdb-list.rst
+++ b/source/user-manual/ruleset/cdb-list.rst
@@ -53,7 +53,7 @@ Each list must be defined in the ``ossec.conf`` file using the following syntax:
 
 .. code-block:: xml
 
-  <ossec_config>
+  <wazuh_config>
     <ruleset>
       <list>etc/lists/list-IP</list>
 


### PR DESCRIPTION
## Description

This PR implements all the necessary changes in the Wazuh documentation to adapt all the references to `ossec` in the configuration tags. 

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns.