### PR TITLE
[3.1] Fixed the dropdown menu in mobile and the sidebar

### DIFF
--- a/source/_static/css/style.css
+++ b/source/_static/css/style.css
@@ -3741,7 +3741,7 @@ div.highlight pre {
   .side-scroll {
     position: -webkit-sticky;
     position: sticky;
-    overflow: hidden;
+    overflow-y: auto;
     height: 100%;
     flex-direction: column;
     padding-right: 15px;

--- a/source/_static/js/style.js
+++ b/source/_static/js/style.js
@@ -291,14 +291,15 @@ $(function() {
    * Changes the navbar (globaltoc) height
    */
   function heightNavbar() {
-    noticeHeight = parseInt($('.no-latest-notice').outerHeight());
+    const noticeElement = $('.no-latest-notice');
+    noticeHeight = noticeElement.length == 0 ? 0 : parseInt(noticeElement.outerHeight());
     if ($(window).width() >= 992) {
       if (!$('body').hasClass('scrolled')) {
         navbarTop = parseInt($('#header').outerHeight());
         $('#navbar').css({'padding-top': (navbarTop - documentScroll) + 'px'});
         $('#navbar-globaltoc').css({'height': 'calc(100vh - ' + (parseInt($('#navbar .search_main').outerHeight()) + parseInt($('#header').outerHeight())) + 'px + ' + documentScroll + 'px)', 'padding-top': 0});
       } else {
-        $('#navbar').css({'padding-top': parseInt($('.no-latest-notice').outerHeight())+'px'});
+        $('#navbar').css({'padding-top': noticeHeight +'px'});
         $('#navbar-globaltoc').css({'height': 'calc(100vh - ' + noticeHeight + 'px - ' + parseInt($('#header-sticky').outerHeight()) + 'px)', 'padding-top': 0});
       }
     } else {


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

Related issue: https://github.com/wazuh/wazuh-website/issues/1588

This PR fixes a problem with the position of the dropdown menu on mobile screens. In addition, it removes a bug in overflow control of the sidebar for wider screen sizes,

## Checks
- [x] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
