### PR TITLE
4.1 fix macOS deployment variables

### DIFF
--- a/source/installation-guide/wazuh-agent/deployment_variables/deployment_variables_macos.rst
+++ b/source/installation-guide/wazuh-agent/deployment_variables/deployment_variables_macos.rst
@@ -48,36 +48,36 @@ Examples:
 
 .. code-block:: console
 
-     # launchctl setenv WAZUH_MANAGER="10.0.0.2" WAZUH_REGISTRATION_PASSWORD="TopSecret" \
-          WAZUH_AGENT_NAME="macos-agent" && installer -pkg wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_OSX|.pkg -target /
+     # launchctl setenv WAZUH_MANAGER "10.0.0.2" WAZUH_REGISTRATION_PASSWORD "TopSecret" \
+          WAZUH_AGENT_NAME "macos-agent" && installer -pkg wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_OSX|.pkg -target /
 
 * Registration with password and assigning a group:
 
 .. code-block:: console
 
-     # launchctl setenv WAZUH_MANAGER="10.0.0.2" WAZUH_REGISTRATION_SERVER="10.0.0.2" WAZUH_REGISTRATION_PASSWORD="TopSecret" \
-          WAZUH_AGENT_GROUP="my-group" && installer -pkg wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_OSX|.pkg -target /
+     # launchctl setenv WAZUH_MANAGER "10.0.0.2" WAZUH_REGISTRATION_SERVER "10.0.0.2" WAZUH_REGISTRATION_PASSWORD "TopSecret" \
+          WAZUH_AGENT_GROUP "my-group" && installer -pkg wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_OSX|.pkg -target /
 
 * Registration with relative path to CA. It will be searched at your Wazuh installation folder:
 
 .. code-block:: console
 
-     # launchctl setenv WAZUH_MANAGER="10.0.0.2" WAZUH_REGISTRATION_SERVER="10.0.0.2" WAZUH_AGENT_NAME="macos-agent" \
-          WAZUH_REGISTRATION_CA="rootCA.pem" && installer -pkg wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_OSX|.pkg -target /
+     # launchctl setenv WAZUH_MANAGER "10.0.0.2" WAZUH_REGISTRATION_SERVER "10.0.0.2" WAZUH_AGENT_NAME "macos-agent" \
+          WAZUH_REGISTRATION_CA "rootCA.pem" && installer -pkg wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_OSX|.pkg -target /
 
 * Registration with protocol:
 
 .. code-block:: console
 
-     # launchctl setenv WAZUH_MANAGER="10.0.0.2" WAZUH_REGISTRATION_SERVER="10.0.0.2" WAZUH_AGENT_NAME="macos-agent" \
-          WAZUH_PROTOCOL="tcp" && installer -pkg wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_OSX|.pkg -target /
+     # launchctl setenv WAZUH_MANAGER "10.0.0.2" WAZUH_REGISTRATION_SERVER "10.0.0.2" WAZUH_AGENT_NAME "macos-agent" \
+          WAZUH_PROTOCOL "tcp" && installer -pkg wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_OSX|.pkg -target /
 
 * Registration and adding multiple address:
 
 .. code-block:: console
 
-     # launchctl setenv WAZUH_MANAGER="10.0.0.2,10.0.0.3" WAZUH_REGISTRATION_SERVER="10.0.0.2" \
-          WAZUH_AGENT_NAME="macos-agent" && installer -pkg wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_OSX|.pkg -target /
+     # launchctl setenv WAZUH_MANAGER "10.0.0.2,10.0.0.3" WAZUH_REGISTRATION_SERVER "10.0.0.2" \
+          WAZUH_AGENT_NAME "macos-agent" && installer -pkg wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_OSX|.pkg -target /
 
 * Absolute paths to CA, certificate or key that contain spaces can be written as shown below:
 


### PR DESCRIPTION

## Description
This closes #3470 where the syntax for macOS environment variable declaration was wrong.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
