### PR TITLE
Add run_as endpoint reference to auth_context api documentation and improve examples format

### DIFF
--- a/source/user-manual/api/getting-started.rst
+++ b/source/user-manual/api/getting-started.rst
@@ -41,7 +41,7 @@ Wazuh API endpoints require authentication in order to be used. Therefore, all c
 
     By default (``raw=false``), the token is obtained in an ``application/json`` format. If using this option, copy the token found in ``<YOUR_JWT_TOKEN>`` without the quotes.
 
-    .. code-block:: none
+    .. code-block:: json
         :class: output
 
         {

--- a/source/user-manual/api/rbac/auth_context.rst
+++ b/source/user-manual/api/rbac/auth_context.rst
@@ -10,20 +10,22 @@ This guide provides the basic information needed to start using the Authorizatio
 Authorization context login method
 ----------------------------------
 
-This authentication method is used to obtain the permissions dynamically. It allows any authorized user to possibly obtain any desired permissions without it being assigned to any role. To do this, a proper formalization of the authorization context is needed. In this case, the user-roles relations are not taken into consideration.
+This authentication method (:api-ref:`GET /security/user/authenticate/run_as <operation/api.controllers.security_controller.run_as_login>`) is used to obtain the permissions dynamically. It allows any authorized user to possibly obtain any desired permissions without it being assigned to any role. To do this, a proper formalization of the authorization context is needed. In this case, the user-roles relations are not taken into consideration.
 
 In order to use this authentication method, a user allowed to use authorization context is needed (how to create and allow a user to use authorization context information :ref:`here <api_rbac_user>`). After that, and having created the necessary security rules, an authorization context with all the required information must be sent, it will be checked against the security rules and finally, the permissions associated with them will be granted:
 
 .. code-block:: console
-        :class: output
 
-        curl -k -u <user>:<password> -X POST https://localhost:55000/security/user/authenticate/run_as -H 'content-type: application/json' -d '{
+        # curl -k -u <user>:<password> -X POST https://localhost:55000/security/user/authenticate/run_as -H 'content-type: application/json' -d '{
                 "name": "Initial_auth",
                 "auth": {
                         "name": "Bill",
                         "office": ["20", "21", "30"]
                 }
         }'
+
+.. code-block:: json
+        :class: output
 
         {
                 "data": {
@@ -227,7 +229,6 @@ Example 1
 - To achieve this, the user uses the following authorization context:
 
 .. code-block:: json
-        :class: output
 
         {
             "name": "Eleventh_auth",
@@ -326,7 +327,6 @@ Example 2
 - To achieve this match, the user sends the following authorization context:
 
 .. code-block:: json
-        :class: output
 
         {
             "name": "First_example",


### PR DESCRIPTION
Hi team,

This PR is related to https://github.com/wazuh/wazuh/issues/7845.

In this PR, I have added a link to the `run_as` login endpoint to the authorization context API documentation.
This link redirects to the new security controller used for the `run_as` login.

I have also updated the examples of that section and of the getting started section in order to improve their format.

Regards,
Manuel. 