### PR TITLE
Docu 3.13 - Changing text for pointing Filebeat installation from sources.

### DIFF
--- a/source/installation-guide/installing-wazuh-manager/linux/centos/wazuh_server_sources_centos.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/centos/wazuh_server_sources_centos.rst
@@ -130,8 +130,9 @@ Installing Filebeat
 
 Filebeat is the tool on the Wazuh server that securely forwards alerts and archived events to Elasticsearch.
 
-While Filebeat can be installed from sources (`see this doc <https://www.elastic.co/guide/en/beats/devguide/current/beats-contributing.html>`_),
+While `Filebeat can be installed from sources <https://www.elastic.co/guide/en/beats/devguide/current/beats-contributing.html>`_,
 the process is more complex than you may like and it is beyond the scope of Wazuh documentation. We recommend :ref:`installing Filebeat via repository package  <wazuh_server_packages_centos_filebeat>`.
+
 
 Next steps
 ----------

--- a/source/installation-guide/installing-wazuh-manager/linux/debian/wazuh_server_sources_deb.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/debian/wazuh_server_sources_deb.rst
@@ -138,8 +138,9 @@ Installing Filebeat
 
 Filebeat is the tool on the Wazuh server that securely forwards alerts and archived events to Elasticsearch.
 
-While Filebeat can be installed from sources (`see this doc <https://www.elastic.co/guide/en/beats/devguide/current/beats-contributing.html>`_),
+While `Filebeat can be installed from sources <https://www.elastic.co/guide/en/beats/devguide/current/beats-contributing.html>`_,
 the process is more complex than you may like and it is beyond the scope of Wazuh documentation. We recommend :ref:`installing Filebeat via repository package  <wazuh_server_packages_deb_filebeat>`.
+
 
 Next steps
 ----------

--- a/source/installation-guide/installing-wazuh-manager/linux/fedora/wazuh_server_sources_fedora.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/fedora/wazuh_server_sources_fedora.rst
@@ -136,8 +136,9 @@ Installing Filebeat
 
 Filebeat is the tool on the Wazuh server that securely forwards alerts and archived events to Elasticsearch.
 
-While Filebeat can be installed from sources (`see this doc <https://www.elastic.co/guide/en/beats/devguide/current/beats-contributing.html>`_),
+While `Filebeat can be installed from sources <https://www.elastic.co/guide/en/beats/devguide/current/beats-contributing.html>`_,
 the process is more complex than you may like and it is beyond the scope of Wazuh documentation. We recommend :ref:`installing Filebeat via repository package  <wazuh_server_packages_fedora_filebeat>`.
+
 
 Next steps
 ----------

--- a/source/installation-guide/installing-wazuh-manager/linux/opensuse/wazuh_server_sources_opensuse.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/opensuse/wazuh_server_sources_opensuse.rst
@@ -130,8 +130,9 @@ Installing Filebeat
 
 Filebeat is the tool on the Wazuh server that securely forwards alerts and archived events to Elasticsearch.
 
-While Filebeat can be installed from sources (`see this doc <https://www.elastic.co/guide/en/beats/devguide/current/beats-contributing.html>`_),
+While `Filebeat can be installed from sources <https://www.elastic.co/guide/en/beats/devguide/current/beats-contributing.html>`_,
 the process is more complex than you may like and it is beyond the scope of Wazuh documentation. We recommend :ref:`installing Filebeat via repository package  <wazuh_server_packages_opensuse_filebeat>`.
+
 
 Next steps
 ----------

--- a/source/installation-guide/installing-wazuh-manager/linux/oracle/wazuh_server_sources_oracle.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/oracle/wazuh_server_sources_oracle.rst
@@ -130,8 +130,9 @@ Installing Filebeat
 
 Filebeat is the tool on the Wazuh server that securely forwards alerts and archived events to Elasticsearch.
 
-While Filebeat can be installed from sources (`see this doc <https://www.elastic.co/guide/en/beats/devguide/current/beats-contributing.html>`_),
+While `Filebeat can be installed from sources <https://www.elastic.co/guide/en/beats/devguide/current/beats-contributing.html>`_,
 the process is more complex than you may like and it is beyond the scope of Wazuh documentation. We recommend :ref:`installing Filebeat via repository package  <wazuh_server_packages_oracle_filebeat>`.
+
 
 Next steps
 ----------

--- a/source/installation-guide/installing-wazuh-manager/linux/rhel/wazuh_server_sources_rhel.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/rhel/wazuh_server_sources_rhel.rst
@@ -130,8 +130,9 @@ Installing Filebeat
 
 Filebeat is the tool on the Wazuh server that securely forwards alerts and archived events to Elasticsearch.
 
-While Filebeat can be installed from sources (`see this doc <https://www.elastic.co/guide/en/beats/devguide/current/beats-contributing.html>`_),
+While `Filebeat can be installed from sources <https://www.elastic.co/guide/en/beats/devguide/current/beats-contributing.html>`_,
 the process is more complex than you may like and it is beyond the scope of Wazuh documentation. We recommend :ref:`installing Filebeat via repository package  <wazuh_server_packages_rhel_filebeat>`.
+
 
 Next steps
 ----------

--- a/source/installation-guide/installing-wazuh-manager/linux/suse/wazuh_server_sources_suse.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/suse/wazuh_server_sources_suse.rst
@@ -130,8 +130,9 @@ Installing Filebeat
 
 Filebeat is the tool on the Wazuh server that securely forwards alerts and archived events to Elasticsearch.
 
-While Filebeat can be installed from sources (`see this doc <https://www.elastic.co/guide/en/beats/devguide/current/beats-contributing.html>`_),
+While `Filebeat can be installed from sources <https://www.elastic.co/guide/en/beats/devguide/current/beats-contributing.html>`_,
 the process is more complex than you may like and it is beyond the scope of Wazuh documentation. We recommend :ref:`installing Filebeat via repository package  <wazuh_server_packages_suse_filebeat>`.
+
 
 Next steps
 ----------

--- a/source/installation-guide/installing-wazuh-manager/linux/ubuntu/wazuh_server_sources_ubuntu.rst
+++ b/source/installation-guide/installing-wazuh-manager/linux/ubuntu/wazuh_server_sources_ubuntu.rst
@@ -138,8 +138,9 @@ Installing Filebeat
 
 Filebeat is the tool on the Wazuh server that securely forwards alerts and archived events to Elasticsearch.
 
-While Filebeat can be installed from sources (`see this doc <https://www.elastic.co/guide/en/beats/devguide/current/beats-contributing.html>`_),
+While `Filebeat can be installed from sources <https://www.elastic.co/guide/en/beats/devguide/current/beats-contributing.html>`_,
 the process is more complex than you may like and it is beyond the scope of Wazuh documentation. We recommend :ref:`installing Filebeat via repository package  <wazuh_server_packages_ubuntu_filebeat>`.
+
 
 Next steps
 ----------


### PR DESCRIPTION
## Description


Hello Team!

This PR closes it #4315 

Hi, Team!

Proposing new text for the Fileabeat installation hyperlink text. For all options under: 

_Installation guide -> Installing Wazuh server -> Distro Name -> Distro Name from sources_

Installing Filebeat section:

**Current text:**  While Filebeat can be installed from sources [see this doc](https://www.elastic.co/guide/en/beats/devguide/current/beats-contributing.html), the process is more complex than you may like and it is beyond the scope of Wazuh documentation. 

**Proposed text:**  [While Filebeat can be installed from sources,](https://www.elastic.co/guide/en/beats/devguide/current/beats-contributing.html) the process is more complex than you may like and it is beyond the scope of Wazuh documentation. 

Regards,


## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

