### PR TITLE
Updated the required port for Kibana

### DIFF
--- a/source/getting-started/architecture.rst
+++ b/source/getting-started/architecture.rst
@@ -66,7 +66,7 @@ For the communication of Wazuh components several services are used. Below is th
 +               + Elasticsearch +-----------+---------------+----------------------------------------------+
 | Elastic Stack |               | 9300-9400 | TCP           | Elasticsearch cluster communication          |
 +               +---------------+-----------+---------------+----------------------------------------------+
-|               | Kibana        | 5601      | TCP           | Kibana web interface                         |
+|               | Kibana        | 443       | TCP           | Kibana web interface                         |
 +---------------+---------------+-----------+---------------+----------------------------------------------+
 
 Archival data storage


### PR DESCRIPTION
Updated the required port for Kibana from 5601 to 443.


## Description
This PR closes #4300 to update the Kibana port from the default Kibana value to that used by the configurations provided in our installation guides. 

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
