### PR TITLE
Clarify that multiple `if_sid` values are allowed

### DIFF
--- a/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
@@ -83,7 +83,7 @@ The **xml labels** used to configure ``rules`` are listed here.
 | `dstgeoip`_             | Any `regular expression <regex.html>`_.                       | It will compare a regular expression representing a GeoIP destination with a value decoded           |
 |                         |                                                               | as ``dstgeoip``.                                                                                     |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
-| `if_sid`_               | A comma separated list of rule IDs.                           | It works similar to parent decoder. It will match when a rule ID in the list has previously matched. |
+| `if_sid`_               | A list of rule IDs separated by commas or spaces.             | It works similar to parent decoder. It will match when a rule ID in the list has previously matched. |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
 | `if_group`_             | Any group name.                                               | It will match if the indicated group has matched before.                                             |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
@@ -1276,11 +1276,11 @@ if_sid
 
 Used as a requisite to trigger the rule. Matches when an ID in the list has previously matched. It is similar to a child decoder, with the key difference that alerts can have as many descendants as necessary, whereas decoder cannot have "grandchildren".
 
-+--------------------+----------------------------------------------------------+
-| **Default Value**  | n/a                                                      |
-+--------------------+----------------------------------------------------------+
-| **Allowed values** | Any rule ID. Multiple values must be separated by commas.|
-+--------------------+----------------------------------------------------------+
++--------------------+--------------------------------------------------------------------+
+| **Default Value**  | n/a                                                                |
++--------------------+--------------------------------------------------------------------+
+| **Allowed values** | Any rule ID. Multiple values must be separated by commas or spaces.|
++--------------------+--------------------------------------------------------------------+
 
 
 
@@ -1294,7 +1294,8 @@ Example:
         <description>There is an error in the log.</description>
       </rule>
 
-The rule will be triggered both when the rule with id: ``100100`` and when the rule with id: ``100101`` have previously been triggered and the logs contain the word "Error".
+The rule ``100110`` will be triggered in both cases, when the rule with id: ``100100`` and when the rule with id: ``100101`` have previously been triggered and the logs contain the word "Error".
+
 
 if_group
 ^^^^^^^^

--- a/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
@@ -83,7 +83,7 @@ The **xml labels** used to configure ``rules`` are listed here.
 | `dstgeoip`_             | Any `regular expression <regex.html>`_.                       | It will compare a regular expression representing a GeoIP destination with a value decoded           |
 |                         |                                                               | as ``dstgeoip``.                                                                                     |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
-| `if_sid`_               | A comma separated list of rules IDs.                          | It works similar to parent decoder. It will match when a rule ID in the list has previously matched. |
+| `if_sid`_               | A comma separated list of rule IDs.                           | It works similar to parent decoder. It will match when a rule ID in the list has previously matched. |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
 | `if_group`_             | Any group name.                                               | It will match if the indicated group has matched before.                                             |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+

--- a/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
@@ -1274,7 +1274,7 @@ If ``dstgeoip`` label is declared multiple times within the rule, the following 
 if_sid
 ^^^^^^
 
-Used as a requisite to trigger the rule. Matches when an ID in the list has previously matched. It is similar to a child decoder, with the key difference that alerts can have as many descendants as necessary, whereas decoder cannot have "grandchildren".
+Used as a requisite to trigger the rule. Matches when an ID on the list has previously matched. It is similar to a child decoder, with the key difference that alerts can have as many descendants as necessary, whereas decoder cannot have "grandchildren".
 
 +--------------------+--------------------------------------------------------------------+
 | **Default Value**  | n/a                                                                |
@@ -1294,7 +1294,7 @@ Example:
         <description>There is an error in the log.</description>
       </rule>
 
-The rule ``100110`` will be triggered when either of the parent rules has matched and the logs contain the word "Error".
+The rule ``100110`` is triggered when either of the parent rules has matched and the logs contain the word "Error".
 
 
 if_group

--- a/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
@@ -1294,7 +1294,7 @@ Example:
         <description>There is an error in the log.</description>
       </rule>
 
-The rule ``100110`` will be triggered in both cases, when the rule with id: ``100100`` and when the rule with id: ``100101`` have previously been triggered and the logs contain the word "Error".
+The rule ``100110`` will be triggered when either of the parent rules has matched and the logs contain the word "Error".
 
 
 if_group

--- a/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
@@ -83,7 +83,7 @@ The **xml labels** used to configure ``rules`` are listed here.
 | `dstgeoip`_             | Any `regular expression <regex.html>`_.                       | It will compare a regular expression representing a GeoIP destination with a value decoded           |
 |                         |                                                               | as ``dstgeoip``.                                                                                     |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
-| `if_sid`_               | A rule ID.                                                    | It works similar to parent decoder. It will match if that rule ID has previously matched.            |
+| `if_sid`_               | A comma separated list of rules IDs.                          | It works similar to parent decoder. It will match when a rule ID in the list has previously matched. |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
 | `if_group`_             | Any group name.                                               | It will match if the indicated group has matched before.                                             |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
@@ -1274,13 +1274,13 @@ If ``dstgeoip`` label is declared multiple times within the rule, the following 
 if_sid
 ^^^^^^
 
-Used as a requisite to trigger the rule. Matches if the ID has previously matched. It is similar to a child decoder, with the key difference that alerts can have as many descendants as necessary, whereas decoder cannot have "grandchildren".
+Used as a requisite to trigger the rule. Matches when an ID in the list has previously matched. It is similar to a child decoder, with the key difference that alerts can have as many descendants as necessary, whereas decoder cannot have "grandchildren".
 
-+--------------------+-------------+
-| **Default Value**  | n/a         |
-+--------------------+-------------+
-| **Allowed values** | Any rule id |
-+--------------------+-------------+
++--------------------+----------------------------------------------------------+
+| **Default Value**  | n/a                                                      |
++--------------------+----------------------------------------------------------+
+| **Allowed values** | Any rule ID. Multiple values must be separated by commas.|
++--------------------+----------------------------------------------------------+
 
 
 
@@ -1289,12 +1289,12 @@ Example:
   .. code-block:: xml
 
       <rule id="100110" level="5">
-        <if_sid>100100</if_sid>
+        <if_sid>100100, 100101</if_sid>
         <match>Error</match>
         <description>There is an error in the log.</description>
       </rule>
 
-The rule will be triggered if the rule with id: ``100100`` has previously been triggered and the log contains the word "Error".
+The rule will be triggered both when the rule with id: ``100100`` and when the rule with id: ``100101`` have previously been triggered and the logs contain the word "Error".
 
 if_group
 ^^^^^^^^

--- a/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
@@ -83,7 +83,7 @@ The **xml labels** used to configure ``rules`` are listed here.
 | `dstgeoip`_             | Any `regular expression <regex.html>`_.                       | It will compare a regular expression representing a GeoIP destination with a value decoded           |
 |                         |                                                               | as ``dstgeoip``.                                                                                     |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
-| `if_sid`_               | A list of rule IDs separated by commas or spaces.             | It works similar to parent decoder. It will match when a rule ID in the list has previously matched. |
+| `if_sid`_               | A list of rule IDs separated by commas or spaces.             | It works similar to parent decoder. It will match when a rule ID on the list has previously matched. |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+
 | `if_group`_             | Any group name.                                               | It will match if the indicated group has matched before.                                             |
 +-------------------------+---------------------------------------------------------------+------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
## Description

This PR closes #3653 It adds clarifications about the possibility of using a list of rules IDs rather than just one rule ID.

## Checks
- [X] It compiles without warnings.
- [X] Spelling and grammar. 
- [X] Used impersonal speech. 
- [X] Used uppercase only on nouns. 
- [X] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).