### PR TITLE
Fix path to `wazuhapp.log`

### DIFF
--- a/source/user-manual/kibana-app/troubleshooting.rst
+++ b/source/user-manual/kibana-app/troubleshooting.rst
@@ -164,7 +164,7 @@ All the technologies we are using have their own logs files, you can check them 
 
     .. code-block:: console
 
-      # cat /usr/share/kibana/optimize/wazuh-logs/wazuhapp.log | grep -i -E "error|warn"
+      # cat /usr/share/kibana/optimize/wazuh/logs/wazuhapp.log | grep -i -E "error|warn"
 
 3. Check the Wazuh manager log file:
 


### PR DESCRIPTION
## Description
This PR fixes the path to `wazuhapp.log` file documented in the [v3.13 Kibana app troubleshooting section](https://documentation.wazuh.com/3.13/user-manual/kibana-app/troubleshooting.html#none-of-the-above-solutions-are-fixing-my-problem).

## Checks
- [X] It compiles without warnings.
- [X] Spelling and grammar. 
- [X] Used impersonal speech. 
- [X] Used uppercase only on nouns. 
- [X] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).