### PR TITLE
Added missing line break that was breaking a heading

### DIFF
--- a/source/gdpr/gdpr-IV.rst
+++ b/source/gdpr/gdpr-IV.rst
@@ -64,6 +64,7 @@ Chapter IV, Article 28, Head 3 (c)
 Entities must ensure data protection during data processing through technical and organizational measures. While processing data, it is necessary to ensure its protection and integrity in order to avoid any alteration that may be harmful to the individual to whom the information belongs.
 
 By using `Syscheck <https://documentation.wazuh.com/|CURRENT_MAJOR|/user-manual/reference/ossec-conf/syscheck.html>`_ and through technical measures, Wazuh can ensure the protection measures established are met.
+
 Use cases
 ^^^^^^^^^
 


### PR DESCRIPTION
## Description
I noticed a heading was broken in the GDPR section. 
This was due to the fact that it was missing a line break before the heading. 
This byte-sized PR fixes that issue.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
