### PR TITLE
Add remote_enrollment option to auth

### DIFF
--- a/source/user-manual/reference/ossec-conf/auth.rst
+++ b/source/user-manual/reference/ossec-conf/auth.rst
@@ -21,6 +21,7 @@ Options
 -------
 
 - `disabled`_
+- `remote_enrollment`_
 - `port`_
 - `use_source_ip`_
 - `force_insert`_
@@ -41,6 +42,17 @@ Toggles the execution of the Auth daemon on or off.
 
 +--------------------+---------------------+
 | **Default value**  | no                  |
++--------------------+---------------------+
+| **Allowed values** | yes, no             |
++--------------------+---------------------+
+
+remote_enrollment
+^^^^^^^^^^^^^^^^^
+
+Allow listening for new agents on TLS port (1515 by default).
+
++--------------------+---------------------+
+| **Default value**  | yes                 |
 +--------------------+---------------------+
 | **Allowed values** | yes, no             |
 +--------------------+---------------------+
@@ -199,6 +211,7 @@ Default configuration
 
   <auth>
     <disabled>no</disabled>
+    <remote_enrollment>yes<remote_enrollment>
     <port>1515</port>
     <use_source_ip>no</use_source_ip>
     <force_insert>yes</force_insert>

--- a/source/user-manual/reference/ossec-conf/auth.rst
+++ b/source/user-manual/reference/ossec-conf/auth.rst
@@ -49,6 +49,8 @@ Toggles the execution of the Auth daemon on or off.
 remote_enrollment
 ^^^^^^^^^^^^^^^^^
 
+.. versionadded:: 4.2.0
+
 Allow listening for new agents on TLS port (1515 by default).
 
 +--------------------+---------------------+


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/8616|

## Description

New `remote_enrollment` configuration option added to `auth` block.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns.
