### PR TITLE
Syscollector alerting is not currently supported

### DIFF
--- a/source/user-manual/capabilities/syscollector.rst
+++ b/source/user-manual/capabilities/syscollector.rst
@@ -440,13 +440,15 @@ The following table shows the operating systems that this module currently suppo
 Using Syscollector information to trigger alerts
 ------------------------------------------------
 
-  Since Wazuh 3.9 version, ``Syscollector`` module information can be used to trigger alerts and show that information in the alerts' description.
+.. deprecated:: 4.2
 
-  To allow this configuration, in a rule declaration set the ``<decoded_as>`` field as **syscollector**.
+Since Wazuh 3.9 version, ``Syscollector`` module information can be used to trigger alerts and show that information in the alerts' description.
 
-  As an example, this rule will be triggered when the interface ``eth0`` of an agent is enabled and will show what IPv4 has that interface.
+To allow this configuration, in a rule declaration set the ``<decoded_as>`` field as **syscollector**.
 
-  .. code-block:: xml
+As an example, this rule will be triggered when the interface ``eth0`` of an agent is enabled and will show what IPv4 has that interface.
+
+.. code-block:: xml
 
     <rule id="100001" level="5">
       <if_sid>221</if_sid>
@@ -455,11 +457,11 @@ Using Syscollector information to trigger alerts
       <description>eth0 interface enabled. IP: $(netinfo.iface.ipv4.address)</description>
     </rule>
 
-  .. warning::
+.. warning::
 
     The tag ``<if_sid>221</if_sid>`` is necessary because the events from Syscollector are muted by default with that rule.
 
-  When the alerts are triggered they will be displayed in Kibana this way:
+When the alerts are triggered they will be displayed in Kibana this way:
 
     .. thumbnail:: ../../images/manual/internal-capabilities/syscollector_alerts.png
       :title: Information from syscollector for "port" value.


### PR DESCRIPTION
## Description

This PR adds a deprecation message to the ["Using Syscollector information to trigger alerts"](https://documentation.wazuh.com/current/user-manual/capabilities/syscollector.html#using-syscollector-information-to-trigger-alertsl) subsection. This PR closes #4400.  

![image](https://user-images.githubusercontent.com/61882981/136372230-2f67bc0d-1e90-42f0-bc31-db99ac53b58b.png)


## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

