### PR TITLE
Added option to read certificates location

### DIFF
--- a/resources/open-distro/tools/wazuh-passwords-tool.sh
+++ b/resources/open-distro/tools/wazuh-passwords-tool.sh
@@ -66,6 +66,8 @@ getHelp() {
    echo -e "\t-a     | --change-all Changes all the Open Distro user passwords and prints them on screen"
    echo -e "\t-u     | --user <user> Indicates the name of the user whose password will be changed. If no password specified it will generate a random one"
    echo -e "\t-p     | --password <password> Indicates the new password, must be used with option -u"
+   echo -e "\t-c     | --cert <route-admin-certificate> Indicates route to the admin certificate"
+   echo -e "\t-k     | --certkey <route-admin-certificate-key> Indicates route to the admin certificate key"
    echo -e "\t-v     | --verbose Shows the complete script execution output"
    echo -e "\t-h     | --help Shows help"
    exit 1 # Exit script after printing help


### PR DESCRIPTION
Hello team!

This PR closes #3915.

## Description

I've added a function to read the `root-ca.pem` certificate from the `elasticsearch.yml` file. Besides, the scripts now checks if the `admin.pem` and the `admin.key`/`admin-key.pem` certificates are located on the default route. If they aren't, the script will exit showing a message explaining how to indicate their location. 

These are the new options:

- `-c`/`--cert` <route-admin-certificate> Indicates route to the admin certificate.
- `-k`/`--certkey` <route-admin-certificate-key> Indicates route to the admin certificate key.

<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

Regards,

David