### PR TITLE
Extend variables explanation for SCA policies

### DIFF
--- a/source/user-manual/capabilities/sec-config-assessment/creating_custom_policies.rst
+++ b/source/user-manual/capabilities/sec-config-assessment/creating_custom_policies.rst
@@ -126,6 +126,16 @@ Variables are set in the **variables** section. Their names are preceded by ``$`
 
     $list_of_files: /etc/ssh/sshd_config,/etc/sysctl.conf,/var/log/dmesg
     $list_of_folders: /etc,/var,/tmp
+    $program_name: apache2
+
+Variables can be placed anywhere in the left part of the rule. Therefore, regarding the variables above, the following rules could be built:
+
+.. code-block:: yaml
+
+    f:$list_of_files -> r:^Content to be found
+    c:systemctl is-enabled $program_name -> r:^enabled
+
+There is no limit on the number of variables to add within a rule.
 
 Checks
 ^^^^^^^^^


### PR DESCRIPTION
## Description

This pull request adds a brief explanation of the changes added at https://github.com/wazuh/wazuh/pull/8826, which extends the `variables` behavior for SCA by:

- Allowing them to be inserted anywhere inside a rule
- Allowing to add more than one variable in the same rule

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns.
