### PR TITLE
Changing option same_source_ip by same_srcip - Docu 4.1

### DIFF
--- a/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
@@ -1355,7 +1355,7 @@ Example:
 
       <rule id="30316" level="10" frequency="10" timeframe="120">
         <if_matched_sid>30315</if_matched_sid>
-        <same_source_ip />
+        <same_srcip />
         <description>Apache: Multiple Invalid URI requests from same source.</description>
         <group>invalid_request,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,</group>
       </rule>


### PR DESCRIPTION
Hello Team!

This PR closes it #4277 

On the `if_matched_sid` example snippet, the `same_source_ip` field is being used:

![image](https://user-images.githubusercontent.com/11634351/132653375-d3c78462-105c-4008-9440-972521528105.png)

Even though the example is correct, the field has been deprecated:

![image](https://user-images.githubusercontent.com/11634351/132653587-f942658c-d66d-4b12-9b38-a5ad14dbcfe2.png)

So it would be better to encourage users to use the `same_srcip` option instead.

Section URL: https://documentation.wazuh.com/current/user-manual/ruleset/ruleset-xml-syntax/rules.html#if-matched-sid


Regards,


## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

