### PR TITLE
Fix multiline_regex example on localfile reference

### DIFF
--- a/source/user-manual/reference/ossec-conf/localfile.rst
+++ b/source/user-manual/reference/ossec-conf/localfile.rst
@@ -546,9 +546,9 @@ For example, we may want to read a Python Traceback output as one single log, re
 .. code-block:: xml
 
   <localfile>
-      <log_format>syslog</log_format>
+      <log_format>multi-line-regex</log_format>
       <location>/var/logs/my_python_app.log</location>
-      <multiline replace="wspace">^Traceback</multiline>
+      <multiline_regex replace="wspace">^Traceback</multiline_regex>
    </localfile>
 
 


### PR DESCRIPTION
Closes #3807 

# Description

Hi team!

This PR fix wrong `log_format` value and invalid `multiline` option in `multiline_regex` example.

From this:
![image](https://user-images.githubusercontent.com/1791430/117982030-f61c6400-b30b-11eb-9cc2-3ddfdb43d869.png)

To this:
![image](https://user-images.githubusercontent.com/1791430/117982097-08969d80-b30c-11eb-9ef0-8dd04705d0a7.png)


## Checks
- [X] It compiles without warnings.
- [X] Spelling and grammar. 
- [X] Used impersonal speech. 
- [X] Used uppercase only on nouns. 
- [X] ~Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).~


Regards,
Nico
