### PR TITLE
Steps simplified for deploying certificates

### DIFF
--- a/source/_templates/installations/elastic/common/copy_certificates_filebeat_wazuh_cluster.rst
+++ b/source/_templates/installations/elastic/common/copy_certificates_filebeat_wazuh_cluster.rst
@@ -7,8 +7,7 @@
 .. code-block:: console
   
   # mkdir /etc/filebeat/certs
-  # mv ~/certs.tar /etc/filebeat/certs/
-  # cd /etc/filebeat/certs/
+  # cp ~/certs.tar /etc/filebeat/certs/
   # tar -xf certs.tar $NODE_NAME.pem $NODE_NAME-key.pem root-ca.pem
   # mv /etc/filebeat/certs/$NODE_NAME.pem /etc/filebeat/certs/filebeat.pem
   # mv /etc/filebeat/certs/$NODE_NAME-key.pem /etc/filebeat/certs/filebeat-key.pem

--- a/source/_templates/installations/elastic/common/elastic-multi-node/deploy_certificates.rst
+++ b/source/_templates/installations/elastic/common/elastic-multi-node/deploy_certificates.rst
@@ -10,7 +10,6 @@
       
       # mkdir /etc/elasticsearch/certs
       # mv ~/certs.tar /etc/elasticsearch/certs/
-      # cd /etc/elasticsearch/certs/
       # tar -xf certs.tar $NODE_NAME.pem $NODE_NAME-key.pem root-ca.pem
       # mv /etc/elasticsearch/certs/$NODE_NAME.pem /etc/elasticsearch/certs/elasticsearch.pem
       # mv /etc/elasticsearch/certs/$NODE_NAME-key.pem /etc/elasticsearch/certs/elasticsearch-key.pem

--- a/source/_templates/installations/elastic/common/generate_new_kibana_certificates.rst
+++ b/source/_templates/installations/elastic/common/generate_new_kibana_certificates.rst
@@ -7,12 +7,10 @@
 .. code-block:: console  
   
   # mkdir /etc/kibana/certs
-  # mv ~/certs.tar /etc/kibana/certs/
-  # chown kibana:kibana /etc/kibana/certs/*
-  # cd /etc/kibana/certs/
+  # cp ~/certs.tar /etc/kibana/certs/
   # tar -xf certs.tar $NODE_NAME.pem $NODE_NAME-key.pem root-ca.pem
   # mv /etc/kibana/certs/$NODE_NAME.pem /etc/kibana/certs/kibana.pem
   # mv /etc/kibana/certs/$NODE_NAME-key.pem /etc/kibana/certs/kibana-key.pem
-  # rm -f certs.tar
+  # chown kibana:kibana /etc/kibana/certs/*
 
 .. End of include file


### PR DESCRIPTION

## Description

Hello Team!

This PR closes it #4229 

Below step in order to deploy certificates for elasticsearch, filebeat, and kibana:

**elasticsearch**

```
# mkdir /etc/elasticsearch/certs/
# mv ~/certs/$NODE_NAME* /etc/elasticsearch/certs/
# mv ~/certs/admin* /etc/elasticsearch/certs/
# cp ~/certs/root-ca* /etc/elasticsearch/certs/
# mv /etc/elasticsearch/certs/$NODE_NAME.pem /etc/elasticsearch/certs/elasticsearch.pem
# mv /etc/elasticsearch/certs/$NODE_NAME-key.pem /etc/elasticsearch/certs/elasticsearch-key.pem

```

**filebeat**

```
# mkdir /etc/filebeat/certs
# cp ~/certs.tar /etc/filebeat/certs/
# tar -xf certs.tar $NODE_NAME.pem $NODE_NAME-key.pem root-ca.pem
# mv /etc/filebeat/certs/$NODE_NAME.pem /etc/filebeat/certs/filebeat.pem
# mv /etc/filebeat/certs/$NODE_NAME-key.pem /etc/filebeat/certs/filebeat-key.pem
```

**kibana**

```
# mkdir /etc/kibana/certs
# cp ~/certs.tar /etc/kibana/certs/
# tar -xf certs.tar $NODE_NAME.pem $NODE_NAME-key.pem root-ca.pem
# mv /etc/kibana/certs/$NODE_NAME.pem /etc/kibana/certs/kibana.pem
# mv /etc/kibana/certs/$NODE_NAME-key.pem /etc/kibana/certs/kibana-key.pem
# chown kibana:kibana /etc/kibana/certs/*
```


Regards,


## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

