### PR TITLE
Scaping character $ in repo name with \- Docu 4.2

### DIFF
--- a/source/_templates/installations/wazuh/yum/add_repository.rst
+++ b/source/_templates/installations/wazuh/yum/add_repository.rst
@@ -15,7 +15,7 @@
       gpgcheck=1
       gpgkey=https://packages.wazuh.com/key/GPG-KEY-WAZUH
       enabled=1
-      name=EL-$releasever - Wazuh
+      name=EL-\$releasever - Wazuh
       baseurl=https://packages.wazuh.com/4.x/yum/
       protect=1 
       EOF 


### PR DESCRIPTION
## Description


Hello Team!

This PR closes it #4292  

The variable $releasever, is a variable that expands itself with the version of the release. The problem is that there is a bug related to it. More info about it https://bugzilla.redhat.com/show_bug.cgi?id=1913008

Current text: 

`name=EL-$releasever - Wazuh`

Change proposed:

`name=EL-\$releasever - Wazuh`

Test in CentOS 7 after changes:

![image](https://user-images.githubusercontent.com/6249657/132731213-5725cfb5-005b-4aac-9a36-f198424c5102.png)

Test in CentOS 8 after changes:

![image](https://user-images.githubusercontent.com/6249657/132731284-2507766a-e973-4d8e-8993-60357f6f340e.png)



Regards,


## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

