### PR TITLE
4108 Replace gnupg2 with gnupg

### DIFF
--- a/source/_templates/installations/basic/before_installation_all_in_one.rst
+++ b/source/_templates/installations/basic/before_installation_all_in_one.rst
@@ -16,7 +16,7 @@
 
                 .. code-block:: console
 
-                    # apt-get install apt-transport-https zip unzip lsb-release curl gnupg2
+                    # apt-get install apt-transport-https zip unzip lsb-release curl gnupg
 
         .. group-tab:: ZYpp
 


### PR DESCRIPTION
## Description
This PR is to replace `gnupg2` with `gnupg` in dependencies installation with apt for Basic all-in-one- step-by-step installation. It closes issue 4108.

## Checks
- [X] It compiles without warnings.
- [X] Spelling and grammar. 
- [X] Used impersonal speech. 
- [X] Used uppercase only on nouns. 
- [X] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).