### PR TITLE
OpenSCAP deprecated since version 4.0

### DIFF
--- a/source/deploying-with-ansible/reference.rst
+++ b/source/deploying-with-ansible/reference.rst
@@ -359,6 +359,8 @@ Wazuh Manager
 
 **wazuh_manager_openscap**
 
+  .. deprecated:: 4.0
+
   Configures the :ref:`wodle<wodle_openscap>` item named ``open-scap`` from ``ossec.conf``.
 
   *Default:*

--- a/source/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-agent-class.rst
+++ b/source/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-agent-class.rst
@@ -521,6 +521,8 @@ $ossec_syscheck_skip_nfs
 Wodle OpenSCAP
 --------------
 
+.. deprecated:: 4.0
+
 $configure_wodle_openscap
   Enables Wodle OpenSCAP section render on this host.
 

--- a/source/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-manager-class.rst
+++ b/source/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-manager-class.rst
@@ -714,6 +714,8 @@ $wazuh_api_experimental_features
 Wodle OpenSCAP variables
 ------------------------
 
+.. deprecated:: 4.0
+
 $configure_wodle_openscap
   Enables Wodle OpenSCAP section render on this host.
 

--- a/source/gdpr/gdpr-IV.rst
+++ b/source/gdpr/gdpr-IV.rst
@@ -18,6 +18,10 @@ Wazuh monitors configuration files to ensure they are compliant with your securi
 
 Policy monitoring is the process of verifying that all systems conform to a set of predefined rules regarding configuration settings and approved application usage. Wazuh uses three components to perform this task: `Rootcheck <https://documentation.wazuh.com/current/user-manual/capabilities/policy-monitoring/rootcheck/how-it-works.html>`_, `OpenSCAP <https://documentation.wazuh.com/current/user-manual/capabilities/policy-monitoring/openscap/index.html>`_ and `CIS-CAT <https://documentation.wazuh.com/current/user-manual/capabilities/policy-monitoring/ciscat/ciscat.html>`_.
 
+.. note::
+    Since OpenSCAP was deprecated from version 4.0, we recommend using :ref:`Security Configuration Assessment (SCA) <manual_sec_config_assessment>` instead. The SCA was specially created by Wazuh to overcome limitations inherent to the other integrations such as OpenSCAP.
+	
+
 Use cases
 ^^^^^^^^^
 

--- a/source/user-manual/capabilities/policy-monitoring/index.rst
+++ b/source/user-manual/capabilities/policy-monitoring/index.rst
@@ -12,6 +12,10 @@ Policy monitoring is the process of verifying that all systems conform to a set 
 
 Wazuh uses three components to perform this task: *Rootcheck*, *OpenSCAP* and *CIS-CAT*.
 
+.. note::
+    Since OpenSCAP was deprecated from version 4.0, we recommend using :ref:`Security Configuration Assessment (SCA) <manual_sec_config_assessment>` instead. The SCA was specially created by Wazuh to overcome limitations inherent to the other integrations such as OpenSCAP.
+
+
 .. topic:: Contents
 
     .. toctree::

--- a/source/user-manual/capabilities/policy-monitoring/openscap/how-it-works.rst
+++ b/source/user-manual/capabilities/policy-monitoring/openscap/how-it-works.rst
@@ -6,6 +6,10 @@
 How it works
 ============
 
+.. note::
+    Since OpenSCAP was deprecated from version 4.0, we recommend using :ref:`Security Configuration Assessment (SCA) <manual_sec_config_assessment>` instead. The SCA was specially created by Wazuh to overcome limitations inherent to the other integrations such as OpenSCAP.
+
+
 The `Security Content Automation Protocol (SCAP) <https://scap.nist.gov/>`_ is a specification for expressing and manipulating security data in standardized ways. SCAP uses several specifications in order to automate continuous monitoring, vulnerability management, and reporting the results of security compliance scans.
 
 Components of the security compliance evaluation process:

--- a/source/user-manual/capabilities/policy-monitoring/openscap/index.rst
+++ b/source/user-manual/capabilities/policy-monitoring/openscap/index.rst
@@ -8,6 +8,8 @@
 OpenSCAP
 ========
 
+.. deprecated:: 4.0
+
 The **OpenSCAP wodle** is an integration of `OpenSCAP <https://www.open-scap.org/>`_ with *Wazuh HIDS* that provides the ability to perform configuration and vulnerability scans of an agent. It is primarily used for:
 
  - Verifying **security compliance**:  OpenSCAP policies define the requirements that all systems in an organization must meet in order to be in line with applicable *security policies* and/or *security benchmarks*.

--- a/source/user-manual/capabilities/policy-monitoring/openscap/index.rst
+++ b/source/user-manual/capabilities/policy-monitoring/openscap/index.rst
@@ -10,7 +10,8 @@ OpenSCAP
 
 .. deprecated:: 4.0
 
-Since OpenSCAP was deprecated from version 4.0, we recommend using :ref:`Security Configuration Assessment (SCA) <manual_sec_config_assessment>` instead. The SCA was specially created by Wazuh to overcome limitations inherent to the other integrations such as OpenSCAP.
+.. note::
+    Since OpenSCAP was deprecated from version 4.0, we recommend using :ref:`Security Configuration Assessment (SCA) <manual_sec_config_assessment>` instead. The SCA was specially created by Wazuh to overcome limitations inherent to the other integrations such as OpenSCAP.
 
 The **OpenSCAP wodle** is an integration of `OpenSCAP <https://www.open-scap.org/>`_ with *Wazuh HIDS* that provides the ability to perform configuration and vulnerability scans of an agent. It is primarily used for:
 

--- a/source/user-manual/capabilities/policy-monitoring/openscap/index.rst
+++ b/source/user-manual/capabilities/policy-monitoring/openscap/index.rst
@@ -10,6 +10,8 @@ OpenSCAP
 
 .. deprecated:: 4.0
 
+Since OpenSCAP was deprecated since version 4.0 we recommend that you use :ref:`Security Configuration Assessment (SCA) <manual_sec_config_assessment>` instead. The SCA was specially created by Wazuh to overcome limitations that were inherent to the other integrations.
+
 The **OpenSCAP wodle** is an integration of `OpenSCAP <https://www.open-scap.org/>`_ with *Wazuh HIDS* that provides the ability to perform configuration and vulnerability scans of an agent. It is primarily used for:
 
  - Verifying **security compliance**:  OpenSCAP policies define the requirements that all systems in an organization must meet in order to be in line with applicable *security policies* and/or *security benchmarks*.

--- a/source/user-manual/capabilities/policy-monitoring/openscap/index.rst
+++ b/source/user-manual/capabilities/policy-monitoring/openscap/index.rst
@@ -10,7 +10,7 @@ OpenSCAP
 
 .. deprecated:: 4.0
 
-Since OpenSCAP was deprecated since version 4.0 we recommend that you use :ref:`Security Configuration Assessment (SCA) <manual_sec_config_assessment>` instead. The SCA was specially created by Wazuh to overcome limitations that were inherent to other integrations such as OpenSCAP.
+Since OpenSCAP was deprecated since version 4.0, we recommend using :ref:`Security Configuration Assessment (SCA) <manual_sec_config_assessment>` instead. The SCA was specially created by Wazuh to overcome limitations inherent to the other integrations such as OpenSCAP.
 
 The **OpenSCAP wodle** is an integration of `OpenSCAP <https://www.open-scap.org/>`_ with *Wazuh HIDS* that provides the ability to perform configuration and vulnerability scans of an agent. It is primarily used for:
 

--- a/source/user-manual/capabilities/policy-monitoring/openscap/index.rst
+++ b/source/user-manual/capabilities/policy-monitoring/openscap/index.rst
@@ -10,7 +10,7 @@ OpenSCAP
 
 .. deprecated:: 4.0
 
-Since OpenSCAP was deprecated since version 4.0 we recommend that you use :ref:`Security Configuration Assessment (SCA) <manual_sec_config_assessment>` instead. The SCA was specially created by Wazuh to overcome limitations that were inherent to the other integrations.
+Since OpenSCAP was deprecated since version 4.0 we recommend that you use :ref:`Security Configuration Assessment (SCA) <manual_sec_config_assessment>` instead. The SCA was specially created by Wazuh to overcome limitations that were inherent to other integrations such as OpenSCAP.
 
 The **OpenSCAP wodle** is an integration of `OpenSCAP <https://www.open-scap.org/>`_ with *Wazuh HIDS* that provides the ability to perform configuration and vulnerability scans of an agent. It is primarily used for:
 

--- a/source/user-manual/capabilities/policy-monitoring/openscap/index.rst
+++ b/source/user-manual/capabilities/policy-monitoring/openscap/index.rst
@@ -10,7 +10,7 @@ OpenSCAP
 
 .. deprecated:: 4.0
 
-Since OpenSCAP was deprecated since version 4.0, we recommend using :ref:`Security Configuration Assessment (SCA) <manual_sec_config_assessment>` instead. The SCA was specially created by Wazuh to overcome limitations inherent to the other integrations such as OpenSCAP.
+Since OpenSCAP was deprecated from version 4.0, we recommend using :ref:`Security Configuration Assessment (SCA) <manual_sec_config_assessment>` instead. The SCA was specially created by Wazuh to overcome limitations inherent to the other integrations such as OpenSCAP.
 
 The **OpenSCAP wodle** is an integration of `OpenSCAP <https://www.open-scap.org/>`_ with *Wazuh HIDS* that provides the ability to perform configuration and vulnerability scans of an agent. It is primarily used for:
 

--- a/source/user-manual/capabilities/policy-monitoring/openscap/oscap-configuration.rst
+++ b/source/user-manual/capabilities/policy-monitoring/openscap/oscap-configuration.rst
@@ -8,6 +8,10 @@
 Configuration
 =============
 
+.. note::
+    Since OpenSCAP was deprecated from version 4.0, we recommend using :ref:`Security Configuration Assessment (SCA) <manual_sec_config_assessment>` instead. The SCA was specially created by Wazuh to overcome limitations inherent to the other integrations such as OpenSCAP.
+
+
 #. `Basic usage`_
 #. `Evaluate PCI-DSS compliance on RHEL7`_
 #. `Auditing Security Vulnerabilities of Red Hat Products`_

--- a/source/user-manual/capabilities/policy-monitoring/openscap/oscap-faq.rst
+++ b/source/user-manual/capabilities/policy-monitoring/openscap/oscap-faq.rst
@@ -5,6 +5,10 @@
 FAQ
 ===
 
+.. note::
+    Since OpenSCAP was deprecated from version 4.0, we recommend using :ref:`Security Configuration Assessment (SCA) <manual_sec_config_assessment>` instead. The SCA was specially created by Wazuh to overcome limitations inherent to the other integrations such as OpenSCAP.
+
+
 #. `Is there a noticeable performance impact when the OpenSCAP wodle is enabled on an agent?`_
 #. `Are evaluations executed in parallel?`_
 #. `How does the interval work?`_

--- a/source/user-manual/reference/ossec-conf/wodle-openscap.rst
+++ b/source/user-manual/reference/ossec-conf/wodle-openscap.rst
@@ -3,7 +3,13 @@
 .. _wodle_openscap:
 
 wodle name="open-scap"
-========================
+======================
+
+.. deprecated:: 4.0
+
+.. note::
+    Since OpenSCAP was deprecated from version 4.0, we recommend using :ref:`Security Configuration Assessment (SCA) <manual_sec_config_assessment>` instead. The SCA was specially created by Wazuh to overcome limitations inherent to the other integrations such as OpenSCAP.
+
 
 .. topic:: XML section name
 


### PR DESCRIPTION
## Description

<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->
This PR aims to recommend using SCA instead of OpenSCAP. 
This PR closes issue #3357.

Activities of the issue
----------------------------

**Information from issue #4398**
- The [release notes](https://documentation.wazuh.com/current/release-notes/release_4_0_0.html#breaking-changes) of the v4.0 that the OpenSCAP module no longer includes the policies
```
OpenSCAP policies removed from RPM and DEB packages. Folder present policies in the agent installation will be removed.
``` 
- Now, this module is replaced for [SCA](https://documentation.wazuh.com/current/user-manual/capabilities/sec-config-assessment/index.html), but the [OpenSCAP documentation section](https://documentation.wazuh.com/4.2/user-manual/capabilities/policy-monitoring/openscap/index.html) doesn't mention these changes.
- An update is required to avoid using this module in newer versions.
- [x] Create a branch to modify this content in the documentation: `3357_4.2_openscap_deprecated`
- [x] Inform that OpenSCAP is deprecated since version 4.0
- [x] Recommend using SCA instead of OpenSCAP
- [x] Make a complete review of the whole documentation
- [x] Perform a revision of all the changes
- [x] Ask the content team for review

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

Regards,
Damian