### PR TITLE
fix disable_account link

### DIFF
--- a/source/user-manual/capabilities/active-response/how-it-works.rst
+++ b/source/user-manual/capabilities/active-response/how-it-works.rst
@@ -89,7 +89,7 @@ Wazuh is preconfigured with the following scripts for Linux, located at ``/var/o
 +---------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------+
 | Script name                                                                                                                           |                          Description                          |
 +=======================================================================================================================================+===============================================================+
-| `disable-account <https://github.com/wazuh/wazuh/blob/|WAZUH_LATEST_MINOR|/src/active-response/disable-account.c>`_                                   | Disables an account by setting ``passwd-l``                   |
+| `disable-account <https://github.com/wazuh/wazuh/blob/|WAZUH_LATEST_MINOR|/src/active-response/disable-account.c>`_                                    | Disables an account by setting ``passwd-l``                   |
 +---------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------+
 | `firewall-drop <https://github.com/wazuh/wazuh/blob/|WAZUH_LATEST_MINOR|/src/active-response/firewalls/default-firewall-drop.c>`_                      | Adds an IP to the iptables deny list                          |
 +---------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------+


### PR DESCRIPTION
## Description

The link to `disable_account.c` redirected to `active_responses.c` instead.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).