### PR TITLE
[4.1] Fixed a bug in the links to the api reference page

### DIFF
--- a/source/_static/js/style.js
+++ b/source/_static/js/style.js
@@ -13,7 +13,7 @@ $(function() {
   if ( useApiRedoc ) {
     /* Change DOMAIN in href */
     const domainReplacePattern = 'https://DOMAIN';
-    const urlRoot = DOCUMENTATION_OPTIONS.VERSION;
+    const urlRoot = $('[data-url_root]').length == 0 ? '' : $('[data-url_root]').data('url_root');
     $('[href^="'+domainReplacePattern+'/"]').each(function() {
       const oldHref = $(this).attr('href');
       $(this).attr('href', oldHref.replace(domainReplacePattern+'/', urlRoot));

--- a/source/_static/js/style.js
+++ b/source/_static/js/style.js
@@ -13,7 +13,7 @@ $(function() {
   if ( useApiRedoc ) {
     /* Change DOMAIN in href */
     const domainReplacePattern = 'https://DOMAIN';
-    const urlRoot = $('[data-url_root]').length == 0 ? '' : $('[data-url_root]').data('url_root');
+    const urlRoot = $('[data-url_root]').length == 0 ? '/' : $('[data-url_root]').data('url_root');
     $('[href^="'+domainReplacePattern+'/"]').each(function() {
       const oldHref = $(this).attr('href');
       $(this).attr('href', oldHref.replace(domainReplacePattern+'/', urlRoot));


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

This PR fixes a bug that breaks the links to the API reference page.

Related issue: https://github.com/wazuh/wazuh-documentation/issues/3427

## Checks
- [x] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

