### PR TITLE
Simplify enabling and starting execution of services

### DIFF
--- a/source/_templates/installations/basic/elastic/common/enable_elasticsearch.rst
+++ b/source/_templates/installations/basic/elastic/common/enable_elasticsearch.rst
@@ -9,8 +9,7 @@
     .. code-block:: console
 
       # systemctl daemon-reload
-      # systemctl enable elasticsearch
-      # systemctl start elasticsearch
+      # systemctl enable elasticsearch --now
 
 
 

--- a/source/_templates/installations/basic/elastic/common/enable_filebeat.rst
+++ b/source/_templates/installations/basic/elastic/common/enable_filebeat.rst
@@ -9,8 +9,7 @@
     .. code-block:: console
 
       # systemctl daemon-reload
-      # systemctl enable filebeat
-      # systemctl start filebeat
+      # systemctl enable filebeat --now
 
 
 

--- a/source/_templates/installations/basic/elastic/common/enable_kibana.rst
+++ b/source/_templates/installations/basic/elastic/common/enable_kibana.rst
@@ -9,8 +9,7 @@
     .. code-block:: console
 
       # systemctl daemon-reload
-      # systemctl enable kibana
-      # systemctl start kibana
+      # systemctl enable kibana --now
 
 
 

--- a/source/_templates/installations/elastic/common/enable_elasticsearch.rst
+++ b/source/_templates/installations/elastic/common/enable_elasticsearch.rst
@@ -9,8 +9,7 @@
     .. code-block:: console
 
       # systemctl daemon-reload
-      # systemctl enable elasticsearch
-      # systemctl start elasticsearch
+      # systemctl enable elasticsearch --now
 
 
 

--- a/source/_templates/installations/elastic/common/enable_filebeat.rst
+++ b/source/_templates/installations/elastic/common/enable_filebeat.rst
@@ -9,8 +9,7 @@
     .. code-block:: console
 
       # systemctl daemon-reload
-      # systemctl enable filebeat
-      # systemctl start filebeat
+      # systemctl enable filebeat --now
 
 
 

--- a/source/_templates/installations/elastic/common/enable_kibana.rst
+++ b/source/_templates/installations/elastic/common/enable_kibana.rst
@@ -9,8 +9,7 @@
     .. code-block:: console
 
       # systemctl daemon-reload
-      # systemctl enable kibana
-      # systemctl start kibana
+      # systemctl enable kibana --now
 
 
 

--- a/source/_templates/installations/wazuh/common/enable_wazuh_agent_service.rst
+++ b/source/_templates/installations/wazuh/common/enable_wazuh_agent_service.rst
@@ -9,8 +9,7 @@
     .. code-block:: console
 
       # systemctl daemon-reload
-      # systemctl enable wazuh-agent
-      # systemctl start wazuh-agent
+      # systemctl enable wazuh-agent --now
 
 
   .. group-tab:: SysV Init

--- a/source/_templates/installations/wazuh/common/enable_wazuh_manager_service.rst
+++ b/source/_templates/installations/wazuh/common/enable_wazuh_manager_service.rst
@@ -9,8 +9,7 @@
     .. code-block:: console
 
       # systemctl daemon-reload
-      # systemctl enable wazuh-manager
-      # systemctl start wazuh-manager
+      # systemctl enable wazuh-manager --now
 
 
   .. group-tab:: SysV Init

--- a/source/learning-wazuh/build-lab/install-elastic-stack.rst
+++ b/source/learning-wazuh/build-lab/install-elastic-stack.rst
@@ -64,8 +64,7 @@ to Kibana. For more information, please see `Elasticsearch
   .. code-block:: console
 
   	# systemctl daemon-reload
-  	# systemctl enable elasticsearch.service
-  	# systemctl start elasticsearch.service
+  	# systemctl enable elasticsearch.service --now
 
 3. Optimize Elasticsearch for lab use according to :ref:`this guide <elastic_tuning>`.
 
@@ -143,8 +142,7 @@ events and archives stored in Elasticsearch. More info at `Kibana
   .. code-block:: console
 
   	# systemctl daemon-reload
-  	# systemctl enable kibana.service
-  	# systemctl start kibana.service
+  	# systemctl enable kibana.service --now
 
 7. Configure the credentials to access the Wazuh API:
 

--- a/source/learning-wazuh/build-lab/install-wazuh-manager.rst
+++ b/source/learning-wazuh/build-lab/install-wazuh-manager.rst
@@ -138,8 +138,7 @@ and archived events to the Elasticsearch service.
   .. code-block:: console
 
     # systemctl daemon-reload
-    # systemctl enable filebeat.service
-    # systemctl start filebeat.service
+    # systemctl enable filebeat.service --now
 
 8. Now disable the Wazuh and Elastic repositories in order to prevent
    unintended upgrades that may cause a version conflict with the current installation.

--- a/source/learning-wazuh/suricata.rst
+++ b/source/learning-wazuh/suricata.rst
@@ -43,8 +43,7 @@ On both agents as root, install Suricata and its dependencies, along with the Em
     rm -f /etc/suricata/suricata.yaml
     wget -O /etc/suricata/suricata.yaml http://www.branchnetconsulting.com/wazuh/suricata.yaml
     systemctl daemon-reload
-    systemctl enable suricata
-    systemctl start suricata
+    systemctl enable suricata --now
 
 
 Trigger NIDS alerts on both agents and see the output

--- a/source/upgrade-guide/legacy/upgrading-elastic-stack/from-6.x-to-6.8.rst
+++ b/source/upgrade-guide/legacy/upgrading-elastic-stack/from-6.x-to-6.8.rst
@@ -297,8 +297,7 @@ Upgrading Kibana
     .. code-block:: console
 
       # systemctl daemon-reload
-      # systemctl enable kibana
-      # systemctl start kibana
+      # systemctl enable kibana --now
 
 Disabling the repositories
 --------------------------

--- a/source/user-manual/capabilities/osquery.rst
+++ b/source/user-manual/capabilities/osquery.rst
@@ -114,8 +114,7 @@ After this enable and start the osquery Daemon:
 
 .. code-block:: console
 
-  systemctl enable osqueryd
-  systemctl start osqueryd
+  systemctl enable osqueryd --now
 
 And the osquery module must be enabled for the agents where the osquery is running by adding:
 


### PR DESCRIPTION
## Description
This PR is to document a simpler way to enable and start services with ``systemctl``. It replaces invoking ``start`` with the `--now` option at ``enable``.

## Checks
- [X] It compiles without warnings.
- [X] Spelling and grammar. 
- [X] Used impersonal speech. 
- [X] Used uppercase only on nouns. 
- [X] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).