### PR TITLE
Add information about the new run_as endpoint

### DIFF
--- a/source/user-manual/api/rbac/auth_context.rst
+++ b/source/user-manual/api/rbac/auth_context.rst
@@ -12,7 +12,7 @@ Authorization context login method
 
 This authentication method is used to obtain the permissions dynamically. It allows any authorized user to possibly obtain any desired permissions without it being assigned to any role. To do this, a proper formalization of the authorization context is needed. In this case, the user-roles relations are not taken into consideration.
 
-In order to use this authentication method, a user allowed to use authorization context is needed (how to create and allow a user to use authorization context information :ref:`here <api_rbac_user>`). After that, and having created the necessary security rules, an authorization context with all the required information must be sent, it will be checked against the security rules and finally the permissions associated with them will be granted:
+In order to use this authentication method, a user allowed to use authorization context is needed (how to create and allow a user to use authorization context information :ref:`here <api_rbac_user>`). After that, and having created the necessary security rules, an authorization context with all the required information must be sent, it will be checked against the security rules and finally, the permissions associated with them will be granted:
 
 .. code-block:: console
         :class: output

--- a/source/user-manual/api/rbac/auth_context.rst
+++ b/source/user-manual/api/rbac/auth_context.rst
@@ -10,7 +10,7 @@ This guide provides the basic information needed to start using the Authorizatio
 Authorization context login method
 ----------------------------------
 
-This authentication method is used to obtain the permissions dynamically. It allows any authorized user to possibly obtain any desired permissions without it being assigned to any role. To do this, a proper formalization of the authorization context is needed. In this case the user-roles relations are not taken into consideration.
+This authentication method is used to obtain the permissions dynamically. It allows any authorized user to possibly obtain any desired permissions without it being assigned to any role. To do this, a proper formalization of the authorization context is needed. In this case, the user-roles relations are not taken into consideration.
 
 In order to use this authentication method, a user allowed to use authorization context is needed (how to create and allow a user to use authorization context information :ref:`here <api_rbac_user>`). After that, and having created the necessary security rules, an authorization context with all the required information must be sent, it will be checked against the security rules and finally the permissions associated with them will be granted:
 

--- a/source/user-manual/api/rbac/auth_context.rst
+++ b/source/user-manual/api/rbac/auth_context.rst
@@ -10,7 +10,9 @@ This guide provides the basic information needed to start using the Authorizatio
 Authorization context login method
 ----------------------------------
 
-This authentication method is used to obtain the permissions dynamically. It allows any authorized user to possibly obtain any desired permissions without assigning it to any role. To do this, a properly formalization of the authorization context is needed. In this case the user-roles relations are not taken in consideration. In order to use this method of authentication, a user allowed to use authorization context is needed (how to create a user allowed to use authorization context information :ref:`here <api_rbac_user>`). After that, and having created the necessary security rules, an authorization context with all the required information must be sent, it will be checked against the security rules and finally the permissions associated with them will be granted:
+This authentication method is used to obtain the permissions dynamically. It allows any authorized user to possibly obtain any desired permissions without assigning it to any role. To do this, a properly formalization of the authorization context is needed. In this case the user-roles relations are not taken in consideration.
+
+In order to use this method of authentication, a user allowed to use authorization context is needed (how to create and allow a user to use authorization context information :ref:`here <api_rbac_user>`). After that, and having created the necessary security rules, an authorization context with all the required information must be sent, it will be checked against the security rules and finally the permissions associated with them will be granted:
 
 .. code-block:: console
         :class: output

--- a/source/user-manual/api/rbac/auth_context.rst
+++ b/source/user-manual/api/rbac/auth_context.rst
@@ -10,9 +10,9 @@ This guide provides the basic information needed to start using the Authorizatio
 Authorization context login method
 ----------------------------------
 
-This authentication method is used to obtain the permissions dynamically. It allows any authorized user to possibly obtain any desired permissions without assigning it to any role. To do this, a properly formalization of the authorization context is needed. In this case the user-roles relations are not taken in consideration.
+This authentication method is used to obtain the permissions dynamically. It allows any authorized user to possibly obtain any desired permissions without it being assigned to any role. To do this, a proper formalization of the authorization context is needed. In this case the user-roles relations are not taken into consideration.
 
-In order to use this method of authentication, a user allowed to use authorization context is needed (how to create and allow a user to use authorization context information :ref:`here <api_rbac_user>`). After that, and having created the necessary security rules, an authorization context with all the required information must be sent, it will be checked against the security rules and finally the permissions associated with them will be granted:
+In order to use this authentication method, a user allowed to use authorization context is needed (how to create and allow a user to use authorization context information :ref:`here <api_rbac_user>`). After that, and having created the necessary security rules, an authorization context with all the required information must be sent, it will be checked against the security rules and finally the permissions associated with them will be granted:
 
 .. code-block:: console
         :class: output

--- a/source/user-manual/api/rbac/configuration.rst
+++ b/source/user-manual/api/rbac/configuration.rst
@@ -193,7 +193,7 @@ By default, new users will not be able to authenticate using an authorization co
 
     # curl -k -X PUT "https://localhost:55000/security/users/{user_id}/run_as?allow_run_as=true" -H  "Authorization: Bearer $TOKEN"
 
-The output would look like below:
+The output should look like this:
 
 .. code-block:: json
     :class: output

--- a/source/user-manual/api/rbac/configuration.rst
+++ b/source/user-manual/api/rbac/configuration.rst
@@ -35,7 +35,6 @@ Create a new policy
 As an example, in order to grant access to the agents of a given customer to the "Sales-team", a policy that specifies what actions and on which agents these actions can be carried out must be created. The required policy can be defined like the following one:
 
 .. code-block:: json
-    :class: output
 
     {
       "name": "customer_x_agents",

--- a/source/user-manual/api/rbac/configuration.rst
+++ b/source/user-manual/api/rbac/configuration.rst
@@ -155,13 +155,12 @@ This information needs to be specified in order to create a new user. As an exam
 
     {
       "username": "sales-member-1",
-      "password": "Sales-Member-1",
-      "allow_run_as": false
+      "password": "Sales-Member-1"
     }
 
 .. code-block:: console
 
-    # curl -k -X POST "https://localhost:55000/security/users?pretty=true" -H  "accept: application/json" -H  "Authorization: Bearer $TOKEN" -H  "Content-Type: application/json" -d "{\"username\":\"sales-member-1\",\"password\":\"Sales-Member-1\",\"allow_run_as\":false}"
+    # curl -k -X POST "https://localhost:55000/security/users?pretty=true" -H  "accept: application/json" -H  "Authorization: Bearer $TOKEN" -H  "Content-Type: application/json" -d "{\"username\":\"sales-member-1\",\"password\":\"Sales-Member-1\"}"
 
 There is a parameter called ``allow_run_as`` on the highlighted line. If set to *true*, roles can be assigned to the user based on the information of an authorization context. Visit this section to find more detailed information about :ref:`Authorization Context <authorization_context_method>`.
 
@@ -183,6 +182,35 @@ The output would look like below:
         "failed_items": []
       },
       "message": "User was successfully created",
+      "error": 0
+    }
+
+Enable run_as
+-------------
+By default, new users will not be able to authenticate using an authorization context. To enable this option, it is necessary to give permission to the user. To do this, make a request to :api-ref:`PUT /security/users/{user_id}/run_as <operation/api.controllers.security_controller.edit_run_as>`.
+
+.. code-block:: console
+
+    # curl -k -X PUT "https://localhost:55000/security/users/{user_id}/run_as?allow_run_as=true" -H  "Authorization: Bearer $TOKEN"
+
+The output would look like below:
+
+.. code-block:: json
+    :class: output
+
+    {
+      "data": {
+        "affected_items": [{
+          "id": 101,
+          "username": "sales-member-1",
+          "allow_run_as": true,
+          "roles": []
+        }],
+        "total_affected_items": 1,
+        "total_failed_items": 0,
+        "failed_items": []
+      },
+      "message": "Parameter allow_run_as has been enabled for the user",
       "error": 0
     }
 
@@ -292,7 +320,7 @@ Following the previous example, it is possible to assign a new user named "sales
           {
             "id": 101,
             "username": "sales-member-1",
-            "allow_run_as": false,
+            "allow_run_as": true,
             "roles": [
               100
             ]

--- a/source/user-manual/api/rbac/configuration.rst
+++ b/source/user-manual/api/rbac/configuration.rst
@@ -35,6 +35,7 @@ Create a new policy
 As an example, in order to grant access to the agents of a given customer to the "Sales-team", a policy that specifies what actions and on which agents these actions can be carried out must be created. The required policy can be defined like the following one:
 
 .. code-block:: json
+    :class: output
 
     {
       "name": "customer_x_agents",
@@ -151,7 +152,6 @@ To create a new user, make a request to :api-ref:`POST /security/users <operatio
 This information needs to be specified in order to create a new user. As an example, its name will be "sales-member-1":
 
 .. code-block:: json
-    :emphasize-lines: 4
 
     {
       "username": "sales-member-1",

--- a/source/user-manual/api/rbac/configuration.rst
+++ b/source/user-manual/api/rbac/configuration.rst
@@ -185,9 +185,9 @@ The output would look like below:
       "error": 0
     }
 
-Enable run_as
--------------
-By default, new users will not be able to authenticate using an authorization context. To enable this option, it is necessary to give permission to the user. To do this, make a request to :api-ref:`PUT /security/users/{user_id}/run_as <operation/api.controllers.security_controller.edit_run_as>`.
+Edit allow_run_as
+-----------------
+By default, new users will not be able to authenticate using an authorization context. To enable this option, it is necessary to enable the ``allow_run_as`` parameter for the user. To do this, make a request to :api-ref:`PUT /security/users/{user_id}/run_as <operation/api.controllers.security_controller.edit_run_as>`.
 
 .. code-block:: console
 

--- a/source/user-manual/api/rbac/reference.rst
+++ b/source/user-manual/api/rbac/reference.rst
@@ -101,6 +101,7 @@ This reference also contains a set of default roles and policies that can be imm
         - `security:create_user`_
         - `security:create`_
         - `security:delete`_
+        - `security:edit_run_as`_
         - `security:read_config`_
         - `security:read`_
         - `security:revoke`_
@@ -563,6 +564,10 @@ security:delete
 - :api-ref:`DELETE /security/users <operation/api.controllers.security_controller.delete_users>` (`user:id`_)
 - :api-ref:`DELETE /security/users/{user_id}/roles <operation/api.controllers.security_controller.remove_user_role>` (`user:id`_, `role:id`_)
 
+security:edit_run_as
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+- :api-ref:`PUT /security/users/{user_id}/run_as <operation/api.controllers.security_controller.edit_run_as>` (`*:*`_)
+
 security:read_config
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 - :api-ref:`GET /security/config <operation/api.controllers.security_controller.get_security_config>` (`*:*`_)
@@ -955,6 +960,7 @@ Provide full access to all security related functionalities.
       actions:
         - security:create
         - security:create_user
+        - security:edit_run_as
         - security:read_config
         - security:update_config
         - security:revoke
@@ -1036,6 +1042,7 @@ Provide full access to all users related functionalities.
     resourceless:
       actions:
         - security:create_user
+        - security:edit_run_as
         - security:revoke
       resources:
         - '*:*:*'
@@ -1047,6 +1054,19 @@ Provide full access to all users related functionalities.
         - security:delete
       resources:
         - user:id:*
+      effect: allow
+
+users_modify_run_as
+^^^^^^^^^^^^^^^^^^^
+Provides the capability to modify the users' run_as parameter.
+
+.. code-block:: yaml
+
+    flag:
+      actions:
+        - security:edit_run_as
+      resources:
+        - '*:*:*'
       effect: allow
 
 vulnerability_read


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

Hi team,

In this PR, we have modified and added information regarding the new way to use the run_as parameter of the API users.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->
