### PR TITLE
Add new `err_str` command in Cluster development section

### DIFF
--- a/source/development/wazuh-cluster.rst
+++ b/source/development/wazuh-cluster.rst
@@ -315,20 +315,23 @@ As said before, all protocols are built from a common abstract base. This base d
 +---------------+-------------+--------------------+--------------------------------------------------------------------------+
 | Message       | Received in | Arguments          | Description                                                              |
 +===============+=============+====================+==========================================================================+
-| ``echo``      | Both        | Message<str>       | Used to send keep alives to the peer. Replies the same received message. |
-+---------------+-------------+--------------------+--------------------------------------------------------------------------+
-| ``new_file``  | Both        | Filename<str>      | Used to start the sending file process.                                  |
-+---------------+-------------+--------------------+--------------------------------------------------------------------------+
 | ``new_str``   | Both        | String length<int> | Used to start the sending long strings process.                          |
-+---------------+-------------+--------------------+--------------------------------------------------------------------------+
-| ``file_upd``  | Both        | Filename<str>,     | Used to send a file chunk during the sending file process.               |
-|               |             | Data chunk<str>    |                                                                          |
 +---------------+-------------+--------------------+--------------------------------------------------------------------------+
 | ``str_upd``   | Both        | String Id<str>,    | Used to send a string chunk during the sending long strings process.     |
 |               |             | Data chunk<str>    |                                                                          |
 +---------------+-------------+--------------------+--------------------------------------------------------------------------+
+| ``err_str``   | Both        | String length<int> | Used to notify an error while sending a string so the reserved space is  |
+|               |             |                    | freed.                                                                   |
++---------------+-------------+--------------------+--------------------------------------------------------------------------+
+| ``new_file``  | Both        | Filename<str>      | Used to start the sending file process.                                  |
++---------------+-------------+--------------------+--------------------------------------------------------------------------+
+| ``file_upd``  | Both        | Filename<str>,     | Used to send a file chunk during the sending file process.               |
+|               |             | Data chunk<str>    |                                                                          |
++---------------+-------------+--------------------+--------------------------------------------------------------------------+
 | ``file_end``  | Both        | Filename<str>,     | Used to finish the sending file process.                                 |
 |               |             | File checksum<str> |                                                                          |
++---------------+-------------+--------------------+--------------------------------------------------------------------------+
+| ``echo``      | Both        | Message<str>       | Used to send keep alives to the peer. Replies the same received message. |
 +---------------+-------------+--------------------+--------------------------------------------------------------------------+
 | ``echo-c``    | Server      | Message<str>       | Used by the client to send keep alives to the server.                    |
 +---------------+-------------+--------------------+--------------------------------------------------------------------------+


### PR DESCRIPTION

## Description

Hey team,

This PR is related to #8935. It adds the description of the new `err_str` command inside `Wazuh Cluster` development section.


## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

Regards,
Selu.