### PR TITLE
Fix Open distro for Elasticsearch package version name in installation step when upgrading v4.1

### DIFF
--- a/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-open-distro.rst
+++ b/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-open-distro.rst
@@ -158,7 +158,7 @@ In the commands below ``127.0.0.1`` IP address is used. If Elasticsearch is boun
 
           .. code-block:: console
 
-            # apt install opendistroforelasticsearch=|OPEN_DISTRO_LATEST|
+            # apt install opendistroforelasticsearch=|OPEN_DISTRO_LATEST|-1
 
 
         .. group-tab:: ZYpp


### PR DESCRIPTION
## Description

This PR fixes the version name for the Open Distro for Elasticsearch package when upgrading Wazuh to v4.1

## Checks
- [X] It compiles without warnings.
- [X] Spelling and grammar. 
- [X] Used impersonal speech. 
- [X] Used uppercase only on nouns. 
- [X] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).