### PR TITLE
Fix import key command

### DIFF
--- a/source/user-manual/registering/restful-api-registration.rst
+++ b/source/user-manual/registering/restful-api-registration.rst
@@ -159,7 +159,7 @@ Choose the tab corresponding to the Wazuh agent host operating system:
 
          .. code-block:: console
 
-          # 'C:\Program Files (x86)\ossec-agent\manage_agents' -i <key>
+          # & "C:\Program Files (x86)\ossec-agent\manage_agents.exe" -i <key>
 
          An example output of the command looks as follows:
 


### PR DESCRIPTION
## Description

This PR only addresses the non-working `'C:\Program Files (x86)\ossec-agent\manage_agents' -i KEY` command. It changes it to a working Powershell command version. It closes #4299.

## Checks
- [X] It compiles without warnings.
- [X] Spelling and grammar. 
- [X] Used impersonal speech. 
- [X] Used uppercase only on nouns. 
- [X] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).