### PR TITLE
[3803] Updated Installing Puppet agent and manager sections with the Ubuntu …

### DIFF
--- a/source/deploying-with-puppet/setup-puppet/install-puppet-agent.rst
+++ b/source/deploying-with-puppet/setup-puppet/install-puppet-agent.rst
@@ -22,13 +22,16 @@ Install the Puppet yum repository and then the "puppet-agent" package. See this 
 Installation on Debian/Ubuntu
 -----------------------------
 
-+----------------------------------------------------------------------------+
-| The releases supported by the manifest to install Wazuh are as follows:    |
-+------------+---------+--------+---------+------+--------+---------+--------+
-| **Ubuntu** | precise | trusty | vivid   | wily | xenial | yakketi | bionic |
-+------------+---------+--------+---------+------+--------+---------+--------+
-| **Debian** | jessie  | wheezy | stretch | sid                              |
-+------------+---------+--------+---------+----------------------------------+
++----------------------------------------------------------------------------+-------------+
+| The releases supported by the manifest to install Wazuh are as follows:                  |
++------------+---------+--------+---------+------+--------+---------+--------+-------------+
+| **Ubuntu** | precise | trusty | vivid   | wily | xenial | yakketi | bionic | Focal Fossa |
++------------+---------+--------+---------+------+--------+---------+--------+-------------+
+| **Debian** | jessie  | wheezy | stretch | sid                                            |
++------------+---------+--------+---------+----------------------------------+-------------+
+
+.. note::
+  ``Ubuntu Focal Fossa`` is supported since version 4.0.4
 
 Install ``curl``, ``apt-transport-https`` and ``lsb-release``:
 

--- a/source/deploying-with-puppet/setup-puppet/install-puppet-master.rst
+++ b/source/deploying-with-puppet/setup-puppet/install-puppet-master.rst
@@ -21,13 +21,17 @@ Install the Puppet yum repository and then the "puppetserver" package. See this 
 Installation on Debian/Ubuntu
 -----------------------------
 
-+----------------------------------------------------------------------------+
-| The releases supported by the manifest to install Wazuh are as follows:    |
-+------------+---------+--------+---------+------+--------+---------+--------+
-| **Ubuntu** | precise | trusty | vivid   | wily | xenial | yakketi | bionic |
-+------------+---------+--------+---------+------+--------+---------+--------+
-| **Debian** | jessie  | wheezy | stretch | sid                              |
-+------------+---------+--------+---------+----------------------------------+
++----------------------------------------------------------------------------+-------------+
+| The releases supported by the manifest to install Wazuh are as follows:                  |
++------------+---------+--------+---------+------+--------+---------+--------+-------------+
+| **Ubuntu** | precise | trusty | vivid   | wily | xenial | yakketi | bionic | Focal Fossa |
++------------+---------+--------+---------+------+--------+---------+--------+-------------+
+| **Debian** | jessie  | wheezy | stretch | sid                                            |
++------------+---------+--------+---------+----------------------------------+-------------+
+
+.. note::
+  ``Ubuntu Focal Fossa`` is supported since version 4.0.4
+
 
 Install ``curl``, ``apt-transport-https`` and ``lsb-release``:
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes #3803  |

## **Description**
The following Wazuh documentation section: [install puppet agent on debian/ubuntu](https://documentation.wazuh.com/current/deploying-with-puppet/setup-puppet/install-puppet-agent.html#installation-on-debian-ubuntu) is out of date. Since version 4.0.4, `Ubuntu Focal Fossa` is supported but is not listed in the mentioned table.

- **Actual results:** Ubuntu Focal Fossa is not listed as supported OS distribution since 4.0.4 version.
- **Expected results:** Ubuntu Focal Fossa is listed as supported OS distribution since 4.0.4 version.

This is issue has been created from the following community case analysis: https://wazuh.slack.com/archives/C0A933R8E/p1620682220122200

The resolution of this issue should impact Wazuh documentation version 4.0, 4.1, 4.2 and 5.0

Following is how this will look after these changes:
![image](https://user-images.githubusercontent.com/22640902/117812881-bfc1e480-b238-11eb-8665-345e3406a98a.png)


## Checks
- [X] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [X] Used uppercase only on nouns. 

