### PR TITLE
Fix wazuh-logcollector.state default interval value

### DIFF
--- a/source/user-manual/reference/statistics-files/wazuh-logcollector-state.rst
+++ b/source/user-manual/reference/statistics-files/wazuh-logcollector-state.rst
@@ -11,7 +11,7 @@ The statistics file for **wazuh-logcollector** is located at ``/var/ossec/var/ru
 
 It can be helpful to identify and measure if Wazuh is collecting and sending logs consistently.
 
-By default, this file is updated every 5 seconds. This interval can be changed by modifying the ``logcollector.state_interval`` value from the :ref:`internal configuration <reference_internal_options>` file.
+By default, this file is updated every 60 seconds. This interval can be changed by modifying the ``logcollector.state_interval`` value from the :ref:`internal configuration <reference_internal_options>` file.
 
 Below there is an example of the file content:
 
@@ -21,7 +21,7 @@ Below there is an example of the file content:
     {
     "global": {
         "start": "2021-01-27 12:07:29",
-        "end": "2021-01-27 12:08:34",
+        "end": "2021-01-27 12:09:29",
         "files": [
         {
             "location": "df -P",
@@ -104,7 +104,7 @@ Below there is an example of the file content:
     },
     "interval": {
         "start": "2021-01-27 12:08:29",
-        "end": "2021-01-27 12:08:34",
+        "end": "2021-01-27 12:09:29",
         "files": [
         {
             "location": "df -P",


### PR DESCRIPTION
| Related issue |
|---|
| Closes #4395 |

## Description
Hi team!

This PR aims to fix `wazuh-logcollector.state` default interval value to 60s, change merged by wazuh/wazuh#9586. 

Regards,
Nico

## Checks
- [X] It compiles without warnings.
- [X] ~Spelling and grammar. ~
- [X] ~Used impersonal speech. ~
- [X] ~Used uppercase only on nouns. ~
- [X] ~Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).~

