### PR TITLE
quick typo fix

### DIFF
--- a/source/user-manual/ruleset/ruleset-xml-syntax/pcre2.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/pcre2.rst
@@ -44,7 +44,7 @@ Case sensitivity
 
 Compared to `OSRegex <regex.html#regex-os-regex-syntax>`_ and `OSMatch <regex.html#regex-os-regex-syntax>`_ 
 that are case insensitive, PCRE regex are case sensitive by default. This can be changed by using ``(?i)``.
-Example: `post` will match ``(?i)POST|GET|PUT`` regex but no ``POST|GET|PUT``.
+Example: `post` will match ``(?i)POST|GET|PUT`` regex but not ``POST|GET|PUT``.
 
 Groups within groups
 --------------------


### PR DESCRIPTION
noticed a `t` was missing


## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
