### PR TITLE
Remove behind_proxy_server API configuration option

### DIFF
--- a/source/deploying-with-ansible/reference.rst
+++ b/source/deploying-with-ansible/reference.rst
@@ -753,7 +753,6 @@ Wazuh Manager
     wazuh_manager_api:
       bind_addr: 0.0.0.0
       port: 55000
-      behind_proxy_server: no
       https: yes
       https_key: "api/configuration/ssl/server.key"
       https_cert: "api/configuration/ssl/server.crt"

--- a/source/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-manager-class.rst
+++ b/source/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-manager-class.rst
@@ -608,11 +608,6 @@ $wazuh_api_port
 
   `Default 55000`
 
-$wazuh_api_behind_proxy_server
-  Set this option to “yes” in case the Wazuh API is running behind a proxy server.
-
-  `Default true`
-
 $wazuh_api_https_enabled
   Enable or disable SSL (https) in the Wazuh API.
 

--- a/source/user-manual/api/configuration.rst
+++ b/source/user-manual/api/configuration.rst
@@ -21,7 +21,6 @@ Here are all the available settings for the ``api.yaml`` configuration file. For
 
      host: 0.0.0.0
      port: 55000
-     behind_proxy_server: no
 
      use_only_authd: no
      drop_privileges: yes
@@ -157,14 +156,6 @@ port
 +===============================+===============+=======================================+
 | Any value between 1 and 65535 | 55000         | Port where the Wazuh API will listen. |
 +-------------------------------+---------------+---------------------------------------+
-
-behind_proxy_server
-^^^^^^^^^^^^^^^^^^^^^^
-+----------------------+---------------+----------------------------------------------------------------------------------+
-| Allowed values       | Default value | Description                                                                      |
-+======================+===============+==================================================================================+
-| yes, true, no, false | true          | Set this option to "yes" in case the Wazuh API is running behind a proxy server. |
-+----------------------+---------------+----------------------------------------------------------------------------------+
 
 use_only_authd
 ^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/7006|

## Description
Hi team!

As requested in #7006, this PR removes everything related to `behind_proxy_server` API configuration option.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

Regards,
Selu.