### PR TITLE
Fix error with securityadmin and 0.0.0.0 IP

### DIFF
--- a/resources/open-distro/tools/wazuh-passwords-tool.sh
+++ b/resources/open-distro/tools/wazuh-passwords-tool.sh
@@ -79,6 +79,10 @@ getNetworkHost() {
     IP=$(grep -hr "network.host:" /etc/elasticsearch/elasticsearch.yml)
     NH="network.host: "
     IP="${IP//$NH}"
+    
+    if [ ${IP} == "0.0.0.0" ]; then
+        IP="localhost"
+    fi
 }
 
 ## Checks if Open Distro for Elasticsearch is installed


### PR DESCRIPTION
Hello team!

This PR closes #4070 
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

Due to some configurations, when the Elasticsearch `network.host` is set to `0.0.0.0`, the `securityadmin.sh` won't be able to resolve the IP and will cause a failure in the `wazuh-passwords-too.sh`.

To resolve this, I've added a check that compares the `network.host` and if it is set to `0.0.0.0`, it will use the option `-h` of the script to indicate the `localhost` IP.

<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

Regards,

David