### PR TITLE
Remove ossec-init.conf mention from macOS unistall steps

### DIFF
--- a/source/installation-guide/wazuh-agent/wazuh_agent_package_macos.rst
+++ b/source/installation-guide/wazuh-agent/wazuh_agent_package_macos.rst
@@ -68,7 +68,7 @@ To uninstall the agent, follow these steps:
 
       # /Library/Ossec/bin/wazuh-control stop
 
-#. Remove the ``/Library/Ossec/`` folder and ``ossec-init.conf`` file.
+#. Remove the ``/Library/Ossec/`` folder.
 
     .. code-block:: console
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

Hi team!

This PR aims to fix ossec-init.conf mention from macOS unistall steps

## Checks
- [X] It compiles without warnings.
- [X] Spelling and grammar. 
- [X] Used impersonal speech. 
- [X] Used uppercase only on nouns. 

Regards,
Nico