### PR TITLE
Values for opendistro node structure in configuration file - Wazuh Indexer Recomendation Action

### DIFF
--- a/source/_templates/installations/elastic/common/elastic-multi-node/configure_elasticsearch_initial.rst
+++ b/source/_templates/installations/elastic/common/elastic-multi-node/configure_elasticsearch_initial.rst
@@ -31,8 +31,9 @@
     - ``<node_name>``: the node name; for example, ``node-1``. 
     - ``<elastic_cluster>``: Elasticsearch cluster name; for example, ``elastic-cluster-production``.
     - ``<elasticsearch_ip_nodeX>``: Elasticsearch cluster master-eligible nodes IP; for example, ``10.0.0.3``.
-    - ``opendistro_security.nodes_dn``: value used to specify each node certificate. Make sure to use the same names to create the certificates. 
+    - ``opendistro_security.nodes_dn``: value used to specify each node certificate. Make sure to use the same names to create the certificates. You can use the following structure: ``CN=<common_name>,OU=<operational_unit>,O=<organization_name>,L=<locality>,C=<country_code>``.
   
+
     .. code-block:: yaml
         :emphasize-lines: 5
 
@@ -40,6 +41,6 @@
             - CN=node-1,OU=Docu,O=Wazuh,L=California,C=US
             - CN=node-2,OU=Docu,O=Wazuh,L=California,C=US
             - CN=node-3,OU=Docu,O=Wazuh,L=California,C=US
-            - CN=<common_name>,OU=<operational_unit>,O=<organization_name>,L=<locality>,C=<country_code>
+           
 
 .. End of include file

--- a/source/_templates/installations/elastic/common/elastic-multi-node/configure_elasticsearch_subsequent.rst
+++ b/source/_templates/installations/elastic/common/elastic-multi-node/configure_elasticsearch_subsequent.rst
@@ -31,7 +31,8 @@
     - ``<node_name>``: the node name; for example, ``node-2``.
     - ``<elastic_cluster>``: Elasticsearch cluster name; for example, ``elastic-cluster-production``.
     - ``<elasticsearch_ip_nodeX>`` Elasticsearch cluster master-eligible nodes IP; for example, ``10.0.0.3``.
-    - ``opendistro_security.nodes_dn``: value used to specify each node certificate.
+    - ``opendistro_security.nodes_dn``: value used to specify each node certificate. Make sure to use the same names to create the certificates. You can use the following structure:
+      ``CN=<common_name>,OU=<operational_unit>,O=<organization_name>,L=<locality>,C=<country_code>``
   
         .. code-block:: yaml
             :emphasize-lines: 5
@@ -40,6 +41,6 @@
                 - CN=node-1,OU=Docu,O=Wazuh,L=California,C=US
                 - CN=node-2,OU=Docu,O=Wazuh,L=California,C=US
                 - CN=node-3,OU=Docu,O=Wazuh,L=California,C=US
-                - CN=<common_name>,OU=<operational_unit>,O=<organization_name>,L=<locality>,C=<country_code>
+                
 
 .. End of include file

--- a/source/installation-guide/wazuh-indexer/step-by-step.rst
+++ b/source/installation-guide/wazuh-indexer/step-by-step.rst
@@ -95,8 +95,6 @@ Create and deploy SSL certificates to encrypt communications between the Wazuh c
 
     .. include:: ../../_templates/installations/elastic/common/elastic-multi-node/generate_certificates.rst
 
-#. Enable and start the Elasticsearch service.
-
     **Recommended action**  - Remove Open Distro for Elasticsearch performance analyzer plugin
 
      The Open Distro for Elasticsearch performance analyzer plugin is installed by default and can have a negative impact on system resources. We recommend removing it with the following command:  
@@ -105,13 +103,10 @@ Create and deploy SSL certificates to encrypt communications between the Wazuh c
   
        # /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro-performance-analyzer
      
-     Proceed with enabling and starting Elasticsearch service:
+#. Enable and start the Elasticsearch service.
 
-    .. include:: ../../_templates/installations/elastic/common/enable_elasticsearch.rst
+        .. include:: ../../_templates/installations/elastic/common/enable_elasticsearch.rst
 
-
-
-  
  
 You now have installed and configured the initial Wazuh indexer node. 
 
@@ -182,17 +177,15 @@ Deploy the certificates to encrypt communications between the Wazuh central comp
 
     .. include:: ../../_templates/installations/elastic/common/elastic-multi-node/deploy_certificates.rst
 
-#. Enable and start the Elasticsearch service.
+    - **Recommended action**  - Remove Open Distro for Elasticsearch performance analyzer plugin. 
 
-    **Recommended action**  - Remove Open Distro for Elasticsearch performance analyzer plugin
+      The Open Distro for Elasticsearch performance analyzer plugin is installed by default and can have a negative impact on system resources. We recommend removing it with the following command:  
 
-     The Open Distro for Elasticsearch performance analyzer plugin is installed by default and can have a negative impact on system resources. We recommend removing it with the following command:  
-
-     .. code-block:: console
+      .. code-block:: console
   
-       # /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro-performance-analyzer
-     
-     Proceed with enabling and starting Elasticsearch service:
+        # /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro-performance-analyzer
+
+#. Enable and start the Elasticsearch service.
 
     .. include:: ../../_templates/installations/elastic/common/enable_elasticsearch.rst
 

--- a/source/installation-guide/wazuh-indexer/step-by-step.rst
+++ b/source/installation-guide/wazuh-indexer/step-by-step.rst
@@ -104,6 +104,8 @@ Create and deploy SSL certificates to encrypt communications between the Wazuh c
      .. code-block:: console
   
        # /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro-performance-analyzer
+     
+     Proceed with enabling and starting Elasticsearch service:
 
     .. include:: ../../_templates/installations/elastic/common/enable_elasticsearch.rst
 

--- a/source/installation-guide/wazuh-indexer/step-by-step.rst
+++ b/source/installation-guide/wazuh-indexer/step-by-step.rst
@@ -97,18 +97,18 @@ Create and deploy SSL certificates to encrypt communications between the Wazuh c
 
 #. Enable and start the Elasticsearch service.
 
+    **Recommended action**  - Remove Open Distro for Elasticsearch performance analyzer plugin
+
+     The Open Distro for Elasticsearch performance analyzer plugin is installed by default and can have a negative impact on system resources. We recommend removing it with the following command:  
+
+     .. code-block:: console
+  
+       # /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro-performance-analyzer
+
     .. include:: ../../_templates/installations/elastic/common/enable_elasticsearch.rst
 
 
-- **Recommended action**  - Remove Open Distro for Elasticsearch performance analyzer plugin. 
 
-  The Open Distro for Elasticsearch performance analyzer plugin is installed by default and can have a negative impact on system resources. We recommend removing it with the following command:  
-
-  .. code-block:: console
-  
-    # /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro-performance-analyzer
-
-  Restart Elasticsearch after removing the plugin. 
   
  
 You now have installed and configured the initial Wazuh indexer node. 

--- a/source/installation-guide/wazuh-indexer/step-by-step.rst
+++ b/source/installation-guide/wazuh-indexer/step-by-step.rst
@@ -184,17 +184,19 @@ Deploy the certificates to encrypt communications between the Wazuh central comp
 
 #. Enable and start the Elasticsearch service.
 
+    **Recommended action**  - Remove Open Distro for Elasticsearch performance analyzer plugin
+
+     The Open Distro for Elasticsearch performance analyzer plugin is installed by default and can have a negative impact on system resources. We recommend removing it with the following command:  
+
+     .. code-block:: console
+  
+       # /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro-performance-analyzer
+     
+     Proceed with enabling and starting Elasticsearch service:
+
     .. include:: ../../_templates/installations/elastic/common/enable_elasticsearch.rst
 
-- **Recommended action**  - Remove Open Distro for Elasticsearch performance analyzer plugin. 
-
-  The Open Distro for Elasticsearch performance analyzer plugin is installed by default and can have a negative impact on system resources. We recommend removing it with the following command:  
-
-  .. code-block:: console
-  
-    # /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro-performance-analyzer
-
-  Restart Elasticsearch after removing the plugin.
+   
 
 You now have installed a subsequent node of your Wazuh indexer multi-node cluster. Repeat this process on every other subsequent node that you want to add to your cluster and proceed with initializing the cluster. 
 


### PR DESCRIPTION
## Description


Hello Team!

This PR closes it #4191 and [#4204](https://github.com/wazuh/wazuh-documentation/issues/4204)

In the Configuring Elasticsearch Multi-node section in the work project for the new documentation. 

Change proposed: 

> opendistro_security.nodes_dn: value used to specify each node certificate. Make sure to use the same names to create the certificates. You can use the following structure: CN=<common_name>,OU=<operational_unit>,O=<organization_name>,L=<locality>,C=<country_code>.


Issue #4204  Task:

For the Recommendation action in Step by Step installation of the Wazuh Index, it could be before the commands of enabling and starting service:

**It is currently:**
      
Enable and start the Elasticsearch service.

> systemctl daemon-reload
> systemctl enable elasticsearch
> systemctl start elasticsearch

    **Recommended action** - Remove Open Distro for Elasticsearch performance analyzer plugin.

    The Open Distro for Elasticsearch performance analyzer plugin is installed by default and can have a negative impact on system resources. We recommend removing it with the following command:

> /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro-performance-analyzer

Restart Elasticsearch after removing the plugin.

----------------------------------------------------------------------------------------------------

**New changes recommended:**
      
Enable and start the Elasticsearch service.

**Recommended action** - Remove Open Distro for Elasticsearch performance analyzer plugin.

    The Open Distro for Elasticsearch performance analyzer plugin is installed by default and can have a negative impact on system resources. We recommend removing it with the following command:

> /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro-performance-analyzer

Proceed with enabling and starting Elasticsearch service:

> systemctl daemon-reload
> systemctl enable elasticsearch
> systemctl start elasticsearch



Regards,


## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->



