### PR TITLE
Fixed typo in Adding authentication for Elasticsearch section 

### DIFF
--- a/source/learning-wazuh/build-lab/xpack-security-setup.rst
+++ b/source/learning-wazuh/build-lab/xpack-security-setup.rst
@@ -206,7 +206,7 @@ Adding authentication for Elasticsearch
 X-Pack security also provides authentication within each component. The credentials
 are configured in the Elastic Server using Elasticsearch directly.
 
-1. Add ``x.pack.security.enabled`` to ``/etc/elasticsearch/elasticsearch.yml``.
+1. Add ``xpack.security.enabled`` to ``/etc/elasticsearch/elasticsearch.yml``.
 
   .. code-block:: console
 


### PR DESCRIPTION
Hi team
## Description

This PR closes #4440 and fixes a typo in the section: https://documentation.wazuh.com/current/learning-wazuh/build-lab/xpack-security-setup.html#adding-authentication-for-elasticsearch

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

Regards, 
Mariel