### PR TITLE
Add registry enabled to syscheck synchronization section

### DIFF
--- a/source/user-manual/reference/ossec-conf/syscheck.rst
+++ b/source/user-manual/reference/ossec-conf/syscheck.rst
@@ -824,6 +824,19 @@ Specifies whether there will be periodic inventory synchronizations or not.
 | **Allowed values** | yes/no                                |
 +--------------------+---------------------------------------+
 
+**registry_enabled**
+
+.. versionadded:: 4.1.0
+
+On Windows agents, enables inventory synchronizations for registry entries. If ``enabled`` is set to no,
+this parameter is ignored.
+
++--------------------+---------------------------------------+
+| **Default value**  | yes                                   |
++--------------------+---------------------------------------+
+| **Allowed values** | yes/no                                |
++--------------------+---------------------------------------+
+
 **interval**
 
 .. versionadded:: 3.12.0


### PR DESCRIPTION
## Description

This PR adds the `registry_enabled` stanza to the syscheck synchronization section.

<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

## Checks
- [ ] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

