### PR TITLE
Add MITRE groups endpoint to RBAC reference

### DIFF
--- a/source/user-manual/api/equivalence.rst
+++ b/source/user-manual/api/equivalence.rst
@@ -516,6 +516,8 @@ Cache
 +--------------------------------------------------+------------------------------------+----------------------------------------------------------------------------------------------+-----------------------------------------------+
 | Get MITRE techniques information from database   | ``GET /mitre``                     | :api-ref:`GET /mitre/techniques <operation/api.controllers.mitre_controller.get_techniques>` | Added new endpoints to get MITRE information. |
 +--------------------------------------------------+------------------------------------+----------------------------------------------------------------------------------------------+-----------------------------------------------+
+| Get MITRE groups information from database       | ``GET /mitre``                     | :api-ref:`GET /mitre/groups <operation/api.controllers.mitre_controller.get_groups>`         | Added new endpoints to get MITRE information. |
++--------------------------------------------------+------------------------------------+----------------------------------------------------------------------------------------------+-----------------------------------------------+
 
 
 :api-ref:`Rootcheck <tag/Rootcheck>`

--- a/source/user-manual/api/equivalence.rst
+++ b/source/user-manual/api/equivalence.rst
@@ -516,8 +516,6 @@ Cache
 +--------------------------------------------------+------------------------------------+----------------------------------------------------------------------------------------------+-----------------------------------------------+
 | Get MITRE techniques information from database   | ``GET /mitre``                     | :api-ref:`GET /mitre/techniques <operation/api.controllers.mitre_controller.get_techniques>` | Added new endpoints to get MITRE information. |
 +--------------------------------------------------+------------------------------------+----------------------------------------------------------------------------------------------+-----------------------------------------------+
-| Get MITRE groups information from database       | ``GET /mitre``                     | :api-ref:`GET /mitre/groups <operation/api.controllers.mitre_controller.get_groups>`         | Added new endpoints to get MITRE information. |
-+--------------------------------------------------+------------------------------------+----------------------------------------------------------------------------------------------+-----------------------------------------------+
 
 
 :api-ref:`Rootcheck <tag/Rootcheck>`

--- a/source/user-manual/api/rbac/reference.rst
+++ b/source/user-manual/api/rbac/reference.rst
@@ -506,6 +506,7 @@ mitre:read
 - :api-ref:`GET /mitre/metadata <operation/api.controllers.mitre_controller.get_metadata>` (`*:*`_)
 - :api-ref:`GET /mitre/tactics <operation/api.controllers.mitre_controller.get_tactics>` (`*:*`_)
 - :api-ref:`GET /mitre/techniques <operation/api.controllers.mitre_controller.get_techniques>` (`*:*`_)
+- :api-ref:`GET /mitre/groups <operation/api.controllers.mitre_controller.get_groups>` (`*:*`_)
 
 Rootcheck
 ^^^^^^^^^^^^^^^


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

Hello team,

## Description

<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

This PR adds the related documentation to the development of the `GET /mitre/groups` endpoint.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

Regards,
Víctor Fernández
