### PR TITLE
Fixed error in active response XML documentation tag

### DIFF
--- a/source/user-manual/capabilities/active-response/remediation-configuration.rst
+++ b/source/user-manual/capabilities/active-response/remediation-configuration.rst
@@ -89,7 +89,7 @@ In this example, the ``firewall-drop`` command is configured to use the ``firewa
 Command::
 
   <command>
-    <name>firewall-drop</command>
+    <name>firewall-drop</name>
     <executable>firewall-drop</executable>
   </command>
 


### PR DESCRIPTION

## Description

This PR closes #4634 and fixes an active response XML documentation tag.

## Checks
- [x] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

Regards,
Mariel
