### PR TITLE
Fix by swapping rules 550 and 554 descriptions

### DIFF
--- a/source/user-manual/capabilities/active-response/ar-use-cases/wazuh-with-yara.rst
+++ b/source/user-manual/capabilities/active-response/ar-use-cases/wazuh-with-yara.rst
@@ -63,7 +63,9 @@ It defines the criteria used to execute a specific command:
 
 - The ``location`` setting as ``local``. It means that the active response is executed on the agent that generates the alert.
 
-- You can write a list of rule IDs that will trigger the active response in the ``rules_id`` setting. This example uses rule ``550``, new file added to the system, and rule ``554``, file modified in the system.
+- You can write a list of rule IDs that will trigger the active response in the ``rules_id`` setting. This example uses:
+   * Rule ``550``, file modified in the system.
+   * Rule ``554``, new file added to the system.
 
 Rules and decoders
 ^^^^^^^^^^^^^^^^^^

--- a/source/user-manual/capabilities/active-response/ar-use-cases/wazuh-with-yara.rst
+++ b/source/user-manual/capabilities/active-response/ar-use-cases/wazuh-with-yara.rst
@@ -63,7 +63,7 @@ It defines the criteria used to execute a specific command:
 
 - The ``location`` setting as ``local``. It means that the active response is executed on the agent that generates the alert.
 
-- You can write a list of rule IDs that will trigger the active response in the ``rules_id`` setting. This example uses:
+- You can write a list of rule IDs that will trigger the active response in the ``rules_id`` setting. This example uses the following rule IDs.
    * Rule ``550``, file modified in the system.
    * Rule ``554``: new file added to the system
 

--- a/source/user-manual/capabilities/active-response/ar-use-cases/wazuh-with-yara.rst
+++ b/source/user-manual/capabilities/active-response/ar-use-cases/wazuh-with-yara.rst
@@ -65,7 +65,7 @@ It defines the criteria used to execute a specific command:
 
 - You can write a list of rule IDs that will trigger the active response in the ``rules_id`` setting. This example uses:
    * Rule ``550``, file modified in the system.
-   * Rule ``554``, new file added to the system.
+   * Rule ``554``: new file added to the system
 
 Rules and decoders
 ^^^^^^^^^^^^^^^^^^

--- a/source/user-manual/capabilities/active-response/ar-use-cases/wazuh-with-yara.rst
+++ b/source/user-manual/capabilities/active-response/ar-use-cases/wazuh-with-yara.rst
@@ -64,7 +64,7 @@ It defines the criteria used to execute a specific command:
 - The ``location`` setting as ``local``. It means that the active response is executed on the agent that generates the alert.
 
 - You can write a list of rule IDs that will trigger the active response in the ``rules_id`` setting. This example uses the following rule IDs.
-   * Rule ``550``, file modified in the system.
+   * Rule ``550``: file modified in the system
    * Rule ``554``: new file added to the system
 
 Rules and decoders


### PR DESCRIPTION
## Description

This PR closes #4640 . It swaps the descriptions and includes a bulleted list for better readability.

## Checks
- [X] It compiles without warnings.
- [X] Spelling and grammar. 
- [X] Used impersonal speech. 
- [X] Used uppercase only on nouns. 
- [X] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).