### PR TITLE
Added the url of the fim fields table to redirect.js file

### DIFF
--- a/source/_static/js/redirects.js
+++ b/source/_static/js/redirects.js
@@ -43,6 +43,7 @@ newUrls['4.3'] = [
   '/office365/index.html',
   '/office365/monitoring-office365-activity.html',
   '/user-manual/reference/ossec-conf/office365-module.html',
+  '/user-manual/capabilities/file-integrity/fim-fields-rule-mapping.html',
 ];
 
 /* *** RELEASE 4.2 ****/
@@ -79,7 +80,7 @@ newUrls['4.2'] = [
   '/user-manual/reference/statistics-files/wazuh-remoted-state.html',
   '/user-manual/reference/statistics-files/wazuh-logcollector-state.html',
   '/user-manual/reference/tools/wazuh-control.html',
-  '/user-manual/reference/tools/wazuh-regex.html',  
+  '/user-manual/reference/tools/wazuh-regex.html',
   '/cloud-service/index.html',
   '/cloud-service/glossary.html',
   '/cloud-service/account-billing/index.html',
@@ -102,7 +103,7 @@ newUrls['4.2'] = [
   '/cloud-service/your-environment/understanding-storage.html',
   '/cloud-service/getting-started/sign-up-trial.html',
   '/cloud-service/getting-started/access-wazuh-wui.html',
-  '/cloud-service/getting-started/register-agents.html', 
+  '/cloud-service/getting-started/register-agents.html',
 ];
 
 removedUrls['4.2'] = [
@@ -282,7 +283,7 @@ redirections.push(
     'target': ['4.0=>4.1', '4.1=>4.0'],
     '4.0': '/installation-guide/wazuh-agent/deployment_variables/linux/deployment_variables_zypper.html',
     '4.1': '/installation-guide/wazuh-agent/deployment_variables/deployment_variables_linux.html',
-  },  
+  },
 );
 
 /* *** RELEASE 4.0 ****/
@@ -1169,7 +1170,7 @@ redirections.push(
       '3.13': '/installation-guide/installing-wazuh-agent/linux/oracle5/wazuh_agent_package_oracle5.html',
       '4.0':  '/installation-guide/wazuh-agent/index.html',
     },
-); 
+);
 
 /* *** RELEASE 3.13 ****/
 


### PR DESCRIPTION
## Description

Hi team, this PR is to add the URL needed in the redirect.js file of this other old PR:
https://github.com/wazuh/wazuh-documentation/pull/3913
in which a new section was added to the docu for a table of correspondences of the dynamic fields and the FIM alert fields.

## Note to the reviewer

This PR includes changes to the `redirect.js` script that need to be included in all production branches.
