### PR TITLE
Update to link to intended Wazuh ruleset destination

### DIFF
--- a/source/user-manual/ruleset/getting-started.rst
+++ b/source/user-manual/ruleset/getting-started.rst
@@ -68,7 +68,7 @@ In the ruleset repository you will find:
 
 Resources
 ^^^^^^^^^
-* Visit our repository to view the rules in detail at `GitHub Wazuh Ruleset <https://github.com/wazuh/wazuh-ruleset>`_
+* Visit our repository to view the rules in detail at `GitHub Wazuh Ruleset <https://github.com/wazuh/wazuh/tree/master/ruleset>`_
 * Find a complete description of the available rules at `Wazuh Ruleset Summary <http://www.wazuh.com/resources/Wazuh_Ruleset.pdf>`_
 
 


### PR DESCRIPTION
## Description

The existing Wazuh ruleset link points to the read-only, no longer used repository. The existing ruleset has been ported to the Wazuh repository, as mentioned in the README of the wazuh-ruleset repository.

This commit replaces the hyperlink with the intended Wazuh ruleset destination.

## Checks
- [x] Spelling and grammar. 