### PR TITLE
Add history cleaning commands to CLI and API agent registration sections

### DIFF
--- a/source/user-manual/registering/command-line-registration.rst
+++ b/source/user-manual/registering/command-line-registration.rst
@@ -12,6 +12,10 @@ This method consists on registering the Wazuh agent on the Wazuh manager using `
 
 .. note:: Root/Administrator user privileges are necessary to execute all the commands described below.
 
+.. warning::
+
+  Terminal history will keep the generated agent key when using the ``manage_agents`` utility. Consider disabling it beforehand, cleaning it afterwards or using another registration method.
+
 The Wazuh agent's key extraction from the Wazuh manager
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -82,6 +86,21 @@ Choose the tab corresponding to the Wazuh agent's host operating system:
                Confirm adding it?(y/n): y
                Added.
 
+        Optionally, clean the terminal history if it was not disabled. There are two options:
+
+          #. Clean it all
+
+              .. code-block:: console
+
+                # history -c
+
+
+          #. Clean any specific line
+
+              .. code-block:: console
+
+                # history -d <line to delete>
+
 
     #. To enable the communication with the Wazuh manager, edit the Wazuh agent's configuration file placed at ``/var/ossec/etc/ossec.conf``.
 
@@ -121,6 +140,21 @@ Choose the tab corresponding to the Wazuh agent's host operating system:
                  Confirm adding it?(y/n): y
                  Added.
 
+        Optionally, clean the terminal history if it was not disabled. There are two options:
+
+          #. Clean it all
+
+              .. code-block:: console
+
+                # Clear-History
+
+
+          #. Clean any specific line
+
+              .. code-block:: console
+
+                # Clear-History -Id <line IDs separated by a comma and a whitespace>
+
 
     #. To enable the communication with the Wazuh manager, edit the Wazuh agent's configuration file placed at ``C:\Program Files (x86)\ossec-agent\ossec.conf``.
 
@@ -157,6 +191,21 @@ Choose the tab corresponding to the Wazuh agent's host operating system:
 
             Confirm adding it?(y/n): y
             Added.
+
+        Optionally, clean the terminal history if it was not disabled. There are two options:
+
+          #. Clean it all
+
+              .. code-block:: console
+
+                # history -c
+
+
+          #. Clean any specific line
+
+              .. code-block:: console
+
+                # history -d <line to delete>
 
     #. To enable the communication with the Wazuh manager, edit the Wazuh agent's configuration file placed at ``/Library/Ossec/etc/ossec.conf``.
 

--- a/source/user-manual/registering/restful-api-registration.rst
+++ b/source/user-manual/registering/restful-api-registration.rst
@@ -9,6 +9,10 @@ The Wazuh API allows the Wazuh agent registration by running a single request fr
 
 .. note:: Root user privileges are necessary to execute all the commands described below, and the Wazuh API must be accessible from the host on which the request is executed.
 
+.. warning::
+
+  Terminal history will keep the generated agent key when using the ``manage_agents`` utility. Consider disabling it beforehand, cleaning it afterwards or using another registration method.
+
 Choose the tab corresponding to the Wazuh agent host operating system:
 
 .. tabs::
@@ -57,6 +61,21 @@ Choose the tab corresponding to the Wazuh agent host operating system:
 
                 Confirm adding it?(y/n): y
                 Added.
+
+        Optionally, clean the terminal history if it was not disabled. There are two options:
+
+          #. Clean it all
+
+              .. code-block:: console
+
+                # history -c
+
+
+          #. Clean any specific line
+
+              .. code-block:: console
+
+                # history -d <line to delete>
 
 
     #. To enable the communication with the Wazuh manager, edit the Wazuh agent's configuration file placed at ``/var/ossec/etc/ossec.conf``.
@@ -152,6 +171,21 @@ Choose the tab corresponding to the Wazuh agent host operating system:
                 Confirm adding it?(y/n): y
                 Added.
 
+        Optionally, clean the terminal history if it was not disabled. There are two options:
+
+          #. Clean it all
+
+              .. code-block:: console
+
+                # Clear-History
+
+
+          #. Clean any specific line
+
+              .. code-block:: console
+
+                # Clear-History -Id <line IDs separated by a comma and a whitespace>
+
 
     #. To enable the communication with the Wazuh manager, edit the Wazuh agent's configuration file placed at ``C:\Program Files (x86)\ossec-agent\ossec.conf``.
 
@@ -207,6 +241,21 @@ Choose the tab corresponding to the Wazuh agent host operating system:
 
                 Confirm adding it?(y/n): y
                 Added.
+
+        Optionally, clean the terminal history if it was not disabled. There are two options:
+
+          #. Clean it all
+
+              .. code-block:: console
+
+                # history -c
+
+
+          #. Clean any specific line
+
+              .. code-block:: console
+
+                # history -d <line to delete>
 
 
     #. To enable the communication with the Wazuh manager, edit the Wazuh agent's configuration file placed at ``/Library/Ossec/etc/ossec.conf``.


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

Hello team,

This PR closes #4001 . It adds specific commands for each platform to clean the terminal history as the agent key would remain in it when using the `manage_agents` utility. In addition, a warning has also been added.


## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

Regards,
Víctor