### PR TITLE
[3.6] Slight change in the style of the element 'no-latest-notice'

### DIFF
--- a/source/_static/css/style.css
+++ b/source/_static/css/style.css
@@ -187,7 +187,6 @@ dt {
 .no-latest-notice .no-latest-icon-wrapper {
   color: #ffb600;
   padding: 0;
-  background-color: #fff;
   height: 100%;
   display: flex;
   align-items: center;
@@ -203,11 +202,7 @@ dt {
 
 .no-latest-docs .no-latest-notice {
   display: flex;
-  justify-content: flex-start;
-}
-
-.no-latest-notice .link-latest {
-  color: #333;
+  justify-content: center;
 }
 
 #header {
@@ -3282,17 +3277,16 @@ div.highlight pre {
   .no-latest-notice {
     position: relative;
     border: 1px solid #ffb600;
+		border-radius: 12px;
     margin: 35px 0 15px 0;
     height: auto;
     align-items: stretch;
-    width: fit-content;
-    width: -moz-fit-content;
+    width: 100%;
+    padding: 0 10px;
   }
   
   .no-latest-notice .no-latest-icon-wrapper {
     padding: 7px;
-    background-color: #ffb600;
-    color: #fff;
     min-width: 35px;
     height: auto;
     padding: 10px;
@@ -3300,12 +3294,13 @@ div.highlight pre {
   
   .no-latest-notice .no-latest-text-wrapper {
     font-size: 1.07rem;
-    padding: 15px;
+    padding: 15px 10px;
   }
   
   .scrolled .no-latest-notice {
     margin: 0;
     border: 1px solid #fff;
+    border-radius: 0;
     position: fixed;
     top: 0;
     width: 100%;
@@ -3905,6 +3900,10 @@ div.highlight pre {
 }
 
 @media (min-width: 1440px) {
+  
+  .no-latest-notice .no-latest-text-wrapper {
+    padding: 15px 15px 15px 5px;
+  }
   
   #rst-content.deprecated-content:after {
     height: 540px;

--- a/source/_themes/wazuh_doc_theme/layout.html
+++ b/source/_themes/wazuh_doc_theme/layout.html
@@ -200,7 +200,7 @@
             <div class="no-latest-notice-wrapper">
               <div class="no-latest-notice" data-version="{{ nav_version }}">
                 <div class="no-latest-icon-wrapper"><i class="fas fa-exclamation-triangle"></i></div>
-                <div class="no-latest-text-wrapper"><span class="font-weight-bold d-none d-sm-inline-block">Warning:</span> This is the documentation for Wazuh {{ nav_version }}. Check out the docs for <a class="link-latest font-weight-bold" href="#">the latest version of Wazuh</a>!</div>
+                <div class="no-latest-text-wrapper"><span class="font-weight-bold d-none d-sm-inline-block">Warning:</span> This is the documentation for Wazuh {{ nav_version }}. Check out the docs for <a class="link-latest" href="#">the latest version of Wazuh</a>!</div>
               </div>
             </div>
             {% endif %}


### PR DESCRIPTION
## Description

This PR slightly changes the style of the element with the class `no-latest-notice` on wide screens when the page is not scrolled down, so it should look like this:
![imagen](https://user-images.githubusercontent.com/13232723/108830028-2d129180-75c9-11eb-9506-4df27828707d.png)

Related issue: https://github.com/wazuh/wazuh-website/issues/1584

## Checks
- [x] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).