### PR TITLE
Make the Vulnerability Detector module obtain the packages to be scaned in an atomic way - Documentation changes

### DIFF
--- a/source/user-manual/reference/ossec-conf/vuln-detector.rst
+++ b/source/user-manual/reference/ossec-conf/vuln-detector.rst
@@ -22,6 +22,7 @@ Options
 - `enabled`_
 - `interval`_
 - `run_on_start`_
+- `retry_interval`_
 - `min_full_scan_interval`_
 - `provider`_
 
@@ -35,6 +36,8 @@ Options
 | `run_on_start`_           | yes, no                     |
 +---------------------------+-----------------------------+
 | `min_full_scan_interval`_ | A positive number (seconds) |
++---------------------------+-----------------------------+
+| `retry_interval`_         | A positive number (seconds) |
 +---------------------------+-----------------------------+
 | `provider`_               | A valid vulnerability vendor|
 +---------------------------+-----------------------------+
@@ -86,6 +89,19 @@ The time during which a full scan will not be performed even if the database of 
 
 +----------------------+------------------------------------------------------------------------------------------------------------------------------------+
 | **Default value**    | 6 hours                                                                                                                            |
++----------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| **Allowed values**   | A positive number that should contain a suffix character indicating a time unit: s (seconds), m (minutes), h (hours) or d (days).  |
++----------------------+------------------------------------------------------------------------------------------------------------------------------------+
+
+.. _retry_interval:
+
+retry_interval
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The time to wait after a scan completes to retry the agents that had a problem to be scanned.
+
++----------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| **Default value**    | 30 seconds                                                                                                                         |
 +----------------------+------------------------------------------------------------------------------------------------------------------------------------+
 | **Allowed values**   | A positive number that should contain a suffix character indicating a time unit: s (seconds), m (minutes), h (hours) or d (days).  |
 +----------------------+------------------------------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
## Description
This PR adds the required description for the new Vulnerability Detection config **retry_interval**
This setting is hidden by default and is designed to normally work with the default values so it only requires to be included in the **ossec.conf** sections of Vulnerability Detector. It doesn't affect any usage description of Vulnerability Detector.

## Checks
- [X] It compiles without warnings.
- [X] Spelling and grammar. 
- [X] Used impersonal speech. 
- [X] Used uppercase only on nouns. 

