### PR TITLE
[4.1] Prevent indexing old releases

### DIFF
--- a/source/_templates/api-redoc.html
+++ b/source/_templates/api-redoc.html
@@ -29,6 +29,9 @@
     <meta name="twitter:title" content="{{ pagetitle|e + titlesuffix }}" />
     <meta name="twitter:description" content="User manual, installation and configuration guides. Learn how to get the most out of the Wazuh platform." />
     <meta name="twitter:image" content="{{ theme_wazuh_doc_url + '/' + version + '/_static/img/wazuh-docs-card.png' }}" />
+    {% if not is_latest_release %}
+    <meta name="robots" content="noindex" />
+    {% endif %}
     <!--
     ReDoc doesn't change outer page styles
     -->

--- a/source/_themes/wazuh_doc_theme/layout.html
+++ b/source/_themes/wazuh_doc_theme/layout.html
@@ -63,6 +63,9 @@
 <meta name="twitter:title" content="{{ pagetitle|e + titlesuffix }}" />
 <meta name="twitter:description" content="User manual, installation and configuration guides. Learn how to get the most out of the Wazuh platform." />
 <meta name="twitter:image" content="{{ theme_wazuh_doc_url + '/current/_static/img/wazuh-docs-card.png' }}" />
+{% if not is_latest_release %}
+<meta name="robots" content="noindex" />
+{% endif %}
 
 {{- metatags }}
 


### PR DESCRIPTION
## Description

This PR adds the meta tag `noindex` to all the documents except the ones of the latest release.

Related issue: https://github.com/wazuh/wazuh-website/issues/1795

## Checks
- [x] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
