### PR TITLE
Fixed certificates deployment instructions for distributed deployments

### DIFF
--- a/source/_templates/installations/elastic/common/copy_certificates_filebeat.rst
+++ b/source/_templates/installations/elastic/common/copy_certificates_filebeat.rst
@@ -3,6 +3,9 @@
 .. code-block:: console
 
   # node_name=wazuh-node-name 
+
+.. code-block:: console
+  
   # mkdir /etc/filebeat/certs
   # mv ~/certs.tar /etc/filebeat/certs/
   # cd /etc/filebeat/certs/

--- a/source/_templates/installations/elastic/common/copy_certificates_filebeat.rst
+++ b/source/_templates/installations/elastic/common/copy_certificates_filebeat.rst
@@ -1,13 +1,13 @@
 .. Copyright (C) 2021 Wazuh, Inc.
 
-During the Elasticsearch installation, the ``certs.tar`` file was created. This guide assumes that a copy of this file has been placed in the root home folder (``~/``):
-
 .. code-block:: console
 
+  # node_name=wazuh-node-name 
   # mkdir /etc/filebeat/certs
   # mv ~/certs.tar /etc/filebeat/certs/
   # cd /etc/filebeat/certs/
-  # tar -xf certs.tar filebeat.pem filebeat-key.pem root-ca.pem
-
+  # tar -xf certs.tar $node_name.pem $node_name-key.pem root-ca.pem
+  # mv /etc/filebeat/certs/$node_name.pem /etc/filebeat/certs/filebeat.pem
+  # mv /etc/filebeat/certs/$node_name-key.pem /etc/filebeat/certs/filebeat-key.pem
 
 .. End of copy_certificates_filebeat.rst

--- a/source/_templates/installations/elastic/common/copy_certificates_filebeat_wazuh_cluster.rst
+++ b/source/_templates/installations/elastic/common/copy_certificates_filebeat_wazuh_cluster.rst
@@ -7,7 +7,7 @@
   # mkdir /etc/filebeat/certs
   # mv ~/certs.tar /etc/filebeat/certs/
   # cd /etc/filebeat/certs/
-  # tar -xf certs.tar $node_name.pem $node_name.pem root-ca.pem
+  # tar -xf certs.tar $node_name.pem $node_name-key.pem root-ca.pem
   # mv /etc/filebeat/certs/$node_name.pem /etc/filebeat/certs/filebeat.pem
   # mv /etc/filebeat/certs/$node_name-key.pem /etc/filebeat/certs/filebeat-key.pem
 

--- a/source/_templates/installations/elastic/common/copy_certificates_filebeat_wazuh_cluster.rst
+++ b/source/_templates/installations/elastic/common/copy_certificates_filebeat_wazuh_cluster.rst
@@ -1,16 +1,14 @@
 .. Copyright (C) 2021 Wazuh, Inc.
 
-During the Elasticsearch installation, the ``certs.tar`` file was created.This guide assumes that a copy of this file has been placed in the root home folder (``~/``).
-
-The ``X`` must be replaced with the number used in the certificate name defined for this Wazuh server:
 
 .. code-block:: console
 
+  # node_name=wazuh-node-name 
   # mkdir /etc/filebeat/certs
   # mv ~/certs.tar /etc/filebeat/certs/
   # cd /etc/filebeat/certs/
-  # tar -xf certs.tar filebeat-X.pem filebeat-X-key.pem root-ca.pem
-  # mv /etc/filebeat/certs/filebeat-X.pem /etc/filebeat/certs/filebeat.pem
-  # mv /etc/filebeat/certs/filebeat-X-key.pem /etc/filebeat/certs/filebeat-key.pem
+  # tar -xf certs.tar $node_name.pem $node_name.pem root-ca.pem
+  # mv /etc/filebeat/certs/$node_name.pem /etc/filebeat/certs/filebeat.pem
+  # mv /etc/filebeat/certs/$node_name-key.pem /etc/filebeat/certs/filebeat-key.pem
 
 .. End of copy_certificates_filebeat_wazuh_cluster.rst

--- a/source/_templates/installations/elastic/common/copy_certificates_filebeat_wazuh_cluster.rst
+++ b/source/_templates/installations/elastic/common/copy_certificates_filebeat_wazuh_cluster.rst
@@ -4,6 +4,9 @@
 .. code-block:: console
 
   # node_name=wazuh-node-name 
+
+.. code-block:: console
+  
   # mkdir /etc/filebeat/certs
   # mv ~/certs.tar /etc/filebeat/certs/
   # cd /etc/filebeat/certs/

--- a/source/_templates/installations/elastic/common/elastic-multi-node/configure_elasticsearch_initial.rst
+++ b/source/_templates/installations/elastic/common/elastic-multi-node/configure_elasticsearch_initial.rst
@@ -30,7 +30,7 @@ Values to be replaced in the file:
 - ``<elasticsearch_ip>``: the host's IP. For example, ``10.0.0.2``. 
 - ``<elastic_cluster>``: Elasticsearch cluster name. For example, ``elastic-cluster-production``.
 - ``<elasticsearch_ip_nodeX>`` Elasticsearch cluster master-eligible nodes IP. For example, ``10.0.0.3``.
-- The node certificates for each node must be specified under the ``opendistro_security.nodes_dn`` section.
+- The node certificates for each Elasticsearch node must be specified under the ``opendistro_security.nodes_dn`` section. Make sure to use the same names to create the nodes certificates. 
 
     .. code-block:: yaml
         :emphasize-lines: 5

--- a/source/_templates/installations/elastic/common/elastic-multi-node/deploy_certificates.rst
+++ b/source/_templates/installations/elastic/common/elastic-multi-node/deploy_certificates.rst
@@ -4,7 +4,10 @@
 
     .. code-block:: console
 
-      # node_name=elasticsearch-node-name  
+      # node_name=elasticsearch-node-name
+      
+    .. code-block:: console
+      
       # mkdir /etc/elasticsearch/certs
       # mv ~/certs.tar /etc/elasticsearch/certs/
       # cd /etc/elasticsearch/certs/

--- a/source/_templates/installations/elastic/common/elastic-multi-node/deploy_certificates.rst
+++ b/source/_templates/installations/elastic/common/elastic-multi-node/deploy_certificates.rst
@@ -1,16 +1,16 @@
 .. Copyright (C) 2021 Wazuh, Inc.
 
-#. The next step is the certificates placement, replace the ``X`` with the corresponding node number and execute the following commands.  The ``certs.tar`` file should be placed in ~/ (root home user folder).
+#. Replace ``elasticsearch-node-name`` with your Elasticsearch node name, the same used in ``instances.yml`` to create the certificates, and move the certificates to their corresponding location.  The ``certs.tar`` file should be placed in ~/ (root home user folder).
 
     .. code-block:: console
 
+      # node_name=elasticsearch-node-name  
       # mkdir /etc/elasticsearch/certs
       # mv ~/certs.tar /etc/elasticsearch/certs/
       # cd /etc/elasticsearch/certs/
-      # tar -xf certs.tar node-X.pem node-X-key.pem root-ca.pem
-      # mv /etc/elasticsearch/certs/node-X.pem /etc/elasticsearch/certs/elasticsearch.pem
-      # mv /etc/elasticsearch/certs/node-X-key.pem /etc/elasticsearch/certs/elasticsearch-key.pem
-
+      # tar -xf certs.tar $node_name.pem $node_name-key.pem root-ca.pem
+      # mv /etc/elasticsearch/certs/$node_name.pem /etc/elasticsearch/certs/elasticsearch.pem
+      # mv /etc/elasticsearch/certs/$node_name-key.pem /etc/elasticsearch/certs/elasticsearch-key.pem
 
 #. If Kibana will be installed in this node, keep the certificates file. Otherwise, remove it to increase security  ``rm -f certs.tar``.
 

--- a/source/_templates/installations/elastic/common/elastic-multi-node/generate_certificates.rst
+++ b/source/_templates/installations/elastic/common/elastic-multi-node/generate_certificates.rst
@@ -52,6 +52,9 @@
    .. code-block:: console
 
      # node_name=elasticsearch-node-name
+
+   .. code-block:: console 
+     
      # mkdir /etc/elasticsearch/certs/
      # mv ~/certs/$node_name* /etc/elasticsearch/certs/
      # mv ~/certs/admin* /etc/elasticsearch/certs/

--- a/source/_templates/installations/elastic/common/elastic-multi-node/generate_certificates.rst
+++ b/source/_templates/installations/elastic/common/elastic-multi-node/generate_certificates.rst
@@ -7,7 +7,8 @@
      # curl -so ~/wazuh-cert-tool.sh https://packages.wazuh.com/resources/4.1/open-distro/tools/certificate-utility/wazuh-cert-tool.sh
      # curl -so ~/instances.yml https://packages.wazuh.com/resources/4.1/open-distro/tools/certificate-utility/instances.yml
 
-#. Replace the values ``<node-name>`` and ``<node-ip>``  with the corresponding names and IP addresses. There can be added as many nodes fields as needed:
+
+#. Edit ``~/instances.yml`` and replace the values ``<node-name>`` and ``node-IP``  with the corresponding names and IP addresses. Add as many nodes fields as needed:
 
    .. code-block:: yaml
 
@@ -16,12 +17,21 @@
        - name: <node-name>
          ip:
            - node-IP
-     
+       - name: <node-name>
+         ip:
+           - node-IP
+       - name: <node-name>
+         ip:
+           - node-IP             
+
      # Wazuh server nodes
      wazuh-servers:
        - name: <node-name>
          ip:
-           - node-IP      
+           - node-IP  
+       - name: <node-name>
+         ip:
+           - node-IP     
      
      # Kibana node
      kibana:

--- a/source/_templates/installations/elastic/common/elastic-multi-node/generate_certificates.rst
+++ b/source/_templates/installations/elastic/common/elastic-multi-node/generate_certificates.rst
@@ -2,62 +2,63 @@
 
 #. Download the ``wazuh-cert-tool.sh`` to create the certificates:
 
-  .. code-block:: console
+   .. code-block:: console
 
-    # curl -so ~/wazuh-cert-tool.sh https://packages.wazuh.com/resources/4.1/open-distro/tools/certificate-utility/wazuh-cert-tool.sh
-    # curl -so ~/instances.yml https://packages.wazuh.com/resources/4.1/open-distro/tools/certificate-utility/instances.yml
+     # curl -so ~/wazuh-cert-tool.sh https://packages.wazuh.com/resources/4.1/open-distro/tools/certificate-utility/wazuh-cert-tool.sh
+     # curl -so ~/instances.yml https://packages.wazuh.com/resources/4.1/open-distro/tools/certificate-utility/instances.yml
 
-Replace the values ``<node-name>`` and ``<node-ip>``  with the corresponding names and IP addresses. There can be added as many nodes fields as needed:
+#. Replace the values ``<node-name>`` and ``<node-ip>``  with the corresponding names and IP addresses. There can be added as many nodes fields as needed:
 
-  .. code-block:: yaml
+   .. code-block:: yaml
 
-    # Elasticsearch nodes
-    elasticsearch-nodes:
-      - name: <node-name>
-        ip:
-          - node-IP
-    
-    # Wazuh server nodes
-    wazuh-servers:
-      - name: <node-name>
-        ip:
-          - node-IP      
-    
-    # Kibana node
-    kibana:
-      - name: <node-name>
-        ip:
-          - node-IP      
+     # Elasticsearch nodes
+     elasticsearch-nodes:
+       - name: <node-name>
+         ip:
+           - node-IP
+     
+     # Wazuh server nodes
+     wazuh-servers:
+       - name: <node-name>
+         ip:
+           - node-IP      
+     
+     # Kibana node
+     kibana:
+       - name: <node-name>
+         ip:
+           - node-IP      
   
-  To learn more about how to create and configure the certificates, see the :ref:`Certificates deployment <user_manual_certificates>` section.
+   To learn more about how to create and configure the certificates, see the :ref:`Certificates deployment <user_manual_certificates>` section.
 
-* Run the ``wazuh-cert-tool.sh`` to create the certificates:
+#. Run the ``wazuh-cert-tool.sh`` to create the certificates:
 
-  .. code-block:: console
+   .. code-block:: console
 
-    #  bash ~/wazuh-cert-tool.sh
+     #  bash ~/wazuh-cert-tool.sh
 
-* Move the Elasticsearch certificates to their corresponding location:
+#. Replace ``elasticsearch-node-name`` with your Elasticsearch node name, the same used in ``instances.yml`` to create the certificates, and move the certificates to their corresponding location:
 
-  .. code-block:: console
+   .. code-block:: console
 
-    # mkdir /etc/elasticsearch/certs/
-    # mv ~/certs/elasticsearch* /etc/elasticsearch/certs/
-    # mv ~/certs/admin* /etc/elasticsearch/certs/
-    # cp ~/certs/root-ca* /etc/elasticsearch/certs/
+     # node_name=elasticsearch-node-name
+     # mkdir /etc/elasticsearch/certs/
+     # mv ~/certs/$node_name* /etc/elasticsearch/certs/
+     # mv ~/certs/admin* /etc/elasticsearch/certs/
+     # cp ~/certs/root-ca* /etc/elasticsearch/certs/
+     # mv /etc/elasticsearch/certs/$node_name.pem /etc/elasticsearch/certs/elasticsearch.pem
+     # mv /etc/elasticsearch/certs/$node_name-key.pem /etc/elasticsearch/certs/elasticsearch-key.pem     
 
+#. Compress all the necessary files to be sent to all the instances:
 
+   .. code-block:: console
 
-* Compress all the necessary files to be sent to all the instances:
+     # cd ~/certs/  
+     # tar -cvf certs.tar *
+     # mv ~/certs/certs.tar ~/
 
-  .. code-block:: console
+#. Copy ``certs.tar`` to all the servers of the distributed deployment. This can be done by using, for example, ``scp``. 
 
-    # cd ~/certs/  
-    # tar -cvf certs.tar *
-    # mv ~/certs/certs.tar ~/
-
-* Copy ``certs.tar`` to all the servers of the distributed deployment. This can be done by using, for example, ``scp``. 
-
-* If Kibana will be installed on this node, keep the certificates file. Otherwise, if the file is already copied to all the instances of the distributed deployment, remove it to increase security  ``rm -f certs.tar``.
+#. If Kibana will be installed on this node, keep the certificates file. Otherwise, if the file is already copied to all the instances of the distributed deployment, remove it to increase security  ``rm -f certs.tar``.
 
 .. End of include file

--- a/source/_templates/installations/elastic/common/elastic-single-node/generate_deploy_certificates.rst
+++ b/source/_templates/installations/elastic/common/elastic-single-node/generate_deploy_certificates.rst
@@ -1,69 +1,66 @@
 .. Copyright (C) 2021 Wazuh, Inc.
 
-* Move to the installation location and create the certificates directory:
-
-  .. code-block:: console
-
-    # mkdir /etc/elasticsearch/certs
 
 #. Download the ``wazuh-cert-tool.sh`` to create the certificates:
 
-  .. code-block:: console
+   .. code-block:: console
+ 
+     # curl -so ~/wazuh-cert-tool.sh https://packages.wazuh.com/resources/4.1/open-distro/tools/certificate-utility/wazuh-cert-tool.sh
+     # curl -so ~/instances.yml https://packages.wazuh.com/resources/4.1/open-distro/tools/certificate-utility/instances.yml
 
-    # curl -so ~/wazuh-cert-tool.sh https://packages.wazuh.com/resources/4.1/open-distro/tools/certificate-utility/wazuh-cert-tool.sh
-    # curl -so ~/instances.yml https://packages.wazuh.com/resources/4.1/open-distro/tools/certificate-utility/instances.yml
+#. Replace the values ``<node-name>`` and ``<node-ip>``  with the corresponding names and IP addresses. There can be added as many nodes fields as needed:
+ 
+   .. code-block:: yaml
+ 
+     # Elasticsearch nodes
+     elasticsearch-nodes:
+       - name: <node-name>
+         ip:
+           - node-IP
+     
+     # Wazuh server nodes
+     wazuh-servers:
+       - name: <node-name>
+         ip:
+           - node-IP      
+     
+     # Kibana node
+     kibana:
+       - name: <node-name>
+         ip:
+           - node-IP      
+   
+   To learn more about how to create and configure the certificates, see the :ref:`Certificates deployment <user_manual_certificates>` section.
 
-Replace the values ``<node-name>`` and ``<node-ip>``  with the corresponding names and IP addresses. There can be added as many nodes fields as needed:
+#. Run the ``wazuh-cert-tool.sh`` to create the certificates:
 
-  .. code-block:: yaml
+   .. code-block:: console
 
-    # Elasticsearch nodes
-    elasticsearch-nodes:
-      - name: <node-name>
-        ip:
-          - node-IP
-    
-    # Wazuh server nodes
-    wazuh-servers:
-      - name: <node-name>
-        ip:
-          - node-IP      
-    
-    # Kibana node
-    kibana:
-      - name: <node-name>
-        ip:
-          - node-IP      
-  
-  To learn more about how to create and configure the certificates, see the :ref:`Certificates deployment <user_manual_certificates>` section.
+     #  bash ~/wazuh-cert-tool.sh
 
-* Run the ``wazuh-cert-tool.sh`` to create the certificates:
+#. Replace ``elasticsearch-node-name`` with your Elasticsearch node name, the same used in ``instances.yml`` to create the certificates, and move the certificates to their corresponding location:
 
-  .. code-block:: console
+   .. code-block:: console
 
-    #  bash ~/wazuh-cert-tool.sh
-
-* Move the Elasticsearch certificates to their corresponding location:
-
-  .. code-block:: console
-
-    # mkdir /etc/elasticsearch/certs/
-    # mv ~/certs/elasticsearch* /etc/elasticsearch/certs/
-    # mv ~/certs/admin* /etc/elasticsearch/certs/
-    # cp ~/certs/root-ca* /etc/elasticsearch/certs/
+     # node_name=elasticsearch-node-name
+     # mkdir /etc/elasticsearch/certs/
+     # mv ~/certs/$node_name* /etc/elasticsearch/certs/
+     # mv ~/certs/admin* /etc/elasticsearch/certs/
+     # cp ~/certs/root-ca* /etc/elasticsearch/certs/
+     # mv /etc/elasticsearch/certs/$node_name.pem /etc/elasticsearch/certs/elasticsearch.pem
+     # mv /etc/elasticsearch/certs/$node_name-key.pem /etc/elasticsearch/certs/elasticsearch-key.pem
 
 
+#. Compress all the necessary files to be sent to all the instances:
 
-* Compress all the necessary files to be sent to all the instances:
+   .. code-block:: console
 
-  .. code-block:: console
+     # cd ~/certs/  
+     # tar -cvf certs.tar *
+     # mv ~/certs/certs.tar ~/
 
-    # cd ~/certs/  
-    # tar -cvf certs.tar *
-    # mv ~/certs/certs.tar ~/
+#. Copy ``certs.tar`` to all the servers of the distributed deployment. This can be done by using, for example, ``scp``. 
 
-* Copy ``certs.tar`` to all the servers of the distributed deployment. This can be done by using, for example, ``scp``. 
-
-* If Kibana will be installed on this node, keep the certificates file. Otherwise, if the file is already copied to all the instances of the distributed deployment, remove it to increase security  ``rm -f certs.tar``.
+#. If Kibana will be installed on this node, keep the certificates file. Otherwise, if the file is already copied to all the instances of the distributed deployment, remove it to increase security  ``rm -f certs.tar``.
 
 .. End of include file

--- a/source/_templates/installations/elastic/common/elastic-single-node/generate_deploy_certificates.rst
+++ b/source/_templates/installations/elastic/common/elastic-single-node/generate_deploy_certificates.rst
@@ -8,7 +8,7 @@
      # curl -so ~/wazuh-cert-tool.sh https://packages.wazuh.com/resources/4.1/open-distro/tools/certificate-utility/wazuh-cert-tool.sh
      # curl -so ~/instances.yml https://packages.wazuh.com/resources/4.1/open-distro/tools/certificate-utility/instances.yml
 
-#. Replace the values ``<node-name>`` and ``<node-ip>``  with the corresponding names and IP addresses. There can be added as many nodes fields as needed:
+#. Edit ``~/instances.yml`` and replace the values ``<node-name>`` and ``node-IP``  with the corresponding names and IP addresses. Add as many nodes fields as needed:
  
    .. code-block:: yaml
  
@@ -16,8 +16,8 @@
      elasticsearch-nodes:
        - name: <node-name>
          ip:
-           - node-IP
-     
+           - node-IP  
+
      # Wazuh server nodes
      wazuh-servers:
        - name: <node-name>

--- a/source/_templates/installations/elastic/common/elastic-single-node/generate_deploy_certificates.rst
+++ b/source/_templates/installations/elastic/common/elastic-single-node/generate_deploy_certificates.rst
@@ -43,6 +43,9 @@
    .. code-block:: console
 
      # node_name=elasticsearch-node-name
+
+   .. code-block:: console
+     
      # mkdir /etc/elasticsearch/certs/
      # mv ~/certs/$node_name* /etc/elasticsearch/certs/
      # mv ~/certs/admin* /etc/elasticsearch/certs/

--- a/source/_templates/installations/elastic/common/generate_new_kibana_certificates.rst
+++ b/source/_templates/installations/elastic/common/generate_new_kibana_certificates.rst
@@ -3,7 +3,10 @@
 
 .. code-block:: console
 
-  # node_name=kibana-node-name 
+  # node_name=kibana-node-name
+  
+.. code-block:: console  
+  
   # mkdir /etc/kibana/certs
   # mv ~/certs.tar /etc/kibana/certs/
   # chown kibana:kibana /etc/kibana/certs/*

--- a/source/_templates/installations/elastic/common/generate_new_kibana_certificates.rst
+++ b/source/_templates/installations/elastic/common/generate_new_kibana_certificates.rst
@@ -3,11 +3,14 @@
 
 .. code-block:: console
 
+  # node_name=kibana-node-name 
   # mkdir /etc/kibana/certs
   # mv ~/certs.tar /etc/kibana/certs/
   # chown kibana:kibana /etc/kibana/certs/*
   # cd /etc/kibana/certs/
-  # tar -xf certs.tar kibana.pem kibana-key.pem root-ca.pem
+  # tar -xf certs.tar $node_name.pem $node_name-key.pem root-ca.pem
+  # mv /etc/kibana/certs/$node_name.pem /etc/kibana/certs/kibana.pem
+  # mv /etc/kibana/certs/$node_name-key.pem /etc/kibana/certs/kibana-key.pem
   # rm -f certs.tar
 
 .. End of include file

--- a/source/installation-guide/open-distro/distributed-deployment/step-by-step-installation/kibana/index.rst
+++ b/source/installation-guide/open-distro/distributed-deployment/step-by-step-installation/kibana/index.rst
@@ -92,7 +92,7 @@ Kibana installation and configuration
         # sudo -u kibana bin/kibana-plugin install https://packages.wazuh.com/|CURRENT_MAJOR|/ui/kibana/wazuh_kibana-|WAZUH_LATEST|_|ELASTICSEARCH_LATEST|-1.zip
         
 
-#. The next step involves the certificates placement. This guide assumes that a copy of ``certs.tar`` is placed in the root home folder (~/):
+#. Replace ``kibana-node-name`` with your Kibana node name, the same used in ``instances.yml`` to create the certificates, and move the certificates to their corresponding location. This guide assumes that a copy of ``certs.tar``, created during the Elasticsearch installation,  has been placed in the root home folder (``~/``). 
 
     .. include:: ../../../../../_templates/installations/elastic/common/generate_new_kibana_certificates.rst
 

--- a/source/installation-guide/open-distro/distributed-deployment/step-by-step-installation/wazuh-cluster/wazuh_multi_node_cluster.rst
+++ b/source/installation-guide/open-distro/distributed-deployment/step-by-step-installation/wazuh-cluster/wazuh_multi_node_cluster.rst
@@ -174,7 +174,7 @@ Filebeat installation and configuration
 
     .. include:: ../../../../../_templates/installations/elastic/common/configure_filebeat.rst
 
-#. Configure Filebeat certificates:
+#. Replace ``wazuh-node-name`` with your Wazuh node name, the same used in ``instances.yml`` to create the certificates, and move the certificates to their corresponding location. This guide assumes that a copy of ``certs.tar``, created during the Elasticsearch installation,  has been placed in the root home folder (``~/``). 
 
     .. include:: ../../../../../_templates/installations/elastic/common/copy_certificates_filebeat_wazuh_cluster.rst
 

--- a/source/installation-guide/open-distro/distributed-deployment/step-by-step-installation/wazuh-cluster/wazuh_single_node_cluster.rst
+++ b/source/installation-guide/open-distro/distributed-deployment/step-by-step-installation/wazuh-cluster/wazuh_single_node_cluster.rst
@@ -140,7 +140,7 @@ Filebeat installation and configuration
 
     .. include:: ../../../../../_templates/installations/elastic/common/configure_filebeat.rst
 
-#. Configure Filebeat certificates:
+#. Replace ``wazuh-node-name`` with your Wazuh node name, the same used in ``instances.yml`` to create the certificates, and move the certificates to their corresponding location. This guide assumes that a copy of ``certs.tar``, created during the Elasticsearch installation,  has been placed in the root home folder (``~/``). 
 
     .. include:: ../../../../../_templates/installations/elastic/common/copy_certificates_filebeat.rst
 


### PR DESCRIPTION
## Description

This PR fixes the certificates deployment instructions for distributed deployments. The variable `node_name` is introduced for convenience. 

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

## Note to the reviewer

This PR includes changes to the `redirect.js` script that need to be included in all production branches.
