### PR TITLE
Updating Installing Wazuh from sources section for Centos 8

### DIFF
--- a/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-agent/index.rst
+++ b/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-agent/index.rst
@@ -47,10 +47,10 @@ Installing Wazuh agent from sources
 
             .. code-block:: console
 
-              # yum install make gcc gcc-c++ python3 python3-policycoreutils automake autoconf libtool openssl-devel
+              # yum install make gcc gcc-c++ python3 python3-policycoreutils automake autoconf libtool openssl-devel cmake
               # rpm -i $(rpm --eval https://packages.wazuh.com/utils/libstdc%2B%2B/libstdc%2B%2B-static-8.4.1-1.el8.'%{_arch}'.rpm)
 
-            CMake 3.18 installation
+            **Optional** CMake 3.18 installation from sources
 
             .. code-block:: console
 

--- a/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-server/index.rst
+++ b/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-server/index.rst
@@ -49,11 +49,11 @@ Installing Wazuh manager
 
           .. code-block:: console
 
-            # yum install make cmake gcc gcc-c++ python3 python3-policycoreutils automake autoconf libtool openssl-devel
+            # yum install make cmake gcc gcc-c++ python3 python3-policycoreutils automake autoconf libtool openssl-devel cmake
             # rpm -i $(rpm --eval https://packages.wazuh.com/utils/libstdc%2B%2B/libstdc%2B%2B-static-8.4.1-1.el8.'%{_arch}'.rpm)
 
 
-          CMake 3.18 installation
+          **Optional** CMake 3.18 installation from sources
 
           .. code-block:: console
 


### PR DESCRIPTION
|Related Issue|
|---|
|#4285|

## Description

This PR aims to fix the documentation under [Wazuh Installation from Sources](https://documentation.wazuh.com/current/installation-guide/more-installation-alternatives/wazuh-from-sources/index.html) section from both Manager and Agent sub-sections for CentOS 8. This Operating System already has the needed version using the default package manager (`yum`) so, this needs to be clarified in the documentation to avoid any confusion.
**RPM default cmake package:**
![image](https://user-images.githubusercontent.com/22640902/132714868-b64b151b-93c8-44ac-a713-12af5d1ef800.png)

**The New changes look like this:**
- **Manager**
![image](https://user-images.githubusercontent.com/22640902/132719217-79032173-9c53-4e33-bb1e-c836cb10ef9f.png)
- **Agent**
![image](https://user-images.githubusercontent.com/22640902/132719304-cf95e930-a422-41a2-9aee-f5cb14d555f7.png)



## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 

###  These changes should be applied to the current official documentation version 4.2 as well.