### PR TITLE
Fixed Wazuh agent's version in the 'Deployment variables for AIX' section

### DIFF
--- a/source/installation-guide/wazuh-agent/deployment_variables/deployment_variables_aix.rst
+++ b/source/installation-guide/wazuh-agent/deployment_variables/deployment_variables_aix.rst
@@ -50,41 +50,41 @@ Examples:
 .. code-block:: console
 
      # WAZUH_MANAGER="10.0.0.2" WAZUH_REGISTRATION_PASSWORD="TopSecret" \
-          WAZUH_AGENT_NAME="aix-agent" rpm -i wazuh-agent-|WAZUH_LATEST_AIX|-|WAZUH_REVISION_AIX|.aix.ppc.rpm
+          WAZUH_AGENT_NAME="aix-agent" rpm -i wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_AIX|.aix.ppc.rpm
 
 * Registration with password and assigning a group:
 
 .. code-block:: console
 
      # WAZUH_MANAGER="10.0.0.2" WAZUH_REGISTRATION_SERVER="10.0.0.2" WAZUH_REGISTRATION_PASSWORD="TopSecret" \
-          WAZUH_AGENT_GROUP="my-group" rpm -i wazuh-agent-|WAZUH_LATEST_AIX|-|WAZUH_REVISION_AIX|.aix.ppc.rpm
+          WAZUH_AGENT_GROUP="my-group" rpm -i wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_AIX|.aix.ppc.rpm
 
 * Registration with relative path to CA. It will be searched at your Wazuh installation folder:
 
 .. code-block:: console
 
      # WAZUH_MANAGER="10.0.0.2" WAZUH_REGISTRATION_SERVER="10.0.0.2" WAZUH_AGENT_NAME="aix-agent" \
-          WAZUH_REGISTRATION_CA="rootCA.pem" rpm -i wazuh-agent-|WAZUH_LATEST_AIX|-|WAZUH_REVISION_AIX|.aix.ppc.rpm
+          WAZUH_REGISTRATION_CA="rootCA.pem" rpm -i wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_AIX|.aix.ppc.rpm
 
 * Registration with protocol:
 
 .. code-block:: console
 
      # WAZUH_MANAGER="10.0.0.2" WAZUH_REGISTRATION_SERVER="10.0.0.2" WAZUH_AGENT_NAME="aix-agent" \
-          WAZUH_PROTOCOL="tcp" rpm -i wazuh-agent-|WAZUH_LATEST_AIX|-|WAZUH_REVISION_AIX|.aix.ppc.rpm
+          WAZUH_PROTOCOL="tcp" rpm -i wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_AIX|.aix.ppc.rpm
 
 * Registration and adding multiple address:
 
 .. code-block:: console
 
      # WAZUH_MANAGER="10.0.0.2,10.0.0.3" WAZUH_REGISTRATION_SERVER="10.0.0.2" \
-          WAZUH_AGENT_NAME="aix-agent" rpm -i wazuh-agent-|WAZUH_LATEST_AIX|-|WAZUH_REVISION_AIX|.aix.ppc.rpm
+          WAZUH_AGENT_NAME="aix-agent" rpm -i wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_AIX|.aix.ppc.rpm
 
 * Absolute paths to CA, certificate or key that contain spaces can be written as shown below:
 
 .. code-block:: console
 
      # WAZUH_MANAGER "10.0.0.2" WAZUH_REGISTRATION_SERVER "10.0.0.2" WAZUH_REGISTRATION_KEY "/var/ossec/etc/sslagent.key" \
-          WAZUH_REGISTRATION_CERTIFICATE "/var/ossec/etc/sslagent.cert" rpm -i wazuh-agent-|WAZUH_LATEST_AIX|-|WAZUH_REVISION_AIX|.aix.ppc.rpm
+          WAZUH_REGISTRATION_CERTIFICATE "/var/ossec/etc/sslagent.cert" rpm -i wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_AIX|.aix.ppc.rpm
 
 .. note:: To verify agents identity with the registration server, it's necessary to use both KEY and PEM options. See the :ref:`Registration Service with host verification - Agent verification with host validation <host-verification-registration>` section.


### PR DESCRIPTION
## Description

This PR fixes Wazuh agents' version in the 'Deployment variables for AIX' section. 
 
## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
