### PR TITLE
Syscheck deprecated options

### DIFF
--- a/source/user-manual/capabilities/file-integrity/fim-configuration.rst
+++ b/source/user-manual/capabilities/file-integrity/fim-configuration.rst
@@ -477,7 +477,7 @@ Configuring synchronization
       <interval>5m</interval>
       <max_interval>1h</max_interval>
       <response_timeout>30</response_timeout>
-      <sync_queue_size>16384</sync_queue_size>
+      <queue_size>16384</queue_size>
       <max_eps>10</max_eps>
     </synchronization>
   </syscheck>

--- a/source/user-manual/reference/ossec-conf/syscheck.rst
+++ b/source/user-manual/reference/ossec-conf/syscheck.rst
@@ -52,6 +52,8 @@ Configuration options for file integrity monitoring:
 alert_new_files
 ---------------
 
+.. deprecated:: 3.11.0
+
 Specifies if syscheck should alert when new files are created.
 
 +--------------------+----------+
@@ -102,6 +104,8 @@ Example:
 
 auto_ignore
 -----------
+
+.. deprecated:: 3.11.0
 
 Specifies whether or not syscheck will ignore files that change too many times (manager only).
 
@@ -625,6 +629,8 @@ Example:
 scan_on_start
 -------------
 
+.. deprecated:: 3.12.0
+
 Specifies if syscheck scans immediately when started.
 
 +--------------------+----------+
@@ -810,7 +816,7 @@ The database synchronization settings are configured inside this tag.
       <interval>5m</interval>
       <max_interval>1h</max_interval>
       <response_timeout>30</response_timeout>
-      <sync_queue_size>16384</sync_queue_size>
+      <queue_size>16384</queue_size>
       <max_eps>10</max_eps>
     </synchronization>
 


### PR DESCRIPTION
## Description
This PR notices the reader about syscheck configuration options that are now deprecated:
* `alert_new_files`
* `auto_ignore`
* `scan_on_start`

It also fixes some examples that should be using the new `queue_size` option.

## Checks
- [X] It compiles without warnings.
- [X] Spelling and grammar. 
- [X] Used impersonal speech. 
- [X] Used uppercase only on nouns. 
- [X] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).