### PR TITLE
Fix command in the "How to integrate Wazuh with YARA" section

### DIFF
--- a/source/user-manual/capabilities/active-response/ar-use-cases/wazuh-with-yara.rst
+++ b/source/user-manual/capabilities/active-response/ar-use-cases/wazuh-with-yara.rst
@@ -153,7 +153,7 @@ The script configured to run as part of the active response settings defined on 
   LOCAL=`dirname $0`
   
   # Extra arguments
-  read INPUT_JSON
+  read -r INPUT_JSON
   YARA_PATH=$(echo $INPUT_JSON | jq -r .parameters.extra_args[1])
   YARA_RULES=$(echo $INPUT_JSON | jq -r .parameters.extra_args[3])
   FILENAME=$(echo $INPUT_JSON | jq -r .parameters.alert.syscheck.path)


### PR DESCRIPTION

## Description

This PR fixes a command in the [How to integrate Wazuh with YARA](https://documentation.wazuh.com/current/user-manual/capabilities/active-response/ar-use-cases/wazuh-with-yara.html) section and closes #4518. 

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).


