### PR TITLE
Replace packages generation path

### DIFF
--- a/source/development/packaging/generate-aix-package.rst
+++ b/source/development/packaging/generate-aix-package.rst
@@ -63,6 +63,6 @@ This will generate a |WAZUH_LATEST| Wazuh agent AIX package with checksum.
 
 .. code-block:: console
 
-  # ./generate_wazuh_packages.sh -b v|WAZUH_LATEST|  -p /opt
+  # ./generate_wazuh_packages.sh -b v|WAZUH_LATEST|  -p /opt/ossec
 
-This will generate a |WAZUH_LATEST| Wazuh agent AIX package with ``/opt`` as installation directory.
+This will generate a |WAZUH_LATEST| Wazuh agent AIX package with ``/opt/ossec`` as installation directory.

--- a/source/development/packaging/generate-deb-package.rst
+++ b/source/development/packaging/generate-deb-package.rst
@@ -64,6 +64,6 @@ This will generate a |WAZUH_LATEST| Wazuh api package DEB with revision ``my_rev
 
 .. code-block:: console
 
-  # ./generate_debian_package.sh -b v|WAZUH_LATEST| --packages-branch |WAZUH_PACKAGES_BRANCH| -t agent -a amd64 -p /opt
+  # ./generate_debian_package.sh -b v|WAZUH_LATEST| --packages-branch |WAZUH_PACKAGES_BRANCH| -t agent -a amd64 -p /opt/ossec
 
-This will generate a |WAZUH_LATEST| Wazuh agent DEB package with ``/opt`` as installation directory for ``amd64`` systems.
+This will generate a |WAZUH_LATEST| Wazuh agent DEB package with ``/opt/ossec`` as installation directory for ``amd64`` systems.

--- a/source/development/packaging/generate-hpux-package.rst
+++ b/source/development/packaging/generate-hpux-package.rst
@@ -66,6 +66,6 @@ This will generate a |WAZUH_LATEST| Wazuh agent HPUX package with checksum.
 
 .. code-block:: console
 
-  # ./generate_wazuh_packages.sh -b v|WAZUH_LATEST|  -p /opt
+  # ./generate_wazuh_packages.sh -b v|WAZUH_LATEST|  -p /opt/ossec
 
-This will generate a |WAZUH_LATEST| Wazuh agent HPUX package with ``opt`` as installation directory.
+This will generate a |WAZUH_LATEST| Wazuh agent HPUX package with ``/opt/ossec`` as installation directory.


### PR DESCRIPTION
## Description

This PR closes issue #4222 It replaces the installation path for the generated packages except for RPM packages which is addressed in PRs #4209

## Checks
- [X] It compiles without warnings.
- [X] Spelling and grammar. 
- [X] Used impersonal speech. 
- [X] Used uppercase only on nouns. 
- [X] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).