### PR TITLE
Update the 'Install the Elastic Stack' section in 'Learning Wazuh' 

### DIFF
--- a/source/learning-wazuh/build-lab/install-elastic-stack.rst
+++ b/source/learning-wazuh/build-lab/install-elastic-stack.rst
@@ -138,8 +138,15 @@ events and archives stored in Elasticsearch. More info at `Kibana
 
     # setcap 'CAP_NET_BIND_SERVICE=+eip' /usr/share/kibana/node/bin/node
 
+6. Enable and start the Kibana service:
 
-6. Configure the credentials to access the Wazuh API:
+  .. code-block:: console
+
+  	# systemctl daemon-reload
+  	# systemctl enable kibana.service
+  	# systemctl start kibana.service
+
+7. Configure the credentials to access the Wazuh API:
 
   .. code-block:: console
 
@@ -150,15 +157,7 @@ events and archives stored in Elasticsearch. More info at `Kibana
          port: 55000
          username: wazuhapiuser
          password: wazuhlab
-    EOF
-
-8. Enable and start the Kibana service:
-
-  .. code-block:: console
-
-  	# systemctl daemon-reload
-  	# systemctl enable kibana.service
-  	# systemctl start kibana.service
+    EOF    
 
 Disable the Elastic repository
 ------------------------------

--- a/source/learning-wazuh/build-lab/install-elastic-stack.rst
+++ b/source/learning-wazuh/build-lab/install-elastic-stack.rst
@@ -138,14 +138,8 @@ events and archives stored in Elasticsearch. More info at `Kibana
 
     # setcap 'CAP_NET_BIND_SERVICE=+eip' /usr/share/kibana/node/bin/node
 
-6. Optimize Kibana packages:
 
-  .. code-block:: console
-
-    # cd /usr/share/kibana/
-    NODE_OPTIONS="--max-old-space-size=4096" /usr/share/kibana/bin/kibana --optimize --allow-root
-
-7. Configure the credentials to access the Wazuh API:
+6. Configure the credentials to access the Wazuh API:
 
   .. code-block:: console
 


### PR DESCRIPTION

## Description

This PR updates the [Install the Elastic Stack](https://documentation.wazuh.com/current/learning-wazuh/build-lab/install-elastic-stack.html) in 'Learning Wazuh' and closes https://github.com/wazuh/wazuh-documentation/issues/4020. 

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

