### PR TITLE
Adding force_reconnect_interval to the shared configuration settings list

### DIFF
--- a/source/user-manual/reference/centralized-configuration.rst
+++ b/source/user-manual/reference/centralized-configuration.rst
@@ -1,7 +1,7 @@
 .. Copyright (C) 2021 Wazuh, Inc.
 
 .. meta::
-  :description: Learn how to remotely configure agents using agent.conf. In this section you will find which capabilities can be configured remotely.
+  :description: Learn how to remotely configure agents using agent.conf. In this section of the Wazuh documentation, you will find which capabilities can be configured remotely.
 
 .. _reference_agent_conf:
 

--- a/source/user-manual/reference/centralized-configuration.rst
+++ b/source/user-manual/reference/centralized-configuration.rst
@@ -1,7 +1,7 @@
 .. Copyright (C) 2021 Wazuh, Inc.
 
 .. meta::
-  :description: Learn how to remotely configure agents using agent.conf. In this section you will find which capabilities can be configured remotely. 
+  :description: Learn how to remotely configure agents using agent.conf. In this section you will find which capabilities can be configured remotely.
 
 .. _reference_agent_conf:
 
@@ -23,6 +23,7 @@ Agents can be configured remotely by using the ``agent.conf`` file. The followin
 - :doc:`System inventory <../capabilities/syscollector>` (**syscollector**)
 - :doc:`Avoid events flooding <ossec-conf/client_buffer>` (**client_buffer**)
 - :doc:`Configure osquery wodle <ossec-conf/wodle-osquery>` (**wodle name="osquery"**)
+- :doc:`force_reconnect_interval setting <ossec-conf/client>` (**client**)
 
 .. note::
   When setting up remote commands in the shared agent configuration, **you must enable remote commands for Agent Modules**. This is enabled by adding the following line to the ``/var/ossec/etc/local_internal_options.conf`` file in the agent:

--- a/source/user-manual/reference/ossec-conf/client.rst
+++ b/source/user-manual/reference/ossec-conf/client.rst
@@ -1,7 +1,7 @@
 .. Copyright (C) 2021 Wazuh, Inc.
 .. meta::
-  :description: Learn more about client configuration, connection to the manager, and its configuring options in this section of the Wazuh user manual. 
-  
+  :description: Learn more about client configuration, connection to the manager, and its configuring options in this section of the Wazuh user manual.
+
 .. _reference_ossec_client:
 
 client
@@ -15,6 +15,9 @@ client
 		</client>
 
 This section explains how to configure the connection to the manager.
+
+.. note::
+  To avoid a permanent lost of communication with the manager, the only setting included in the shared configuration of this section is **force_reconnect_interval**
 
 Subsections
 -----------

--- a/source/user-manual/reference/ossec-conf/client.rst
+++ b/source/user-manual/reference/ossec-conf/client.rst
@@ -1,6 +1,6 @@
 .. Copyright (C) 2021 Wazuh, Inc.
 .. meta::
-  :description: Learn more about client configuration, connection to the manager, and its configuring options in this section of the Wazuh user manual.
+  :description: Learn more about client configuration, connection to the manager, and its configuring options in this section of the Wazuh documentation.
 
 .. _reference_ossec_client:
 
@@ -17,7 +17,7 @@ client
 This section explains how to configure the connection to the manager.
 
 .. note::
-  To avoid a permanent lost of communication with the manager, the only setting included in the shared configuration of this section is **force_reconnect_interval**
+  To avoid a permanent lost of communication with the manager, the only setting included in the shared configuration of this section is **force_reconnect_interval**.
 
 Subsections
 -----------


### PR DESCRIPTION
|Related issue|
|---|
|#4569|

## Description

This PR updates the centralized configuration list to include the `force_reconnect_interval` setting. Also, a note is added explaining that the rest of the settings in the **client** section aren't included.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 