### PR TITLE
Update logcollector max file reference

### DIFF
--- a/source/user-manual/reference/ossec-conf/localfile.rst
+++ b/source/user-manual/reference/ossec-conf/localfile.rst
@@ -87,7 +87,7 @@ Below we have some Windows wildcard examples.
   * ``strftime`` format strings and wildcards cannot be used on the same entry.
 
   * On Windows systems, only character ``*`` is supported as a wildcard. For instance ``*ANY_STRING*``, will match all files that have ``ANY_STRING`` inside its name, another example is ``*.log`` this will match any log file.
-  * The maximum amount of files monitored at same time is limited to 200.
+  * The maximum amount of files monitored at same time is limited to 1000.
 
 .. _command:
 


### PR DESCRIPTION

## Community contributions advice

Closes https://github.com/wazuh/wazuh-documentation/issues/3761


## Description

[This document](https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/localfile.html) states that the maximum amount of files allowed to be monitored by logcollector is 200:
![image](https://user-images.githubusercontent.com/15269938/115680760-264b9500-a354-11eb-8485-2bb9d98277dc.png)

Nevertheless, the actual value by default is 1000:

![image](https://user-images.githubusercontent.com/15269938/115680889-45e2bd80-a354-11eb-8bea-56b24afe3562.png)

![image](https://user-images.githubusercontent.com/15269938/115680990-60b53200-a354-11eb-8df7-74a2ac38ae04.png)


## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 

