### PR TITLE
ignore_time property renamed to min_full_scan_interval

### DIFF
--- a/source/deploying-with-ansible/reference.rst
+++ b/source/deploying-with-ansible/reference.rst
@@ -472,7 +472,7 @@ Wazuh Manager
     wazuh_manager_vulnerability_detector:
       enabled: 'no'
       interval: '5m'
-      ignore_time: '6h'
+      min_full_scan_interval: '6h'
       run_on_start: 'yes'
       providers:
         - enabled: 'no'

--- a/source/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-manager-class.rst
+++ b/source/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-manager-class.rst
@@ -492,7 +492,7 @@ $vulnerability_detector_interval
   `Default 5m`
 
 $vulnerability_detector_min_full_scan_interval
-  Time interval which a full scan will be triggered if vulnerability database is updated with new CVEs information.
+  Time interval in which a full scan will be triggered if vulnerability database is updated with new CVEs information.
 
   `Default 6h`
 

--- a/source/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-manager-class.rst
+++ b/source/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-manager-class.rst
@@ -491,8 +491,8 @@ $vulnerability_detector_interval
 
   `Default 5m`
 
-$vulnerability_detector_ignore_time
-  Time during which vulnerabilities that have already been alerted will be ignored.
+$vulnerability_detector_min_full_scan_interval
+  Time interval which a full scan will be triggered if vulnerability database is updated with new CVEs information.
 
   `Default 6h`
 

--- a/source/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-manager-class.rst
+++ b/source/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-manager-class.rst
@@ -492,7 +492,7 @@ $vulnerability_detector_interval
   `Default 5m`
 
 $vulnerability_detector_min_full_scan_interval
-  Time interval in which a full scan will be triggered if vulnerability database is updated with new CVEs information.
+  Time interval in which a full scan will be triggered if the database of vulnerabilities is updated with new CVEs information.
 
   `Default 6h`
 

--- a/source/learning-wazuh/vuln-detection.rst
+++ b/source/learning-wazuh/vuln-detection.rst
@@ -85,7 +85,7 @@ In the ``/var/ossec/etc/ossec.conf`` file of the Wazuh manager, scroll down to t
     <vulnerability-detector>
       <enabled>yes</enabled>
       <interval>5m</interval>
-      <ignore_time>6h</ignore_time>
+      <min_full_scan_interval>6h</min_full_scan_interval>
       <run_on_start>yes</run_on_start>
       <provider name="canonical">
         <enabled>no</enabled>

--- a/source/user-manual/capabilities/vulnerability-detection/how_it_works.rst
+++ b/source/user-manual/capabilities/vulnerability-detection/how_it_works.rst
@@ -30,7 +30,7 @@ In any of these cases, the packages and the operating system that were already s
 This improves the performance and avoids repeated alerts during a configurable time. We have then three different types of scan:
 
 - Baseline: This scan type will be triggered the first time after Vulnerability Detector is enabled. It performs a full scan for every single package installed as well as the operating system. As a result, the CVEs inventory will have the information of the vulnerabilities detected but no alerts will be generated.
-- Full scan: In this scan type, all the available packages are scanned and alerted only when the configured :ref:`min_full_scan_interval <vuln_det_min_full_scan_interval>` expires and the CVEs database is updated with new information.
+- Full scan: In this scan type, every single package installed as well as the operating system are scanned. It runs only when the configured :ref:`min_full_scan_interval <vuln_det_min_full_scan_interval>` expires and the CVEs database is updated with new information. As a result, the newly detected vulnerabilities and the ones that no longer affect the agent will be alerted.
 - Partial scans: Only new packages are scanned and alerted.
 
 There are few considerations that arise from this behavior:

--- a/source/user-manual/capabilities/vulnerability-detection/how_it_works.rst
+++ b/source/user-manual/capabilities/vulnerability-detection/how_it_works.rst
@@ -31,7 +31,7 @@ This improves the performance and avoids repeated alerts during a configurable t
 
 - Baseline: This scan type will be triggered the first time after Vulnerability Detector is enabled. It performs a full scan for every single package installed as well as the operating system. As a result, the CVEs inventory will have the information of the vulnerabilities detected but no alerts will be generated.
 - Full scan: In this scan type, every single package installed as well as the operating system are scanned. It runs only when the configured :ref:`min_full_scan_interval <vuln_det_min_full_scan_interval>` expires and the CVEs database is updated with new information. As a result, the newly detected vulnerabilities and the ones that no longer affect the agent will be alerted.
-- Partial scans: Only new packages are scanned and alerted.
+- Partial scans: Only new packages are scanned and the vulnerabilities detected are alerted.
 
 There are few considerations that arise from this behavior:
 

--- a/source/user-manual/capabilities/vulnerability-detection/how_it_works.rst
+++ b/source/user-manual/capabilities/vulnerability-detection/how_it_works.rst
@@ -29,7 +29,7 @@ The Vulnerability Detector module can run a scan on startup (:ref:`run_on_start 
 In any of these cases, the packages and the operating system that were already scanned will be re-scanned if the database of vulnerabilities receives new CVEs information and :ref:`min_full_scan_interval <vuln_det_min_full_scan_interval>` expires.
 This improves the performance and avoids repeated alerts during a configurable time. We have then three different types of scan:
 
-- Baseline: This scan type will be triggered the first time after Vulnerability Detector is enabled, it performs a full scan considering every single package installed as well as the operating system without alerting any of those events.
+- Baseline: This scan type will be triggered the first time after Vulnerability Detector is enabled. It performs a full scan for every single package installed as well as the operating system. As a result, the CVEs inventory will have the information of the vulnerabilities detected but no alerts will be generated.
 - Full scan: In this scan type, all the available packages are scanned and alerted only when the configured :ref:`min_full_scan_interval <vuln_det_min_full_scan_interval>` expires and the CVEs database is updated with new information.
 - Partial scans: Only new packages are scanned and alerted.
 

--- a/source/user-manual/capabilities/vulnerability-detection/how_it_works.rst
+++ b/source/user-manual/capabilities/vulnerability-detection/how_it_works.rst
@@ -26,7 +26,7 @@ Scan types
 ^^^^^^^^^^
 
 The Vulnerability Detector module can run a scan on startup (:ref:`run_on_start <vuln_det_run_on_start>`) and every certain period of time (:ref:`interval <vuln_det_interval>`).
-In any of these cases, the packages and operating system that have already been scanned will be re-scanned if the vulnerability database receives new CVEs information and :ref:`min_full_scan_interval <vuln_det_min_full_scan_interval>` expires.
+In any of these cases, the packages and the operating system that were already scanned will be re-scanned if the database of vulnerabilities receives new CVEs information and :ref:`min_full_scan_interval <vuln_det_min_full_scan_interval>` expires.
 This improves the performance and avoids repeated alerts during a configurable time. We have then three different types of scan:
 
 - Baseline: This scan type will be triggered the first time after Vulnerability Detector is enabled, it performs a full scan considering every single package installed as well as the operating system without alerting any of those events.

--- a/source/user-manual/capabilities/vulnerability-detection/how_it_works.rst
+++ b/source/user-manual/capabilities/vulnerability-detection/how_it_works.rst
@@ -35,7 +35,6 @@ This improves the performance and avoids repeated alerts during a configurable t
 
 There are few considerations that arise from this behavior:
 
-- Full and partial scans will generate alerts for all the new vulnerabilities found after the CVEs database is updated.
 - The user can not trigger a full scan manually, the only option is to disable and enable Vulnerability Detector to trigger the baseline scan. For that purpose a service restart is needed.
 - The partial scans generate alerts for new packages, but they do not delete alerts for removed packages.
 - Partial scans can be triggered with a Manager restart.

--- a/source/user-manual/capabilities/vulnerability-detection/how_it_works.rst
+++ b/source/user-manual/capabilities/vulnerability-detection/how_it_works.rst
@@ -35,7 +35,7 @@ This improves the performance and avoids repeated alerts during a configurable t
 
 There are few considerations that arise from this behavior:
 
-- The user can not trigger a full scan manually, the only option is to disable and enable Vulnerability Detector to trigger the baseline scan. For that purpose a service restart is needed.
+- The user can not trigger a full scan manually. The only option is to disable and enable Vulnerability Detector to trigger the baseline scan. For that purpose, a service restart is needed.
 - The partial scans generate alerts for new packages, but they do not delete alerts for removed packages.
 - Partial scans can be triggered with a Manager restart.
 

--- a/source/user-manual/capabilities/vulnerability-detection/how_it_works.rst
+++ b/source/user-manual/capabilities/vulnerability-detection/how_it_works.rst
@@ -26,16 +26,17 @@ Scan types
 ^^^^^^^^^^
 
 The Vulnerability Detector module can run a scan on startup (:ref:`run_on_start <vuln_det_run_on_start>`) and every certain period of time (:ref:`interval <vuln_det_interval>`).
-In any of these cases, the packages that have already been scanned will wait until the :ref:`ignore_time <vuln_det_ignore_time>` expires to be re-scanned.
-This improves the performance and avoids repeated alerts during a configurable time. We have then two different types of scan:
+In any of these cases, the packages and operating system that have already been scanned will be re-scanned if the vulnerability database receives new CVEs information and :ref:`min_full_scan_interval <vuln_det_min_full_scan_interval>` expires.
+This improves the performance and avoids repeated alerts during a configurable time. We have then three different types of scan:
 
-- Full scan: The first time, Vulnerability Detector scans every single package installed. After this, all the available packages are scanned again only when the configured :ref:`ignore_time <vuln_det_ignore_time>` expires.
-- Partial scans: Only new packages are scanned while :ref:`ignore_time <vuln_det_ignore_time>` is still valid.
+- Baseline: This scan type will be triggered after Vulnerability Detector is enabled, Vulnerability Detector performs a full scan considering every single package installed without alerting any of these events.
+- Full scan: In this scan type, all the available packages are scanned again only when the configured :ref:`min_full_scan_interval <vuln_det_min_full_scan_interval>` expires and the CVEs database is updated with new information.
+- Partial scans: Only new packages are scanned.
 
 There are few considerations that arise from this behavior:
 
-- Every full scan generates alerts for all the packages, so the alerts are repeated until they get fixed.
-- The user ca not trigger a full scan manually, the only option is to decrease the :ref:`ignore_time <vuln_det_ignore_time>` setting.
+- Every full scan (not baseline) generates alerts for all the packages, so the alerts are repeated until they get fixed.
+- The user can not trigger a full scan manually, the only option is to disable and enable Vulnerability Detector to trigger the baseline scan.
 - The partial scans generate alerts for new packages, but they do not delete alerts for removed packages.
 - Partial scans can be triggered with a Manager restart.
 

--- a/source/user-manual/capabilities/vulnerability-detection/how_it_works.rst
+++ b/source/user-manual/capabilities/vulnerability-detection/how_it_works.rst
@@ -29,14 +29,14 @@ The Vulnerability Detector module can run a scan on startup (:ref:`run_on_start 
 In any of these cases, the packages and operating system that have already been scanned will be re-scanned if the vulnerability database receives new CVEs information and :ref:`min_full_scan_interval <vuln_det_min_full_scan_interval>` expires.
 This improves the performance and avoids repeated alerts during a configurable time. We have then three different types of scan:
 
-- Baseline: This scan type will be triggered after Vulnerability Detector is enabled, Vulnerability Detector performs a full scan considering every single package installed without alerting any of these events.
-- Full scan: In this scan type, all the available packages are scanned again only when the configured :ref:`min_full_scan_interval <vuln_det_min_full_scan_interval>` expires and the CVEs database is updated with new information.
-- Partial scans: Only new packages are scanned.
+- Baseline: This scan type will be triggered the first time after Vulnerability Detector is enabled, it performs a full scan considering every single package installed as well as the operating system without alerting any of those events.
+- Full scan: In this scan type, all the available packages are scanned and alerted only when the configured :ref:`min_full_scan_interval <vuln_det_min_full_scan_interval>` expires and the CVEs database is updated with new information.
+- Partial scans: Only new packages are scanned and alerted.
 
 There are few considerations that arise from this behavior:
 
-- Every full scan (not baseline) generates alerts for all the packages, so the alerts are repeated until they get fixed.
-- The user can not trigger a full scan manually, the only option is to disable and enable Vulnerability Detector to trigger the baseline scan.
+- Full and partial scans will generate alerts for all the new vulnerabilities found after the CVEs database is updated.
+- The user can not trigger a full scan manually, the only option is to disable and enable Vulnerability Detector to trigger the baseline scan. For that purpose a service restart is needed.
 - The partial scans generate alerts for new packages, but they do not delete alerts for removed packages.
 - Partial scans can be triggered with a Manager restart.
 

--- a/source/user-manual/reference/ossec-conf/vuln-detector.rst
+++ b/source/user-manual/reference/ossec-conf/vuln-detector.rst
@@ -82,7 +82,7 @@ Runs updates and vulnerabilities scans immediately when service is started.
 min_full_scan_interval
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Time during which a full scan will not be performed even if the CVEs database is updated. When this time has passed, a :ref:`full scan <vuln_det_scan_types>` will be performed only if the CVEs database has changed.
+The time during which a full scan will not be performed even if the database of vulnerabilities is updated. When this time expires, a :ref:`full scan <vuln_det_scan_types>` will be performed only if the CVEs database has changed.
 
 +----------------------+------------------------------------------------------------------------------------------------------------------------------------+
 | **Default value**    | 6 hours                                                                                                                            |

--- a/source/user-manual/reference/ossec-conf/vuln-detector.rst
+++ b/source/user-manual/reference/ossec-conf/vuln-detector.rst
@@ -82,7 +82,7 @@ Runs updates and vulnerabilities scans immediately when service is started.
 min_full_scan_interval
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Time during which a full scan will not be performed even if the CVEs database is updated. When this time has passed, only a :ref:`full scan <vuln_det_scan_types>` will be performed if the CVEs database has changed.
+Time during which a full scan will not be performed even if the CVEs database is updated. When this time has passed, a :ref:`full scan <vuln_det_scan_types>` will be performed only if the CVEs database has changed.
 
 +----------------------+------------------------------------------------------------------------------------------------------------------------------------+
 | **Default value**    | 6 hours                                                                                                                            |

--- a/source/user-manual/reference/ossec-conf/vuln-detector.rst
+++ b/source/user-manual/reference/ossec-conf/vuln-detector.rst
@@ -22,7 +22,7 @@ Options
 - `enabled`_
 - `interval`_
 - `run_on_start`_
-- `ignore_time`_
+- `min_full_scan_interval`_
 - `provider`_
 
 +---------------------------+-----------------------------+
@@ -34,7 +34,7 @@ Options
 +---------------------------+-----------------------------+
 | `run_on_start`_           | yes, no                     |
 +---------------------------+-----------------------------+
-| `ignore_time`_            | A positive number (seconds) |
+| `min_full_scan_interval`_ | A positive number (seconds) |
 +---------------------------+-----------------------------+
 | `provider`_               | A valid vulnerability vendor|
 +---------------------------+-----------------------------+
@@ -77,12 +77,12 @@ Runs updates and vulnerabilities scans immediately when service is started.
 | **Allowed values**   | yes, no   |
 +----------------------+-----------+
 
-.. _vuln_det_ignore_time:
+.. _vuln_det_min_full_scan_interval:
 
-ignore_time
-^^^^^^^^^^^^
+min_full_scan_interval
+^^^^^^^^^^^^^^^^^^^^^^^
 
-Time during which vulnerabilities that have already been alerted will be ignored. When this time hasn't passed yet, only :ref:`partial scans <vuln_det_scan_types>` will be performed.
+Time during which a full scan will not be performed even if the CVEs database is updated. When this time has passed, only a :ref:`full scan <vuln_det_scan_types>` will be performed if the CVEs database has changed.
 
 +----------------------+------------------------------------------------------------------------------------------------------------------------------------+
 | **Default value**    | 6 hours                                                                                                                            |
@@ -258,7 +258,7 @@ The following configuration will update the vulnerability database for Ubuntu, D
     <vulnerability-detector>
         <enabled>no</enabled>
         <interval>5m</interval>
-        <ignore_time>6h</ignore_time>
+        <min_full_scan_interval>6h</min_full_scan_interval>
         <run_on_start>yes</run_on_start>
 
         <!-- Ubuntu OS vulnerabilities -->


### PR DESCRIPTION
## Description
Replaced all references to ignore_time by min_full_scan_interval. This PR closes #3597
## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 