### PR TITLE
Fixed two tables under the disk_quota section 

### DIFF
--- a/source/user-manual/reference/ossec-conf/syscheck.rst
+++ b/source/user-manual/reference/ossec-conf/syscheck.rst
@@ -979,7 +979,7 @@ Specifices the limit for the size of the ``queue/diff/local`` folder.
 | **Default value**  | 1GB                                         |
 +--------------------+---------------------------------------------+
 | **Allowed values** | Any positive number followed by KB/MB/GB    |
-+--------------------------+---------------------------------------+
++--------------------+---------------------------------------------+
 
 file_size
 """""""""
@@ -1010,7 +1010,7 @@ Specifices the limit for the size of files monitored with ``report_changes``.
 | **Default value**  | 50MB                                        |
 +--------------------+---------------------------------------------+
 | **Allowed values** | Any positive number followed by KB/MB/GB    |
-+--------------------------+---------------------------------------+
++--------------------+---------------------------------------------+
 
 .. _reference_ossec_syscheck_nodiff:
 


### PR DESCRIPTION
## Description

There were two tables that were broken since 4.0 under the disk_quota section.

The issue was that the `+` sign in the line for the horizontal separators did not match the position of the previous lines.

It's worth noting that this issue did not generate a warning so there may be other cases within the documentation. 

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
