### PR TITLE
Exit the unattended script when nested script fails

### DIFF
--- a/resources/open-distro/unattended-installation/unattended-installation.sh
+++ b/resources/open-distro/unattended-installation/unattended-installation.sh
@@ -290,7 +290,6 @@ installElasticsearch() {
         if [  "$?" != 0  ]; then
             echo "Error: certificates were not created"
             rollBack
-
             exit 1;
         else
             logger "Certificates created"
@@ -550,7 +549,13 @@ changePasswords() {
     else
         VERBOSE='> /dev/null 2>&1'
         bash ~/wazuh-passwords-tool.sh -a
-    fi     
+    fi    
+    
+    if [  "$?" != 0  ]; then
+        echo "The passwords could not be changed"
+        rollBack
+        exit 1; 
+    fi
 }
 
 checkInstallation() {

--- a/resources/open-distro/unattended-installation/unattended-installation.sh
+++ b/resources/open-distro/unattended-installation/unattended-installation.sh
@@ -627,7 +627,7 @@ main() {
         done    
 
         if [ -n "${verbose}" ]; then
-            debug='>> /var/log/wazuh-unattended-installation.log'
+            debug='2>&1 | tee -a /var/log/wazuh-unattended-installation.log'
         fi
 
         if [ -n "${uninstall}" ]; then


### PR DESCRIPTION
Hello team! 

This PR closes #4072 
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

I've added a check that exists the script if the previous script runs exist with condition 1. This way if the wazuh-passwords-tool or the wazuh-certs-tool scripts fails, the unattended-installation script will perform a rollback and exit.

<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

Regards,

David