### PR TITLE
Fix Centos6/7 deps installing

### DIFF
--- a/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-agent/index.rst
+++ b/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-agent/index.rst
@@ -29,7 +29,9 @@ Installing Wazuh agent from sources
             .. code-block:: console
 
               # yum update
-              # yum install make gcc gcc-c++ policycoreutils-python automake autoconf libtool centos-release-scl devtoolset-7
+              # yum install make gcc gcc-c++ policycoreutils-python automake autoconf libtool centos-release-scl openssl-devel
+              # yum update
+              # yum install devtoolset-7
               # scl enable devtoolset-7 bash
 
             CMake 3.18 installation

--- a/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-server/index.rst
+++ b/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-server/index.rst
@@ -29,7 +29,9 @@ Installing Wazuh manager
           .. code-block:: console
 
             # yum update
-            # yum install make gcc gcc-c++ policycoreutils-python automake autoconf libtool centos-release-scl devtoolset-7
+            # yum install make gcc gcc-c++ policycoreutils-python automake autoconf libtool centos-release-scl openssl-devel
+            # yum update
+            # yum install devtoolset-7
             # scl enable devtoolset-7 bash
 
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->
|Related issue|
|---|
|closes #4093|

## Description

Hi team!

This PR aims to fix error while installing Wazuh from sources following specifically step-by-step.

This happens because `devtoolset-7` dependency should be fetched after adding and upgrading mirror installed by `centos-release-scl` package.


## Checks
- [x] It compiles without warnings.
- [x] ~Spelling and grammar.~
- [x] ~Used impersonal speech.~
- [x] ~Used uppercase only on nouns.~
- [x] ~Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).~

Regards,
Nico
