### PR TITLE
Add libcap-progs dependency installation code to zypper installation steps for the  all-in-one step-by-step installation guide

### DIFF
--- a/source/_templates/installations/wazuh/zypp/add_repository_aio.rst
+++ b/source/_templates/installations/wazuh/zypp/add_repository_aio.rst
@@ -4,7 +4,7 @@
 
     .. code-block:: console
 
-      # zypper install zip unzip tar
+      # zypper install zip unzip tar libcap-progs
 
 #. Import the GPG key:
 


### PR DESCRIPTION
## Description
This pull request adds a fix with a step to install the libcap-progs dependency using zypper which required to run setcap as part of the all-in-one step-by-step Wazuh server installation steps.

## Checks
- [X] It compiles without warnings.
- [X] Spelling and grammar. 
- [X] Used impersonal speech. 
- [X] Used uppercase only on nouns. 
- [X] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).