### PR TITLE
Skip message if wazuh server is going to be installed in the same host.

### DIFF
--- a/source/installation-guide/wazuh-server/step-by-step.rst
+++ b/source/installation-guide/wazuh-server/step-by-step.rst
@@ -38,6 +38,7 @@ Adding the Wazuh repository
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Add the Wazuh repository to download the official Wazuh packages. As an alternative, you can download the Wazuh packages directly from our :ref:`Package list <packages>`. 
+Skip this step to install it on the same host as the Wazuh indexer.
     
    .. tabs::
    


### PR DESCRIPTION

## Description


Hello Team!

This PR closes it #4224 

Hi, Team!

In the step by step installation section, for the Wazuh Server we have:

The **Adding the Wazuh repository** section with the text:

_Add the Wazuh repository to download the official Wazuh packages. As an alternative, you can download the Wazuh packages directly from our Package list._

If the user is going to install the Wazuh server in the same host as the Wazuh indexer, there is no need to repeat the step of adding the Wazuh repository. Text proposed:

_Add the Wazuh repository to download the official Wazuh packages. As an alternative, you can download the Wazuh packages directly from our Package list. **Skip this step to install it on the same host as the Wazuh indexer**._


Regards,


## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

