### PR TITLE
Fix not logging stderr to log file when using verbose command option

### DIFF
--- a/resources/open-distro/unattended-installation/unattended-installation.sh
+++ b/resources/open-distro/unattended-installation/unattended-installation.sh
@@ -953,7 +953,7 @@ main() {
         done    
 
         if [ -n "${verbose}" ]; then
-            debug='>> /var/log/wazuh-unattended-installation.log'
+            debug='2>&1 | tee -a /var/log/wazuh-unattended-installation.log'
         fi
 
         if [ -n "${uninstall}" ]; then


### PR DESCRIPTION
## Description

Closes #4039
Redirects stderr to stdout while still logging its content to the script's log file.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).