### PR TITLE
[develop] Slight change in the style of the element 'no-latest-notice' and theme update

### DIFF
--- a/source/_static/css/style-redirect.css
+++ b/source/_static/css/style-redirect.css
@@ -1,0 +1,81 @@
+body {
+  text-align: center;
+  color: #333;
+  font-family: "Open Sans", sans-serif;
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  padding: 50px 15px;
+}
+
+h1 {
+  font-family: "Montserrat", sans-serif;
+  font-weight: 400;
+  color: #404040;
+  line-height: 1.2;
+  font-size: 26px;
+
+}
+
+#spinner-wrapper {
+  margin: 15px auto;
+  width: 100px;
+  height: 100px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#spinner {
+  display: block;
+  position: relative;
+  width: 60px;
+  height: 60px;
+  border-top: 8px solid #00a9e5;
+  border-right: 8px solid #00a9e5;
+  border-bottom: 8px solid #00a9e5;
+  border-left: 8px solid transparent;
+  border-radius: 50%;
+  -webkit-animation: spin 1s linear infinite;
+  -moz-animation: spin 1s linear infinite;
+  animation: spin 1s linear infinite;
+}
+
+#spinner::before {
+  content: "";
+  height: 8px;
+  width: 8px;
+  border-radius: 50%;
+  position: absolute;
+  background-color: #00a9e5;
+  left: 1px;
+  top: 3px;
+}
+
+#spinner::after {
+  content: "";
+  height: 8px;
+  width: 8px;
+  border-radius: 50%;
+  position: absolute;
+  background-color: #00a9e5;
+  left: 1px;
+  bottom: 3px;
+}
+
+@-moz-keyframes spin {
+  100% {
+    -moz-transform: rotate(360deg);
+  }
+}
+@-webkit-keyframes spin {
+  100% {
+    -webkit-transform: rotate(360deg);
+  }
+}
+@keyframes spin {
+  100% {
+    -webkit-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}

--- a/source/_static/css/style.css
+++ b/source/_static/css/style.css
@@ -187,7 +187,6 @@ dt {
 .no-latest-notice .no-latest-icon-wrapper {
   color: #ffb600;
   padding: 0;
-  background-color: #fff;
   height: 100%;
   display: flex;
   align-items: center;
@@ -203,11 +202,7 @@ dt {
 
 .no-latest-docs .no-latest-notice {
   display: flex;
-  justify-content: flex-start;
-}
-
-.no-latest-notice .link-latest {
-  color: #333;
+  justify-content: center;
 }
 
 #header {
@@ -3282,17 +3277,16 @@ div.highlight pre {
   .no-latest-notice {
     position: relative;
     border: 1px solid #ffb600;
+		border-radius: 12px;
     margin: 35px 0 15px 0;
     height: auto;
     align-items: stretch;
-    width: fit-content;
-    width: -moz-fit-content;
+    width: 100%;
+    padding: 0 10px;
   }
   
   .no-latest-notice .no-latest-icon-wrapper {
     padding: 7px;
-    background-color: #ffb600;
-    color: #fff;
     min-width: 35px;
     height: auto;
     padding: 10px;
@@ -3300,12 +3294,13 @@ div.highlight pre {
   
   .no-latest-notice .no-latest-text-wrapper {
     font-size: 1.07rem;
-    padding: 15px;
+    padding: 15px 10px;
   }
   
   .scrolled .no-latest-notice {
     margin: 0;
     border: 1px solid #fff;
+    border-radius: 0;
     position: fixed;
     top: 0;
     width: 100%;
@@ -3905,6 +3900,10 @@ div.highlight pre {
 }
 
 @media (min-width: 1440px) {
+  
+  .no-latest-notice .no-latest-text-wrapper {
+    padding: 15px 15px 15px 5px;
+  }
   
   #rst-content.deprecated-content:after {
     height: 540px;

--- a/source/_static/js/moved-content.js
+++ b/source/_static/js/moved-content.js
@@ -1,0 +1,209 @@
+const listOfReleases = [
+  '2.1',
+  '3.0',
+  '3.1',
+  '3.2',
+  '3.3',
+  '3.4',
+  '3.5',
+  '3.6',
+  '3.7',
+  '3.8',
+  '3.9',
+  '3.10',
+  '3.11',
+  '3.12',
+  '3.13',
+  '4.0',
+];
+
+/* Get path from query string */
+let [domain, path] = document.location.href.split('moved-content.html?path=');
+
+let finalUrl = '';
+let anchor = '';
+domain = document.location.protocol + '//' + document.location.host;
+finalUrl = domain;
+
+if ( path !== undefined ) {
+  [path, anchor] = path.split('#');
+  finalUrl = getRedirectionUrl(domain, path, anchor, listOfReleases);
+}
+
+document.location = finalUrl;
+
+/**
+* Given a URL that doesn't exist in current, use the redirect array to retrieve
+* the URL of the latest version of the corresponding content or the URL to not_found
+* @param {string} domain current domain of the documentation
+* @param {string} path path of the original URL
+* @param {string} anchor anchor of the original URL
+* @param {string} listOfReleases ordered list with all the releases available
+* @return {string} The most recent URL to the content that was located in the original URL
+*/
+function getRedirectionUrl(domain, path, anchor, listOfReleases) {
+  const notFoundUrl = domain + '/not_found.html';
+  let finalPath = '';
+  let removed = false;
+  let created = false;
+  let relatedRedirect;
+  const excludePaths = [];
+
+  path = '/'+path;
+  if ( path[path.length-1] == '/' ) {
+    path = path + 'index.html';
+  }
+  finalPath = path;
+  tempPath = path;
+  excludePaths.push(path);
+
+  while (tempPath.length > 0) {
+    finalPath = tempPath;
+    tempPath = '';
+    created = false;
+
+    /* Is the path in newUrls? */
+    Object.keys(newUrls).forEach((release) => {
+      let newInRelease = newUrls[release];
+      newInRelease = newInRelease.map((docpath) => docpath[docpath.length-1] == '/' ? docpath + 'index.html' : docpath );
+      if (newInRelease.indexOf(finalPath) > -1 ) {
+        created = release;
+      }
+    });
+    if ( created === false ) {
+      finalPath = notFoundUrl;
+    } else {
+      /* Get related redirections and pick the most recent */
+      relatedRedirect = getRelatedNewestRedirections(redirections, finalPath, created, anchor, excludePaths);
+
+      if (relatedRedirect.length > 0) {
+        /* Get target URL of the most recent redirection */
+        relatedRedirect = relatedRedirect[relatedRedirect.length-1];
+        created = relatedRedirect['created'];
+        tempPath = relatedRedirect['path'];
+        excludePaths.push(tempPath);
+      }
+    }
+  }
+  if ( created !== false ) {
+    /* Is the final path in removedUrls? */
+    removed = false;
+    Object.keys(removedUrls).forEach((release) => {
+      if ( compareReleases(release, created) > 0 ) {
+        let removedInRelease = removedUrls[release];
+        removedInRelease = removedInRelease.map((docpath) => docpath[docpath.length-1] == '/' ? docpath + 'index.html' : docpath );
+        if (removedInRelease.indexOf(finalPath) > -1 ) {
+          removed = release;
+        }
+      }
+    });
+    if ( removed !== false ) {
+      const lastseen = listOfReleases[listOfReleases.indexOf(removed)-1];
+      finalPath = domain + '/' + lastseen + finalPath;
+    } else {
+      finalPath = domain + '/current' + finalPath;
+    }
+  }
+
+  return finalPath;
+}
+
+/**
+* Given a path and a minimum release for said path, retrieves all redirections
+* related to that path occurring from the minimum release on
+* @param {string} redir array of redirections
+* @param {string} currentPath the original path
+* @param {string} created minimum release to consider for the redirections (when the path was created)
+* @param {string} anchor anchor of the original path if any
+* @param {array} excluded list of path to be ignored as a result (they were checked before)
+* @return {array} List of all the related redirection happening after the minimum release
+*/
+function getRelatedNewestRedirections(redir, currentPath, created, anchor, excluded) {
+  const relatedTargets = [];
+  let anchorfound = false;
+
+  /* Get only the related redirections (any) */
+  for (let i = 0; i < redir.length; i++) {
+    const redirObject = redir[i];
+    let validRedir = false;
+
+    if ( anchor !== undefined) {
+      /* Paths with anchor have preference if they exist */
+      if ( Object.values(redirObject).indexOf(currentPath+'#'+anchor) != -1 ) {
+        const targets = redirObject['target'];
+        for ( let j = 0; j < targets.length; j++ ) {
+          const targetReleases = targets[j].split('=>');
+          if ( compareReleases(targetReleases[0], targetReleases[1]) < 0
+          && compareReleases(created, targetReleases[0]) <= 0 ) {
+            validRedir = targetReleases[1];
+            anchorfound = true;
+          }
+        }
+      }
+    }
+    if ( anchorfound === false && Object.values(redirObject).indexOf(currentPath) != -1 ) {
+      const targets = redirObject['target'];
+      for ( let j = 0; j < targets.length; j++ ) {
+        const targetReleases = targets[j].split('=>');
+        if ( compareReleases(targetReleases[0], targetReleases[1]) < 0
+        && compareReleases(created, targetReleases[0]) <= 0 ) {
+          validRedir = targetReleases[1];
+        }
+      }
+    }
+
+    if ( validRedir && !excluded.includes(redirObject[validRedir]) ) {
+      relatedTargets.push(
+          {
+            'created': validRedir,
+            'path': redirObject[validRedir],
+          },
+      );
+    }
+  }
+  return relatedTargets;
+}
+
+/**
+* Given 2 release strings, determine their order
+* @param {string} first first release as first operand of the comparisson
+* @param {string} second second release as second operand of the comparisson
+* @return {int} Possible results:
+*     * false => there was an error
+*     * 1 => first is newer
+*     * 0 => same release
+*     * -1 => second is newer
+*/
+function compareReleases(first, second) {
+  const firstNumbers = first.split('.');
+  const secondNumbers = second.split('.');
+  if ( firstNumbers.length < 2 || secondNumbers.length < 2 ) {
+    return false;
+  }
+
+  /* Comparing majors */
+  firstNumbers[0] = parseInt(firstNumbers[0]);
+  secondNumbers[0] = parseInt(secondNumbers[0]);
+  /* The major of the first release is newer */
+  if ( firstNumbers[0] > secondNumbers[0] ) {
+    return 1;
+  }
+  /* The major of the second release is newer */
+  if ( firstNumbers[0] < secondNumbers[0] ) {
+    return -1;
+  }
+
+  /* Same major. Comparing minors */
+  firstNumbers[1] = parseInt(firstNumbers[1]);
+  secondNumbers[1] = parseInt(secondNumbers[1]);
+  /* The minor of the first release is newer */
+  if ( firstNumbers[1] > secondNumbers[1] ) {
+    return 1;
+  }
+  /* The minor of the second release is newer */
+  if ( firstNumbers[1] < secondNumbers[1] ) {
+    return -1;
+  }
+  /* Same minor */
+  return 0;
+}

--- a/source/_static/js/version-selector.js
+++ b/source/_static/js/version-selector.js
@@ -13,51 +13,52 @@ jQuery(function($) {
   * 2. FUNC: Adds the current version to the selector button
   *    - checkCurrentVersion()
   *
-  * 3. FUNC: Adds the notice "Latest version
-  *    - checkLatestDocs()
-  *
-  * 4. FUNC: Creates the correct links to all the releases
+  * 3. FUNC: Creates the correct links to all the releases
   *    - addVersions()
   *
-  *    | 5. FUNC: Normalize a given URL so it comply with a standard format
+  *    | 3.1. FUNC: Normalize a given URL so it comply with a standard format
   *    |    - normalizeUrl()
   *    |
-  *    | 6. FUNC: Get the redirection history
+  *    | 3.2. FUNC: Get the redirection history
   *    |    - getRedirectionHistory()
   *
-  *         | 7. FUNC: Get the release key number
+  *         | 3.2.1. FUNC: Get the release key number
   *         |    - getReleaseNum()
   *         |
-  *         | 8. FUNC: Return redirections about a URL
+  *         | 3.2.2. FUNC: Return redirections about a URL
   *         |    - getInfoRedirectUrl()
   *         |
-  *         | 9. FUNC: Get the logic of the redirects
+  *         | 3.2.3. FUNC: Get the logic of the redirects
   *         |    - getLogicRedirects()
   *         |
-  *         | 10. FUNC: Find the all the URLs
+  *         | 3.2.4. FUNC: Find the all the URLs
   *         |    - fillUrls()
   *
-  *              | 11. FUNC: Find the following URL
+  *              | 3.2.4.1. FUNC: Find the following URL
   *              |    - findNextUrl()
   *              |
-  *              | 12. FUNC: Find the previous URL
+  *              | 3.2.4.2. FUNC: Find the previous URL
   *              |    - findPrevUrl()
   *
-  *         | 13. FUNC: Return the release when a URL is new
+  *         | 3.2.5. FUNC: Return the release when a URL is new
   *         |    - getInfoNewsUrl()
   *         |
-  *         | 14. FUNC: Return the release when a URL was removed
+  *         | 3.2.6. FUNC: Return the release when a URL was removed
   *         |    - getInfoRemovedUrl()
   *
-  * 15. FUNC: Initialize the tooltip of bootstrap
+  * 4. FUNC: Adds the notice "Latest version
+  *    - checkLatestDocs()
+  *
+  * 5. FUNC: Initialize the tooltip of bootstrap
   *    - tooltip()
   *
   */
 
   /* Versions main constants */
-  const currentVersion = '4.0';
+  const currentVersion = '4.1';
   const versions = [
-    {name: '4.0 (current)', url: '/'+currentVersion},
+    {name: '4.1 (current)', url: '/current'},
+    {name: '4.0', url: '/4.0'},
     {name: '3.13', url: '/3.13'},
     {name: '3.12', url: '/3.12'},
     {name: '3.11', url: '/3.11'},
@@ -78,14 +79,28 @@ jQuery(function($) {
   /* Adds the current version to the selector button */
   checkCurrentVersion();
 
-  /* Adds the notice "Latest version" */
-  checkLatestDocs();
-
   /* Creates the correct links to all the releases */
-  addVersions();
+  let documentHistory = addVersions();
   $(window).on('hashchange', function() {
-    addVersions();
+    documentHistory = addVersions();
   });
+
+  /* Adds the notice "Latest version" */
+  checkLatestDocs(documentHistory);
+
+  /* Get proper path for the canonical */
+  const documentInReleases = Object.keys(documentHistory);
+  let canonicalRelease = documentInReleases[documentInReleases.length-1];
+  const canonicalPath = documentHistory[canonicalRelease];
+  if ( canonicalRelease == currentVersion ) {
+    canonicalRelease = 'current';
+  }
+
+  /* Link rel=canonical tag based on the selector */
+  const canonicalTag = !!document.querySelector('link[rel=\'canonical\']') ? document.querySelector('link[rel=\'canonical\']') : document.createElement('link');
+  canonicalTag.setAttribute('rel', 'canonical');
+  canonicalTag.setAttribute('href', document.location.protocol + '//' + document.location.host + '/' + canonicalRelease + canonicalPath);
+  document.head.appendChild(canonicalTag);
 
   /* Initialize the tooltip of bootstrap */
   $('#select-version [data-toggle="tooltip"]').tooltip();
@@ -95,46 +110,65 @@ jQuery(function($) {
    */
   function checkCurrentVersion() {
     let selected = -1;
-    let path = document.location.pathname.replace(/\/{2,}/, '/').split('/')[1];
+    let thisVersion = DOCUMENTATION_OPTIONS.VERSION;
     const selectVersionCurrent = $('#select-version .current');
-    if (path == 'current' || path == '4.0' ) {
-      path = currentVersion;
+    if ( thisVersion == currentVersion ) {
+      thisVersion = 'current';
     }
     for (let i = 0; i < versions.length; i++) {
-      if ( versions[i].url == '/' + path ) {
+      if ( versions[i].url.indexOf('/' + thisVersion) > -1 ) {
         selected = i;
       }
     }
-    selectVersionCurrent.html(versions[selected].name);
+    if ( versions[selected] ) {
+      selectVersionCurrent.html(versions[selected].name);
+    } else {
+      selectVersionCurrent.html(DOCUMENTATION_OPTIONS.VERSION);
+    }
   }
 
   /**
     * Shows a warning message to the user if current doc version is not the latest version.
     * Note: For this to work, it requires the documentation version variable (in file conf.py)
     * and the array of versions (in this script) to be updated.
+    * @param {Object} redirHistory Javascript object containing the corresponding path of
+    *   the current page in every release.
     */
-  function checkLatestDocs() {
-    const thisVersion = document.querySelector('.no-latest-notice').getAttribute('data-version');
-    const latestVersion = versions[0].url.replace('/', '');
+  function checkLatestDocs(redirHistory) {
+    const thisVersion = DOCUMENTATION_OPTIONS.VERSION;
+    const latestVersion = currentVersion;
     let page = '';
     if ( thisVersion !== latestVersion ) {
-      const pageID = document.querySelector('#page');
-      pageID.classList.add('no-latest-docs');
-    }
+      const pageElement = document.querySelector('#page');
+      pageElement.classList.add('no-latest-docs');
+      /* Updates link to the latest version with the correct path */
+      page = document.location.pathname;
+      if ( page[page.length-1] == '/') {
+        page = page+'index.html';
+      }
+      if ( page.indexOf(thisVersion) != -1 ) {
+        page = page.split('/'+thisVersion)[1];
+      } else if ( page.indexOf('current') != -1 ) {
+        page = page.split('/current')[1];
+      }
 
-    /* Updates link to the latest version with the correct path (documentation's home) */
-    page = document.location.pathname.split('/'+thisVersion)[1];
-    const link = document.querySelector('.link-latest');
-    link.setAttribute('href', 'https://' + window.location.hostname + '/' + latestVersion + page);
+      const link = document.querySelector('.link-latest');
+      let targetURL = 'https://' + window.location.hostname + '/current';
+      if ( documentHistory.hasOwnProperty(latestVersion) ) {
+        targetURL = targetURL + redirHistory[latestVersion];
+      }
+      link.setAttribute('href', targetURL);
+    }
   }
 
   /**
    * Adds the available versions to the version selector.
+   * @return {Object} Object with the URL history for the current path
    */
   function addVersions() {
     let ele = '';
     const selectVersionUl = $('#select-version .dropdown-menu');
-    let path = document.location.pathname.replace(/\/{2,}/, '/').split('/')[1];
+    const thisVersion = DOCUMENTATION_OPTIONS.VERSION;
     let fullUrl = window.location.href;
     let page = '';
     let paramDivision = [];
@@ -142,14 +176,19 @@ jQuery(function($) {
     if (fullUrl == null) {
       fullUrl = document.URL; /* Firefox fix */
     }
-    page = fullUrl.split('/'+path)[1];
+
+    page = fullUrl.split(document.location.host)[1];
+    if ( page[page.length-1] == '/' ) {
+      page = page+'index.html';
+    }
+    if ( page.indexOf(thisVersion) != -1 ) {
+      page = page.split('/'+thisVersion)[1];
+    } else if ( page.indexOf('current') != -1 ) {
+      page = page.split('/current')[1];
+    }
     paramDivision = page.split('?');
     page = normalizeUrl(paramDivision[0]);
     param = paramDivision.length == 2 ? ('?'+paramDivision[1]) : '';
-
-    if (path == 'current' || path == '4.0' ) {
-      path = currentVersion;
-    }
 
     /* Creates the links to others versions */
     let href;
@@ -182,7 +221,7 @@ jQuery(function($) {
     }
 
     /* Get the redirection history */
-    const redirHistory = getRedirectionHistory(versionsClean, path, page, newUrls, redirections, removedUrls);
+    const redirHistory = getRedirectionHistory(versionsClean, thisVersion, page, newUrls, redirections, removedUrls);
     versionsClean = versionsClean.reverse();
 
     /* Print the correct links in the selector */
@@ -191,7 +230,11 @@ jQuery(function($) {
       tooltip = '';
       ver = versionsClean[i];
       if ( redirHistory[ver] != null && redirHistory[ver].length ) {
-        href = '/'+ver+redirHistory[ver]+param;
+        if ( ver == currentVersion ) {
+          href = '/current'+redirHistory[ver]+param;
+        } else {
+          href = '/'+ver+redirHistory[ver]+param;
+        }
       } else {
         tooltip = 'class="disable" data-toggle="tooltip" data-placement="left" title="This page is not available in version ' + versions[i].name +'"';
       }
@@ -201,6 +244,7 @@ jQuery(function($) {
       }
     }
     selectVersionUl.html(ele);
+    return redirHistory;
   }
 
   /**

--- a/source/_templates/moved-content.html
+++ b/source/_templates/moved-content.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+{%- set titlesuffix = " · "|safe + docstitle|e %}
+{%- set pagetitle = "Redirecting ..." %}
+<html lang="{{ language }}">
+  <head>
+    <title>{{ pagetitle + titlesuffix }}</title>
+    <meta name="robots" content="noindex">
+    <link rel="stylesheet" id="google-fonts-css" href="https://fonts.googleapis.com/css?family=Montserrat:400,500|Open+Sans:400" type="text/css" media="all">
+    <link rel="stylesheet" href="{{ pathto('_static/css/style-redirect.min.css?ver=' + compilation_ts, 1) }}" type="text/css" />
+
+    {# FAVICON #}
+    {%- if favicon %}
+      <link rel="shortcut icon" href="{{ pathto('_static/' + favicon, 1) }}"/>
+    {%- endif %}
+
+  </head>
+  <body>
+
+    <h1>This content was moved</h1>
+
+    <div id="spinner-wrapper">
+      <span id="spinner"></span>
+    </div>
+
+    <p>Redirecting ...</p>
+    <script src="{{ pathto('_static/js/redirects.min.js?ver=' + compilation_ts, 1) }}"></script>
+    <script src="{{ pathto('_static/js/moved-content.min.js?ver=' + compilation_ts, 1) }}"></script>
+  </body>
+</html>

--- a/source/_themes/wazuh_doc_theme/layout.html
+++ b/source/_themes/wazuh_doc_theme/layout.html
@@ -188,6 +188,21 @@
           </div>
           {% endif %}
 
+          {%- block latest %}
+            {%- set nav_version = version %}
+            {% if current_version %}
+              {%- set nav_version = current_version %}
+            {% endif %}
+            {% if nav_version and not is_latest_release %}
+            <div class="no-latest-notice-wrapper">
+              <div class="no-latest-notice" data-version="{{ nav_version }}">
+                <div class="no-latest-icon-wrapper"><i class="fas fa-exclamation-triangle"></i></div>
+                <div class="no-latest-text-wrapper"><span class="font-weight-bold d-none d-sm-inline-block">Warning:</span> This is the documentation for Wazuh {{ nav_version }}. Check out the docs for <a class="link-latest" href="#">the latest version of Wazuh</a>!</div>
+              </div>
+            </div>
+            {% endif %}
+          {% endblock latest %}
+          
           {# Main content #}
           <main role="main">
             {% block body %} {% endblock %}


### PR DESCRIPTION
## Description

This PR slightly changes the style of the element with the class `no-latest-notice` on wide screens when the page is not scrolled down, so it should look like this:
![imagen](https://user-images.githubusercontent.com/13232723/108830028-2d129180-75c9-11eb-9506-4df27828707d.png)

In addition, the PR updates the documentation's theme with the latest changes that were included since `4.1`.

Related issue: https://github.com/wazuh/wazuh-website/issues/1584

## Checks
- [x] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).