### PR TITLE
Fix APT dependency steps to install wazuh in custom path

### DIFF
--- a/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-server/index.rst
+++ b/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-server/index.rst
@@ -115,9 +115,9 @@ To install the build dependencies of CPython, follow these steps:
 
     .. code-block:: console
 
-        # echo "deb-src http://deb.debian.org/debian $(lsb_release -cs) main" >> /etc/apt/sources.list
+        # sed -Ei 's/^# deb-src /deb-src /' /etc/apt/sources.list
         # apt-get update
-        # apt-get build-dep python3.5 -y
+        # apt-get build-dep python3.9 -y
 
 
   .. group-tab:: ZYpp
@@ -148,7 +148,7 @@ To install the build dependencies of CPython, follow these steps:
       # cd wazuh-*
       # ./install.sh
 
-    If you have previously compiled for another platform, you must clean the build using the Makefile in ``src``:
+    If you have previously compiled for another platform or **you want to install Wazuh in a custom path**, you must clean the build using the Makefile in ``src``:
 
     .. code-block:: console
 


### PR DESCRIPTION

Hi team,

This PR closes #3584.

In this pull request, I have updated the APT installation steps to install Wazuh from sources in a custom path different to `/var/ossec`.

There was another problem when indicating a path different to `/var/ossec` when executing `install.sh`.
Python was being installed in `/var/ossec` anyway as we were hardcoding the path in the framework Makefile. I have updated the framework and api makefiles to assign `PREFIX=/var/ossec` only if prefix wasn't assigned beffore.

New installation steps to install wazuh in a different path:

- Clean deps from precompiled python:

```
cd wazuh-*
make -C src clean
make -C src clean-deps
```

- Uncomment deb-src sources and install python dependencies:

```
sed -Ei 's/^# deb-src /deb-src /' /etc/apt/sources.list
apt-get update
apt-get build-dep python3.9 -y

```

### Manual tests:

**Ubuntu 20.04.2**

```
root@wazuh-master:/# service wazuh-manager status
wazuh-clusterd not running...
wazuh-modulesd is running...
wazuh-monitord is running...
wazuh-logcollector is running...
wazuh-remoted is running...
wazuh-syscheckd is running...
wazuh-analysisd is running...
wazuh-maild not running...
wazuh-execd is running...
wazuh-db is running...
wazuh-authd is running...
wazuh-agentlessd not running...
wazuh-integratord not running...
wazuh-dbd not running...
wazuh-csyslogd not running...
wazuh-apid is running...
```


**tree /cus (the python installation was the conflictive part)**

```
/cus
|-- active-response
|   `-- bin
|-- agentless
|-- api
|   |-- configuration
|   |   |-- security
|   |   `-- ssl
|   `-- scripts
...
|-- framework
|   |-- python
|   |   |-- bin
|   |   |   `-- __pycache__
|   |   |-- include
|   |   |   `-- python3.9
|   |   |       |-- cpython
|   |   |       `-- internal
|   |   |-- lib
|   |   |   |-- pkgconfig
|   |   |   `-- python3.9
|   |   |       |-- __pycache__
|   |   |       |-- asyncio
|   |   |       |   `-- __pycache__
|   |   |       |-- collections
|   |   |       |   `-- __pycache__
|   |   |       |-- concurrent
...
```

Regards,
Manuel.

