### PR TITLE
Separate Cloud service-GS content into separate sections

### DIFF
--- a/source/_static/js/redirects.js
+++ b/source/_static/js/redirects.js
@@ -86,6 +86,9 @@ newUrls['4.2'] = [
   '/cloud-service/your-environment/cancel-environment.html',
   '/cloud-service/your-environment/manage-wui-access.html',
   '/cloud-service/your-environment/understanding-storage.html',
+  '/cloud-service/getting-started/sign-up-trial',
+  '/cloud-service/getting-started/access-wazuh-wui',
+  '/cloud-service/getting-started/register-agents', 
 ];
 
 removedUrls['4.2'] = [

--- a/source/cloud-service/getting-started/access-wazuh-wui.rst
+++ b/source/cloud-service/getting-started/access-wazuh-wui.rst
@@ -5,7 +5,7 @@
 
 
 Access Wazuh WUI
-----------------
+================
 
 The Wazuh WUI is a flexible and intuitive web interface. Through this WUI, you have access to the tools for mining and visualizing events, giving you a comprehensive insight into your monitored systems.
 
@@ -23,3 +23,11 @@ Follow these steps to access Wazuh WUI:
 It is highly recommended for security reasons to change the default password and create your own users. 
 
 .. note:: You can access the Wazuh WUI directly using the URL *https://<cloud_id>.cloud.wazuh.com*, where ``<cloud_id>`` is the Cloud ID of your environment.
+
+
+If you have any questions about the Wazuh Cloud, see the :ref:`Cloud service FAQ <cloud_getting_started_starting_faq>`.
+
+Next steps
+----------
+
+Your Wazuh Cloud environment is ready and you can install a Wazuh agent on every endpoint to be monitored. To learn how to install agents, check :ref:`Register agents <cloud_register_agents>` section.

--- a/source/cloud-service/getting-started/access-wazuh-wui.rst
+++ b/source/cloud-service/getting-started/access-wazuh-wui.rst
@@ -1,0 +1,25 @@
+.. _cloud_wui_access:
+
+.. meta::
+  :description: Learn more about how to get started with Wazuh Cloud Service. Explore the potential of Wazuh Cloud with your 14-day free trial.
+
+
+Access Wazuh WUI
+----------------
+
+The Wazuh WUI is a flexible and intuitive web interface. Through this WUI, you have access to the tools for mining and visualizing events, giving you a comprehensive insight into your monitored systems.
+
+Follow these steps to access Wazuh WUI:
+
+#. Log in to the `Wazuh Cloud Console <https://console.cloud.wazuh.com/>`_.
+#. On the **Environments** page, select the environment you want to access.
+#. Click **Open Wazuh** to open Wazuh WUI.
+#. Choose from one of these methods to log in:
+  
+  - Log in with the default credentials. You can download them by clicking **Default credentials** on the Environments page. Then, use the `Wazuh WUI - Username` and `Wazuh WUI - Password` to log in.
+  - If Single sign-on (SSO) is enabled, use your own account.
+  - You can also log in with any user you already created in Wazuh WUI.
+
+It is highly recommended for security reasons to change the default password and create your own users. 
+
+.. note:: You can access the Wazuh WUI directly using the URL *https://<cloud_id>.cloud.wazuh.com*, where ``<cloud_id>`` is the Cloud ID of your environment.

--- a/source/cloud-service/getting-started/index.rst
+++ b/source/cloud-service/getting-started/index.rst
@@ -10,7 +10,7 @@ Getting started
 
 To get started with Wazuh Cloud, you need to create a Wazuh Cloud account and set up your environment, a deployment that contains all the Wazuh components ready to be used. Creating an environment is streamlined for you. Installing and updating the Wazuh components, and defining scalability is all handled by Wazuh Cloud. Once your environment is ready, you need to access the Wazuh WUI and simply deploy the Wazuh agent to your endpoints. 
 
-Learn more about how to get started with Wazuh Cloud in the below sections.
+Learn how to get started with Wazuh Cloud in the below sections.
 
 	   
    .. toctree::

--- a/source/cloud-service/getting-started/index.rst
+++ b/source/cloud-service/getting-started/index.rst
@@ -10,101 +10,15 @@ Getting started
 
 To get started with Wazuh Cloud, you need to create a Wazuh Cloud account and set up your environment, a deployment that contains all the Wazuh components ready to be used. Creating an environment is streamlined for you. Installing and updating the Wazuh components, and defining scalability is all handled by Wazuh Cloud. Once your environment is ready, you need to access the Wazuh WUI and simply deploy the Wazuh agent to your endpoints. 
 
+Learn more about how to get started with Wazuh Cloud in the below sections.
 
-.. _cloud_getting_started_sign_up:
-
-Sign up for a trial
--------------------
-
-Wazuh provides a free trial for you to create a cloud environment and explore the Wazuh Cloud service. 
-
-Follow the next steps to create your trial environment.
-
-Sign up
-^^^^^^^
-
-To sign up, all you need is an email address:
-
-#. Go to our `Wazuh Cloud Console <https://console.cloud.wazuh.com/>`_ page.
-
-#. Enter your email address and password, or sign up with a Google account.
-
-Now you are ready to create your first :ref:`environment <cloud_glossary_environment>`.
-
-Create environment
-^^^^^^^^^^^^^^^^^^
-
-Follow these steps to quickly set up and run your environment:
-
-#. From the `Wazuh Cloud Console <https://console.cloud.wazuh.com/>`_, click **Start your free trial**.
-
-#. Configure your environment:
-
-   #. Give your environment a name.
-
-   #. Choose a :ref:`tier <cloud_glossary_tier>` to define the size in bytes of the indexed events. You can use this `estimation tool <https://wazuh.com/cloud/#pricing>`_ to calculate the Wazuh Cloud data tier.
-   
-      .. note:: During the 14-day trial period, the tier limit is 100GB. Then, after your first payment, the full tier becomes unlocked. For testing purposes, 100 GB is more than enough to get an insight into Wazuh Cloud.
-
-   #. Select the :ref:`region <cloud_glossary_region>` where your environment gets hosted. If you are not sure what to pick, select one that is the closest to your location since this typically reduces latency for indexing and search requests.
-
-   #. Choose the support plan that best suits your needs. 
-
-#. Click **View the summary** and then **Create** to build your environment. This process might take a moment.
-
-Once the environment is ready, you can access the Wazuh WUI and register the agents.
-
-.. _cloud_getting_started_wui_access:
-
-Access Wazuh WUI
-----------------
-
-The Wazuh WUI is a flexible and intuitive web interface. Through this WUI, you have access to the tools for mining and visualizing events, giving you a comprehensive insight into your monitored systems.
-
-Follow these steps to access Wazuh WUI:
-
-#. Log in to the `Wazuh Cloud Console <https://console.cloud.wazuh.com/>`_.
-#. On the **Environments** page, select the environment you want to access.
-#. Click **Open Wazuh** to open Wazuh WUI.
-#. Choose from one of these methods to log in:
-  
-  - Log in with the default credentials. You can download them by clicking **Default credentials** on the Environments page. Then, use the `Wazuh WUI - Username` and `Wazuh WUI - Password` to log in.
-  - If Single sign-on (SSO) is enabled, use your own account.
-  - You can also log in with any user you already created in Wazuh WUI.
-
-It is highly recommended for security reasons to change the default password and create your own users. 
-
-.. note:: You can access the Wazuh WUI directly using the URL *https://<cloud_id>.cloud.wazuh.com*, where ``<cloud_id>`` is the Cloud ID of your environment.
-
-.. _cloud_getting_started_register_agents:
-
-Register agents
----------------
-
-To start using Wazuh, you need to install a Wazuh agent on your endpoint and register it in your environment. 
-
-Follow these steps to register an agent:
-
-#. Log into the Wazuh WUI.
-
-#. Click **Wazuh** and then **Agents**.
-
-#. Click **Deploy a new agent**.
-
-#. Follow the steps described in Wazuh WUI.
-
-.. note::
-
-   Agents must use **TCP** to communicate with your environment.
-  
-
-If you have any questions about the Wazuh Cloud, see the :ref:`Cloud service FAQ <cloud_getting_started_starting_faq>`.
 	   
    .. toctree::
-      :hidden:
+      :titlesonly:
+      :includehidden:
       :maxdepth: 1
 
-      Sign up for a trial <https://documentation.wazuh.com/current/cloud-service/getting-started/index.html#cloud_getting_started_sign_up>
-      Access Wazuh WUI <https://documentation.wazuh.com/current/cloud-service/getting-started/index.html#cloud_getting_started_wui_access>
-      Register agents <https://documentation.wazuh.com/current/cloud-service/getting-started/index.html#register-agents>
+      sign-up-trial
+      access-wazuh-wui
+      register-agents
       starting-faq

--- a/source/cloud-service/getting-started/register-agents.rst
+++ b/source/cloud-service/getting-started/register-agents.rst
@@ -1,0 +1,27 @@
+.. _cloud_register_agents:
+
+.. meta::
+  :description: Learn more about how to get started with Wazuh Cloud Service. Explore the potential of Wazuh Cloud with your 14-day free trial.
+
+
+Register agents
+---------------
+
+To start using Wazuh, you need to install a Wazuh agent on your endpoint and register it in your environment. 
+
+Follow these steps to register an agent:
+
+#. Log into the Wazuh WUI.
+
+#. Click **Wazuh** and then **Agents**.
+
+#. Click **Deploy a new agent**.
+
+#. Follow the steps described in Wazuh WUI.
+
+.. note::
+
+   Agents must use **TCP** to communicate with your environment.
+  
+
+If you have any questions about the Wazuh Cloud, see the :ref:`Cloud service FAQ <cloud_getting_started_starting_faq>`.

--- a/source/cloud-service/getting-started/register-agents.rst
+++ b/source/cloud-service/getting-started/register-agents.rst
@@ -5,7 +5,7 @@
 
 
 Register agents
----------------
+===============
 
 To start using Wazuh, you need to install a Wazuh agent on your endpoint and register it in your environment. 
 

--- a/source/cloud-service/getting-started/sign-up-trial.rst
+++ b/source/cloud-service/getting-started/sign-up-trial.rst
@@ -1,0 +1,45 @@
+.. _cloud_sign_up:
+
+.. meta::
+  :description: Wazuh offers cloud-delivered protection. Prevent, detect, and respond to threats in real-time. Learn more about Wazuh Cloud here. 
+
+Sign up for a trial
+-------------------
+
+Wazuh provides a free trial for you to create a cloud environment and explore the Wazuh Cloud service. 
+
+Follow the next steps to create your trial environment.
+
+Sign up
+^^^^^^^
+
+To sign up, all you need is an email address:
+
+#. Go to our `Wazuh Cloud Console <https://console.cloud.wazuh.com/>`_ page.
+
+#. Enter your email address and password, or sign up with a Google account.
+
+Now you are ready to create your first :ref:`environment <cloud_glossary_environment>`.
+
+Create environment
+^^^^^^^^^^^^^^^^^^
+
+Follow these steps to quickly set up and run your environment:
+
+#. From the `Wazuh Cloud Console <https://console.cloud.wazuh.com/>`_, click **Start your free trial**.
+
+#. Configure your environment:
+
+   #. Give your environment a name.
+
+   #. Choose a :ref:`tier <cloud_glossary_tier>` to define the size in bytes of the indexed events. You can use this `estimation tool <https://wazuh.com/cloud/#pricing>`_ to calculate the Wazuh Cloud data tier.
+   
+      .. note:: During the 14-day trial period, the tier limit is 100GB. Then, after your first payment, the full tier becomes unlocked. For testing purposes, 100 GB is more than enough to get an insight into Wazuh Cloud.
+
+   #. Select the :ref:`region <cloud_glossary_region>` where your environment gets hosted. If you are not sure what to pick, select one that is the closest to your location since this typically reduces latency for indexing and search requests.
+
+   #. Choose the support plan that best suits your needs. 
+
+#. Click **View the summary** and then **Create** to build your environment. This process might take a moment.
+
+Once the environment is ready, you can access the Wazuh WUI and register the agents.

--- a/source/cloud-service/getting-started/sign-up-trial.rst
+++ b/source/cloud-service/getting-started/sign-up-trial.rst
@@ -4,16 +4,16 @@
   :description: Wazuh offers cloud-delivered protection. Prevent, detect, and respond to threats in real-time. Learn more about Wazuh Cloud here. 
 
 Sign up for a trial
--------------------
+===================
 
-Wazuh provides a free trial for you to create a cloud environment and explore the Wazuh Cloud service. 
+Wazuh provides a 14-day free trial for you to create a cloud environment and explore the Wazuh Cloud service. 
 
 Follow the next steps to create your trial environment.
 
 Sign up
-^^^^^^^
+-------
 
-To sign up, all you need is an email address:
+To sign up for a free trial, all you need is an email address:
 
 #. Go to our `Wazuh Cloud Console <https://console.cloud.wazuh.com/>`_ page.
 
@@ -22,7 +22,7 @@ To sign up, all you need is an email address:
 Now you are ready to create your first :ref:`environment <cloud_glossary_environment>`.
 
 Create environment
-^^^^^^^^^^^^^^^^^^
+------------------
 
 Follow these steps to quickly set up and run your environment:
 
@@ -42,4 +42,6 @@ Follow these steps to quickly set up and run your environment:
 
 #. Click **View the summary** and then **Create** to build your environment. This process might take a moment.
 
-Once the environment is ready, you can access the Wazuh WUI and register the agents.
+Once the environment is ready, you can :ref:`access the Wazuh WUI <cloud_wui_access>`  and register the agents. 
+
+If you have any questions about the Wazuh Cloud, see the :ref:`Cloud service FAQ <cloud_getting_started_starting_faq>`.

--- a/source/cloud-service/getting-started/starting-faq.rst
+++ b/source/cloud-service/getting-started/starting-faq.rst
@@ -39,7 +39,7 @@ Wazuh Cloud hosts and manages all the Wazuh components in one integrated platfor
 Can I try it for free?
 ----------------------
 
-Yes, Wazuh provides a free trial for you to create a cloud environment and access the Wazuh Cloud. You can :ref:`sign up for a 14-day free trial <cloud_getting_started_sign_up>` and no credit card information is required to complete this process.
+Yes, Wazuh provides a free trial for you to create a cloud environment and access the Wazuh Cloud. You can :ref:`sign up for a 14-day free trial <cloud_sign_up>` and no credit card information is required to complete this process.
 
 Will I be charged when my trial is over?
 ----------------------------------------

--- a/source/cloud-service/your-environment/agents-without-internet.rst
+++ b/source/cloud-service/your-environment/agents-without-internet.rst
@@ -68,7 +68,7 @@ To achieve this configuration, follow these steps:
 	
    #. Restart NGINX with ``systemctl restart nginx``.
 
-   #. Register your agent but replace the *WAZUH_MANAGER_IP* value (``nginx_ip``) with the NGINX instance IP. To learn more on how to register agents, see the :ref:`Register agents <cloud_getting_started_register_agents>` section.
+   #. Register your agent but replace the *WAZUH_MANAGER_IP* value (``nginx_ip``) with the NGINX instance IP. To learn more on how to register agents, see the :ref:`Register agents <cloud_register_agents>` section.
 
       Example:
 

--- a/source/cloud-service/your-environment/manage-auth.rst
+++ b/source/cloud-service/your-environment/manage-auth.rst
@@ -30,7 +30,7 @@ Creating an internal user and mapping it to Wazuh
 
 Follow these steps to create an internal user and map it to its appropriate role.
 
-#. :ref:`Log into your WUI<cloud_getting_started_wui_access>` as administrator.
+#. :ref:`Log into your WUI <cloud_wui_access>` as administrator.
 
 #. Click the upper-left menu icon to open the options, select **Security** and then **Internal users** to open the internal users page.
 
@@ -59,7 +59,7 @@ Creating and setting a Wazuh admin user
 
 Follow these steps to create an internal user, create a new role mapping, and give administrator permissions to the user.
 
-#. :ref:`Log into your WUI<cloud_getting_started_wui_access>` as administrator.
+#. :ref:`Log into your WUI <cloud_wui_access>` as administrator.
 
 #. Click the upper-left menu icon to open the options, select **Security** and then **Internal users** to open the internal users page.
 
@@ -93,7 +93,7 @@ Creating and setting a Wazuh read-only user
 
 Follow these steps to create an internal user, create a new role mapping, and give read-only permissions to the user.
 
-#. :ref:`Log into your WUI<cloud_getting_started_wui_access>` as administrator.
+#. :ref:`Log into your WUI <cloud_wui_access>` as administrator.
 
 #. Click the upper-left menu icon to open the options, select **Security** and then **Internal users** to open the internal users page.
 


### PR DESCRIPTION

Hi team,

## Description

This PR closes #4238
 I reorganized the content of the Getting started section for the Cloud service documentation.
Initially, the content was all included inside the "Getting started" section but we still kept de menu entries for reference.
This was not working as it should and might be confusing for users as well. For that reason, we separated the content and included the respective texts inside the corresponding sections.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

## Note to the reviewer

This PR includes changes to the `redirect.js` script 
I added the new URLs here `newUrls['4.2'] =`, please review. 

Regards, 
Mariel