### PR TITLE
Deprecating rootcheck from agent_control tool documentation

### DIFF
--- a/source/user-manual/reference/tools/agent_control.rst
+++ b/source/user-manual/reference/tools/agent_control.rst
@@ -5,7 +5,7 @@
 agent_control
 =============
 
-The agent_control program allows you to query the manager for information about any agent and also allows you to initiate a syscheck/rootcheck scan on an agent the next time it checks in.
+The agent_control program allows you to query the manager for information about any agent and also allows you to initiate a syscheck scan on an agent the next time it checks in.
 
 With this tool you can check the status of each available agent, which can be any of the following:
 
@@ -30,7 +30,7 @@ agent_control options
 +-------------------+---------------------------------------------------------+
 | **-R <agent_id>** | Restart the Wazuh processes on the agent                |
 +-------------------+---------------------------------------------------------+
-| **-r**            | Run the integrity/rootcheck checking on agents.         |
+| **-r**            | Run the integrity checking on agents.                   |
 |                   |                                                         |
 |                   | This must be used in conjunction with options -a or -u. |
 +-------------------+---------------------------------------------------------+


### PR DESCRIPTION
## Description

This pull request includes all the necessary changes in the Wazuh documentation after deprecating the rootcheck data output from the `agent_control` tool.

## Checks
- [x] It compiles without warnings.