### PR TITLE
Fix Wazuh's changelog links redirecting to the actual changelog files

### DIFF
--- a/source/release-notes/release_2_1.rst
+++ b/source/release-notes/release_2_1.rst
@@ -7,7 +7,7 @@
 2.1 Release notes
 ===================
 
-This section shows the most relevant new features of Wazuh v2.1. You will find more detailed information in our `changelog <https://github.com/wazuh/wazuh/blob/2.1/CHANGELOG.md>`_ file.
+This section shows the most relevant new features of Wazuh v2.1. You will find more detailed information in our `changelog <https://github.com/wazuh/wazuh/blob/v2.1.0/CHANGELOG.md>`_ file.
 
 **New features:**
 

--- a/source/release-notes/release_3_0_0.rst
+++ b/source/release-notes/release_3_0_0.rst
@@ -7,7 +7,7 @@
 3.0.0 Release notes
 ===================
 
-This section shows the most relevant new features of Wazuh v3.0.0. You will find more detailed information in our `changelog <https://github.com/wazuh/wazuh/blob/3.0/CHANGELOG.md>`_ file.
+This section shows the most relevant new features of Wazuh v3.0.0. You will find more detailed information in our `changelog <https://github.com/wazuh/wazuh/blob/v3.0.0/CHANGELOG.md>`_ file.
 
 For deploying your Wazuh environment see the :doc:`Installation guide <../installation-guide/index>`.
 

--- a/source/release-notes/release_3_13_0.rst
+++ b/source/release-notes/release_3_13_0.rst
@@ -10,7 +10,7 @@
 
 This section lists the changes in version 3.13.0. More details about these changes are provided in each component changelog:
 
-- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/3.13/CHANGELOG.md>`_
+- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/v3.13.0/CHANGELOG.md>`_
 - `wazuh/wazuh-kibana-app <https://github.com/wazuh/wazuh-kibana-app/blob/3.13-7.7/CHANGELOG.md>`_
 - `wazuh/wazuh-api <https://github.com/wazuh/wazuh-api/blob/3.13/CHANGELOG.md>`_
 - `wazuh/wazuh-ruleset <https://github.com/wazuh/wazuh-ruleset/blob/3.13/CHANGELOG.md>`_

--- a/source/release-notes/release_3_13_1.rst
+++ b/source/release-notes/release_3_13_1.rst
@@ -10,7 +10,7 @@
 
 This section lists the changes in version 3.13.1. More details about these changes are provided in each component changelog:
 
-- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/3.13/CHANGELOG.md>`_
+- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/v3.13.1/CHANGELOG.md>`_
 - `wazuh/wazuh-kibana-app <https://github.com/wazuh/wazuh-kibana-app/blob/3.13.1-7.8.0/CHANGELOG.md>`_
 - `wazuh/wazuh-api <https://github.com/wazuh/wazuh-api/blob/3.13/CHANGELOG.md>`_
 - `wazuh/wazuh-splunk <https://github.com/wazuh/wazuh-splunk/blob/3.13-8.0/CHANGELOG.md>`_

--- a/source/release-notes/release_3_13_2.rst
+++ b/source/release-notes/release_3_13_2.rst
@@ -10,7 +10,7 @@
 
 This section lists the changes in version 3.13.2. More details about these changes are provided in each component changelog:
 
-- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/3.13/CHANGELOG.md>`_
+- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/v3.13.2/CHANGELOG.md>`_
 - `wazuh/wazuh-kibana-app <https://github.com/wazuh/wazuh-kibana-app/blob/3.13.2-7.9.1/CHANGELOG.md>`_
 - `wazuh/wazuh-splunk <https://github.com/wazuh/wazuh-splunk/blob/3.13-8.0/CHANGELOG.md>`_
 

--- a/source/release-notes/release_3_13_3.rst
+++ b/source/release-notes/release_3_13_3.rst
@@ -10,7 +10,7 @@
 
 This section lists the changes in version 3.13.3. More details about these changes are provided in each component changelog:
 
-- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/3.13/CHANGELOG.md>`_
+- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/v3.13.3/CHANGELOG.md>`_
 - `wazuh/wazuh-kibana-app <https://github.com/wazuh/wazuh-kibana-app/blob/v3.13.3-7.9.2/CHANGELOG.md>`_
 - `wazuh/wazuh-splunk <https://github.com/wazuh/wazuh-splunk/blob/v3.13.3-8.0.4/CHANGELOG.md>`_
   

--- a/source/release-notes/release_3_1_0.rst
+++ b/source/release-notes/release_3_1_0.rst
@@ -7,7 +7,7 @@
 3.1.0 Release notes
 ===================
 
-This section shows the most relevant new features of Wazuh v3.1.0. You will find more detailed information in our `changelog <https://github.com/wazuh/wazuh/blob/3.1/CHANGELOG.md>`_ file.
+This section shows the most relevant new features of Wazuh v3.1.0. You will find more detailed information in our `changelog <https://github.com/wazuh/wazuh/blob/v3.1.0/CHANGELOG.md>`_ file.
 
 **New features:**
 

--- a/source/release-notes/release_3_2_0.rst
+++ b/source/release-notes/release_3_2_0.rst
@@ -7,7 +7,7 @@
 3.2.0 Release notes
 ===================
 
-This section shows the most relevant new features of Wazuh v3.2.0. You will find more detailed information in our `changelog <https://github.com/wazuh/wazuh/blob/3.2/CHANGELOG.md>`_ file.
+This section shows the most relevant new features of Wazuh v3.2.0. You will find more detailed information in our `changelog <https://github.com/wazuh/wazuh/blob/v3.2.0/CHANGELOG.md>`_ file.
 
 **New features:**
 

--- a/source/release-notes/release_3_2_1.rst
+++ b/source/release-notes/release_3_2_1.rst
@@ -7,7 +7,7 @@
 3.2.1 Release notes
 ===================
 
-This release is a bug fix release. This section shows the most relevant improvements and fixes of Wazuh v3.2.1. You will find more detailed information in the `changelog <https://github.com/wazuh/wazuh/blob/3.2/CHANGELOG.md#v321>`_ file.
+This release is a bug fix release. This section shows the most relevant improvements and fixes of Wazuh v3.2.1. You will find more detailed information in the `changelog <https://github.com/wazuh/wazuh/blob/v3.2.1/CHANGELOG.md#v321>`_ file.
 
 - `Wazuh modules`_
 - `Cluster`_

--- a/source/release-notes/release_4_0_0.rst
+++ b/source/release-notes/release_4_0_0.rst
@@ -10,7 +10,7 @@
 
 This section lists the changes in version 4.0.0. More details about these changes are provided in the changelog of each component:
 
-- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/4.0/CHANGELOG.md>`_
+- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/v4.0.0/CHANGELOG.md>`_
 - `wazuh/wazuh-kibana-app <https://github.com/wazuh/wazuh-kibana-app/blob/4.0-7.9/CHANGELOG.md>`_
 - `wazuh/ruleset <https://github.com/wazuh/wazuh-ruleset/blob/4.0/CHANGELOG.md>`_
 - `wazuh/wazuh-packages <https://github.com/wazuh/wazuh-packages/blob/master/CHANGELOG.md>`_

--- a/source/release-notes/release_4_0_1.rst
+++ b/source/release-notes/release_4_0_1.rst
@@ -10,7 +10,7 @@
 
 This section lists the changes in version 4.0.1. More details about these changes are provided in the changelog of each component:
 
-- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/4.0.1/CHANGELOG.md>`_
+- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/v4.0.1/CHANGELOG.md>`_
 - `wazuh/wazuh-kibana-app <https://github.com/wazuh/wazuh-kibana-app/blob/v4.0.1-7.9.3/CHANGELOG.md>`_
 - `wazuh/ruleset <https://github.com/wazuh/wazuh-ruleset/blob/4.0.1/CHANGELOG.md>`_
 

--- a/source/release-notes/release_4_0_2.rst
+++ b/source/release-notes/release_4_0_2.rst
@@ -10,7 +10,7 @@
 
 This section lists the changes in version 4.0.2. More details about these changes are provided in the changelog of each component:
 
-- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/4.0.2/CHANGELOG.md>`_
+- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/v4.0.2/CHANGELOG.md>`_
 - `wazuh/wazuh-kibana-app <https://github.com/wazuh/wazuh-kibana-app/blob/v4.0.2-7.9.3/CHANGELOG.md>`_
 
 
@@ -82,9 +82,3 @@ Fixed
 - Changes done via a worker API were overwritten.
 - Default user field in Security Role mapping is now provided depending on whether ODFE or X-Pack is installed. 
 - Bug that replaced index-pattern title with its ID during the updating process.
-
-
-
-
-
-

--- a/source/release-notes/release_4_0_3.rst
+++ b/source/release-notes/release_4_0_3.rst
@@ -10,7 +10,7 @@
 
 This section lists the changes in version 4.0.3. More details about these changes are provided in the changelog of each component:
 
-- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/4.0.3/CHANGELOG.md>`_
+- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/v4.0.3/CHANGELOG.md>`_
 - `wazuh/wazuh-kibana-app <https://github.com/wazuh/wazuh-kibana-app/blob/v4.0.3-7.9.3/CHANGELOG.md>`_
 
 

--- a/source/release-notes/release_4_0_4.rst
+++ b/source/release-notes/release_4_0_4.rst
@@ -10,7 +10,7 @@
 
 This section lists the changes in version 4.0.4. More details about these changes are provided in the changelog of each component:
 
-- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/4.0.4/CHANGELOG.md>`_
+- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/v4.0.4/CHANGELOG.md>`_
 - `wazuh/wazuh-kibana-app <https://github.com/wazuh/wazuh-kibana-app/blob/v4.0.4-7.9.3/CHANGELOG.md>`_
 
 

--- a/source/release-notes/release_4_1_0.rst
+++ b/source/release-notes/release_4_1_0.rst
@@ -10,22 +10,22 @@
 
 This section lists the changes in version 4.1.0. More details about these changes are provided in the changelog of each component:
 
-- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/4.1/CHANGELOG.md>`_
+- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/v4.1.0/CHANGELOG.md>`_
 - `wazuh/wazuh-kibana-app <https://github.com/wazuh/wazuh-kibana-app/blob/4.1-7.10/CHANGELOG.md>`_
 - `wazuh/wazuh-ruleset <https://github.com/wazuh/wazuh-ruleset/blob/4.1/CHANGELOG.md>`_
 
 Highlights
 ----------
 
-- Added support for regular expressions negation and PCRE2 format in rules and decoders. 
+- Added support for regular expressions negation and PCRE2 format in rules and decoders.
 - New **ruleset test module** managed by the analysis daemon allowing testing sessions of rules and decoders.
-- New **upgrade module** that provides simultaneous agent upgrades in a single node or cluster architecture. 
+- New **upgrade module** that provides simultaneous agent upgrades in a single node or cluster architecture.
 - The Vulnerability Detector now supports macOS agents. These agents must be updated to 4.1 to scan vulnerabilities.
 - Support for AWS load balancers logs: Application Load Balancer, Classic Load Balancer, and Network Load Balancer.
 - Removed the limit on the number of agents a manager can support.
 - New endpoints to query and manage Rootcheck data.
-- Support for Open Distro for Elasticsearch 1.12.0. 
-- Support for Elastic Stack basic license 7.10.0 and 7.10.2. 
+- Support for Open Distro for Elasticsearch 1.12.0.
+- Support for Elastic Stack basic license 7.10.0 and 7.10.2.
 
 Wazuh core
 ----------

--- a/source/release-notes/release_4_1_1.rst
+++ b/source/release-notes/release_4_1_1.rst
@@ -10,7 +10,7 @@
 
 This section lists the changes in version 4.1.1. More details about these changes are provided in the changelog of each component:
 
-- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/4.1/CHANGELOG.md>`_
+- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/v4.1.1/CHANGELOG.md>`_
 - `wazuh/wazuh-kibana-app <https://github.com/wazuh/wazuh-kibana-app/blob/v4.1.1-7.10.0/CHANGELOG.md>`_
 
 

--- a/source/release-notes/release_4_1_2.rst
+++ b/source/release-notes/release_4_1_2.rst
@@ -10,7 +10,7 @@
 
 This section lists the changes in version 4.1.2. More details about these changes are provided in the changelog of each component:
 
-- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/4.1/CHANGELOG.md>`_
+- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/v4.1.2/CHANGELOG.md>`_
 - `wazuh/wazuh-kibana-app <https://github.com/wazuh/wazuh-kibana-app/blob/4.1-7.10/CHANGELOG.md>`_
 
 

--- a/source/release-notes/release_4_1_3.rst
+++ b/source/release-notes/release_4_1_3.rst
@@ -9,7 +9,7 @@
 
 This section lists the changes in version 4.1.3. More details about these changes are provided in the changelog of each component:
 
-- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/4.1/CHANGELOG.md>`_
+- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/v4.1.3/CHANGELOG.md>`_
 - `wazuh/wazuh-kibana-app <https://github.com/wazuh/wazuh-kibana-app/blob/4.1-7.10/CHANGELOG.md>`_
 
 

--- a/source/release-notes/release_4_1_4.rst
+++ b/source/release-notes/release_4_1_4.rst
@@ -9,7 +9,7 @@
 
 This section lists the changes in version 4.1.4. More details about these changes are provided in the changelog of each component:
 
-- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/4.1/CHANGELOG.md>`_
+- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/v4.1.4/CHANGELOG.md>`_
 - `wazuh/wazuh-kibana-app <https://github.com/wazuh/wazuh-kibana-app/blob/4.1-7.10/CHANGELOG.md>`_
 
 

--- a/source/release-notes/release_4_1_5.rst
+++ b/source/release-notes/release_4_1_5.rst
@@ -9,7 +9,7 @@
 
 This section lists the changes in version 4.1.5. More details about these changes are provided in the changelog of each component:
 
-- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/4.1/CHANGELOG.md>`_
+- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/v4.1.5/CHANGELOG.md>`_
 - `wazuh/wazuh-kibana-app <https://github.com/wazuh/wazuh-kibana-app/blob/4.1-7.10/CHANGELOG.md>`_
 - `wazuh/wazuh-splunk <https://github.com/wazuh/wazuh-splunk/blob/4.1-8.1/CHANGELOG.md>`_
 


### PR DESCRIPTION
## Description

Hello team.

This is to fix broken links to Wazuh's changelog files. They are located in the Release notes sections as informed in issue #4064.  This is only for docs version 4.1.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).