### PR TITLE
Azure module supported by the agent

### DIFF
--- a/source/user-manual/reference/ossec-conf/index.rst
+++ b/source/user-manual/reference/ossec-conf/index.rst
@@ -88,7 +88,7 @@ Wazuh can be installed in two ways: as a manager by using the "server/manager" i
 +---------------------------------------------------------------------+------------------------+
 | :doc:`wodle name="aws-s3" <wodle-s3>`                               | manager, agent         |
 +---------------------------------------------------------------------+------------------------+
-| :doc:`wodle name="azure-logs" <wodle-azure-logs>`                   | manager                |
+| :doc:`wodle name="azure-logs" <wodle-azure-logs>`                   | manager, agent         |
 +---------------------------------------------------------------------+------------------------+
 | :doc:`wodle name="cis-cat" <wodle-ciscat>`                          | manager, agent         |
 +---------------------------------------------------------------------+------------------------+


### PR DESCRIPTION
## Related issue

https://github.com/wazuh/wazuh/issues/9181

## Description

This PR add `agent` to the list of supported installations in the configuration section of the Azure module.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 



