### PR TITLE
Changing url for ruleset

### DIFF
--- a/source/learning-wazuh/replace-stock-rule.rst
+++ b/source/learning-wazuh/replace-stock-rule.rst
@@ -7,7 +7,7 @@
 Change the rules
 ================
 
-The `Wazuh Ruleset <https://github.com/wazuh/wazuh/tree/master/ruleset>`_ is maintained by Wazuh, Inc.
+The `Wazuh Ruleset <https://github.com/wazuh/wazuh/tree/|WAZUH_LATEST_MINOR|/ruleset>`_ is maintained by Wazuh, Inc.
 and is contributed to by the Wazuh community.  These stock rules are located in various files
 in ``/var/ossec/ruleset/rules/`` on the Wazuh Manager and should not be edited in that location
 because they are overwritten when you make an upgrade.

--- a/source/user-manual/ruleset/getting-started.rst
+++ b/source/user-manual/ruleset/getting-started.rst
@@ -70,7 +70,7 @@ In the Wazuh repository you will find:
 
 Resources
 ^^^^^^^^^
-* Visit our repository to view the rules in detail at `GitHub Wazuh <https://github.com/wazuh/wazuh/ruleset>`_
+* Visit our repository to view the rules in detail at `GitHub Wazuh <https://github.com/wazuh/wazuh/tree/|WAZUH_LATEST_MINOR|/ruleset>`_
 * Find a complete description of the available rules at `Wazuh Ruleset Summary <http://www.wazuh.com/resources/Wazuh_Ruleset.pdf>`_
 
 


### PR DESCRIPTION

## Description


Hello Team!

This PR closes it #4432 


Wazuh ruleset Github repository link is broken in the [Getting Started documentation page for the ruleset](https://documentation.wazuh.com/current/user-manual/ruleset/getting-started.html).

![docu-link](https://user-images.githubusercontent.com/11089305/136519793-dcae09b6-b766-4a34-a7aa-cfce6b2e9e1c.png)


This [link](https://github.com/wazuh/wazuh/ruleset) should be replaced by [this](https://github.com/wazuh/wazuh/tree/master/ruleset) one


Regards,


## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

