### PR TITLE
Clarify password authorization for cluster configurations

### DIFF
--- a/source/user-manual/registering/password-authorization-registration.rst
+++ b/source/user-manual/registering/password-authorization-registration.rst
@@ -9,7 +9,7 @@ Registration service with password authorization
 
 This method is similar to the :ref:`simple registration service <simple-registration-service>`, except that it provides protection from unauthorized registrations by requiring a password during the registration process.
 
-Password protected registration is enabled in the Wazuh manager configuration. To protect a multinode cluster from unauthorized agent registrations, password authorization must be enabled on every one of the manager nodes to avoid unauthorized registrations through one of them. The password to be used with agents registration can be the one provided by the service or a custom one defined during the manager configuration.
+Password protected registration is enabled in the Wazuh manager configuration. To protect a multi-node cluster from unauthorized agent registrations, password authorization must be enabled on every one of the Wazuh manager nodes. Doing this on every node prevents unauthorized registrations to the cluster through a node not properly configured.
 
 When the configuration is complete, running the ``agent-auth`` utility providing the appropriate password will register the Wazuh agent. After the registration, the Wazuh agent has to be configured to indicate the destination where the collected security events will be sent.
 

--- a/source/user-manual/registering/password-authorization-registration.rst
+++ b/source/user-manual/registering/password-authorization-registration.rst
@@ -7,11 +7,11 @@
 Registration service with password authorization
 ================================================
 
-This method is similar to the :ref:`simple registration service <simple-registration-service>`, except that it provides additional protection of the Wazuh manager from unauthorized registrations by using a password.
+This method is similar to the :ref:`simple registration service <simple-registration-service>`, except that it provides protection from unauthorized registrations by requiring a password during the registration process.
 
-Before the registration process, enabling the password authorization option and creating the registration password has to be done on the Wazuh manager. This password can be used for the subsequent agent registrations with the same Wazuh manager.
+Password protected registration is enabled in the Wazuh manager configuration. To protect a multinode cluster from unauthorized agent registrations, password authorization must be enabled on every one of the manager nodes to avoid unauthorized registrations through one of them. The password to be used with agents registration can be the one provided by the service or a custom one defined during the manager configuration.
 
-When those steps are completed, the Wazuh agent can be registered using the ``agent-auth`` utility and providing the password. After the registration, the Wazuh agent has to be configured to indicate the destination where the collected security events will be sent.
+When the configuration is complete, running the ``agent-auth`` utility providing the appropriate password will register the Wazuh agent. After the registration, the Wazuh agent has to be configured to indicate the destination where the collected security events will be sent.
 
 Enabling the password authorization option and creating a registration password on the Wazuh manager
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Description

This is to add a recommendation to configure password authorization in every manager node when there are more than one since agent registration with password is enabled per node and not once for the whole cluster. This PR closes #4507 . 

## Checks
- [X] It compiles without warnings.
- [X] Spelling and grammar. 
- [X] Used impersonal speech. 
- [X] Used uppercase only on nouns. 
- [X] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).