### PR TITLE
Added a step to remove the Wazuh API manually when upgrading from 3.13.3

### DIFF
--- a/source/upgrade-guide/upgrading-wazuh.rst
+++ b/source/upgrade-guide/upgrading-wazuh.rst
@@ -8,7 +8,7 @@
 Upgrading the Wazuh manager
 ===========================
 
-This section describes how to upgrade the Wazuh manager to the latest available version, which includes upgrading to the latest compatible version of Open Distro for Elasticsearch or Elastic Stack basic licence. 
+This section describes how to upgrade the Wazuh manager to the latest available version, which includes upgrading to the latest compatible version of Open Distro for Elasticsearch or Elastic Stack basic licence.
 
 .. note::
   In order to reduce server downtime, it is recommended to update the master node first
@@ -28,8 +28,15 @@ To upgrade the Wazuh manager, choose the appropriate tab for the desired package
       .. code-block:: console
 
         # yum clean all
+
+    4. **(For upgrades from version 3.13.3)** Remove the Wazuh API:
+
+      .. code-block:: console
+
+          # yum remove wazuh-api
+
     
-    4. Upgrade the Wazuh manager to the latest version:
+    5. Upgrade the Wazuh manager to the latest version:
 
       .. code-block:: console
 
@@ -38,8 +45,14 @@ To upgrade the Wazuh manager, choose the appropriate tab for the desired package
   .. group-tab:: APT
 
     .. include:: ../_templates/installations/basic/wazuh/deb/add_repository_aio.rst
+   
+    4. **(For upgrades from version 3.13.3)** Remove the Wazuh API:
 
-    4. Upgrade the Wazuh manager to the latest version:
+      .. code-block:: console 
+
+          # apt-get remove --purge wazuh-api
+
+    5. Upgrade the Wazuh manager to the latest version:
 
       .. code-block:: console
 
@@ -49,7 +62,13 @@ To upgrade the Wazuh manager, choose the appropriate tab for the desired package
 
     .. include:: ../_templates/installations/basic/wazuh/zypp/add_repository_aio.rst
 
-    3. Upgrade the Wazuh manager to the latest version:
+    3. **(For upgrades from version 3.13.3)** Remove the Wazuh API:
+
+      .. code-block:: console 
+
+          # zypper remove wazuh-api
+
+    4. Upgrade the Wazuh manager to the latest version:
 
       .. code-block:: console
 

--- a/source/upgrade-guide/upgrading-wazuh.rst
+++ b/source/upgrade-guide/upgrading-wazuh.rst
@@ -8,10 +8,8 @@
 Upgrading the Wazuh manager
 ===========================
 
-This section describes how to upgrade the Wazuh manager to the latest available version, which includes upgrading to the latest compatible version of Open Distro for Elasticsearch or Elastic Stack basic licence.
+This section describes how to upgrade the Wazuh manager to the latest available version. When upgrading a Wazuh multi-node cluster, it is recommended to update the master node first to reduce server downtime.
 
-.. note::
-  In order to reduce server downtime, it is recommended to update the master node first
 
 .. note:: Root user privileges are required to execute all the commands described below.
 

--- a/source/upgrade-guide/upgrading-wazuh.rst
+++ b/source/upgrade-guide/upgrading-wazuh.rst
@@ -13,7 +13,7 @@ This section describes how to upgrade the Wazuh manager to the latest available 
 
 .. note:: Root user privileges are required to execute all the commands described below.
 
-To upgrade the Wazuh manager, choose the appropriate tab for the desired package manager:
+To upgrade the Wazuh manager, choose your package manager and follow the instructions. 
 
 .. tabs::
 
@@ -115,4 +115,5 @@ It is recommended to disable the Wazuh repository in order to avoid undesired up
 Next step
 ---------
 
-:ref:`Upgrading Elasticsearch, Kibana and Filebeat<upgrade_elasticsearch_filebeat_kibana>`.
+The Wazuh manager is now successfully upgraded and you can proceed with upgrading the Elastic Stack. To perform this action, see the :ref:`Upgrading Elasticsearch, Kibana and Filebeat<upgrade_elasticsearch_filebeat_kibana>` section.
+

--- a/source/upgrade-guide/upgrading-wazuh.rst
+++ b/source/upgrade-guide/upgrading-wazuh.rst
@@ -78,42 +78,44 @@ To upgrade the Wazuh manager, choose your package manager and follow the instruc
 
   If Wazuh runs in a multi-node cluster, it is necessary to update all Wazuh managers to the same version. Otherwise, Wazuh nodes will not join the cluster.
 
-Disabling the Wazuh repository
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-It is recommended to disable the Wazuh repository in order to avoid undesired upgrades and compatibility issues:
+- **Recommended action** -  Disable Wazuh updates
 
-.. tabs::
+  We recommend disabling the Wazuh repository to prevent accidental upgrades. To do so, use the following command:
 
-  .. group-tab:: Yum
 
-    .. code-block:: console
-
-      # sed -i "s/^enabled=1/enabled=0/" /etc/yum.repos.d/wazuh.repo
-
-  .. group-tab:: APT
-
-    This step is not necessary if the user set the packages to a ``hold`` state instead of disabling the repository.
-
-    .. code-block:: console
-
-      # sed -i "s/^deb/#deb/" /etc/apt/sources.list.d/wazuh.list
-      # apt-get update
-
-    Alternatively, the user can set the package state to ``hold``, which will stop updates. It will be still possible to upgrade it manually using ``apt-get install``:
-
-    .. code-block:: console
-
-      # echo "wazuh-manager hold" | sudo dpkg --set-selections
-
-  .. group-tab:: ZYpp
-
-    .. code-block:: console
-
-      # sed -i "s/^enabled=1/enabled=0/" /etc/zypp/repos.d/wazuh.repo
-
-Next step
----------
+  
+  .. tabs::
+  
+    .. group-tab:: Yum
+  
+      .. code-block:: console
+  
+        # sed -i "s/^enabled=1/enabled=0/" /etc/yum.repos.d/wazuh.repo
+  
+    .. group-tab:: APT
+  
+      This step is not necessary if the user set the packages to a ``hold`` state instead of disabling the repository.
+  
+      .. code-block:: console
+  
+        # sed -i "s/^deb/#deb/" /etc/apt/sources.list.d/wazuh.list
+        # apt-get update
+  
+      Alternatively, the user can set the package state to ``hold``, which will stop updates. It will be still possible to upgrade it manually   using ``apt-get install``:
+  
+      .. code-block:: console
+  
+        # echo "wazuh-manager hold" | sudo dpkg --set-selections
+  
+    .. group-tab:: ZYpp
+  
+      .. code-block:: console
+  
+        # sed -i "s/^enabled=1/enabled=0/" /etc/zypp/repos.d/wazuh.repo
+  
+Next steps
+----------
 
 The Wazuh manager is now successfully upgraded and you can proceed with upgrading the Elastic Stack. To perform this action, see the :ref:`Upgrading Elasticsearch, Kibana and Filebeat<upgrade_elasticsearch_filebeat_kibana>` section.
 


### PR DESCRIPTION

## Description

This PR adds a step to remove the Wazuh API manually when upgrading the Wazuh manager from v3.13.3 and closes #4007. This PR also includes an editorial review of the "Upgrading the Wazuh manager" section.    

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

## Note to the reviewer

This PR includes changes to the `redirect.js` script that need to be included in all production branches.
