### PR TITLE
Adding gpg as a Debian dependency

### DIFF
--- a/resources/open-distro/unattended-installation/all-in-one-installation.sh
+++ b/resources/open-distro/unattended-installation/all-in-one-installation.sh
@@ -141,7 +141,7 @@ installPrerequisites() {
         export JAVA_HOME=/usr/
     elif [ ${sys_type} == "apt-get" ]; then
         eval "apt-get update -q ${debug}"
-        eval "apt-get install apt-transport-https curl unzip wget libcap2-bin -y -q ${debug}"
+        eval "apt-get install apt-transport-https curl unzip wget libcap2-bin gpg -y -q ${debug}"
 
         if [ -n "$(command -v add-apt-repository)" ]; then
             eval "add-apt-repository ppa:openjdk-r/ppa -y ${debug}"


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

In order to improve the experience of new users who use the all-in-one script for their initial testing, I added GPG to the list of dependencies, so that the user can effectively install the product on systems with fewer packages (such as the Debian image used by Microsoft Azure, for example).

This PR was tested using the Azure VM that presented the initial problem and also in a local Docker container, using the debian: 10 image and the result was safisfactory in both cases.

<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->
Closes https://github.com/wazuh/wazuh/issues/7688
## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->
