### PR TITLE
Update Osquery-related paths to match v5.0.1 in documentation

### DIFF
--- a/source/user-manual/capabilities/osquery.rst
+++ b/source/user-manual/capabilities/osquery.rst
@@ -70,7 +70,7 @@ Once installed, you will need a configuration file for Osquery. If you don't hav
 
 .. code-block:: console
 
-    # cp /usr/share/osquery/osquery.example.conf /etc/osquery/osquery.conf
+    # cp /opt/osquery/share/osquery/osquery.example.conf /etc/osquery/osquery.conf
 
 Or you can copy our custom configuration in ``/etc/osquery/osquery.conf``:
 
@@ -101,12 +101,12 @@ Or you can copy our custom configuration in ``/etc/osquery/osquery.conf``:
         },
 
         "packs": {
-            "osquery-monitoring": "/usr/share/osquery/packs/osquery-monitoring.conf",
-            "incident-response": "/usr/share/osquery/packs/incident-response.conf",
-            "it-compliance": "/usr/share/osquery/packs/it-compliance.conf",
-            "vuln-management": "/usr/share/osquery/packs/vuln-management.conf",
-            "hardware-monitoring": "/usr/share/osquery/packs/hardware-monitoring.conf",
-            "ossec-rootkit": "/usr/share/osquery/packs/ossec-rootkit.conf"
+            "osquery-monitoring": "/opt/osquery/share/osquery/packs/osquery-monitoring.conf",
+            "incident-response": "/opt/osquery/share/osquery/packs/incident-response.conf",
+            "it-compliance": "/opt/osquery/share/osquery/packs/it-compliance.conf",
+            "vuln-management": "/opt/osquery/share/osquery/packs/vuln-management.conf",
+            "hardware-monitoring": "/opt/osquery/share/osquery/packs/hardware-monitoring.conf",
+            "ossec-rootkit": "/opt/osquery/share/osquery/packs/ossec-rootkit.conf"
         }
     }
 


### PR DESCRIPTION
## Description

Hi team,

As described in https://github.com/wazuh/wazuh/issues/10140, with the recent release of[ Osquery v5.0.1](https://github.com/osquery/osquery/blob/master/CHANGELOG.md#501), its installation path has been moved from `/usr/local` into `/opt/osquery` on **macOS** and **Linux** systems, for portability reasons.

This PR introduces all the necessary changes in our documentation to match the paths used in newer **Osquery** installations.

Best regards.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).


