### PR TITLE
Add MITRE techniques endpoint to RBAC catalog

### DIFF
--- a/source/user-manual/api/rbac/reference.rst
+++ b/source/user-manual/api/rbac/reference.rst
@@ -504,6 +504,7 @@ Mitre
 mitre:read
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 - :api-ref:`GET /mitre/metadata <operation/api.controllers.mitre_controller.get_metadata>` (`*:*`_)
+- :api-ref:`GET /mitre/techniques <operation/api.controllers.mitre_controller.get_techniques>` (`*:*`_)
 
 Rootcheck
 ^^^^^^^^^^^^^^^


### PR DESCRIPTION
Hi team,

This PR its related with https://github.com/wazuh/wazuh/issues/7824. In this PR adds the reference to the MITRE techniques endpoint.

Regards
