### PR TITLE
Adding warning messages to properly set the notify time and the disconnection time

### DIFF
--- a/source/user-manual/reference/ossec-conf/client.rst
+++ b/source/user-manual/reference/ossec-conf/client.rst
@@ -211,6 +211,10 @@ Specifies the time in seconds between agent checkins to the manager.  More frequ
 | **Allowed values** | A positive number (seconds) |
 +--------------------+-----------------------------+
 
+.. warning::
+
+  This setting should always be lower than the :ref:`disconnection time <reference_agents_disconnection_time>` configured for the agents in the manager. This allows them to always notify the manager before it would consider them disconnected.
+
 .. _time_reconnect:
 
 time-reconnect

--- a/source/user-manual/reference/ossec-conf/client.rst
+++ b/source/user-manual/reference/ossec-conf/client.rst
@@ -213,7 +213,7 @@ Specifies the time in seconds between agent checkins to the manager.  More frequ
 
 .. warning::
 
-  This setting should always be lower than the :ref:`disconnection time <reference_agents_disconnection_time>` configured for the agents in the manager. This allows them to always notify the manager before it would consider them disconnected.
+  This setting should always be lower than :ref:`disconnection time <reference_agents_disconnection_time>` configured for the agents in the manager. This allows them to always notify the manager before it would consider them disconnected.
 
 .. _time_reconnect:
 

--- a/source/user-manual/reference/ossec-conf/global.rst
+++ b/source/user-manual/reference/ossec-conf/global.rst
@@ -458,6 +458,10 @@ This sets the time after which the manager considers an agent as disconnected si
 | **Allowed values**      | A positive number that should end with a character indicating a time unit, such as: s (seconds), m (minutes), h (hours), d (days). The minimum allowed is 1s. |
 +-------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
+.. warning::
+
+  This setting should always be greater than the :ref:`notify-time <notify_time>` configured in the agents. This allows them to always notify the manager before it would consider them disconnected.
+
 Example:
 
 .. code-block:: xml

--- a/source/user-manual/reference/ossec-conf/global.rst
+++ b/source/user-manual/reference/ossec-conf/global.rst
@@ -460,7 +460,7 @@ This sets the time after which the manager considers an agent as disconnected si
 
 .. warning::
 
-  This setting should always be greater than the :ref:`notify-time <notify_time>` configured in the agents. This allows them to always notify the manager before it would consider them disconnected.
+  This setting should always be greater than :ref:`notify-time <notify_time>` configured in the agents. This allows them to always notify the manager before it would consider them disconnected.
 
 Example:
 


### PR DESCRIPTION
## Description

This pull request adds some warning messages to keep in mind when configuring the values for the [notify-time](https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/client.html#notify-time) and [agents-disconnection-time](https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/global.html#agents-disconnection-time) settings. This prevents the users to run into a configuration that could result in agents being disconnected constantly.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns.