### PR TITLE
Add new option to configure the API requests timeout

### DIFF
--- a/source/user-manual/api/configuration.rst
+++ b/source/user-manual/api/configuration.rst
@@ -25,6 +25,8 @@ Here are all the available settings for the ``api.yaml`` configuration file. For
      use_only_authd: no
      drop_privileges: yes
      experimental_features: no
+     intervals:
+        request_timeout: 10
 
      https:
         enabled: yes
@@ -181,6 +183,14 @@ experimental_features
 +======================+===============+===================================+
 | yes, true, no, false | false         | Enable features under development |
 +----------------------+---------------+-----------------------------------+
+
+intervals
+^^^^^^^^^^
++-----------------+----------------------+---------------+-----------------------------------------------------------------+
+| Sub-fields      | Allowed values       | Default value | Description                                                     |
++=================+======================+===============+=================================================================+
+| request_timeout | Any positive integer | 10            | Set the maximum response time (in seconds) for each API request |
++-----------------+----------------------+---------------+-----------------------------------------------------------------+
 
 https
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/source/user-manual/api/getting-started.rst
+++ b/source/user-manual/api/getting-started.rst
@@ -419,6 +419,8 @@ Here are some of the basic concepts related to making API requests and understan
 - The Wazuh API log is stored on the manager as ``/var/ossec/logs/api.log`` (the path and verbosity level can be changed in the Wazuh API configuration file). The Wazuh API logs are rotated daily. Rotated logs are stored in ``/var/ossec/logs/api/<year>/<month>`` and compressed using ``gzip``.
 - All Wazuh API requests will be aborted if no response is received after a certain amount of time. The parameter ``wait_for_complete`` can be used to disable this timeout. This is useful for calls that could take more time than expected, such as :ref:`PUT/agents/:agent_id/upgrade <api_reference>`.
 
+.. note:: The maximum API response time can be modified in the :ref:`API configuration <api_configuration_options>`.
+
 .. _wazuh_api_use_cases:
 
 Use cases


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

Hi team,

This PR adds the new API configuration option. Now it is possible to change the maximum response time for API requests.

Regards

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 

