### PR TITLE
[3.0] Fixed the bug in the links to a section of the same page

### DIFF
--- a/source/_static/css/style.css
+++ b/source/_static/css/style.css
@@ -1029,6 +1029,7 @@ li.toctree-l5 > a {
 #navbar-globaltoc {
   height: calc(100vh - 165px); /* 40px search + 100px buttons + 25px padding = 165px */
   visibility: visible;
+  overflow-x: hidden;
 }
  
 #navbar-globaltoc.show, #navbar-globaltoc.collapsing {
@@ -1036,7 +1037,6 @@ li.toctree-l5 > a {
   left: 0;
   background-color: #f8f8f8;
   overflow-y: auto;
-  overflow-x: hidden;
   position: absolute;
   z-index: 2;
 }

--- a/source/_static/js/style.js
+++ b/source/_static/js/style.js
@@ -4,7 +4,6 @@ $(function() {
   const minVersionRedoc = '4.0';
   const simultaneousCapaSlide = (compareVersion(version, minVersionScreenshot) >= 0);
   const useApiRedoc = (compareVersion(version, minVersionRedoc) >= 0);
-  const spaceBeforeAnchor = 60;
   /* List of folders that will be excluded from search */
   const excludedSearchFolders = ['release-notes'];
   const intervalTime = 5000;
@@ -76,8 +75,12 @@ $(function() {
   markTocNodesWithClass(emptyTocNodes, 'empty-toc-node');
   checkScroll();
   if (document.location.hash) {
-    correctScrollTo(spaceBeforeAnchor);
+    correctScrollTo(document.location.hash);
   }
+  $('.headerlink').on('click', function(e) {
+    e.preventDefault();
+    correctScrollTo($(e.target).attr('href'));
+  });
 
   /* Finds all nodes that contains subtrees within the globaltoc and appends a toggle button to them */
   $('.globaltoc .toctree-l1 a').each(function(e) {
@@ -89,8 +92,8 @@ $(function() {
 
   hideSubtree(hideSubtreeNodes);
 
-  $(window).on('hashchange', function() {
-    correctScrollTo(spaceBeforeAnchor);
+  $(window).on('hashchange', function(e) {
+    correctScrollTo(document.location.hash);
   });
 
   /* Turn all tables in responsive table */
@@ -109,7 +112,7 @@ $(function() {
 
   /* Page scroll event -------------------------------------------------------*/
   $('#btn-scroll').on('click', function() {
-    $('html, body').animate({scrollTop: 0}, 'slow');
+    $('html, body').animate({scrollTop: 0}, 'smooth');
     return false;
   });
 
@@ -418,16 +421,26 @@ $(function() {
 
   /**
    * Corrects the scrolling movement so the element to which the page is being scrolled appears correctly in the screen,
-   * having in mind the fixed top bar and the no-latest-notice if present.
-   * @param {int} spaceBeforeAnchor Space required between the target element and the top of the window.
+   * having in mind the top bar and the no-latest-notice if present.
+   * @param {int} targetAnchor Selector of the element in the head of the section where the scroll should stop.
    */
-  function correctScrollTo(spaceBeforeAnchor) {
-    if ($('#page').hasClass('no-latest-docs')) {
-      spaceBeforeAnchor = spaceBeforeAnchor + 40;
+  function correctScrollTo(targetAnchor) {
+    let spaceBeforeAnchor = 0;
+    if ( $(targetAnchor).length > 0 ) {
+      setTimeout(function() {
+        spaceBeforeAnchor = parseInt($('#header').outerHeight());
+        if ($('#page').hasClass('no-latest-docs')) {
+          if ($(window).outerWidth() >= 992) {
+            /* The height of the .no-latest-notice may vary for wide screens
+            but here we are using a fixed value (50px) for now */
+            spaceBeforeAnchor = spaceBeforeAnchor + 50;
+          } else {
+            spaceBeforeAnchor = spaceBeforeAnchor + parseInt($('.no-latest-notice').outerHeight());
+          }
+        }
+        window.scrollTo(window.scrollX, $(targetAnchor).offset().top - spaceBeforeAnchor, 'smooth');
+      }, 100);
     }
-    setTimeout(function() {
-      window.scrollTo(window.scrollX, window.scrollY - spaceBeforeAnchor);
-    }, 10);
   }
 
   /* -- Add functionality for the capabilities in the home page --------------------------------------------- */


### PR DESCRIPTION
## Description

Fix for the bug occurring when clicking a link to a section of the same page, such as the ones in the first section of this page https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/fim-configuration.html or the link next to every headline.

Related issue: https://github.com/wazuh/wazuh-website/issues/1590

## Checks
- [x] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).