### PR TITLE
conf.py: bump WAZUH_LATEST_ANSIBLE to 4.1.1

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -434,7 +434,7 @@ custom_replacements = {
     "|CURRENT_MAJOR|" : "4.x",
     "|WAZUH_LATEST|" : "4.1.1",
     "|WAZUH_LATEST_MINOR|": "4.1",
-    "|WAZUH_LATEST_ANSIBLE|" : "4.0.4",
+    "|WAZUH_LATEST_ANSIBLE|" : "4.1.1",
     "|WAZUH_LATEST_KUBERNETES|" : "4.1.0",
     "|WAZUH_LATEST_PUPPET|" : "4.0.4",
     "|WAZUH_LATEST_OVA|" : "4.1.1",


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

This PR bumps Ansible deployment version to [v4.1.1](https://github.com/wazuh/wazuh-ansible/tree/v4.1.1). The following issues could be closed:
1. #3286
2. #3527

<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

## Checks
- [x] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).


