### PR TITLE
Update upgrade endpoints in RBAC reference

### DIFF
--- a/source/user-manual/api/rbac/reference.rst
+++ b/source/user-manual/api/rbac/reference.rst
@@ -316,9 +316,9 @@ agent:restart
 
 agent:upgrade
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
-- :api-ref:`GET /agents/{agent_id}/upgrade_result <operation/api.controllers.agent_controller.get_agent_upgrade>` (`agent:id`_, `agent:group`_)
-- :api-ref:`PUT /agents/{agent_id}/upgrade <operation/api.controllers.agent_controller.put_upgrade_agent>` (`agent:id`_, `agent:group`_)
-- :api-ref:`PUT /agents/{agent_id}/upgrade_custom <operation/api.controllers.agent_controller.put_upgrade_custom_agent>` (`agent:id`_, `agent:group`_)
+- :api-ref:`GET /agents/upgrade_result <operation/api.controllers.agent_controller.get_agent_upgrade>` (`agent:id`_, `agent:group`_)
+- :api-ref:`PUT /agents/upgrade <operation/api.controllers.agent_controller.put_upgrade_agents>` (`agent:id`_, `agent:group`_)
+- :api-ref:`PUT /agents/upgrade_custom <operation/api.controllers.agent_controller.put_upgrade_custom_agents>` (`agent:id`_, `agent:group`_)
 
 
 Ciscat


### PR DESCRIPTION
## Description

This pull request adds a minor change to the API RBAC reference.

When the upgrade API endpoints were changed to use a list of agents instead of only an agent ID, a pull request to the documentation repository was created and merged. This PR added this change, among others:

https://github.com/wazuh/wazuh-documentation/commit/a4e4341c1ebac6e403cf097f3755ee8f1f092ed3

Related issue: https://github.com/wazuh/wazuh/issues/5536

After a merge, the endpoints were changed again to the old ones in the RBAC reference: https://github.com/wazuh/wazuh-documentation/commit/a9859faf05c3fa823bced521048c87797a1970b4#diff-65941c75de5a5309aadbcb6be5f41fc0841498264276439160b57eaa1f54d9e2

This pull request reverts the last change mentioned.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

## Note to the reviewer

This PR includes changes to the `redirect.js` script that need to be included in all production branches.
