### PR TITLE
Added a missing step in the Kibana installation section

### DIFF
--- a/source/_templates/installations/elastic/common/generate_new_kibana_certificates.rst
+++ b/source/_templates/installations/elastic/common/generate_new_kibana_certificates.rst
@@ -5,6 +5,7 @@
 
   # mkdir /etc/kibana/certs
   # mv ~/certs.tar /etc/kibana/certs/
+  # chown kibana:kibana /etc/kibana/certs/*
   # cd /etc/kibana/certs/
   # tar -xf certs.tar kibana.pem kibana-key.pem root-ca.pem
   # rm -f certs.tar

--- a/source/installation-guide/open-distro/all-in-one-deployment/all_in_one.rst
+++ b/source/installation-guide/open-distro/all-in-one-deployment/all_in_one.rst
@@ -308,6 +308,7 @@ Kibana is a flexible and intuitive web interface for mining and visualizing the 
       # mkdir /etc/kibana/certs
       # cp ~/certs/root-ca.pem /etc/kibana/certs/
       # mv ~/certs/kibana* /etc/kibana/certs/
+      # chown kibana:kibana /etc/kibana/certs/*
 
 #. Link Kibana socket to privileged port 443:
 


### PR DESCRIPTION
## Description

This PR adds a step to change the Kibana certificates folder ownership. This step is required on Debian-based systems. Thanks @guillaumezisa for bringing this to our attention! 

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

