### PR TITLE
Reenable multitenancy

### DIFF
--- a/resources/open-distro/kibana/7.x/kibana.yml
+++ b/resources/open-distro/kibana/7.x/kibana.yml
@@ -5,7 +5,7 @@ elasticsearch.ssl.verificationMode: certificate
 elasticsearch.username: kibanaserver
 elasticsearch.password: kibanaserver
 elasticsearch.requestHeadersWhitelist: ["securitytenant","Authorization"]
-opendistro_security.multitenancy.enabled: false
+opendistro_security.multitenancy.enabled: true
 opendistro_security.readonly_mode.roles: ["kibana_read_only"]
 server.ssl.enabled: true
 server.ssl.key: "/etc/kibana/certs/kibana.key"

--- a/resources/open-distro/kibana/7.x/kibana_all_in_one.yml
+++ b/resources/open-distro/kibana/7.x/kibana_all_in_one.yml
@@ -5,7 +5,7 @@ elasticsearch.ssl.verificationMode: certificate
 elasticsearch.username: kibanaserver
 elasticsearch.password: kibanaserver
 elasticsearch.requestHeadersWhitelist: ["securitytenant","Authorization"]
-opendistro_security.multitenancy.enabled: false
+opendistro_security.multitenancy.enabled: true
 opendistro_security.readonly_mode.roles: ["kibana_read_only"]
 server.ssl.enabled: true
 server.ssl.key: "/etc/kibana/certs/kibana.key"


### PR DESCRIPTION
## Description
Multitenancy was disabled in the Kibana configuration file due to issues observed in older versions of Open Distro. 
With ODFE 1.13 a new welcome dialog prompts the user to select a tenant, if multitenancy is disabled an  error is shown indicating that the administrator must be contacted to enable multi tenancy. 

Attempting to create a report from a custom dashboard will result on the same message being shown on top of the report. 
![image](https://user-images.githubusercontent.com/36071202/114226451-df34cb80-9973-11eb-9790-6d0ab31a504c.png)


This PR simply removes the options to disable multitenancy from the Kibana configuration file.
## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
