### PR TITLE
Fix RPM package generation directory

### DIFF
--- a/source/development/packaging/generate-rpm-package.rst
+++ b/source/development/packaging/generate-rpm-package.rst
@@ -68,4 +68,4 @@ This will generate a |WAZUH_LATEST| Wazuh api RPM package with revision ``my_rev
 
   # ./generate_rpm_package.sh -b v|WAZUH_LATEST| --packages-branch |WAZUH_PACKAGES_BRANCH| -t agent -a x86_64 -p /opt/ossec
 
-This will generate a |WAZUH_LATEST| Wazuh agent RPM package with ``/opt`` as installation directory for ``x86_64`` systems.
+This will generate a |WAZUH_LATEST| Wazuh agent RPM package with ``/opt/ossec`` as installation directory for ``x86_64`` systems.

--- a/source/development/packaging/generate-rpm-package.rst
+++ b/source/development/packaging/generate-rpm-package.rst
@@ -66,6 +66,6 @@ This will generate a |WAZUH_LATEST| Wazuh api RPM package with revision ``my_rev
 
 .. code-block:: console
 
-  # ./generate_rpm_package.sh -b v|WAZUH_LATEST| --packages-branch |WAZUH_PACKAGES_BRANCH| -t agent -a x86_64 -p /opt
+  # ./generate_rpm_package.sh -b v|WAZUH_LATEST| --packages-branch |WAZUH_PACKAGES_BRANCH| -t agent -a x86_64 -p /opt/ossec
 
 This will generate a |WAZUH_LATEST| Wazuh agent RPM package with ``/opt`` as installation directory for ``x86_64`` systems.


### PR DESCRIPTION
## Description

This PR replaces `/opt` directory with `/opt/ossec` directory.

## Checks
- [X] It compiles without warnings.
- [X] Spelling and grammar. 
- [X] Used impersonal speech. 
- [X] Used uppercase only on nouns. 
- [X] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).