### PR TITLE
[3.12] Reduce the length of the document title

### DIFF
--- a/source/_themes/wazuh_doc_theme/layout.html
+++ b/source/_themes/wazuh_doc_theme/layout.html
@@ -31,10 +31,12 @@
   {% endfor %}
 {%- endmacro %}
 
-{%- if not parents[-1] %}
-  {%- set pagetitle = title|striptags %}
-{%- else %}
-  {%- set pagetitle = title|striptags + dash_separator + parents[-1].title|striptags %}
+{%- set pagetitle = title|striptags %}
+{%- if parents[-1] %}
+  {%- set pagetitleparent = pagetitle + dash_separator + parents[-1].title|striptags %}
+  {%- if (pagetitleparent)|length <= 70 %}
+    {%- set pagetitle = pagetitleparent %}
+  {%- endif %}
 {%- endif %}
 
 {%- if (pagetitle + titlesuffix)|length > 70 %}

--- a/source/_themes/wazuh_doc_theme/layout.html
+++ b/source/_themes/wazuh_doc_theme/layout.html
@@ -37,6 +37,10 @@
   {%- set pagetitle = title|striptags + dash_separator + parents[-1].title|striptags %}
 {%- endif %}
 
+{%- if (pagetitle + titlesuffix)|length > 70 %}
+  {%- set titlesuffix = "" %}
+{%- endif %}
+
 <!DOCTYPE html>
 <html lang="{{ language }}">
 {% block head %}


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

This PR helps to control the length of the document title so that it doesn't exceed the recommended length.

**Related issue**: https://github.com/wazuh/wazuh-website/issues/1664

## Checks
- [x] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).