### PR TITLE
Add information about `only_logs_after` and `reparse` in AWS integration's documentation

### DIFF
--- a/source/amazon/services/prerequisites/considerations.rst
+++ b/source/amazon/services/prerequisites/considerations.rst
@@ -29,7 +29,7 @@ Older logs
 
 The ``aws-s3`` Wazuh module only looks for new logs in buckets based upon the key of the last processed log object, which includes the datetime stamp. If older logs are loaded into the S3 bucket or the :ref:`only_logs_after <only_logs_aws_buckets>` option date is set to a datetime earlier than previous executions of the module, the older log files will be ignored and not ingested into Wazuh.
 
-On the other hand, the ``CloudWatch Logs`` module can process logs older than the first one processed. To do that it is only necessary to specify an older ``only_logs_after`` value, and the module will process all logs between the value set for ``only_logs_after`` and the first log executed without generating duplicate alerts.
+On the other hand, the ``CloudWatch Logs`` module can process logs older than the first one processed. To do so, specify an older ``only_logs_after`` value, and the module will process all logs between the value set for ``only_logs_after`` and the first log executed without generating duplicate alerts.
 
 
 Reparse
@@ -39,7 +39,7 @@ Reparse
   Option not available for CloudWatch Logs.
 
 .. warning::
-  Using the ``reparse`` option will fetch and process every log from the beginning date until the present. It will most likely generate duplicate alerts.
+  Using the ``reparse`` option will fetch and process every log from the starting date until the present. This process may generate duplicate alerts.
 
 To process older logs, it's necessary to manually execute the module using the ``--reparse`` or ``-o`` option. Executing the module with this option will use the ``only_logs_after`` value provided to fetch and process every log from that date until the present. If no ``only_logs_after`` value was provided, it will use the date of the first file processed.
 

--- a/source/amazon/services/prerequisites/considerations.rst
+++ b/source/amazon/services/prerequisites/considerations.rst
@@ -27,7 +27,9 @@ If the S3 bucket contains a long history of logs and its directory structure is 
 Older logs
 ----------
 
-The ``aws-s3`` Wazuh module only looks for new logs based upon the key for last processed log object, which includes the datetime stamp. If older logs are loaded into the S3 bucket or the ``only_logs_after`` option date is set to a datetime earlier than previous executions of the module, the older log files will be ignored and not ingested into Wazuh.
+The ``aws-s3`` Wazuh module only looks for new logs in buckets based upon the key for last processed log object, which includes the datetime stamp. If older logs are loaded into the S3 bucket or the ``only_logs_after`` option date is set to a datetime earlier than previous executions of the module, the older log files will be ignored and not ingested into Wazuh.
+
+On the other hand, the ``CloudWatch Logs`` module can process logs older than the first one processed. To do that it is only necessary to specify an older ``only_logs_after`` value, and the module will process all logs between the value set for ``only_logs_after`` and the first log executed without generating duplicate alerts.
 
 
 Reparse

--- a/source/amazon/services/prerequisites/considerations.rst
+++ b/source/amazon/services/prerequisites/considerations.rst
@@ -8,6 +8,11 @@
 Considerations for configuration
 ================================
 
+First execution
+---------------
+
+If no ``only_logs_after`` value was provided, the module will only fetch the logs of the date of the execution.
+
 Filtering
 ---------
 
@@ -24,6 +29,26 @@ Older logs
 
 The ``aws-s3`` Wazuh module only looks for new logs based upon the key for last processed log object, which includes the datetime stamp. If older logs are loaded into the S3 bucket or the ``only_logs_after`` option date is set to a datetime earlier than previous executions of the module, the older log files will be ignored and not ingested into Wazuh.
 
+
+Reparse
+~~~~~~~
+
+.. note::
+  Option not available for CloudWatch Logs.
+
+.. warning::
+  Using the ``reparse`` option will fetch and process every log from the beginning date until the present. It will most likely generate duplicate alerts.
+
+To process older logs, it's necessary to manually execute the module using the ``--reparse`` or ``-o`` option. Executing the module with this option will use the ``only_logs_after`` value provided to fetch and process every log from that date until the present. If no ``only_logs_after`` value was provided, it will use the date of the first file processed.
+
+Below there is an example of a manual execution of the module using the ``--reparse`` option on a manager using ``/var/ossec`` as the Wazuh installation path:
+
+.. code-block:: console
+
+  # cd /var/ossec/wodles/aws
+  # ./aws-s3 -b 'wazuh-example-bucket' --reparse --only_logs_after '2021-Jun-10' --debug 2
+
+The ``--debug 2`` parameter was used to get a verbose output since by default the script won't print anything on the terminal, and it could seem like it's not working when it could be handling a great amount of data instead.
 
 Configuring multiple services
 -----------------------------

--- a/source/amazon/services/prerequisites/considerations.rst
+++ b/source/amazon/services/prerequisites/considerations.rst
@@ -11,7 +11,7 @@ Considerations for configuration
 First execution
 ---------------
 
-If no ``only_logs_after`` value was provided, the module will only fetch the logs of the date of the execution.
+If no :ref:`only_logs_after <only_logs_aws_buckets>` value was provided, the module will only fetch the logs of the date of the execution.
 
 Filtering
 ---------
@@ -27,7 +27,7 @@ If the S3 bucket contains a long history of logs and its directory structure is 
 Older logs
 ----------
 
-The ``aws-s3`` Wazuh module only looks for new logs in buckets based upon the key of the last processed log object, which includes the datetime stamp. If older logs are loaded into the S3 bucket or the ``only_logs_after`` option date is set to a datetime earlier than previous executions of the module, the older log files will be ignored and not ingested into Wazuh.
+The ``aws-s3`` Wazuh module only looks for new logs in buckets based upon the key of the last processed log object, which includes the datetime stamp. If older logs are loaded into the S3 bucket or the :ref:`only_logs_after <only_logs_aws_buckets>` option date is set to a datetime earlier than previous executions of the module, the older log files will be ignored and not ingested into Wazuh.
 
 On the other hand, the ``CloudWatch Logs`` module can process logs older than the first one processed. To do that it is only necessary to specify an older ``only_logs_after`` value, and the module will process all logs between the value set for ``only_logs_after`` and the first log executed without generating duplicate alerts.
 

--- a/source/amazon/services/prerequisites/considerations.rst
+++ b/source/amazon/services/prerequisites/considerations.rst
@@ -27,7 +27,7 @@ If the S3 bucket contains a long history of logs and its directory structure is 
 Older logs
 ----------
 
-The ``aws-s3`` Wazuh module only looks for new logs in buckets based upon the key for last processed log object, which includes the datetime stamp. If older logs are loaded into the S3 bucket or the ``only_logs_after`` option date is set to a datetime earlier than previous executions of the module, the older log files will be ignored and not ingested into Wazuh.
+The ``aws-s3`` Wazuh module only looks for new logs in buckets based upon the key of the last processed log object, which includes the datetime stamp. If older logs are loaded into the S3 bucket or the ``only_logs_after`` option date is set to a datetime earlier than previous executions of the module, the older log files will be ignored and not ingested into Wazuh.
 
 On the other hand, the ``CloudWatch Logs`` module can process logs older than the first one processed. To do that it is only necessary to specify an older ``only_logs_after`` value, and the module will process all logs between the value set for ``only_logs_after`` and the first log executed without generating duplicate alerts.
 
@@ -43,7 +43,7 @@ Reparse
 
 To process older logs, it's necessary to manually execute the module using the ``--reparse`` or ``-o`` option. Executing the module with this option will use the ``only_logs_after`` value provided to fetch and process every log from that date until the present. If no ``only_logs_after`` value was provided, it will use the date of the first file processed.
 
-Below there is an example of a manual execution of the module using the ``--reparse`` option on a manager using ``/var/ossec`` as the Wazuh installation path:
+Below there is an example of a manual execution of the module using the ``--reparse`` option on a manager, being ``/var/ossec`` the Wazuh installation path:
 
 .. code-block:: console
 

--- a/source/user-manual/reference/ossec-conf/wodle-s3.rst
+++ b/source/user-manual/reference/ossec-conf/wodle-s3.rst
@@ -333,10 +333,10 @@ If defined, the suffix for the bucket. Only works with buckets which contain the
 bucket\\only_logs_after
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-A valid date, in YYYY-MMM-DD format, that only logs from after that date will be parsed.  All logs from before that date will be skipped.
+A valid date, in YYYY-MMM-DD format. Only logs from that date onwards will be parsed.
 
 +--------------------+-------------+
-| **Default value**  | 1970-JAN-01 |
+| **Default value**  | None        |
 +--------------------+-------------+
 | **Allowed values** | Valid date  |
 +--------------------+-------------+
@@ -609,10 +609,10 @@ Service\\only_logs_after
 
 .. versionadded:: 4.0.0
 
-A valid date, in YYYY-MMM-DD format. Only those logs from after that date will be parsed, the logs from before that date will be skipped. Only works for CloudWatch Logs service.
+A valid date, in YYYY-MMM-DD format. Only logs from that date onwards will be parsed. Only works with the CloudWatch Logs service.
 
 +--------------------+-------------+
-| **Default value**  | 1970-JAN-01 |
+| **Default value**  | None        |
 +--------------------+-------------+
 | **Allowed values** | Valid date  |
 +--------------------+-------------+

--- a/source/user-manual/reference/ossec-conf/wodle-s3.rst
+++ b/source/user-manual/reference/ossec-conf/wodle-s3.rst
@@ -330,16 +330,18 @@ If defined, the suffix for the bucket. Only works with buckets which contain the
 | **Allowed values** | Valid path    |
 +--------------------+---------------+
 
+.. _only_logs_aws_buckets:
+
 bucket\\only_logs_after
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 A valid date, in YYYY-MMM-DD format. Only logs from that date onwards will be parsed.
 
-+--------------------+-------------+
-| **Default value**  | None        |
-+--------------------+-------------+
-| **Allowed values** | Valid date  |
-+--------------------+-------------+
++--------------------+-----------------------------------+
+| **Default value**  | Date of execution at ``00:00:00`` |
++--------------------+-----------------------------------+
+| **Allowed values** | Valid date                        |
++--------------------+-----------------------------------+
 
 bucket\\regions
 ^^^^^^^^^^^^^^^
@@ -611,11 +613,11 @@ Service\\only_logs_after
 
 A valid date, in YYYY-MMM-DD format. Only logs from that date onwards will be parsed. This option is only available for the CloudWatch Logs service.
 
-+--------------------+-------------+
-| **Default value**  | None        |
-+--------------------+-------------+
-| **Allowed values** | Valid date  |
-+--------------------+-------------+
++--------------------+-----------------------------------+
+| **Default value**  | Date of execution at ``00:00:00`` |
++--------------------+-----------------------------------+
+| **Allowed values** | Valid date                        |
++--------------------+-----------------------------------+
 
 Service\\regions
 ^^^^^^^^^^^^^^^^

--- a/source/user-manual/reference/ossec-conf/wodle-s3.rst
+++ b/source/user-manual/reference/ossec-conf/wodle-s3.rst
@@ -609,7 +609,7 @@ Service\\only_logs_after
 
 .. versionadded:: 4.0.0
 
-A valid date, in YYYY-MMM-DD format. Only logs from that date onwards will be parsed. Only works with the CloudWatch Logs service.
+A valid date, in YYYY-MMM-DD format. Only logs from that date onwards will be parsed. This option is only available for the CloudWatch Logs service.
 
 +--------------------+-------------+
 | **Default value**  | None        |


### PR DESCRIPTION
## Description
This PR adds information regarding using the `only_logs_after` and `reparse` parameters in the AWS integration module. This PR is part of the #4648 issue.

## Screenshots of the changes made to the documentation
![image](https://user-images.githubusercontent.com/72474806/144625218-61b37046-94a9-463e-9a65-7432a8db76ea.png)
![image](https://user-images.githubusercontent.com/72474806/144626263-06c008a7-9bf0-4fc1-ae45-aee118ff67bb.png)
![image](https://user-images.githubusercontent.com/72474806/144625394-80ee5bdb-3b24-445e-95d4-6dfbeb215ed5.png)
![image](https://user-images.githubusercontent.com/72474806/144625441-832a3539-7571-4eaf-b186-64fbfe949c7b.png)


## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
