### PR TITLE
Update upgrade API endpoints documentation after setting the agents limit

### DIFF
--- a/source/user-manual/agents/remote-upgrading/upgrading-agent.rst
+++ b/source/user-manual/agents/remote-upgrading/upgrading-agent.rst
@@ -24,7 +24,7 @@ To upgrade agents using the command line, use the :doc:`agent_upgrade <../../ref
 
     .. code-block:: console
 
-        # agent_upgrade -l
+        # /var/ossec/bin/agent_upgrade -l
 
     .. code-block:: none
         :class: output
@@ -36,11 +36,11 @@ To upgrade agents using the command line, use the :doc:`agent_upgrade <../../ref
 
         Total outdated agents: 3
 
-2. Upgrade the agent with ID 002 using the *'-a'* parameter followed by the agent ID:
+2. Upgrade the agent with ID 002 using the *'-a'* parameter followed by the agent ID and the *'-v'* parameter followed by the version to upgrade:
 
     .. code-block:: console
 
-        # agent_upgrade -a 002
+        # /var/ossec/bin/agent_upgrade -a 002 -v 4.0.0
 
     .. code-block:: none
         :class: output
@@ -105,7 +105,15 @@ Using the RESTful API
         }
 
 
-2. Upgrade the agents with ID 002 and 003 using endpoint :api-ref:`PUT /agents/upgrade <operation/api.controllers.agent_controller.put_upgrade_agent>`:
+2. Upgrade the agents with ID 002 and 003 using endpoint :api-ref:`PUT /agents/upgrade <operation/api.controllers.agent_controller.put_upgrade_agents>`:
+
+    .. versionadded:: 4.3.0
+
+        The parameter `agents_list` of endpoints :api-ref:`PUT /agents/upgrade <operation/api.controllers.agent_controller.put_upgrade_agents>` and :api-ref:`PUT /agents/upgrade_custom <operation/api.controllers.agent_controller.put_upgrade_custom_agents>` allows the value `all`. When setting this value, an upgrade request will be sent to all agents.
+
+    Despite the fact that there is no API limit when upgrading agents at the same time, it is not advised to upgrade an agents list exceeding 3000 agents. In case of doing it, it is highly recommended to use the parameter `wait_for_complete` set to `true` to avoid a possible API timeout.
+
+    This agents list size limit has been set after testing the endpoint in a Wazuh environment whose manager was installed in a host with specifications: 2.5 GHz AMD EPYC 7000 series processor and 4 GiB of memory. Using an agents list with size less than or equal to 3000 and a host with same or higher specs will guarantee this endpoint to return a response before the API timeout.
 
     .. code-block:: console
 
@@ -156,8 +164,8 @@ Using the RESTful API
                 "module": "upgrade_module",
                 "command": "upgrade",
                 "status": "Updated",
-                "create_time": "2020/10/21 17:13:45",
-                "update_time": "2020/10/21 17:14:07"
+                "create_time": "2020-10-21T17:13:45Z",
+                "update_time": "2020-10-21T17:14:07Z"
               },
               {
                 "message": "Success",
@@ -167,15 +175,15 @@ Using the RESTful API
                 "module": "upgrade_module",
                 "command": "upgrade",
                 "status": "Updated",
-                "create_time": "2020/10/21 17:13:45",
-                "update_time": "2020/10/21 17:14:11"
+                "create_time": "2020-10-21T17:13:45Z",
+                "update_time": "2020-10-21T17:14:11Z"
               }
             ],
             "total_affected_items": 2,
             "total_failed_items": 0,
             "failed_items": []
           },
-          "message": "All agents have been updated",
+          "message": "All upgrade tasks were returned",
           "error": 0
         }
 
@@ -194,11 +202,11 @@ Using the RESTful API
             "affected_items": [
               {
                 "id": "002",
-                "version": "Wazuh v4.2.2"
+                "version": "Wazuh v4.0.0"
               },
               {
                 "id": "003",
-                "version": "Wazuh v4.2.2"
+                "version": "Wazuh v4.0.0"
               }
             ],
             "total_affected_items": 2,

--- a/source/user-manual/api/getting-started.rst
+++ b/source/user-manual/api/getting-started.rst
@@ -418,7 +418,7 @@ Here are some of the basic concepts related to making API requests and understan
 - All responses have an HTTP status code: 2xx (success), 4xx (client error), 5xx (server error), etc.
 - All requests (except ``GET /security/user/authenticate`` and ``POST /security/user/authenticate/run_as``) accept the parameter ``pretty`` to convert the JSON response to a more human-readable format.
 - The Wazuh API log is stored on the manager as ``/var/ossec/logs/api.log`` (the path and verbosity level can be changed in the Wazuh API configuration file). The Wazuh API logs are rotated daily. Rotated logs are stored in ``/var/ossec/logs/api/<year>/<month>`` and compressed using ``gzip``.
-- All Wazuh API requests will be aborted if no response is received after a certain amount of time. The parameter ``wait_for_complete`` can be used to disable this timeout. This is useful for calls that could take more time than expected, such as :ref:`PUT/agents/:agent_id/upgrade <api_reference>`.
+- All Wazuh API requests will be aborted if no response is received after a certain amount of time. The parameter ``wait_for_complete`` can be used to disable this timeout. This is useful for calls that could take more time than expected, such as :api-ref:`PUT /agents/upgrade <operation/api.controllers.agent_controller.put_upgrade_agents>`.
 
 .. note:: The maximum API response time can be modified in the :ref:`API configuration <api_configuration_options>`.
 

--- a/source/user-manual/api/rbac/reference.rst
+++ b/source/user-manual/api/rbac/reference.rst
@@ -333,8 +333,8 @@ agent:restart
 agent:upgrade
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 - :api-ref:`GET /agents/{agent_id}/upgrade_result <operation/api.controllers.agent_controller.get_agent_upgrade>` (`agent:id`_, `agent:group`_)
-- :api-ref:`PUT /agents/{agent_id}/upgrade <operation/api.controllers.agent_controller.put_upgrade_agent>` (`agent:id`_, `agent:group`_)
-- :api-ref:`PUT /agents/{agent_id}/upgrade_custom <operation/api.controllers.agent_controller.put_upgrade_custom_agent>` (`agent:id`_, `agent:group`_)
+- :api-ref:`PUT /agents/{agent_id}/upgrade <operation/api.controllers.agent_controller.put_upgrade_agents>` (`agent:id`_, `agent:group`_)
+- :api-ref:`PUT /agents/{agent_id}/upgrade_custom <operation/api.controllers.agent_controller.put_upgrade_custom_agents>` (`agent:id`_, `agent:group`_)
 
 
 Ciscat

--- a/source/user-manual/reference/tools/agent_upgrade.rst
+++ b/source/user-manual/reference/tools/agent_upgrade.rst
@@ -60,7 +60,7 @@ Examples
 
 .. code-block:: console
 
-    # agent_upgrade -a 002
+    # agent_upgrade -a 002 -v 4.0.0
 
 .. code-block:: none
     :class: output


### PR DESCRIPTION


## Description

This pull request is related to the issue https://github.com/wazuh/wazuh/issues/9504.

After the investigation done in the related issue, the theoretical limit (3000) that is going to be used in the API endpoint to upgrade agents needs to be documented. This documentation is included in this pull request.

Some minor fixes to outputs and references to the upgrade endpoints are also included in this PR.

<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

## Checks
- [ ] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

## Note to the reviewer

This PR includes changes to the `redirect.js` script that need to be included in all production branches.
