### PR TITLE
[4.2] Code-blocks without the button 'Copy to clipboard'

### DIFF
--- a/source/_static/css/style.css
+++ b/source/_static/css/style.css
@@ -4023,6 +4023,10 @@ div[class*='highlight'] pre {
   overflow: auto;
 }
 
+div[class*='highlight'].no-copy .copy-to-clipboard {
+  display: none;
+}
+
 div[class*='highlight'] .copy-to-clipboard {
   z-index: 1;
   cursor: pointer;

--- a/source/_static/js/style.js
+++ b/source/_static/js/style.js
@@ -714,10 +714,12 @@ $(function() {
     const blockCode = $(this).parent();
 
     /* Output */
-    if (!blockCode.hasClass('output')) {
+    if (!blockCode.hasClass('output') && !blockCode.hasClass('no-copy')) {
       blockCode.prepend('<button type="button" class="copy-to-clipboard" title="Copy to clipboard"><span>Copied to clipboard</span><i class="far fa-copy" aria-hidden="true"></i></button>');
     } else {
-      blockCode.prepend('<div class="admonition admonition-output"><p class="first admonition-title">Output</p></div>');
+      if (blockCode.hasClass('output')) {
+        blockCode.prepend('<div class="admonition admonition-output"><p class="first admonition-title">Output</p></div>');
+      }
     }
 
     /* Escaped tag signs */


### PR DESCRIPTION
## Description

This PR adds the possibility to disable the button `Copy to clipboard` in a particular code-block just by adding the class `no-copy` to the code-block.

Related issue: https://github.com/wazuh/wazuh-website/issues/1697

## Checks
- [x] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
