### PR TITLE
[3.12] Fix for the header links

### DIFF
--- a/source/_static/css/style.css
+++ b/source/_static/css/style.css
@@ -1249,11 +1249,12 @@ aside.help {
   font-size: 1.4rem;
 }
 
-.index a.headerlink {
-  content: none;
+.index h1 a.headerlink,
+.index h1:hover a.headerlink {
+  display: none;
 }
 
-:not(.index) a.headerlink {
+a.headerlink {
   min-height: 1.5rem;
   color: transparent;
   -webkit-user-select: none;
@@ -1262,7 +1263,7 @@ aside.help {
   user-select: none;
   font-size: 1rem;
   vertical-align: middle;
-  display: none;
+  display: inline-block;
 }
 
 a.headerlink:before {
@@ -1296,6 +1297,7 @@ h5:active > a.headerlink,
 h6:hover > a.headerlink,
 h6:active > a.headerlink {
   display: inline-block;
+  opacity: 1;
 }
 
 .index h3:hover > a.headerlink,
@@ -2992,6 +2994,16 @@ div.highlight pre {
   background-position: center;
 }
 
+.section {
+  padding-top: 60px;
+  margin-top: -60px;
+}
+
+.no-latest-docs .section {
+  padding-top: 140px;
+  margin-top: -140px;
+}
+
 @media (min-width:576px){
   
   #capabilities .right .topic p:not(.topic-title) {
@@ -3273,6 +3285,15 @@ div.highlight pre {
   
   #page.no-latest-docs {
     padding-top: 0;
+  }
+  
+  a.headerlink {
+    opacity: 0;
+  }
+  
+  .no-latest-docs .section {
+    padding-top: 110px;
+    margin-top: -110px;
   }
 
   .no-latest-notice-wrapper {

--- a/source/_static/js/style.js
+++ b/source/_static/js/style.js
@@ -74,13 +74,6 @@ $(function() {
 
   markTocNodesWithClass(emptyTocNodes, 'empty-toc-node');
   checkScroll();
-  if (document.location.hash) {
-    correctScrollTo(document.location.hash);
-  }
-  $('.headerlink').on('click', function(e) {
-    e.preventDefault();
-    correctScrollTo($(e.target).attr('href'));
-  });
 
   /* Finds all nodes that contains subtrees within the globaltoc and appends a toggle button to them */
   $('.globaltoc .toctree-l1 a').each(function(e) {
@@ -91,10 +84,6 @@ $(function() {
   });
 
   hideSubtree(hideSubtreeNodes);
-
-  $(window).on('hashchange', function(e) {
-    correctScrollTo(document.location.hash);
-  });
 
   /* Turn all tables in responsive table */
   reponsiveTables();
@@ -418,30 +407,6 @@ $(function() {
     reponsiveTables();
     checkScroll();
   });
-
-  /**
-   * Corrects the scrolling movement so the element to which the page is being scrolled appears correctly in the screen,
-   * having in mind the top bar and the no-latest-notice if present.
-   * @param {int} targetAnchor Selector of the element in the head of the section where the scroll should stop.
-   */
-  function correctScrollTo(targetAnchor) {
-    let spaceBeforeAnchor = 0;
-    if ( $(targetAnchor).length > 0 ) {
-      setTimeout(function() {
-        spaceBeforeAnchor = parseInt($('#header').outerHeight());
-        if ($('#page').hasClass('no-latest-docs')) {
-          if ($(window).outerWidth() >= 992) {
-            /* The height of the .no-latest-notice may vary for wide screens
-            but here we are using a fixed value (50px) for now */
-            spaceBeforeAnchor = spaceBeforeAnchor + 50;
-          } else {
-            spaceBeforeAnchor = spaceBeforeAnchor + parseInt($('.no-latest-notice').outerHeight());
-          }
-        }
-        window.scrollTo(window.scrollX, $(targetAnchor).offset().top - spaceBeforeAnchor, 'smooth');
-      }, 100);
-    }
-  }
 
   /* -- Add functionality for the capabilities in the home page --------------------------------------------- */
 


### PR DESCRIPTION
## Description

This PR fixes the bug that prevents the update of the hash in the address bar after clicking the link next to any heading.

Related issue: https://github.com/wazuh/wazuh-website/issues/1601

## Checks
- [x] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).