### PR TITLE
Changing node_name to NODE_NAME in the installation guide

### DIFF
--- a/source/_templates/installations/elastic/common/copy_certificates_filebeat.rst
+++ b/source/_templates/installations/elastic/common/copy_certificates_filebeat.rst
@@ -2,15 +2,15 @@
 
 .. code-block:: console
 
-  # node_name=wazuh-node-name 
+  # NODE_NAME=wazuh-node-name 
 
 .. code-block:: console
   
   # mkdir /etc/filebeat/certs
   # mv ~/certs.tar /etc/filebeat/certs/
   # cd /etc/filebeat/certs/
-  # tar -xf certs.tar $node_name.pem $node_name-key.pem root-ca.pem
-  # mv /etc/filebeat/certs/$node_name.pem /etc/filebeat/certs/filebeat.pem
-  # mv /etc/filebeat/certs/$node_name-key.pem /etc/filebeat/certs/filebeat-key.pem
+  # tar -xf certs.tar $NODE_NAME.pem $NODE_NAME-key.pem root-ca.pem
+  # mv /etc/filebeat/certs/$NODE_NAME.pem /etc/filebeat/certs/filebeat.pem
+  # mv /etc/filebeat/certs/$NODE_NAME-key.pem /etc/filebeat/certs/filebeat-key.pem
 
 .. End of copy_certificates_filebeat.rst

--- a/source/_templates/installations/elastic/common/copy_certificates_filebeat_wazuh_cluster.rst
+++ b/source/_templates/installations/elastic/common/copy_certificates_filebeat_wazuh_cluster.rst
@@ -2,16 +2,16 @@
 
 .. code-block:: console
 
-  # node_name=wazuh-node-name 
+  # NODE_NAME=wazuh-node-name 
 
 .. code-block:: console
   
   # mkdir /etc/filebeat/certs
   # mv ~/certs.tar /etc/filebeat/certs/
   # cd /etc/filebeat/certs/
-  # tar -xf certs.tar $node_name.pem $node_name-key.pem root-ca.pem
-  # mv /etc/filebeat/certs/$node_name.pem /etc/filebeat/certs/filebeat.pem
-  # mv /etc/filebeat/certs/$node_name-key.pem /etc/filebeat/certs/filebeat-key.pem
+  # tar -xf certs.tar $NODE_NAME.pem $NODE_NAME-key.pem root-ca.pem
+  # mv /etc/filebeat/certs/$NODE_NAME.pem /etc/filebeat/certs/filebeat.pem
+  # mv /etc/filebeat/certs/$NODE_NAME-key.pem /etc/filebeat/certs/filebeat-key.pem
 
   
 .. End of copy_certificates_filebeat_wazuh_cluster.rst

--- a/source/_templates/installations/elastic/common/elastic-multi-node/deploy_certificates.rst
+++ b/source/_templates/installations/elastic/common/elastic-multi-node/deploy_certificates.rst
@@ -4,16 +4,16 @@
 
     .. code-block:: console
 
-      # node_name=elasticsearch-node-name
+      # NODE_NAME=elasticsearch-node-name
       
     .. code-block:: console
       
       # mkdir /etc/elasticsearch/certs
       # mv ~/certs.tar /etc/elasticsearch/certs/
       # cd /etc/elasticsearch/certs/
-      # tar -xf certs.tar $node_name.pem $node_name-key.pem root-ca.pem
-      # mv /etc/elasticsearch/certs/$node_name.pem /etc/elasticsearch/certs/elasticsearch.pem
-      # mv /etc/elasticsearch/certs/$node_name-key.pem /etc/elasticsearch/certs/elasticsearch-key.pem
+      # tar -xf certs.tar $NODE_NAME.pem $NODE_NAME-key.pem root-ca.pem
+      # mv /etc/elasticsearch/certs/$NODE_NAME.pem /etc/elasticsearch/certs/elasticsearch.pem
+      # mv /etc/elasticsearch/certs/$NODE_NAME-key.pem /etc/elasticsearch/certs/elasticsearch-key.pem
 
 #. If you want to later install the Wazuh dashboard on this node, keep the certificates file. Otherwise, remove it with ``rm -f certs.tar`` to increase security.
 

--- a/source/_templates/installations/elastic/common/elastic-multi-node/generate_certificates.rst
+++ b/source/_templates/installations/elastic/common/elastic-multi-node/generate_certificates.rst
@@ -50,16 +50,16 @@
 
    .. code-block:: console
 
-     # node_name=elasticsearch-node-name
+     # NODE_NAME=elasticsearch-node-name
 
    .. code-block:: console 
      
      # mkdir /etc/elasticsearch/certs/
-     # mv ~/certs/$node_name* /etc/elasticsearch/certs/
+     # mv ~/certs/$NODE_NAME* /etc/elasticsearch/certs/
      # mv ~/certs/admin* /etc/elasticsearch/certs/
      # cp ~/certs/root-ca* /etc/elasticsearch/certs/
-     # mv /etc/elasticsearch/certs/$node_name.pem /etc/elasticsearch/certs/elasticsearch.pem
-     # mv /etc/elasticsearch/certs/$node_name-key.pem /etc/elasticsearch/certs/elasticsearch-key.pem     
+     # mv /etc/elasticsearch/certs/$NODE_NAME.pem /etc/elasticsearch/certs/elasticsearch.pem
+     # mv /etc/elasticsearch/certs/$NODE_NAME-key.pem /etc/elasticsearch/certs/elasticsearch-key.pem     
 
 #. Compress all the necessary files to be sent to all the instances.
 

--- a/source/_templates/installations/elastic/common/elastic-single-node/generate_deploy_certificates.rst
+++ b/source/_templates/installations/elastic/common/elastic-single-node/generate_deploy_certificates.rst
@@ -44,16 +44,16 @@ Replace the values ``<node-name>`` and ``<node-ip>``  with the corresponding nam
 
    .. code-block:: console
 
-     # node_name=elasticsearch-node-name
+     # NODE_NAME=elasticsearch-node-name
 
    .. code-block:: console
      
      # mkdir /etc/elasticsearch/certs/
-     # mv ~/certs/$node_name* /etc/elasticsearch/certs/
+     # mv ~/certs/$NODE_NAME* /etc/elasticsearch/certs/
      # mv ~/certs/admin* /etc/elasticsearch/certs/
      # cp ~/certs/root-ca* /etc/elasticsearch/certs/
-     # mv /etc/elasticsearch/certs/$node_name.pem /etc/elasticsearch/certs/elasticsearch.pem
-     # mv /etc/elasticsearch/certs/$node_name-key.pem /etc/elasticsearch/certs/elasticsearch-key.pem
+     # mv /etc/elasticsearch/certs/$NODE_NAME.pem /etc/elasticsearch/certs/elasticsearch.pem
+     # mv /etc/elasticsearch/certs/$NODE_NAME-key.pem /etc/elasticsearch/certs/elasticsearch-key.pem
 
 
 #. Compress all the necessary files to be sent to all the instances:

--- a/source/_templates/installations/elastic/common/generate_new_kibana_certificates.rst
+++ b/source/_templates/installations/elastic/common/generate_new_kibana_certificates.rst
@@ -2,7 +2,7 @@
 
 .. code-block:: console
 
-  # node_name=kibana-node-name
+  # NODE_NAME=kibana-node-name
   
 .. code-block:: console  
   
@@ -10,9 +10,9 @@
   # mv ~/certs.tar /etc/kibana/certs/
   # chown kibana:kibana /etc/kibana/certs/*
   # cd /etc/kibana/certs/
-  # tar -xf certs.tar $node_name.pem $node_name-key.pem root-ca.pem
-  # mv /etc/kibana/certs/$node_name.pem /etc/kibana/certs/kibana.pem
-  # mv /etc/kibana/certs/$node_name-key.pem /etc/kibana/certs/kibana-key.pem
+  # tar -xf certs.tar $NODE_NAME.pem $NODE_NAME-key.pem root-ca.pem
+  # mv /etc/kibana/certs/$NODE_NAME.pem /etc/kibana/certs/kibana.pem
+  # mv /etc/kibana/certs/$NODE_NAME-key.pem /etc/kibana/certs/kibana-key.pem
   # rm -f certs.tar
 
 .. End of include file


### PR DESCRIPTION

## Description

Hello Team!

This PR closes it #4214 

Proposal for changing node_name to NODE_NAME in the installation guide for the section where certificates are deployed.

Code example:
```

NODE_NAME=kibana-node-name

mkdir /etc/kibana/certs
# mv ~/certs.tar /etc/kibana/certs/
# chown kibana:kibana /etc/kibana/certs/*
# cd /etc/kibana/certs/
# tar -xf certs.tar $NODE_NAME.pem $NODE_NAME-key.pem root-ca.pem
# mv /etc/kibana/certs/$NODE_NAME.pem /etc/kibana/certs/kibana.pem
# mv /etc/kibana/certs/$NODE_NAME-key.pem /etc/kibana/certs/kibana-key.pem
# rm -f certs.tar
```

Regards,

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).




