### PR TITLE
Fix Wazuh's changelog links not redirecting to the actual changelog files

### DIFF
--- a/source/release-notes/release_2_1.rst
+++ b/source/release-notes/release_2_1.rst
@@ -5,7 +5,7 @@
 2.1 Release notes
 ===================
 
-This section shows the most relevant new features of Wazuh v2.1. You will find more detailed information in our `changelog <https://github.com/wazuh/wazuh/blob/2.1/CHANGELOG.md>`_ file.
+This section shows the most relevant new features of Wazuh v2.1. You will find more detailed information in our `changelog <https://github.com/wazuh/wazuh/blob/v2.1.0/CHANGELOG.md>`_ file.
 
 **New features:**
 

--- a/source/release-notes/release_3_0_0.rst
+++ b/source/release-notes/release_3_0_0.rst
@@ -5,7 +5,7 @@
 3.0.0 Release notes
 ===================
 
-This section shows the most relevant new features of Wazuh v3.0.0. You will find more detailed information in our `changelog <https://github.com/wazuh/wazuh/blob/3.0/CHANGELOG.md>`_ file.
+This section shows the most relevant new features of Wazuh v3.0.0. You will find more detailed information in our `changelog <https://github.com/wazuh/wazuh/blob/v3.0.0/CHANGELOG.md>`_ file.
 
 For deploying your Wazuh environment see the :doc:`Installation guide <../installation-guide/index>`.
 

--- a/source/release-notes/release_3_13_0.rst
+++ b/source/release-notes/release_3_13_0.rst
@@ -7,7 +7,7 @@
 
 This section lists the changes in version 3.13.0. More details about these changes are provided in each component changelog:
 
-- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/3.13/CHANGELOG.md>`_
+- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/v3.13.0/CHANGELOG.md>`_
 - `wazuh/wazuh-kibana-app <https://github.com/wazuh/wazuh-kibana-app/blob/3.13-7.7/CHANGELOG.md>`_
 - `wazuh/wazuh-api <https://github.com/wazuh/wazuh-api/blob/3.13/CHANGELOG.md>`_
 - `wazuh/wazuh-ruleset <https://github.com/wazuh/wazuh-ruleset/blob/3.13/CHANGELOG.md>`_
@@ -151,4 +151,3 @@ Wazuh Splunk
 ------------
 
 - Support for Wazuh v3.13.0
-

--- a/source/release-notes/release_3_13_1.rst
+++ b/source/release-notes/release_3_13_1.rst
@@ -7,7 +7,7 @@
 
 This section lists the changes in version 3.13.1. More details about these changes are provided in each component changelog:
 
-- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/3.13/CHANGELOG.md>`_
+- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/v3.13.1/CHANGELOG.md>`_
 - `wazuh/wazuh-kibana-app <https://github.com/wazuh/wazuh-kibana-app/blob/3.13.1-7.8.0/CHANGELOG.md>`_
 - `wazuh/wazuh-api <https://github.com/wazuh/wazuh-api/blob/3.13/CHANGELOG.md>`_
 - `wazuh/wazuh-splunk <https://github.com/wazuh/wazuh-splunk/blob/3.13-8.0/CHANGELOG.md>`_

--- a/source/release-notes/release_3_13_2.rst
+++ b/source/release-notes/release_3_13_2.rst
@@ -7,7 +7,7 @@
 
 This section lists the changes in version 3.13.2. More details about these changes are provided in each component changelog:
 
-- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/3.13/CHANGELOG.md>`_
+- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/v3.13.2/CHANGELOG.md>`_
 - `wazuh/wazuh-kibana-app <https://github.com/wazuh/wazuh-kibana-app/blob/3.13.2-7.9.1/CHANGELOG.md>`_
 - `wazuh/wazuh-splunk <https://github.com/wazuh/wazuh-splunk/blob/3.13-8.0/CHANGELOG.md>`_
 

--- a/source/release-notes/release_3_13_3.rst
+++ b/source/release-notes/release_3_13_3.rst
@@ -7,7 +7,7 @@
 
 This section lists the changes in version 3.13.3. More details about these changes are provided in each component changelog:
 
-- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/3.13/CHANGELOG.md>`_
+- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/v3.13.3/CHANGELOG.md>`_
 - `wazuh/wazuh-kibana-app <https://github.com/wazuh/wazuh-kibana-app/blob/v3.13.3-7.9.2/CHANGELOG.md>`_
 - `wazuh/wazuh-splunk <https://github.com/wazuh/wazuh-splunk/blob/v3.13.3-8.0.4/CHANGELOG.md>`_
 

--- a/source/release-notes/release_3_1_0.rst
+++ b/source/release-notes/release_3_1_0.rst
@@ -5,7 +5,7 @@
 3.1.0 Release notes
 ===================
 
-This section shows the most relevant new features of Wazuh v3.1.0. You will find more detailed information in our `changelog <https://github.com/wazuh/wazuh/blob/3.1/CHANGELOG.md>`_ file.
+This section shows the most relevant new features of Wazuh v3.1.0. You will find more detailed information in our `changelog <https://github.com/wazuh/wazuh/blob/v3.1.0/CHANGELOG.md>`_ file.
 
 **New features:**
 

--- a/source/release-notes/release_3_2_0.rst
+++ b/source/release-notes/release_3_2_0.rst
@@ -5,7 +5,7 @@
 3.2.0 Release notes
 ===================
 
-This section shows the most relevant new features of Wazuh v3.2.0. You will find more detailed information in our `changelog <https://github.com/wazuh/wazuh/blob/3.2/CHANGELOG.md>`_ file.
+This section shows the most relevant new features of Wazuh v3.2.0. You will find more detailed information in our `changelog <https://github.com/wazuh/wazuh/blob/v3.2.0/CHANGELOG.md>`_ file.
 
 **New features:**
 

--- a/source/release-notes/release_3_2_1.rst
+++ b/source/release-notes/release_3_2_1.rst
@@ -5,7 +5,7 @@
 3.2.1 Release notes
 ===================
 
-This release is a bug fix release. This section shows the most relevant improvements and fixes of Wazuh v3.2.1. You will find more detailed information in the `changelog <https://github.com/wazuh/wazuh/blob/3.2/CHANGELOG.md#v321>`_ file.
+This release is a bug fix release. This section shows the most relevant improvements and fixes of Wazuh v3.2.1. You will find more detailed information in the `changelog <https://github.com/wazuh/wazuh/blob/v3.2.1/CHANGELOG.md#v321>`_ file.
 
 - `Wazuh modules`_
 - `Cluster`_

--- a/source/release-notes/release_4_0_0.rst
+++ b/source/release-notes/release_4_0_0.rst
@@ -7,7 +7,7 @@
 
 This section lists the changes in version 4.0.0. More details about these changes are provided in the changelog of each component:
 
-- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/4.0/CHANGELOG.md>`_
+- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/v4.0.0/CHANGELOG.md>`_
 - `wazuh/wazuh-kibana-app <https://github.com/wazuh/wazuh-kibana-app/blob/4.0-7.9/CHANGELOG.md>`_
 - `wazuh/ruleset <https://github.com/wazuh/wazuh-ruleset/blob/4.0/CHANGELOG.md>`_
 - `wazuh/wazuh-packages <https://github.com/wazuh/wazuh-packages/blob/master/CHANGELOG.md>`_

--- a/source/release-notes/release_4_0_1.rst
+++ b/source/release-notes/release_4_0_1.rst
@@ -7,7 +7,7 @@
 
 This section lists the changes in version 4.0.1. More details about these changes are provided in the changelog of each component:
 
-- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/4.0.1/CHANGELOG.md>`_
+- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/v4.0.1/CHANGELOG.md>`_
 - `wazuh/wazuh-kibana-app <https://github.com/wazuh/wazuh-kibana-app/blob/v4.0.1-7.9.3/CHANGELOG.md>`_
 - `wazuh/ruleset <https://github.com/wazuh/wazuh-ruleset/blob/4.0.1/CHANGELOG.md>`_
 

--- a/source/release-notes/release_4_0_2.rst
+++ b/source/release-notes/release_4_0_2.rst
@@ -7,7 +7,7 @@
 
 This section lists the changes in version 4.0.2. More details about these changes are provided in the changelog of each component:
 
-- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/4.0.2/CHANGELOG.md>`_
+- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/v4.0.2/CHANGELOG.md>`_
 - `wazuh/wazuh-kibana-app <https://github.com/wazuh/wazuh-kibana-app/blob/v4.0.2-7.9.3/CHANGELOG.md>`_
 
 
@@ -79,9 +79,3 @@ Fixed
 - Changes done via a worker API were overwritten.
 - Default user field in Security Role mapping is now provided depending on whether ODFE or X-Pack is installed. 
 - Bug that replaced index-pattern title with its ID during the updating process.
-
-
-
-
-
-

--- a/source/release-notes/release_4_0_3.rst
+++ b/source/release-notes/release_4_0_3.rst
@@ -7,7 +7,7 @@
 
 This section lists the changes in version 4.0.3. More details about these changes are provided in the changelog of each component:
 
-- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/4.0.3/CHANGELOG.md>`_
+- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/v4.0.3/CHANGELOG.md>`_
 - `wazuh/wazuh-kibana-app <https://github.com/wazuh/wazuh-kibana-app/blob/v4.0.3-7.9.3/CHANGELOG.md>`_
 
 

--- a/source/release-notes/release_4_0_4.rst
+++ b/source/release-notes/release_4_0_4.rst
@@ -7,7 +7,7 @@
 
 This section lists the changes in version 4.0.4. More details about these changes are provided in the changelog of each component:
 
-- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/4.0.4/CHANGELOG.md>`_
+- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/v4.0.4/CHANGELOG.md>`_
 - `wazuh/wazuh-kibana-app <https://github.com/wazuh/wazuh-kibana-app/blob/v4.0.4-7.9.3/CHANGELOG.md>`_
 
 


### PR DESCRIPTION
## Description

Hi team. This is to fix broken links to changelog files on version 4.0 of the documentation.

## Checks
- [X] It compiles without warnings.
- [X] Spelling and grammar. 
- [X] Used impersonal speech. 
- [X] Used uppercase only on nouns. 
- [X] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
