### PR TITLE
Edited conf.py WAZUH_SPLUNK_LATEST to 4.2.3

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -464,7 +464,7 @@ custom_replacements = {
     "|OPENDISTRO_LATEST_KUBERNETES|" : "1.13.2",
     "|DOCKER_COMPOSE_VERSION|" : "1.28.3",
     "|SPLUNK_LATEST|" : "8.2.2",
-    "|WAZUH_SPLUNK_LATEST|" : "4.2.2",
+    "|WAZUH_SPLUNK_LATEST|" : "4.2.3",
     "|ELASTIC_6_LATEST|" : "6.8.8",
     "|WAZUH_REVISION_YUM_AGENT_I386|" : "1",
     "|WAZUH_REVISION_YUM_MANAGER_I386|" : "1",


### PR DESCRIPTION
Hi team,

## Description

This PR closes #4425 and updates WAZUH_SPLUNK_LATEST to 4.2.3, correcting the Wazuh version entry in Packages List - Splunk. 

## Checks
- [x] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).



## Note to the reviewer

After changes, the table compiles without errors:


![image](https://user-images.githubusercontent.com/79285586/136254530-786916f7-f7d9-43e8-9a53-e6d43194d36a.png)
