### PR TITLE
decoders: deprecate `empty` value from `json_null_field` option

### DIFF
--- a/source/user-manual/ruleset/ruleset-xml-syntax/decoders.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/decoders.rst
@@ -455,9 +455,11 @@ Specifies how to treat the `NULL` fields coming from the JSON events. Only for t
 +--------------------+-------------------------------------------------------------------------+
 | **Allowed values** | string (It shows the NULL value as string)                              |
 +                    +-------------------------------------------------------------------------+
-|                    | discard (It discard NULL fields and doesn't store them into the alert)  |
+|                    | discard (It discards NULL fields and doesn't store them into the alert) |
 +                    +-------------------------------------------------------------------------+
 |                    | empty (It shows the NULL field as an empty field)                       |
+|                    |                                                                         |
+|                    | .. deprecated:: 3.7                                                     |
 +--------------------+-------------------------------------------------------------------------+
 
 json_array_structure


### PR DESCRIPTION
|Related issue|
|---|
|wazuh/wazuh#7486 |

## Description

Hi team!

This PR aims to add `deprecate` message to `empty` value on decoder's `json_null_field` option, since it was deprecated in v3.7.

## Checks
- [X] It compiles without warnings.
- [X] Spelling and grammar. 
- [X] Used impersonal speech. 
- [X] Used uppercase only on nouns. 
- [X] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

Regards,
Nico