### PR TITLE
Updating RAM min reqs for open-distro unattended script

### DIFF
--- a/resources/open-distro/unattended-installation/distributed/wazuh-server-installation.sh
+++ b/resources/open-distro/unattended-installation/distributed/wazuh-server-installation.sh
@@ -241,7 +241,7 @@ healthCheck() {
     cores=$(cat /proc/cpuinfo | grep processor | wc -l)
     ram_gb=$(free -m | awk '/^Mem:/{print $2}')
 
-    if [ ${cores} -lt 2 ] || [ ${ram_gb} -lt 3700 ]
+    if [ ${cores} -lt 2 ] || [ ${ram_gb} -lt 1700 ]
     then
         echo "Your system does not meet the recommended minimum hardware requirements of 2Gb of RAM and 2 CPU cores . If you want to proceed with the installation use the -i option to ignore these requirements."
         exit 1;


### PR DESCRIPTION
## Description

[As per docs](https://github.com/wazuh/wazuh-documentation/blob/develop/source/installation-guide/requirements.rst#distributed-deployment), the wazuh-server minimum requirements are 2 CPU and 2 Gb of RAM
While trying to perform an unattended installation of the wazuh-server I found that the open-distro script checks for 4Gb of RAM instead of 2Gb for minimum requirements. This is not the case for the [elastic-stack script](https://github.com/wazuh/wazuh-documentation/blob/develop/resources/elastic-stack/unattended-installation/distributed/wazuh-server-installation.sh#L332).

Closes #3319 

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
