### PR TITLE
Fix description of integrationd configuration options

### DIFF
--- a/source/user-manual/reference/ossec-conf/integration.rst
+++ b/source/user-manual/reference/ossec-conf/integration.rst
@@ -96,19 +96,19 @@ This filters alerts by rule group. For the VirusTotal integration, only rules fr
 +--------------------+------------------------------------------------------------+
 | **Default value**  | n/a                                                        |
 +--------------------+------------------------------------------------------------+
-| **Allowed values** | Any rule group or vertical bar-separated rule groups.      |
+| **Allowed values** | Any rule group or comma-separated rule groups.             |
 +--------------------+------------------------------------------------------------+
 
 event_location
 ^^^^^^^^^^^^^^
 
-This filters alerts by where the event originated. Follows the :ref:`OS_Regex Syntax<os_regex_syntax>`.
+This filters alerts by where the event originated.
 
-+--------------------+-----------------------------------------------------------+
-| **Default value**  | n/a                                                       |
-+--------------------+-----------------------------------------------------------+
-| **Allowed values** | Any single log file.                                      |
-+--------------------+-----------------------------------------------------------+
++--------------------+--------------------------------------------------------------+
+| **Default value**  | n/a                                                          |
++--------------------+--------------------------------------------------------------+
+| **Allowed values** | Any :ref:`sregex<os_sregex_syntax>` expression.              |
++--------------------+--------------------------------------------------------------+
 
 alert_format
 ^^^^^^^^^^^^
@@ -121,6 +121,8 @@ This writes the alert file in the JSON format. The Integrator makes use this fil
 | **Allowed values** | json                                                      |
 +--------------------+-----------------------------------------------------------+
 
+.. note:: This option must be set to ``json`` for Slack and VirusTotal integrations.
+
 max_log
 ^^^^^^^
 
@@ -132,6 +134,8 @@ The maximum length of an alert snippet that will be sent to the Integrator.  Lon
 | **Allowed values** | Any integer from 165 to 1024 inclusive.                   |
 +--------------------+-----------------------------------------------------------+
 
+.. note:: This option only applies if ``alert_format`` is not set to ``json``.
+
 Configuration example
 ---------------------
 
@@ -142,7 +146,7 @@ Configuration example
     <name>slack</name>
     <hook_url>https://hooks.slack.com/services/...</hook_url> <!-- Replace with your Slack hook URL -->
     <level>10</level>
-    <group>multiple_drops|authentication_failures</group>
+    <group>multiple_drops,authentication_failures</group>
     <alert_format>json</alert_format>
   </integration>
 
@@ -165,7 +169,7 @@ Configuration example
     <name>custom-integration</name>
     <hook_url>WEBHOOK</hook_url>
     <level>10</level>
-    <group>multiple_drops|authentication_failures</group>
+    <group>multiple_drops,authentication_failures</group>
     <api_key>APIKEY</api_key> <!-- Replace with your external service API key -->
     <alert_format>json</alert_format>
   </integration>

--- a/source/user-manual/ruleset/ruleset-xml-syntax/regex.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/regex.rst
@@ -86,6 +86,8 @@ This library is designed to be simple while still supporting the most common reg
   - ``\s`` matches only an ASCII space (32), not other whitespace like tab
   - there is no syntax to match a literal caret, asterisk or plus (although ``\p`` will match asterisk or plus, along with some other characters)
 
+.. _os_sregex_syntax:
+
 Sregex (OS_Match) syntax
 -----------------------------
 


### PR DESCRIPTION
## Description

Closes #3580 

Hi team!
This PR fix multiple descriptions of integrationd configuration options;

- `group` option use comma separated rules groups
- `location` option use OSMatch as regex
- Add note to `alert_format` about `json` need for Slack and VirusTotal integrations
- `max_log` is only valid when `alert_format` is not set to `json`

## Checks
- [X] It compiles without warnings.
- [X] Spelling and grammar. 
- [X] Used impersonal speech. 
- [X] Used uppercase only on nouns. 
- [X] ~Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).~

Regards,
Nico
