### PR TITLE
Fix AWS load balancers `Path to logs` value and add footnote

### DIFF
--- a/source/amazon/services/supported-services/index.rst
+++ b/source/amazon/services/supported-services/index.rst
@@ -10,8 +10,7 @@ Supported services
 
 All the services except ``Inspector`` and ``CloudWatch Logs`` get their data from log files stored in an ``S3`` bucket. These services store their data into log files which are configured inside ``<bucket type='TYPE'> </bucket>`` tags, while ``Inspector`` and ``CloudWatch Logs`` services are configured inside ``<service type='inspector'> </service>`` and ``<service type='cloudwatchlogs'> </service>`` tags, respectively.
 
-The next table contains the more relevant information about configuring each service in ``ossec.conf``:
-
+The next table contains the most relevant information about configuring each service in ``ossec.conf``:
 
 +--------------+----------------------------------------------------------+-----------------------+----------------+------------------------------------------------------------------------------------------------------------------+
 | **Provider** | **Service**                                              | **Configuration tag** | **Type**       | **Path to logs**                                                                                                 |
@@ -22,11 +21,11 @@ The next table contains the more relevant information about configuring each ser
 +--------------+----------------------------------------------------------+-----------------------+----------------+------------------------------------------------------------------------------------------------------------------+
 | Amazon       | :ref:`Config <amazon_config>`                            | bucket                | config         | <bucket_name>/<prefix>/AWSLogs/<suffix>/<account_id>/Config/<region>/<year>/<month>/<day>                        |
 +--------------+----------------------------------------------------------+-----------------------+----------------+------------------------------------------------------------------------------------------------------------------+
-| Amazon       | :ref:`ALB <amazon_alb>`                                  | bucket                | alb            | <bucket_name>/<prefix>/<account_id>/elasticloadbalancing/<region>/<year>/<month>/<day>                           |
+| Amazon       | :ref:`ALB <amazon_alb>`                                  | bucket                | alb            | <bucket_name>/<prefix>/AWSLogs//<account_id>/elasticloadbalancing/<region>/<year>/<month>/<day>                  |
 +--------------+----------------------------------------------------------+-----------------------+----------------+------------------------------------------------------------------------------------------------------------------+
-| Amazon       | :ref:`CLB <amazon_clb>`                                  | bucket                | clb            | <bucket_name>/<prefix>/<account_id>/elasticloadbalancing/<region>/<year>/<month>/<day>                           |
+| Amazon       | :ref:`CLB <amazon_clb>`                                  | bucket                | clb            | <bucket_name>/<prefix>/AWSLogs/<account_id>/elasticloadbalancing/<region>/<year>/<month>/<day>                   |
 +--------------+----------------------------------------------------------+-----------------------+----------------+------------------------------------------------------------------------------------------------------------------+
-| Amazon       | :ref:`NLB <amazon_nlb>`                                  | bucket                | nlb            | <bucket_name>/<prefix>/<account_id>/elasticloadbalancing/<region>/<year>/<month>/<day>                           |
+| Amazon       | :ref:`NLB <amazon_nlb>`                                  | bucket                | nlb            | <bucket_name>/<prefix>/AWSLogs/<account_id>/elasticloadbalancing/<region>/<year>/<month>/<day>                   |
 +--------------+----------------------------------------------------------+-----------------------+----------------+------------------------------------------------------------------------------------------------------------------+
 | Amazon       | :ref:`KMS <amazon_kms>`                                  | bucket                | custom         | <bucket_name>/<prefix>/<year>/<month>/<day>                                                                      |
 +--------------+----------------------------------------------------------+-----------------------+----------------+------------------------------------------------------------------------------------------------------------------+

--- a/source/amazon/services/supported-services/index.rst
+++ b/source/amazon/services/supported-services/index.rst
@@ -13,7 +13,7 @@ All the services except ``Inspector`` and ``CloudWatch Logs`` get their data fro
 The next table contains the most relevant information about configuring each service in ``ossec.conf``:
 
 +--------------+----------------------------------------------------------+-----------------------+----------------+------------------------------------------------------------------------------------------------------------------+
-| **Provider** | **Service**                                              | **Configuration tag** | **Type**       | **Path to logs**                                                                                                 |
+| **Provider** | **Service**                                              | **Configuration tag** | **Type**       | **Path to logs** [#path]_                                                                                        |
 +--------------+----------------------------------------------------------+-----------------------+----------------+------------------------------------------------------------------------------------------------------------------+
 | Amazon       | :ref:`CloudTrail <amazon_cloudtrail>`                    | bucket                | cloudtrail     | <bucket_name>/<prefix>/AWSLogs/<suffix>/<organization_id>/<account_id>/CloudTrail/<region>/<year>/<month>/<day>  |
 +--------------+----------------------------------------------------------+-----------------------+----------------+------------------------------------------------------------------------------------------------------------------+
@@ -21,7 +21,7 @@ The next table contains the most relevant information about configuring each ser
 +--------------+----------------------------------------------------------+-----------------------+----------------+------------------------------------------------------------------------------------------------------------------+
 | Amazon       | :ref:`Config <amazon_config>`                            | bucket                | config         | <bucket_name>/<prefix>/AWSLogs/<suffix>/<account_id>/Config/<region>/<year>/<month>/<day>                        |
 +--------------+----------------------------------------------------------+-----------------------+----------------+------------------------------------------------------------------------------------------------------------------+
-| Amazon       | :ref:`ALB <amazon_alb>`                                  | bucket                | alb            | <bucket_name>/<prefix>/AWSLogs//<account_id>/elasticloadbalancing/<region>/<year>/<month>/<day>                  |
+| Amazon       | :ref:`ALB <amazon_alb>`                                  | bucket                | alb            | <bucket_name>/<prefix>/AWSLogs/<account_id>/elasticloadbalancing/<region>/<year>/<month>/<day>                   |
 +--------------+----------------------------------------------------------+-----------------------+----------------+------------------------------------------------------------------------------------------------------------------+
 | Amazon       | :ref:`CLB <amazon_clb>`                                  | bucket                | clb            | <bucket_name>/<prefix>/AWSLogs/<account_id>/elasticloadbalancing/<region>/<year>/<month>/<day>                   |
 +--------------+----------------------------------------------------------+-----------------------+----------------+------------------------------------------------------------------------------------------------------------------+
@@ -47,6 +47,9 @@ The next table contains the most relevant information about configuring each ser
 +--------------+----------------------------------------------------------+-----------------------+----------------+------------------------------------------------------------------------------------------------------------------+
 | Cisco        | :ref:`Umbrella <cisco_umbrella>`                         | bucket                | cisco_umbrella | <bucket_name>/<prefix>/<year>-<month>-<day>                                                                      |
 +--------------+----------------------------------------------------------+-----------------------+----------------+------------------------------------------------------------------------------------------------------------------+
+
+.. [#path]
+    The **Path to logs** column is the path where the logs will be stored in the bucket if the corresponding service uses them as its storage medium.
 
 .. toctree::
     :maxdepth: 1

--- a/source/amazon/services/supported-services/index.rst
+++ b/source/amazon/services/supported-services/index.rst
@@ -10,10 +10,10 @@ Supported services
 
 All the services except ``Inspector`` and ``CloudWatch Logs`` get their data from log files stored in an ``S3`` bucket. These services store their data into log files which are configured inside ``<bucket type='TYPE'> </bucket>`` tags, while ``Inspector`` and ``CloudWatch Logs`` services are configured inside ``<service type='inspector'> </service>`` and ``<service type='cloudwatchlogs'> </service>`` tags, respectively.
 
-The next table contains the most relevant information about configuring each service in ``ossec.conf``:
+The next table contains the most relevant information about configuring each service in the ``ossec.conf`` file, as well as the path where the logs will be stored in the bucket if the corresponding service uses them as its storage medium:
 
 +--------------+----------------------------------------------------------+-----------------------+----------------+------------------------------------------------------------------------------------------------------------------+
-| **Provider** | **Service**                                              | **Configuration tag** | **Type**       | **Path to logs** [#path]_                                                                                        |
+| **Provider** | **Service**                                              | **Configuration tag** | **Type**       | **Path to logs**                                                                                                 |
 +--------------+----------------------------------------------------------+-----------------------+----------------+------------------------------------------------------------------------------------------------------------------+
 | Amazon       | :ref:`CloudTrail <amazon_cloudtrail>`                    | bucket                | cloudtrail     | <bucket_name>/<prefix>/AWSLogs/<suffix>/<organization_id>/<account_id>/CloudTrail/<region>/<year>/<month>/<day>  |
 +--------------+----------------------------------------------------------+-----------------------+----------------+------------------------------------------------------------------------------------------------------------------+
@@ -47,9 +47,6 @@ The next table contains the most relevant information about configuring each ser
 +--------------+----------------------------------------------------------+-----------------------+----------------+------------------------------------------------------------------------------------------------------------------+
 | Cisco        | :ref:`Umbrella <cisco_umbrella>`                         | bucket                | cisco_umbrella | <bucket_name>/<prefix>/<year>-<month>-<day>                                                                      |
 +--------------+----------------------------------------------------------+-----------------------+----------------+------------------------------------------------------------------------------------------------------------------+
-
-.. [#path]
-    The **Path to logs** column is the path where the logs will be stored in the bucket if the corresponding service uses them as its storage medium.
 
 .. toctree::
     :maxdepth: 1


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

| Related issue|
|--|
|Closes #4512|

## Description
In this PR we fix the `Path to logs` value of the `ALB`, `NLB`, and  `CLB` buckets in the `amazon/services/supported-services/index.html` page. We also add a footnote explaining the meaning of that column. The results of the additions are the following:
![image](https://user-images.githubusercontent.com/72474806/146414475-83127732-abb5-49aa-8b04-5208a1e7a7ed.png)


## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
