### PR TITLE
[develop] Removed the version from the title tag and the paragraph symbol

### DIFF
--- a/source/_themes/wazuh_doc_theme/layout.html
+++ b/source/_themes/wazuh_doc_theme/layout.html
@@ -52,8 +52,8 @@
 <meta name="author" content="Wazuh" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<meta property="og:image" content="{{ theme_wazuh_doc_url + '/' + version + '/_static/img/wazuh-docs-card.png' }}" />
-<meta property="og:url" content="{{ theme_wazuh_doc_url + '/' + version + '/' + pagename + '.html' }}" />
+<meta property="og:image" content="{{ theme_wazuh_doc_url + '/current/_static/img/wazuh-docs-card.png' }}" />
+<meta property="og:url" content="{{ theme_wazuh_doc_url + '/current/' + pagename + '.html' }}" />
 <meta property="og:type" content="website" />
 <meta property="og:title" content="{{ pagetitle|e + titlesuffix }}" />
 <meta property="og:description" content="User manual, installation and configuration guides. Learn how to get the most out of the Wazuh platform." />
@@ -62,7 +62,7 @@
 <meta name="twitter:creator" content="@wazuh" />
 <meta name="twitter:title" content="{{ pagetitle|e + titlesuffix }}" />
 <meta name="twitter:description" content="User manual, installation and configuration guides. Learn how to get the most out of the Wazuh platform." />
-<meta name="twitter:image" content="{{ theme_wazuh_doc_url + '/' + version + '/_static/img/wazuh-docs-card.png' }}" />
+<meta name="twitter:image" content="{{ theme_wazuh_doc_url + '/current/_static/img/wazuh-docs-card.png' }}" />
 
 {{- metatags }}
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -137,7 +137,7 @@ html_theme_path = ['_themes']
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-#html_title = None
+html_title = project + ' documentation'
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 #html_short_title = None
@@ -210,7 +210,7 @@ html_show_sphinx = False
 html_show_copyright = True
 
 # If empty string, we eliminate permalinks from documentation.
-# html_add_permalinks = ""
+html_add_permalinks = ' '
 
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

This PR removes the version from the title tag to avoid confusion due to the cache of pages indexed by Google. In addition, it removes the paragraph symbol that may be visible in the snippet shown for the search results in Google.
I also updated the URL of the social cards to match the canonical URL.

Related issue: https://github.com/wazuh/wazuh-website/issues/1706

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).