### PR TITLE
Fix the steps in the Agents - Kubernetes config

### DIFF
--- a/source/deploying-with-kubernetes/kubernetes-conf.rst
+++ b/source/deploying-with-kubernetes/kubernetes-conf.rst
@@ -283,13 +283,12 @@ Agents
 
 Wazuh agents are designed to monitor hosts. To start using them:
 
-1. :ref:`Install the agent <installation_agents>`.
+#. :ref:`Install the agent <installation_agents>`.
 
+#. Register the agent following these steps:
 
-2. Now, register the agent using the :doc:`registration service <../../user-manual/registering/index>`.
+   -  Modify the file ``/var/ossec/etc/ossec.conf``, changing the "transport protocol" to *TCP* and replacing the ``MANAGER_IP`` with the external IP of the service pointing to port 1514 or with the DNS provided by *AWS Route 53* if you are using it.
 
+   - Alternatively, use the `authd <https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-authd.html?highlight=authd>`_ daemon with option *-m* specifying the external IP of the Wazuh service that takes to the port 1515, or its DNS if using *AWS Route 53*.
 
-3. Modify the file ``/var/ossec/etc/ossec.conf``, changing the "transport protocol" to *TCP* and changing the ``MANAGER_IP`` for the external IP of the service pointing to port 1514 or for the DNS provided by *AWS Route 53* if you are using it.
-
-
-4. Using the `authd <https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-authd.html?highlight=authd>`_ daemon with option *-m* specifying the external IP of the Wazuh service that takes to the port 1515 or its DNS if using *AWS Route 53*.
+To learn more about registering agents, see the :ref:`Registering Wazuh agents <register_agents>` section of the documentation.


### PR DESCRIPTION
Hi team,

## Description

This PR closes #4297 and fixes the steps in the Agents - Kubernetes config section of our documentation.

Currently, the steps look like this:
![image](https://user-images.githubusercontent.com/79285586/132858772-ca4856f9-bbe5-4f54-85d2-ac46c956fdc1.png)

Proposed version:
![image](https://user-images.githubusercontent.com/79285586/132858824-01df16d8-3a87-415c-a613-6675408b52d0.png)


## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

Regards,
Mariel