### PR TITLE
Increase Logcollector state file interval default value to one minute

### DIFF
--- a/source/user-manual/reference/internal-options.rst
+++ b/source/user-manual/reference/internal-options.rst
@@ -632,7 +632,7 @@ Logcollector
 |                                          |               |                                                                            |
 |                                          |               | .. versionadded:: 4.2                                                      |
 +                                          +---------------+----------------------------------------------------------------------------+
-|                                          | Default value | 5                                                                          |
+|                                          | Default value | 60                                                                         |
 +                                          +---------------+----------------------------------------------------------------------------+
 |                                          | Allowed values| 0: Disable statistics file generation. Statistics information will continue|
 |                                          |               | to be available through the API                                            |


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh/issues/9559|

This PR increases the internal option `logcollector.state_interval` default value from 5 seconds to one minute.