### PR TITLE
Deprecate use_only_authd API configuration option

### DIFF
--- a/source/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-manager-class.rst
+++ b/source/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-manager-class.rst
@@ -693,11 +693,6 @@ $wazuh_api_access_max_request_per_minute
 
   `Default 300`
 
-$wazuh_api_use_only_authd
-  Forces the use of wazuh-authd when registering and removing agents.
-
-  `Default false`
-
 $wazuh_api_drop_privileges
   Run wazuh-api process as wazuh user
 

--- a/source/user-manual/api/configuration.rst
+++ b/source/user-manual/api/configuration.rst
@@ -22,7 +22,6 @@ Here are all the available settings for the ``api.yaml`` configuration file. For
      host: 0.0.0.0
      port: 55000
 
-     use_only_authd: no
      drop_privileges: yes
      experimental_features: no
      max_upload_size: 10485760
@@ -161,6 +160,8 @@ port
 +===============================+===============+=======================================+
 | Any value between 1 and 65535 | 55000         | Port where the Wazuh API will listen. |
 +-------------------------------+---------------+---------------------------------------+
+
+.. deprecated:: 4.3.0
 
 use_only_authd
 ^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION


## Description

This PR is part of https://github.com/wazuh/wazuh/issues/10395.

As part of the removal of the functions `_add_manual` and `_remove_manual`, the `use_only_authd` API option has been deprecated.

From `v4.3.0`, a warning will appear in the `api.log` if the user uses this option to avoid broken configurations when upgrading.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->
