### PR TITLE
Fix CentOS 8 deps when building from sources

### DIFF
--- a/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-agent/index.rst
+++ b/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-agent/index.rst
@@ -29,14 +29,14 @@ Installing Wazuh agent from sources
             .. code-block:: console
 
               # yum update
-              # yum install make gcc gcc-c++ policycoreutils-python automake autoconf libtool centos-release-scl devtoolset-7
+              # yum install make gcc gcc-c++ policycoreutils-python automake autoconf libtool centos-release-scl devtoolset-7 openssl-devel
               # scl enable devtoolset-7 bash
 
             CMake 3.18 installation
 
             .. code-block:: console
 
-              # curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && tar -zxf cmake-3.18.3.tar.gz
+              # curl -OL https://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && tar -zxf cmake-3.18.3.tar.gz
               # cd cmake-3.18.3 && ./bootstrap --no-system-curl
               # make -j$(nproc) && make install
               # cd .. && rm -rf cmake-*
@@ -45,14 +45,14 @@ Installing Wazuh agent from sources
 
             .. code-block:: console
 
-              # yum install make gcc gcc-c++ python3 python3-policycoreutils automake autoconf libtool
-              # rpm -i http://mirror.centos.org/centos/8/PowerTools/x86_64/os/Packages/libstdc++-static-8.3.1-5.1.el8.x86_64.rpm
+              # yum install make gcc gcc-c++ python3 python3-policycoreutils automake autoconf libtool openssl-devel
+              # rpm -i $(rpm --eval https://packages.wazuh.com/utils/libstdc%2B%2B/libstdc%2B%2B-static-8.4.1-1.el8.'%{_arch}'.rpm)
 
             CMake 3.18 installation
 
             .. code-block:: console
 
-              # curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && tar -zxf cmake-3.18.3.tar.gz
+              # curl -OL https://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && tar -zxf cmake-3.18.3.tar.gz
               # cd cmake-3.18.3 && ./bootstrap --no-system-curl
               # make -j$(nproc) && make install
               # cd .. && rm -rf cmake-*
@@ -69,7 +69,7 @@ Installing Wazuh agent from sources
 
         .. code-block:: console
 
-          # curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && tar -zxf cmake-3.18.3.tar.gz
+          # curl -OL https://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && tar -zxf cmake-3.18.3.tar.gz
           # cd cmake-3.18.3 && ./bootstrap --no-system-curl
           # make -j$(nproc) && make install
           # cd .. && rm -rf cmake-*
@@ -86,7 +86,7 @@ Installing Wazuh agent from sources
 
         .. code-block:: console
 
-          # curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && tar -zxf cmake-3.18.3.tar.gz
+          # curl -OL https://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && tar -zxf cmake-3.18.3.tar.gz
           # cd cmake-3.18.3 && ./bootstrap --no-system-curl
           # make -j$(nproc) && make install
           # cd .. && rm -rf cmake-*

--- a/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-agent/index.rst
+++ b/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-agent/index.rst
@@ -56,6 +56,7 @@ Installing Wazuh agent from sources
               # cd cmake-3.18.3 && ./bootstrap --no-system-curl
               # make -j$(nproc) && make install
               # cd .. && rm -rf cmake-*
+              # export PATH=/usr/local/bin:$PATH
 
 
       .. tab:: APT

--- a/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-server/index.rst
+++ b/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-server/index.rst
@@ -59,6 +59,7 @@ Installing Wazuh manager
             # cd cmake-3.18.3 && ./bootstrap --no-system-curl
             # make -j$(nproc) && make install
             # cd .. && rm -rf cmake-*
+            # export PATH=/usr/local/bin:$PATH
 
 
   .. group-tab:: APT

--- a/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-server/index.rst
+++ b/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-server/index.rst
@@ -29,7 +29,7 @@ Installing Wazuh manager
           .. code-block:: console
 
             # yum update
-            # yum install make gcc gcc-c++ policycoreutils-python automake autoconf libtool centos-release-scl devtoolset-7
+            # yum install make gcc gcc-c++ policycoreutils-python automake autoconf libtool centos-release-scl devtoolset-7 openssl-devel
             # scl enable devtoolset-7 bash
 
 
@@ -37,7 +37,7 @@ Installing Wazuh manager
 
           .. code-block:: console
 
-            # curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && tar -zxf cmake-3.18.3.tar.gz
+            # curl -OL https://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && tar -zxf cmake-3.18.3.tar.gz
             # cd cmake-3.18.3 && ./bootstrap --no-system-curl
             # make -j$(nproc) && make install
             # cd .. && rm -rf cmake-*
@@ -47,15 +47,15 @@ Installing Wazuh manager
 
           .. code-block:: console
 
-            # yum install make cmake gcc gcc-c++ python3 python3-policycoreutils automake autoconf libtool
-            # rpm -i http://mirror.centos.org/centos/8/PowerTools/x86_64/os/Packages/libstdc++-static-8.3.1-5.el8.0.2.x86_64.rpm
+            # yum install make cmake gcc gcc-c++ python3 python3-policycoreutils automake autoconf libtool openssl-devel
+            # rpm -i $(rpm --eval https://packages.wazuh.com/utils/libstdc%2B%2B/libstdc%2B%2B-static-8.4.1-1.el8.'%{_arch}'.rpm)
 
 
           CMake 3.18 installation
 
           .. code-block:: console
 
-            # curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && tar -zxf cmake-3.18.3.tar.gz
+            # curl -OL https://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && tar -zxf cmake-3.18.3.tar.gz
             # cd cmake-3.18.3 && ./bootstrap --no-system-curl
             # make -j$(nproc) && make install
             # cd .. && rm -rf cmake-*
@@ -73,7 +73,7 @@ Installing Wazuh manager
 
     .. code-block:: console
 
-      # curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && tar -zxf cmake-3.18.3.tar.gz
+      # curl -OL https://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && tar -zxf cmake-3.18.3.tar.gz
       # cd cmake-3.18.3 && ./bootstrap --no-system-curl
       # make -j$(nproc) && make install
       # cd .. && rm -rf cmake-*
@@ -89,7 +89,7 @@ Installing Wazuh manager
 
     .. code-block:: console
 
-      # curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && tar -zxf cmake-3.18.3.tar.gz
+      # curl -OL https://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && tar -zxf cmake-3.18.3.tar.gz
       # cd cmake-3.18.3 && ./bootstrap --no-system-curl
       # make -j$(nproc) && make install
       # cd .. && rm -rf cmake-*


### PR DESCRIPTION
|Related issue|
|---|
|Closes #4030|

## Description

Hi team!

This PR aims to solve some missing some CentOS dependencies related to CMake compilation (`openssl-devel`) and Wazuh compilation (`libstdc++-static` rpm package) for both Manager and Agent. This last one was uploaded to Wazuh file repository (`https://packages.wazuh.com/utils/libstdc%2B%2B/`).
Also some findings were fixed
- Some `http` URLs were changed to `https`
- Add CMake installation path to PATH env to avoid using pre-installed CMake version

## Checks
- [x] It compiles without warnings.
- [x] ~Spelling and grammar.~
- [x] ~Used impersonal speech.~
- [x] ~Used uppercase only on nouns.~
- [x] ~Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).~

Regards,
Nico