### PR TITLE
Changing an ending point by 2 dots

### DIFF
--- a/source/installation-guide/wazuh-indexer/unattended.rst
+++ b/source/installation-guide/wazuh-indexer/unattended.rst
@@ -13,7 +13,7 @@ Wazuh indexer cluster installation
 
 Install and configure the Wazuh indexer as a single-node or multi-node cluster according to your environment needs. If you want to install a single-node cluster, follow the instructions to install the initial node.
 
-The installation process is divided into three stages.  
+The installation process is divided into three stages:  
 
 #. Initial node installation and configuration
 


### PR DESCRIPTION

## Description


Hello Team!

This PR closes it #4382 

Hi, Team!

Here we have an enumeration:

![image](https://user-images.githubusercontent.com/6249657/134542776-cd5b0663-c581-41d7-bfd2-81e0a77ec688.png)

At the end of the text we have an ending dot: 

> The installation process is divided into three stages.

It should be 2 dots, because we are doing an enumeration:

> The installation process is divided into three stages:


Regards,


## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

