### PR TITLE
Fix SMTP certificate configuration on Ubuntu

### DIFF
--- a/source/user-manual/manager/manual-email-report/smtp_authentication.rst
+++ b/source/user-manual/manager/manual-email-report/smtp_authentication.rst
@@ -32,7 +32,7 @@ If your SMTP server uses authentication (like Gmail, for instance), a server rel
       smtp_sasl_auth_enable = yes
       smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd
       smtp_sasl_security_options = noanonymous
-      smtp_tls_CAfile = /etc/ssl/certs/thawte_Primary_Root_CA.pem
+      smtp_tls_CAfile = /etc/ssl/certs/ca-certificates.crt
       smtp_use_tls = yes
 
     CentOS


### PR DESCRIPTION
|Related issue|
|---|
|#4275|

## Description

This aims to solve incorrect SMTP certificated configuration on Ubuntu. It has changed the name certificate used on Ubuntu because the name certificate used before this PR does not exist. Therefore, it causes an error on the SMTP server. 

Before

![image](https://user-images.githubusercontent.com/58960358/132765369-d3f9b363-33ea-4449-a597-eb3bd6ae8258.png)

After

![image](https://user-images.githubusercontent.com/58960358/132765165-e5d68c5d-a4fc-4783-93a0-35379ba80044.png)

##Ubuntu version tested:
- [x] 14.04
- [x] 16.04
- [x] 18.04
- [x] 20.04

## Checks
- [x] It compiles without warnings.
- [x] ~Spelling and grammar.~
- [x] ~Used impersonal speech.~
- [x] ~Used uppercase only on nouns.~
- [x] ~Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).~

Regards
Hanes
