### PR TITLE
Adds new internal options for remoted.

### DIFF
--- a/source/user-manual/reference/internal-options.rst
+++ b/source/user-manual/reference/internal-options.rst
@@ -890,15 +890,6 @@ Remoted
 +                                   +---------------+--------------------------------------------------------------+
 |                                   | Allowed value | Any integer between 1 and 60.                                |
 +-----------------------------------+---------------+--------------------------------------------------------------+
-|   **remoted.send_timeout**        | Description   | Maximum number of seconds to wait for message delivery in    |
-|                                   |               | TCP.                                                         |
-|                                   |               |                                                              |
-|                                   |               | .. versionadded:: 3.7.0                                      |
-+                                   +---------------+--------------------------------------------------------------+
-|                                   | Default value | 1                                                            |
-+                                   +---------------+--------------------------------------------------------------+
-|                                   | Allowed value | Any integer between 1 and 60.                                |
-+-----------------------------------+---------------+--------------------------------------------------------------+
 |         **remoted.debug**         | Description   | Debug level (manager installation)                           |
 +                                   +---------------+--------------------------------------------------------------+
 |                                   | Default value | 0                                                            |
@@ -959,6 +950,36 @@ Remoted
 +                                   +---------------+--------------------------------------------------------------+
 |                                   | Allowed value | | Any other integer between 1024 and 16384.                  |
 |                                   |               | | Powers of two are suggested.                               |
++-----------------------------------+---------------+--------------------------------------------------------------+
+| **remoted.send_chunk**            | Description   | | Send buffer size for TCP (bytes).                          |
+|                                   |               | | Amount of data that Remoted can send per operation.        |
+|                                   |               |                                                              |
+|                                   |               | .. versionadded:: 4.3.0                                      |
++                                   +---------------+--------------------------------------------------------------+
+|                                   | Default value | 4096                                                         |
++                                   +---------------+--------------------------------------------------------------+
+|                                   | Allowed value | | Any other integer between 512 and 16384.                   |
+|                                   |               | | Powers of two are suggested.                               |
++-----------------------------------+---------------+--------------------------------------------------------------+
+| **remoted.send_buffer_size**      | Description   | | Send queue size for TCP (bytes).                           |
+|                                   |               | | Amount of data that Remoted can queue to send              |
+|                                   |               | | (one queue per agent).                                     |
+|                                   |               |                                                              |
+|                                   |               | .. versionadded:: 4.3.0                                      |
++                                   +---------------+--------------------------------------------------------------+
+|                                   | Default value | 131072                                                       |
++                                   +---------------+--------------------------------------------------------------+
+|                                   | Allowed value | | Any other integer between 65536 and 1048576.               |
+|                                   |               | | Powers of two are suggested.                               |
++-----------------------------------+---------------+--------------------------------------------------------------+
+| **remoted.send_timeout_to_retry** | Description   | | Maximum number of seconds to wait before retrying to       |
+|                                   |               | | queue a packet to send in TCP.                             |
+|                                   |               |                                                              |
+|                                   |               | .. versionadded:: 4.3.0                                      |
++                                   +---------------+--------------------------------------------------------------+
+|                                   | Default value | 1                                                            |
++                                   +---------------+--------------------------------------------------------------+
+|                                   | Allowed value | | Any integer between 1 and 60.                              |
 +-----------------------------------+---------------+--------------------------------------------------------------+
 | **remoted.buffer_relax**          | Description   | | Method for memory deallocation after accepting input data. |
 |                                   |               | | This option applies in TCP mode only.                      |


### PR DESCRIPTION

## Description

This PR adds changes to the internal-options file according to the new `remoted `behavior.
Option removed:

- `remoted.send_timeout`

Options added:

- `remoted.send_chunk`
- `remoted.send_buffer_size`
- `remoted.send_timeout_to_retry`

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

## Note to the reviewer

This PR includes changes to the `redirect.js` script that need to be included in all production branches.
