### PR TITLE
Added clarifying notes related to the active response location

### DIFF
--- a/source/user-manual/reference/ossec-conf/active-response.rst
+++ b/source/user-manual/reference/ossec-conf/active-response.rst
@@ -76,13 +76,18 @@ Indicates which system(s) the command should be executed on.
 +                    +---------------+------------------------------------------------------------------+
 |                    | defined-agent | This runs the command on a specific agent identified by agent_id.|
 +                    +---------------+------------------------------------------------------------------+
-|                    | all           | This runs the command on all agents.                             |
+|                    | all           | This runs the command on all agents, not including the manager.  |
 |                    |               | Use with caution.                                                |
 +--------------------+---------------+------------------------------------------------------------------+
 
 Example:
 
 If the application that interfaces with your edge firewall runs on one of your agents, you might have a firewall-block-edge command that runs a script on that agent to blacklist an offending IP on the edge firewall.
+
+.. note::
+    If it is desired to trigger a particular active response on every agent and
+    the manager as well, two similar configuration blocks can be used setting 
+    the option `"all"` in one of the blocks and `"server"` on the other.
 
 agent_id
 ^^^^^^^^


### PR DESCRIPTION
## Description

Hi team!

This PR aims to close #3977. Some comments were added to the active response location section that clarifies that the manager is not included in this option and a note about how to trigger an active response on every agent and the manager as well.

<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

Best Regards,

Mariano Koremblum
