### PR TITLE
Updated agents_disconnection_time and agents_disconnection_alert_time default values

### DIFF
--- a/source/user-manual/agents/agent-life-cycle.rst
+++ b/source/user-manual/agents/agent-life-cycle.rst
@@ -25,7 +25,7 @@ Agent status
 - **Never connected:** The agent has been registered but has not yet connected to the manager.
 - **Pending.** The authentication process is pending: The manager has received a request for connection from the agent but has not received anything else. This may indicate a firewall issue. The agent will be in this state one time in its life cycle after each startup.
 - **Active:** The agent has successfully connected and can now communicate with the manager.
-- **Disconnected:** The manager will consider the agent disconnected if it does not receive any ``keep alive`` messages within :ref:`agents_disconnection_time<reference_agents_disconnection_time>` (20s default time).
+- **Disconnected:** The manager will consider the agent disconnected if it does not receive any ``keep alive`` messages within :ref:`agents_disconnection_time<reference_agents_disconnection_time>` (10m default time).
 
 Removed agent
 -------------

--- a/source/user-manual/reference/ossec-conf/global.rst
+++ b/source/user-manual/reference/ossec-conf/global.rst
@@ -453,7 +453,7 @@ agents_disconnection_time
 This sets the time after which the manager considers an agent as disconnected since its last keepalive.
 
 +-------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| **Default value**       | 20s                                                                                                                                                           |
+| **Default value**       | 10m                                                                                                                                                           |
 +-------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | **Allowed values**      | A positive number that should end with a character indicating a time unit, such as: s (seconds), m (minutes), h (hours), d (days). The minimum allowed is 1s. |
 +-------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -475,7 +475,7 @@ This sets the time after which an alert is generated since an agent was consider
 As this is a time-lapse after an agent is considered as disconnected because of the :ref:`disconnection time<reference_agents_disconnection_time>`, the minimum time frame to produce an alert taking the default values is 2m and 20s.
 
 +-------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| **Default value**       | 100s                                                                                                                                                                                                                                          |
+| **Default value**       | 0s                                                                                                                                                                                                                                            |
 +-------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | **Allowed values**      | A positive number that should end with a character indicating a time unit, such as: s (seconds), m (minutes), h (hours), d (days). The minimum allowed is 0s in order to generate an alert as soon as an agent is considered as disconnected. |
 +-------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -501,6 +501,6 @@ Default configuration
       <email_from>ossecm@example.wazuh.com</email_from>
       <email_to>recipient@example.wazuh.com</email_to>
       <email_maxperhour>12</email_maxperhour>
-      <agents_disconnection_time>20s</agents_disconnection_time>
-      <agents_disconnection_alert_time>100s</agents_disconnection_alert_time>
+      <agents_disconnection_time>10m</agents_disconnection_time>
+      <agents_disconnection_alert_time>0</agents_disconnection_alert_time>
     </global>


### PR DESCRIPTION

## Description

This PR updates `agents_disconnection_time` and `agents_disconnection_alert_time` default values https://github.com/wazuh/wazuh/pull/7744. 

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).


