### PR TITLE
Rewrite the Configuration section of the manual for the Command monitoring capability

### DIFF
--- a/source/user-manual/capabilities/command-monitoring/command-configuration.rst
+++ b/source/user-manual/capabilities/command-monitoring/command-configuration.rst
@@ -8,78 +8,165 @@
 Configuration
 =============
 
-#. `Basic usage`_
-#. `Monitor running Windows processes`_
-#. `Disk space utilization`_
-#. `Check if the output changed`_
-#. `Load average`_
-#. `Detect USB Storage`_
+.. contents:: :local:
 
-Basic usage
------------
+General utilization
+-------------------
 
-Command monitoring is configured in the :ref:`localfile section<reference_ossec_localfile>` of :ref:`ossec.conf <reference_ossec_conf>`. It can be also be centrally configured in :ref:`agent.conf<reference_agent_conf>`.
+The command monitoring capability is configured either locally or centrally:
 
-Monitor running Windows processes
----------------------------------
-Let's say you want to monitor running processes and alert if an important process is not running.
+*  Locally through the :ref:`ossec.conf <reference_ossec_conf>` local configuration file.
+*  Centrally through the :ref:`agent.conf<reference_agent_conf>` group configuration file.
 
-Example with notepad.exe as the important process to monitor:
+The configuration options are defined in the :ref:`localfile section<reference_ossec_localfile>` of the configuration file, under the ``<localfile>`` section tag.
 
-1. Configure the agent in the agent's **local_internal_options.conf** file to accept remote commands from the manager.
+.. code-block:: xml
 
-    .. code-block:: pkgconfig
+  <localfile>
+      <log_format><!-- `command` or `full_command` options--></log_format>
+      <command><!-- Command and arguments go here --></command>
+      <frequency><!-- Interval in seconds goes here--></frequency>
+  </localfile>
 
-      # Logcollector - Whether or not to accept remote commands from the manager
-      logcollector.remote_commands=1
+The configuration options are as follows:
 
-2. Define the command in the group's **agent.conf** file to list running processes.
+*  ``<log_format>``: The ``full_command`` option is used to turn the command's output into a single log message. With the ``command`` option, each line of output is treated as a separate log.
+*  ``<command>``: The command and arguments whose output is going to be monitored.
+*  ``<frequency>``: The time interval to wait between executions. This value is expressed in seconds. By default, the command will be run every 360 seconds.
 
-    .. code-block:: xml
+Additionally, when central configuration is used, an explicit consent on the monitored system is required. This permission is granted in the agent's :ref:`local_internal_options.conf<reference_internal_options>` configuration file by enabling remote commands on the :ref:`Logcollector<ossec_internal_logcollector>`.
 
-      <localfile>
-          <log_format>full_command</log_format>
-          <command>tasklist</command>
-          <frequency>120</frequency>
-      </localfile>
+.. code-block:: pkgconfig
 
-    The ``<frequency>`` tag defines how often the command will be run in seconds.
+  # Logcollector - Toggles whether to accept remote commands from the manager
+  # 1: Enable remote commands
+  # 0: Disable remote commands
+  logcollector.remote_commands=1
 
-3. Define the rules.
+Depending on the specific application, :ref:`custom rules<ruleset_custom>` may need to be added.
 
-    .. code-block:: xml
+Running processes monitoring
+----------------------------
+The command monitoring capability can be used to alert about the missing execution of a given process.
 
-      <rule id="100010" level="6">
-        <if_sid>530</if_sid>
-        <match>^ossec: output: 'tasklist'</match>
-        <description>Important process not running.</description>
-        <group>process_monitor,</group>
-      </rule>
+As an example, we will configure to check periodically the `clamd.exe` process execution on a monitored Windows system. To do this, we use the command `tasklist` and set it to run repeatedly once every 120 seconds.
 
-      <rule id="100011" level="0">
-        <if_sid>100010</if_sid>
-        <match>notepad.exe</match>
-        <description>Processes running as expected</description>
-        <group>process_monitor,</group>
-      </rule>
+.. code-block:: xml
 
-    The first rule (100010) will generate an alert ("Important process not running"), unless it is overridden by its child rule (100011) that matches `notepad.exe` in the command output.  You may add as many child rules as needed to enumerate all of the important processes you want to monitor.  You can also adapt this example to monitor Linux processes by changing the ``<command>`` from ``tasklist`` to a Linux command that lists processes, like ``ps -auxw``.
+  <localfile>
+      <log_format>full_command</log_format>
+      <command>tasklist</command>
+      <frequency>120</frequency>
+  </localfile>
 
-Disk space utilization
-----------------------
 
-The ``df`` command helps here to check the available disk space for file systems.
+We add two rules:
 
-This can be configured in either the ``agent.conf`` file or the ``ossec.conf`` file:
+*  One level 6 rule to generate an alert about the process not running. This is a fallback rule and is going to be triggered whenever the monitored process is not found within the `tasklist` command's output:
+
+.. code-block:: xml
+
+  <rule id="100010" level="6">
+    <if_sid>530</if_sid>
+    <match>^ossec: output: 'tasklist'</match>
+    <description>clamd.exe not running.</description>
+    <group>process_monitor,</group>
+  </rule>
+
+*  One level 0 child rule to watch specifically for the presence of the process `clamd.exe` in the command's output. If found, no action will be taken.
+
+.. code-block:: xml
+
+  <rule id="100011" level="0">
+    <if_sid>100010</if_sid>
+    <match>clamd.exe</match>
+    <description>clamd.exe running as expected.</description>
+    <group>process_monitor,</group>
+  </rule>
+
+In this example, unless there is a match for ``clamd.exe`` found in the `tasklist` command's output,  `rule id 100010` will trip a level 6 alert.
+
+Following this example, new rules similar to rules `id 100010` and `id 100011` above may be added to watch for other processes as well.
+
+In the case of monitoring Linux processes, this example could be adapted by changing the ``<command>`` option from ``tasklist`` to a Linux command that lists processes, like ``ps -auxw``.
+
+Load average monitoring
+-----------------------
+
+Wazuh can be configured to monitor the Linux `uptime` command's output and alert when its reported load average has reached a given threshold.
+
+The output of `uptime` looks like this:
+
+.. code-block:: PowerShell
+
+  # uptime
+  09:50:11 up 6 days, 48 min, 2 users, load average: 0.22, 0.41, 0.32
+
+..
+  used PowerShell syntax instead of sh due to bad highlighting
+
+In the :ref:`localfile section<reference_ossec_localfile>` of the configuration file we set to run the command ``uptime``.
+
+.. code-block:: xml
+
+  <localfile>
+      <log_format>command</log_format>
+      <command>uptime</command>
+      <frequency>60</frequency>
+  </localfile>
+
+In this example we define a level 7 rule and use the regular expression ``load average: 2.`` to alert when the load average has reached a value of two in the last minute:
+
+.. code-block:: xml
+
+  <rule id="100101" level="7" ignore="7200">
+    <if_sid>530</if_sid>
+    <match>ossec: output: 'uptime': </match>
+    <regex>load average: 2.</regex>
+    <description>Load average reached a value of 2.</description>
+  </rule>
+
+USB storage detection
+---------------------
+
+Wazuh can be configured to alert when a USB storage device is connected.
+
+In this example we configure Windows agents to monitor the `USBSTOR` registry entry by adding the following to the group's `agent.conf` configuration file:
+
+.. code-block:: xml
+
+  <agent_config os="Windows">
+    <localfile>
+        <log_format>full_command</log_format>
+        <command>reg QUERY HKLM\SYSTEM\CurrentControlSet\Enum\USBSTOR</command>
+    </localfile>
+  </agent_config>
+
+We create a custom level 7 rule to monitor for changes using the :ref:`check_diff option <rules_check_diff>`:
+
+.. code-block:: xml
+
+  <rule id="140125" level="7">
+      <if_sid>530</if_sid>
+      <match>ossec: output: 'reg QUERY</match>
+      <check_diff />
+      <description>New USB device connected.</description>
+  </rule>
+
+Disk space usage monitoring
+---------------------------
+
+The `df` command can be used to check the available disk space for file systems.
 
 .. code-block:: xml
 
   <localfile>
       <log_format>command</log_format>
       <command>df -P</command>
+      <frequency>300</frequency>
   </localfile>
 
-Wazuh already has a rule to monitor this
+Wazuh already has a rule to trip an alert once the disk space usage on any partition reaches 100%.
 
 .. code-block:: xml
 
@@ -91,15 +178,10 @@ Wazuh already has a rule to monitor this
     <group>low_diskspace,pci_dss_10.6.1,</group>
   </rule>
 
+Network connections monitoring
+------------------------------
 
-The system will alert once the disk space usage on any partition reaches 100%.
-
-Check if the output changed
----------------------------
-
-In this case, the Linux "netstat" command is used along with the :ref:`check_diff option <rules_check_diff>` to monitor for changes in listening tcp sockets.
-
-This can be configured in either the ``agent.conf`` file or the ``ossec.conf`` file:
+In this example, the Linux `netstat` command is used along with the :ref:`check_diff option <rules_check_diff>` to monitor for changes in listening TCP sockets. If the output changes, the system will generate an alert.
 
 .. code-block:: xml
 
@@ -107,10 +189,10 @@ This can be configured in either the ``agent.conf`` file or the ``ossec.conf`` f
     <log_format>full_command</log_format>
     <command>netstat -tulpn | sed 's/\([[:alnum:]]\+\)\ \+[[:digit:]]\+\ \+[[:digit:]]\+\ \+\(.*\):\([[:digit:]]*\)\ \+\([0-9\.\:\*]\+\).\+\ \([[:digit:]]*\/[[:alnum:]\-]*\).*/\1 \2 == \3 == \4 \5/' | sort -k 4 -g | sed 's/ == \(.*\) ==/:\1/' | sed 1,2d</command>
     <alias>netstat listening ports</alias>
-    <frequency>360</frequency>
+    <frequency>300</frequency>
   </localfile>
 
-Wazuh already has a rule to monitor this:
+Wazuh already has a rule to alert when a network listener has disappeared or a new one has appeared. This may indicate something is broken or a network backdoor has been installed.
 
 .. code-block:: xml
 
@@ -120,58 +202,4 @@ Wazuh already has a rule to monitor this:
     <check_diff />
     <description>Listened ports status (netstat) changed (new port opened or closed).</description>
     <group>pci_dss_10.2.7,pci_dss_10.6.1,gpg13_10.1,gdpr_IV_35.7.d,</group>
-  </rule>
-
-If the output changes, the system will generate an alert indicating a network listener has disappeared or a new one has appeared. This may indicate something is broken or a network backdoor has been installed.
-
-Load average
-------------
-
-Wazuh can be configured to monitor the Linux ``uptime`` command and alert when it is higher than a given threshold, like two load averages in this example.
-
-This can be configured in ``agent.conf`` or ``ossec.conf``:
-
-.. code-block:: xml
-
-  <localfile>
-      <log_format>command</log_format>
-      <command>uptime</command>
-  </localfile>
-
-And the custom rule to alert when "uptime" is higher than two load averages:
-
-.. code-block:: xml
-
-  <rule id="100101" level="7" ignore="7200">
-    <if_sid>530</if_sid>
-    <match>ossec: output: 'uptime': </match>
-    <regex>load average: 2.</regex>
-    <description>Load average reached 2..</description>
-  </rule>
-
-Detect USB Storage
-------------------
-
-Wazuh can be configured to alert when a USB storage device is connected. This example is for a Windows agent.
-
-Configure your agent to monitor the USBSTOR registry entry by adding the following to the group's ``agent.conf``:
-
-.. code-block:: xml
-
-  <agent_config os="Windows">
-    <localfile>
-        <log_format>full_command</log_format>
-        <command>reg QUERY HKLM\SYSTEM\CurrentControlSet\Enum\USBSTOR</command>
-    </localfile>
-  </agent_config>
-
-Next create a custom rule:
-
-.. code-block:: xml
-
-  <rule id="140125" level="7">
-      <if_sid>530</if_sid>
-      <match>ossec: output: 'reg QUERY</match>
-      <check_diff />
-      <description>New USB device connected</description>
   </rule>


### PR DESCRIPTION
## Description

Hi team! This is to address and close issue #4088. The whole configuration section for the command monitoring capability has been rewritten keeping the examples with a little rework.

## Checks
- [X] It compiles without warnings.
- [X] Spelling and grammar. 
- [X] Used impersonal speech. 
- [X] Used uppercase only on nouns. 
- [X] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).