### PR TITLE
Correcting wording in sentences of wodle-s3 section

### DIFF
--- a/source/user-manual/reference/ossec-conf/wodle-s3.rst
+++ b/source/user-manual/reference/ossec-conf/wodle-s3.rst
@@ -294,9 +294,9 @@ A valid role arn with permission to read logs from the bucket.
 +--------------------+----------------+
 
 bucket\\iam_role_duration
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A valid number of seconds that defines the duration of the session assuming the provided :ref:`iam_role_arn<bucket_iam_role_arn>` is used.
+A valid number of seconds that defines the duration of the session assumed when using the provided :ref:`iam_role_arn<bucket_iam_role_arn>`.
 
 +--------------------+------------------------------------------+
 | **Default value**  | N/A                                      |
@@ -590,9 +590,9 @@ A valid role arn with permission to access the service.
 +--------------------+----------------+
 
 Service\\iam_role_duration
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A valid number of seconds that defines the duration of the session assuming the provided :ref:`iam_role_arn<service_iam_role_arn>` is used.
+A valid number of seconds that defines the duration of the session assumed when using the provided :ref:`iam_role_arn<service_iam_role_arn>`.
 
 +--------------------+------------------------------------------+
 | **Default value**  | N/A                                      |


### PR DESCRIPTION
Hi team,

## Description

This PR closes #4418 and aims at correcting the wording of 2 sentences in wodle-s3 section of the documentation. 
Specifically, the short descriptions for bucket\\iam_role_duration and Service\\iam_role_duration are corrected. I noticed the tag for the titles ran longer than they should so I fixed them too. 

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

Regards,
Mariel
