### PR TITLE
Update Elastic Stack basic license version

### DIFF
--- a/source/_templates/installations/basic/elastic/common/install_wazuh_kibana_plugin.rst
+++ b/source/_templates/installations/basic/elastic/common/install_wazuh_kibana_plugin.rst
@@ -8,7 +8,7 @@
 
       .. code-block:: console
 
-        # sudo -u kibana /usr/share/kibana/bin/kibana-plugin install https://packages.wazuh.com/4.x/ui/kibana/wazuh_kibana-4.2.5_7.12.1-1.zip
+        # sudo -u kibana /usr/share/kibana/bin/kibana-plugin install https://packages.wazuh.com/4.x/ui/kibana/wazuh_kibana-4.2.5_7.14.2-1.zip
 
 
 
@@ -17,7 +17,7 @@
 
       .. code-block:: console
 
-        # sudo -u kibana /usr/share/kibana/bin/kibana-plugin install file:///path/wazuh_kibana-4.2.5_7.12.1-1.zip
+        # sudo -u kibana /usr/share/kibana/bin/kibana-plugin install file:///path/wazuh_kibana-4.2.5_7.14.2-1.zip
 
 
 

--- a/source/_templates/installations/basic/elastic/deb/install_elasticsearch.rst
+++ b/source/_templates/installations/basic/elastic/deb/install_elasticsearch.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # apt-get install elasticsearch=7.12.1
+  # apt-get install elasticsearch=7.14.2
 
 .. End of include file

--- a/source/_templates/installations/basic/elastic/deb/install_filebeat.rst
+++ b/source/_templates/installations/basic/elastic/deb/install_filebeat.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # apt-get install filebeat=7.12.1
+  # apt-get install filebeat=7.14.2
 
 .. End of include file

--- a/source/_templates/installations/basic/elastic/deb/install_kibana.rst
+++ b/source/_templates/installations/basic/elastic/deb/install_kibana.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # apt-get install kibana=7.12.1
+  # apt-get install kibana=7.14.2
 
 .. End of include file

--- a/source/_templates/installations/basic/elastic/yum/install_elasticsearch.rst
+++ b/source/_templates/installations/basic/elastic/yum/install_elasticsearch.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # yum install elasticsearch-7.12.1
+  # yum install elasticsearch-7.14.2
 
 .. End of include file

--- a/source/_templates/installations/basic/elastic/yum/install_filebeat.rst
+++ b/source/_templates/installations/basic/elastic/yum/install_filebeat.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # yum install filebeat-7.12.1
+  # yum install filebeat-7.14.2
 
 .. End of include file

--- a/source/_templates/installations/basic/elastic/yum/install_kibana.rst
+++ b/source/_templates/installations/basic/elastic/yum/install_kibana.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # yum install kibana-7.12.1
+  # yum install kibana-7.14.2
 
 .. End of include file

--- a/source/_templates/installations/basic/elastic/zypp/install_elasticsearch.rst
+++ b/source/_templates/installations/basic/elastic/zypp/install_elasticsearch.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # zypper install elasticsearch-7.12.1
+  # zypper install elasticsearch-7.14.2
 
 .. End of include file

--- a/source/_templates/installations/basic/elastic/zypp/install_filebeat.rst
+++ b/source/_templates/installations/basic/elastic/zypp/install_filebeat.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # zypper install filebeat-7.12.1
+  # zypper install filebeat-7.14.2
 
 .. End of include file

--- a/source/_templates/installations/basic/elastic/zypp/install_kibana.rst
+++ b/source/_templates/installations/basic/elastic/zypp/install_kibana.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # zypper install kibana-7.12.1
+  # zypper install kibana-7.14.2
 
 .. End of include file

--- a/source/conf.py
+++ b/source/conf.py
@@ -505,7 +505,7 @@ custom_replacements = {
     "|DEB_MANAGER|" : "https://packages.wazuh.com/4.x/apt/pool/main/w/wazuh-manager/wazuh-manager",
     "|DEB_API|" : "https://packages.wazuh.com/4.x/apt/pool/main/w/wazuh-api/wazuh-api",
     # Variables for Elastic's Elasticsearch
-    "|ELASTICSEARCH_ELK_LATEST|" : "7.12.1",
+    "|ELASTICSEARCH_ELK_LATEST|" : "7.14.2",
     "|ELASTICSEARCH_ELK_LATEST_ANSIBLE|" : "7.10.2",
     "|ELASTICSEARCH_ELK_LATEST_KUBERNETES|" : "7.10.2",
     "|ELASTICSEARCH_ELK_LATEST_PUPPET|" : "7.10.2",

--- a/source/installation-guide/more-installation-alternatives/elastic-stack/all-in-one-deployment/all-in-one.rst
+++ b/source/installation-guide/more-installation-alternatives/elastic-stack/all-in-one-deployment/all-in-one.rst
@@ -135,23 +135,24 @@ This command should have an output like this:
 .. code-block:: console
   :class: output
   
-  {
-    "name" : "elasticsearch",
-    "cluster_name" : "elasticsearch",
-    "cluster_uuid" : "4AgWSXskREu4aSlW9W-WjA",
-    "version" : {
-      "number" : "7.12.1",
-      "build_flavor" : "default",
-      "build_type" : "rpm",
-      "build_hash" : "3186837139b9c6b6d23c3200870651f10d3343b7",
-      "build_date" : "2021-04-20T20:56:39.040728659Z",
-      "build_snapshot" : false,
-      "lucene_version" : "8.8.0",
-      "minimum_wire_compatibility_version" : "6.8.0",
-      "minimum_index_compatibility_version" : "6.0.0-beta1"
-    },
-    "tagline" : "You Know, for Search"
-  }
+   {
+     "name" : "elasticsearch",
+     "cluster_name" : "elasticsearch",
+     "cluster_uuid" : "upF9h1afQN2TfHtt0h3Kuw",
+     "version" : {
+       "number" : "7.14.2",
+       "build_flavor" : "default",
+       "build_type" : "rpm",
+       "build_hash" : "6bc13727ce758c0e943c3c21653b3da82f627f75",
+       "build_date" : "2021-09-15T10:18:09.722761972Z",
+       "build_snapshot" : false,
+       "lucene_version" : "8.9.0",
+       "minimum_wire_compatibility_version" : "6.8.0",
+       "minimum_index_compatibility_version" : "6.0.0-beta1"
+     },
+     "tagline" : "You Know, for Search"
+   }
+
   
   
   
@@ -305,27 +306,6 @@ To ensure that Filebeat has been successfully installed, run the following comma
     .. code-block:: console
 
       # filebeat test output
-
-An example response should look as follows:
-
-.. code-block:: none
-  :class: output
-
-  elasticsearch: https://127.0.0.1:9200...
-    parse url... OK
-    connection...
-      parse host... OK
-      dns lookup... OK
-      addresses: 127.0.0.1
-      dial up... OK
-    TLS...
-      security: server's certificate chain verification is enabled
-      handshake... OK
-      TLS version: TLSv1.3
-      dial up... OK
-    talk to server... OK
-    version: 7.12.1
-   
 
 
 Kibana installation and configuration

--- a/source/installation-guide/more-installation-alternatives/elastic-stack/distributed-deployment/step-by-step-installation/wazuh-cluster/wazuh-multi-node-cluster.rst
+++ b/source/installation-guide/more-installation-alternatives/elastic-stack/distributed-deployment/step-by-step-installation/wazuh-cluster/wazuh-multi-node-cluster.rst
@@ -220,26 +220,6 @@ To ensure that Filebeat has been successfully installed, run the following comma
 
       # filebeat test output
 
-An example response should look as follows:
-
-.. code-block:: none
-  :class: output
-
-  elasticsearch: https://127.0.0.1:9200...
-    parse url... OK
-    connection...
-      parse host... OK
-      dns lookup... OK
-      addresses: 127.0.0.1
-      dial up... OK
-    TLS...
-      security: server's certificate chain verification is enabled
-      handshake... OK
-      TLS version: TLSv1.3
-      dial up... OK
-    talk to server... OK
-    version: 7.12.1
-
 
 Disabling repositories
 ----------------------

--- a/source/installation-guide/more-installation-alternatives/elastic-stack/distributed-deployment/step-by-step-installation/wazuh-cluster/wazuh-single-node-cluster.rst
+++ b/source/installation-guide/more-installation-alternatives/elastic-stack/distributed-deployment/step-by-step-installation/wazuh-cluster/wazuh-single-node-cluster.rst
@@ -190,28 +190,6 @@ To ensure that Filebeat has been successfully installed, run the following comma
 
       # filebeat test output
 
-An example response should look as follows:
-
-.. code-block:: none
-  :class: output
-
-  elasticsearch: https://127.0.0.1:9200...
-    parse url... OK
-    connection...
-      parse host... OK
-      dns lookup... OK
-      addresses: 127.0.0.1
-      dial up... OK
-    TLS...
-      security: server's certificate chain verification is enabled
-      handshake... OK
-      TLS version: TLSv1.3
-      dial up... OK
-    talk to server... OK
-    version: 7.12.1
-   
-
-
 
 Disabling repositories
 ----------------------


### PR DESCRIPTION

## Description

This PR updates the Elastic Stack version to 7.14.2. 

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

## Note to the reviewer

This PR includes changes to the `redirect.js` script that need to be included in all production branches.
