### PR TITLE
3.11 Documentation: Installing-Fileabeat-Amazon-Linux changing installing filebeat hyperlink text

### DIFF
--- a/source/installation-guide/installing-wazuh-manager/linux/amazon/wazuh_server_sources_amazon.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/amazon/wazuh_server_sources_amazon.rst
@@ -130,7 +130,7 @@ Installing Filebeat
 
 Filebeat is the tool on the Wazuh server that securely forwards alerts and archived events to Elasticsearch.
 
-While Filebeat can be installed from sources (`see this doc <https://www.elastic.co/guide/en/beats/devguide/current/beats-contributing.html>`_),
+While Filebeat can be installed `from sources <https://www.elastic.co/guide/en/beats/devguide/current/beats-contributing.html>`_,
 the process is more complex than you may like and it is beyond the scope of Wazuh documentation. We recommend :ref:`installing Filebeat via repository package  <wazuh_server_packages_amazon_filebeat>`.
 
 Next steps

--- a/source/installation-guide/installing-wazuh-manager/linux/amazon/wazuh_server_sources_amazon.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/amazon/wazuh_server_sources_amazon.rst
@@ -130,7 +130,7 @@ Installing Filebeat
 
 Filebeat is the tool on the Wazuh server that securely forwards alerts and archived events to Elasticsearch.
 
-While Filebeat can be installed `from sources <https://www.elastic.co/guide/en/beats/devguide/current/beats-contributing.html>`_,
+While `Filebeat can be installed from sources <https://www.elastic.co/guide/en/beats/devguide/current/beats-contributing.html>`_,
 the process is more complex than you may like and it is beyond the scope of Wazuh documentation. We recommend :ref:`installing Filebeat via repository package  <wazuh_server_packages_amazon_filebeat>`.
 
 Next steps


### PR DESCRIPTION

## Description


Hello Team!

This PR closes it #4269 

At the Installation guide -> Installing Wazuh server -> Amazon Linux -> Amazon Linux from sources for Installing Filebeat section, we have the following text:

While Filebeat can be installed from sources **(see this doc)**

The text proposed:

While Filebeat can be installed **from sources** 

The idea is to use **_from sources_** as hyperlink instead of **_(see this doc)_**


Regards,


## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

