### PR TITLE
Corrected typo in configuration example for Red Hat's offline update

### DIFF
--- a/source/user-manual/capabilities/vulnerability-detection/offline_update.rst
+++ b/source/user-manual/capabilities/vulnerability-detection/offline_update.rst
@@ -162,7 +162,7 @@ To fetch the vulnerability feeds from an alternative repository, the configurati
         <os url="http://local_repo/com.redhat.rhsa-RHEL5.xml.bz2">5</os>
         <os url="http://local_repo/rhel-6-including-unpatched.oval.xml.bz2">6</os>
         <os url="http://local_repo/rhel-7-including-unpatched.oval.xml.bz2">7</os>
-        <os url="http://local_repo/rhel-8-including-unpatched.oval.xml.bz2">7</os>
+        <os url="http://local_repo/rhel-8-including-unpatched.oval.xml.bz2">8</os>
         <update_interval>1h</update_interval>
     </provider>
 


### PR DESCRIPTION
## Description

Hi team,

This Pull Request fixes a minor typo in a configuration example for **Red Hat**'s offline update. Before introducing this fix, the value **7** was used in an configuration example for **Red Hat 8** feeds:

```xml
<provider name="redhat">
    <enabled>yes</enabled>
    ...
    <os url="http://local_repo/rhel-8-including-unpatched.oval.xml.bz2">7</os> 
    <update_interval>1h</update_interval>
</provider>
````
Now, this value has been accordingly changed to **8**.

Best regards,
Álvaro Romero.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 


