### PR TITLE
Changing click here Docu 3.11 - Download packages

### DIFF
--- a/source/installation-guide/installing-wazuh-manager/linux/amazon/wazuh_server_packages_amazon.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/amazon/wazuh_server_packages_amazon.rst
@@ -12,7 +12,7 @@ For Amazon Linux 1 or greater, installing the Wazuh server components entails th
 Adding the Wazuh repository
 ---------------------------
 
-The first step to setting up Wazuh is to add the Wazuh repository to your server. If you want to download the wazuh-manager package directly, or check the compatible versions, click :ref:`here <packages>`.
+The first step to setting up Wazuh is to add the Wazuh repository to your server. You can download the :ref:`wazuh-manager package <packages>`  directly, or check the :ref:`compatible versions <packages>`.
 
 To set up the repository, run this command:
 

--- a/source/installation-guide/installing-wazuh-manager/linux/centos/wazuh_server_packages_centos.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/centos/wazuh_server_packages_centos.rst
@@ -12,7 +12,7 @@ For CentOS 6 or greater, installing the Wazuh server components entails the inst
 Adding the Wazuh repository
 ---------------------------
 
-The first step to setting up Wazuh is to add the Wazuh repository to your server. If you want to download the wazuh-manager package directly, or check the compatible versions, click :ref:`here <packages>`.
+The first step to setting up Wazuh is to add the Wazuh repository to your server. You can download the :ref:`wazuh-manager package <packages>`  directly, or check the :ref:`compatible versions <packages>`.
 
 To set up the repository, run this command:
 

--- a/source/installation-guide/installing-wazuh-manager/linux/debian/wazuh_server_packages_deb.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/debian/wazuh_server_packages_deb.rst
@@ -12,7 +12,7 @@ For Debian 7 or greater, installing the Wazuh server components entails the inst
 Adding the Wazuh repository
 ---------------------------
 
-The first step to setting up Wazuh is to add the Wazuh repository to your server. If you want to download the wazuh-manager package directly, or check the compatible versions, click :ref:`here <packages>`.
+The first step to setting up Wazuh is to add the Wazuh repository to your server. You can download the :ref:`wazuh-manager package <packages>`  directly, or check the :ref:`compatible versions <packages>`.
 
 1. To perform this procedure, the ``curl``, ``apt-transport-https`` and ``lsb-release`` packages must be installed on your system. If they are not already present, install them using the commands below:
 

--- a/source/installation-guide/installing-wazuh-manager/linux/fedora/wazuh_server_packages_fedora.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/fedora/wazuh_server_packages_fedora.rst
@@ -12,7 +12,7 @@ For Fedora 22 or greater, installing the Wazuh server components entails the ins
 Adding the Wazuh repository
 ---------------------------
 
-The first step to setting up Wazuh is to add the Wazuh repository to your server. If you want to download the wazuh-manager package directly, or check the compatible versions, click :ref:`here <packages>`.
+The first step to setting up Wazuh is to add the Wazuh repository to your server. You can download the :ref:`wazuh-manager package <packages>`  directly, or check the :ref:`compatible versions <packages>`.
 
 To set up the repository, run this command:
 

--- a/source/installation-guide/installing-wazuh-manager/linux/opensuse/wazuh_server_packages_opensuse.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/opensuse/wazuh_server_packages_opensuse.rst
@@ -12,7 +12,7 @@ For OpenSUSE OpenSUSE 42, OpenSUSE Leap and OpenSUSE Tumbleweed, installing the 
 Adding the Wazuh repository
 ---------------------------
 
-The first step to setting up Wazuh is to add the Wazuh repository to your server. If you want to download the wazuh-manager package directly, or check the compatible versions, click :ref:`here <packages>`.
+The first step to setting up Wazuh is to add the Wazuh repository to your server. You can download the :ref:`wazuh-manager package <packages>`  directly, or check the :ref:`compatible versions <packages>`.
 
 To set up the repository, run this command:
 

--- a/source/installation-guide/installing-wazuh-manager/linux/oracle/wazuh_server_packages_oracle.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/oracle/wazuh_server_packages_oracle.rst
@@ -12,7 +12,7 @@ For Oracle Linux 6 or greater, installing the Wazuh server components entails th
 Adding the Wazuh repository
 ---------------------------
 
-The first step to setting up Wazuh is to add the Wazuh repository to your server. If you want to download the wazuh-manager package directly, or check the compatible versions, click :ref:`here <packages>`.
+The first step to setting up Wazuh is to add the Wazuh repository to your server. You can download the :ref:`wazuh-manager package <packages>`  directly, or check the :ref:`compatible versions <packages>`.
 
 To set up the repository, run this command:
 

--- a/source/installation-guide/installing-wazuh-manager/linux/rhel/wazuh_server_packages_rhel.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/rhel/wazuh_server_packages_rhel.rst
@@ -12,7 +12,7 @@ For Red Hat Enterprise Linux 6 or greater, installing the Wazuh server component
 Adding the Wazuh repository
 ---------------------------
 
-The first step to setting up Wazuh is to add the Wazuh repository to your server. If you want to download the wazuh-manager package directly, or check the compatible versions, click :ref:`here <packages>`.
+The first step to setting up Wazuh is to add the Wazuh repository to your server. You can download the :ref:`wazuh-manager package <packages>`  directly, or check the :ref:`compatible versions <packages>`.
 
 To set up the repository, run this command:
 

--- a/source/installation-guide/installing-wazuh-manager/linux/suse/wazuh_server_packages_suse.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/suse/wazuh_server_packages_suse.rst
@@ -12,7 +12,7 @@ For SUSE 12, installing the Wazuh server components entails the installation of 
 Adding the Wazuh repository
 ---------------------------
 
-The first step to setting up Wazuh is to add the Wazuh repository to your server. If you want to download the wazuh-manager package directly, or check the compatible versions, click :ref:`here <packages>`.
+The first step to setting up Wazuh is to add the Wazuh repository to your server. You can download the :ref:`wazuh-manager package <packages>`  directly, or check the :ref:`compatible versions <packages>`.
 
 To set up the repository, run this command:
 

--- a/source/installation-guide/installing-wazuh-manager/linux/ubuntu/wazuh_server_packages_ubuntu.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/ubuntu/wazuh_server_packages_ubuntu.rst
@@ -12,7 +12,7 @@ For Ubuntu 12.04 or greater, installing the Wazuh server components entails the 
 Adding the Wazuh repository
 ---------------------------
 
-The first step to setting up Wazuh is to add the Wazuh repository to your server. If you want to download the wazuh-manager package directly, or check the compatible versions, click :ref:`here <packages>`.
+The first step to setting up Wazuh is to add the Wazuh repository to your server. You can download the :ref:`wazuh-manager package <packages>`  directly, or check the :ref:`compatible versions <packages>`.
 
 1. To perform this procedure, the ``curl``, ``apt-transport-https`` and ``lsb-release`` packages must be installed on your system. If they are not already present, install them using the commands below:
 


### PR DESCRIPTION
## Description


Hello Team!

This PR closes it #4309 

Hi, Team!

Proposing new text for the click here hyperlink text. For all options under: 

_Installation guide -> Installing Wazuh server -> Distro Name -> Distro Name from packages_

Adding the Wazuh repository section:

**Current text:**  If you want to download the wazuh-manager package directly, or check the compatible versions, click [here](https://documentation.wazuh.com/3.10/installation-guide/packages-list/index.html#packages).

**Proposed text:**  You can download the [wazuh-manager package ](https://documentation.wazuh.com/3.10/installation-guide/packages-list/index.html#packages) directly, or check the [compatible versions](https://documentation.wazuh.com/3.10/installation-guide/packages-list/index.html#packages).

Regards,


## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

