### PR TITLE
Rename the wazuh-agent binaries

### DIFF
--- a/source/installation-guide/wazuh-agent/wazuh_agent_package_macos.rst
+++ b/source/installation-guide/wazuh-agent/wazuh_agent_package_macos.rst
@@ -33,7 +33,7 @@ The agent runs on the host you want to monitor and communicates with the Wazuh m
     
                 .. code-block:: console
     
-                  # sudo /Library/Ossec/bin/ossec-control start
+                  # sudo /Library/Ossec/bin/wazuh-control start
 
 
             The installation process is now complete and the Wazuh agent is successfully installed, registered, and configured, running on your macOS system.
@@ -50,7 +50,7 @@ The agent runs on the host you want to monitor and communicates with the Wazuh m
     
                 .. code-block:: console
     
-                  # sudo /Library/Ossec/bin/ossec-control start
+                  # sudo /Library/Ossec/bin/wazuh-control start
  
             The installation process is now complete and the Wazuh agent is successfully installed on your macOS system. The next step is to register and configure the agent to communicate with the Wazuh manager. To perform this action, see the :ref:`Registering Wazuh agents <register_agents>` section. 
 


### PR DESCRIPTION
Hello team!

This PR closes #4112 

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

I've renamed the `ossec-control` to `wazuh-control` according to the changes made to the Wazuh agent 4.2.0

<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

Regards,

David