### PR TITLE
Ruleset - MITRE ATT&CK - improve rule syntax to allow tactic ID and technique/subtechnique ID

### DIFF
--- a/source/getting-started/use_cases/log_analysis.rst
+++ b/source/getting-started/use_cases/log_analysis.rst
@@ -19,7 +19,8 @@ Wazuh uses *decoders* to identify the source application of the log message. The
     <match>^Failed|^error: PAM: Authentication</match>
     <description>SSHD authentication failed.</description>
     <mitre>
-      <id>T1110</id>
+      <techniqueID>T1110</techniqueID>
+      <tacticID>TA0006</tacticID>
     </mitre>
     <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>

--- a/source/getting-started/use_cases/regulatory_compliance.rst
+++ b/source/getting-started/use_cases/regulatory_compliance.rst
@@ -26,7 +26,8 @@ Besides, Wazuh rules include mapping with MITRE ATT&CK framework, which is used 
     <id>AH01276</id>
     <description>Apache: Attempt to access forbidden directory index.</description>
     <mitre>
-      <id>T1190</id>
+      <techniqueID>T1190</techniqueID>
+      <tacticID>TA0001</tacticID>
     </mitre>
     <group>access_denied,pci_dss_6.5.8,pci_dss_10.2.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_SA.11,nist_800_53_AU.14,nist_800_53_AC.7,tsc_CC6.6,tsc_CC7.1,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
   </rule>

--- a/source/user-manual/ruleset/mitre.rst
+++ b/source/user-manual/ruleset/mitre.rst
@@ -14,9 +14,11 @@ This feature allows the user to customize the alert information to include speci
 Configuration example
 ---------------------
 
-MITRE ATT&CK assigns each attack technique an ID, which can be consulted on this `link <https://attack.mitre.org>`_. These techniques are grouped by tactics (Defense Evasion, Privilege Escalation, etc.) although some of them belong to more than one tactic. 
+MITRE ATT&CK assigns each attack technique an ID, which can be consulted on this `link <https://attack.mitre.org>`_. These techniques are grouped by tactics (Defense Evasion, Privilege Escalation, etc.) although some of them belong to more than one tactic.
 
-The ID `T1110 <https://attack.mitre.org/techniques/T1110/>`_ is related to the brute force attack. This technique fits in well with the following rule 100002, which detects a force brute attack and generates an alert. Below is an example of how to extend this MITRE ATT&CK technique to that rule.
+.. versionadded:: 5.0.0
+
+The technique ID `T1110 <https://attack.mitre.org/techniques/T1110/>`_ is related to the brute force attack and uses the 'Credential Access' tactic whose ID is `TA0006 <https://attack.mitre.org/tactics/TA0006/>`_. This technique and tactic fit in well with the following rule 100002, which detects a force brute attack and generates an alert. Below is an example of how to extend this MITRE ATT&CK technique and tactic to that rule.
 
 Add the following lines to /var/ossec/etc/rules/local_rules.xml:
 
@@ -36,22 +38,30 @@ Add the following lines to /var/ossec/etc/rules/local_rules.xml:
       <description>sshd: brute force trying to get access to the system.</description>
       <same_srcip />
       <mitre>
-        <id>T1110</id>
+        <techniqueID>T1110</techniqueID>
+        <tacticID>TA0006</tacticID>
       </mitre>
     </rule>
 
   </group>
 
-Restart Wazuh and you will have finished configuring the rule. 
+Restart Wazuh and you will have finished configuring the rule.
 
 If you want to configure a rule using two o more techniques, you can do it as follows:
 
 .. code-block:: xml
 
   <mitre>
-    <id>T1110</id>
-    <id>T1084</id>
-    <id>T1057</id>
+    <techniqueID>T1110</techniqueID>
+    <tacticID>TA0006</tacticID>
+  </mitre>
+  <mitre>
+    <techniqueID>T1078.004</techniqueID>
+    <tacticID>TA0001</tacticID>
+  </mitre>
+  <mitre>
+    <techniqueID>T1078.004</techniqueID>
+    <tacticID>TA0004</tacticID>
   </mitre>
 
 Alert example

--- a/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
@@ -2259,15 +2259,17 @@ It's a very useful label to keep the rules ordered.
 
 mitre
 ^^^^^
-.. versionadded:: 3.13.0
+.. versionadded:: 5.0.0
 
-Specifies the `MITRE ATT&CK <https://attack.mitre.org>`_ technique ID or IDs that fit in well with the rule.
+Specifies both `MITRE ATT&CK <https://attack.mitre.org>`_ technique ID and tactic ID or pairs of technique ID and tactic ID that fit in well with the rule.
 
-+----------------+----------------------------+
-| Required label | Value                      |
-+================+============================+
-| **id**         | MITRE ATT&CK technique ID. |
-+----------------+----------------------------+
++-----------------+----------------------------+
+| Required label  | Value                      |
++=================+============================+
+| **techniqueID** | MITRE ATT&CK technique ID. |
++-----------------+----------------------------+
+| **tacticID**    | MITRE ATT&CK tactic ID.    |
++-----------------+----------------------------+
 
 Example:
 
@@ -2276,8 +2278,12 @@ Example:
     <rule id="100002" level="10">
       <description>Attack technique sample.</description>
       <mitre>
-        <id>T1110</id>
-        <id>T1037</id>
+        <techniqueID>T1562.001</techniqueID>
+        <tacticID>TA0005</tacticID>
+      </mitre>
+      <mitre>
+        <techniqueID>T1594</techniqueID>
+        <tacticID>TA0043</tacticID>
       </mitre>
     </rule>
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

Rules can now include both MITER ATT&CK Technique / Sub-Technique ID and Tactic ID to correctly describe mapping.
It was necessary to change the documentation so that it was in accordance with the new format.

## Checks
- [ ] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->
