### PR TITLE
Fix the command to remove service in sysv init

### DIFF
--- a/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-agent/index.rst
+++ b/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-agent/index.rst
@@ -117,7 +117,7 @@ Installing Wazuh agent from sources
     .. code-block:: console
 
       # [ -f /etc/rc.local ] && sed -i'' '/wazuh-control start/d' /etc/rc.local
-      # find /etc/{init.d,rc*.d} -name "*wazuh" | xargs rm -f
+      # find /etc/{init.d,rc*.d} -name "*wazuh*" | xargs rm -f
 
     For Systemd:
 
@@ -410,7 +410,7 @@ Installing Wazuh agent from sources
 
     .. code-block:: console
 
-     # find /etc/rc.d -name "*wazuh" | xargs rm -f
+     # find /etc/rc.d -name "*wazuh*" | xargs rm -f
 
     Remove users:
 
@@ -531,7 +531,7 @@ Installing Wazuh agent from sources
 
     .. code-block:: console
 
-     # find /sbin/{init.d,rc*.d} -name "*wazuh" | xargs rm -f
+     # find /sbin/{init.d,rc*.d} -name "*wazuh*" | xargs rm -f
 
     Remove users:
 
@@ -648,7 +648,7 @@ Installing Wazuh agent from sources
 
         .. code-block:: console
 
-         # find /sbin/{init.d,rc*.d} -name "*wazuh" | xargs rm -f
+         # find /sbin/{init.d,rc*.d} -name "*wazuh*" | xargs rm -f
 
         Remove users:
 
@@ -783,7 +783,7 @@ Installing Wazuh agent from sources
 
         .. code-block:: console
 
-         # find /sbin/{init.d,rc*.d} -name "*wazuh" | xargs rm -f
+         # find /sbin/{init.d,rc*.d} -name "*wazuh*" | xargs rm -f
 
         Remove users:
 

--- a/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-server/index.rst
+++ b/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-server/index.rst
@@ -172,7 +172,7 @@ Delete the service:
     .. code-block:: console
 
       # [ -f /etc/rc.local ] && sed -i'' '/wazuh-control start/d' /etc/rc.local
-      # find /etc/{init.d,rc*.d} -name "*wazuh" | xargs rm -f
+      # find /etc/{init.d,rc*.d} -name "*wazuh*" | xargs rm -f
 
   For Systemd:
 


### PR DESCRIPTION
Hi team,
I add this PR to fix the commands to remove services in sysv init(manager and agent).

## Description

This PR fix the command to remove service in sysv init.
`find /etc/{init.d,rc*.d} -name "*wazuh*" | xargs rm -f`
instead of:
`find /etc/{init.d,rc*.d} -name "*wazuh" | xargs rm -f`

## Checks
- [ ] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).



