### PR TITLE
Replace all instances of the gnupg2 package dependency installation with gnupg

### DIFF
--- a/source/_templates/installations/basic/before_installation_elastic.rst
+++ b/source/_templates/installations/basic/before_installation_elastic.rst
@@ -16,7 +16,7 @@
 
                 .. code-block:: console
 
-                    # apt-get install lsb-release curl apt-transport-https zip unzip gnupg2
+                    # apt-get install lsb-release curl apt-transport-https zip unzip gnupg
 
         .. group-tab:: ZYpp
 

--- a/source/_templates/installations/before_installation_all_in_one.rst
+++ b/source/_templates/installations/before_installation_all_in_one.rst
@@ -20,7 +20,7 @@
 
                     .. code-block:: console
 
-                        # apt install curl apt-transport-https unzip wget libcap2-bin software-properties-common lsb-release gnupg2
+                        # apt install curl apt-transport-https unzip wget libcap2-bin software-properties-common lsb-release gnupg
 
 
                 Add the repository for Java Development Kit (JDK):

--- a/source/_templates/installations/elastic/common/before_installation_kibana_filebeat.rst
+++ b/source/_templates/installations/elastic/common/before_installation_kibana_filebeat.rst
@@ -18,7 +18,7 @@
 
                 .. code-block:: console
 
-                    # apt install curl apt-transport-https lsb-release gnupg2
+                    # apt install curl apt-transport-https lsb-release gnupg
 
 
                     

--- a/source/_templates/installations/wazuh/deb/add_repository_aio.rst
+++ b/source/_templates/installations/wazuh/deb/add_repository_aio.rst
@@ -4,7 +4,7 @@
 
     .. code-block:: console
 
-      # apt install curl apt-transport-https unzip wget libcap2-bin software-properties-common lsb-release gnupg2
+      # apt install curl apt-transport-https unzip wget libcap2-bin software-properties-common lsb-release gnupg
 
 #. Install the GPG key:
 

--- a/source/_templates/installations/wazuh/deb/add_repository_wazuh_server.rst
+++ b/source/_templates/installations/wazuh/deb/add_repository_wazuh_server.rst
@@ -4,7 +4,7 @@
 
     .. code-block:: console
 
-      # apt install curl apt-transport-https lsb-release gnupg2
+      # apt install curl apt-transport-https lsb-release gnupg
 
 #. Install the GPG key:
 


### PR DESCRIPTION
## Description

This PR is to replace all instances of package `gnupg2` with `gnupg` when installing dependencies.

## Checks
- [X] It compiles without warnings.
- [X] Spelling and grammar. 
- [X] Used impersonal speech. 
- [X] Used uppercase only on nouns. 
- [X] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).