### PR TITLE
Fix typo redesinged by redesigned

### DIFF
--- a/source/release-notes/release_4_0_0.rst
+++ b/source/release-notes/release_4_0_0.rst
@@ -209,7 +209,7 @@ Changed
 
 - Removed the ``known-fields`` functionality.
 
-- Security Events dashboard redesinged.
+- Security Events dashboard redesigned.
 
 - Redesigned the app settings configuration with categories.
 


### PR DESCRIPTION

## Description


Hello Team!

This PR closes it #4166 

In the Change section for the release 4.0.0 there is typo in the text when enumerating details, check here: https://documentation.wazuh.com/current/release-notes/release_4_0_0.html

Current: Security Events dashboard redesinged.

Changed to: Security Events dashboard redesigned.

Regards,


## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->
