### PR TITLE
Steps proposal Cluster Initialization

### DIFF
--- a/source/installation-guide/wazuh-indexer/step-by-step.rst
+++ b/source/installation-guide/wazuh-indexer/step-by-step.rst
@@ -203,7 +203,7 @@ You now have installed a subsequent node of your Wazuh indexer multi-node cluste
 
 The final stage of the process for installing a Wazuh indexer consists in running the security admin script. 
 
-#. Configure ELASTICSEARCH_IP as an environment variable with the IP address of your Elasticsearch initial node.
+#. On the initial node, configure ELASTICSEARCH_IP as an environment variable.
   
    .. code-block:: console
 

--- a/source/installation-guide/wazuh-indexer/step-by-step.rst
+++ b/source/installation-guide/wazuh-indexer/step-by-step.rst
@@ -203,17 +203,24 @@ You now have installed a subsequent node of your Wazuh indexer multi-node cluste
 
 The final stage of the process for installing a Wazuh indexer consists in running the security admin script. 
 
-#. Run the Elasticsearch ``securityadmin`` script on the initial node to load the new certificates information and start the cluster. Replace ``<elasticsearch_IP>`` with the Elasticsearch installation IP and run the following command.
+#. Configure ELASTICSEARCH_MASTER_IP as an environment variable with the IP address of your Elasticsearch master node.
+  
+   .. code-block:: console
+
+    # export ELASTICSEARCH_MASTER_IP="Put here your Elasticsearch master node IP address"
+
+
+#. Run the Elasticsearch ``securityadmin`` script on the initial node to load the new certificates information and start the cluster. Run the following command.
 
     .. code-block:: console
 
-      # export JAVA_HOME=/usr/share/elasticsearch/jdk/ && /usr/share/elasticsearch/plugins/opendistro_security/tools/securityadmin.sh -cd /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/ -icl -nhnv -cacert /etc/elasticsearch/certs/root-ca.pem -cert /etc/elasticsearch/certs/admin.pem -key /etc/elasticsearch/certs/admin-key.pem -h <elasticsearch_IP>
+      # export JAVA_HOME=/usr/share/elasticsearch/jdk/ && /usr/share/elasticsearch/plugins/opendistro_security/tools/securityadmin.sh -cd /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/ -icl -nhnv -cacert /etc/elasticsearch/certs/root-ca.pem -cert /etc/elasticsearch/certs/admin.pem -key /etc/elasticsearch/certs/admin-key.pem -h $ELASTICSEARCH_MASTER_IP
 
-#. Replace ``<elasticsearch_IP>`` and run the command to confirm that the installation is successful. 
+#. Run the command to confirm that the installation is successful. 
 
     .. code-block:: console
 
-      # curl -XGET https://<elasticsearch_ip>:9200 -u admin:admin -k
+      # curl -XGET https://$ELASTICSEARCH_MASTER_IP:9200 -u admin:admin -k
 
     Expand the output to see an example response.
 

--- a/source/installation-guide/wazuh-indexer/step-by-step.rst
+++ b/source/installation-guide/wazuh-indexer/step-by-step.rst
@@ -203,24 +203,24 @@ You now have installed a subsequent node of your Wazuh indexer multi-node cluste
 
 The final stage of the process for installing a Wazuh indexer consists in running the security admin script. 
 
-#. Configure ELASTICSEARCH_MASTER_IP as an environment variable with the IP address of your Elasticsearch master node.
+#. Configure ELASTICSEARCH_IP as an environment variable with the IP address of your Elasticsearch initial node.
   
    .. code-block:: console
 
-    # export ELASTICSEARCH_MASTER_IP="Put here your Elasticsearch master node IP address"
+    # export ELASTICSEARCH_IP="Put here your Elasticsearch initial node IP address"
 
 
 #. Run the Elasticsearch ``securityadmin`` script on the initial node to load the new certificates information and start the cluster. Run the following command.
 
     .. code-block:: console
 
-      # export JAVA_HOME=/usr/share/elasticsearch/jdk/ && /usr/share/elasticsearch/plugins/opendistro_security/tools/securityadmin.sh -cd /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/ -icl -nhnv -cacert /etc/elasticsearch/certs/root-ca.pem -cert /etc/elasticsearch/certs/admin.pem -key /etc/elasticsearch/certs/admin-key.pem -h $ELASTICSEARCH_MASTER_IP
+      # export JAVA_HOME=/usr/share/elasticsearch/jdk/ && /usr/share/elasticsearch/plugins/opendistro_security/tools/securityadmin.sh -cd /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/ -icl -nhnv -cacert /etc/elasticsearch/certs/root-ca.pem -cert /etc/elasticsearch/certs/admin.pem -key /etc/elasticsearch/certs/admin-key.pem -h $ELASTICSEARCH_IP
 
 #. Run the command to confirm that the installation is successful. 
 
     .. code-block:: console
 
-      # curl -XGET https://$ELASTICSEARCH_MASTER_IP:9200 -u admin:admin -k
+      # curl -XGET https://$ELASTICSEARCH_IP:9200 -u admin:admin -k
 
     Expand the output to see an example response.
 


### PR DESCRIPTION
## Description


Hello Team!

This PR closes it #4233 

Hi, Team!

For the Wazuh indexer step-by-step installation, I propose to add a step to the cluster initialization section, in order to simplify and avoid any confusion at some point with the procedure.

The proposal step includes to define a variable with the IP address of the Elasticsearch master node, and use that variable in the next steps:

The final stage of the process for installing a Wazuh indexer consists in running the security admin script.

1. Configure ELASTICSEARCH_MASTER_IP as an environment variable with the IP address of your Elasticsearch initial node.

      `# export ELASTICSEARCH_IP="Put here your Elasticsearch initial node IP address"`

2.  Run the Elasticsearch securityadmin script on the initial node to load the new certificates information and start the cluster. Run the following command.

      ` # export JAVA_HOME=/usr/share/elasticsearch/jdk/ && /usr/share/elasticsearch/plugins/opendistro_security/tools/securityadmin.sh -cd /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/ -icl -nhnv -cacert /etc/elasticsearch/certs/root-ca.pem -cert /etc/elasticsearch/certs/admin.pem -key /etc/elasticsearch/certs/admin-key.pem -h $ELASTICSEARCH_IP`

3. Run the command to confirm that the installation is successful.

   `    # curl -XGET https://$ELASTICSEARCH_IP:9200 -u admin:admin -k`

Regards,


## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

