### PR TITLE
Propagate "Update upgrade endpoints in RBAC reference" changes to 4.2

### DIFF
--- a/source/user-manual/api/rbac/reference.rst
+++ b/source/user-manual/api/rbac/reference.rst
@@ -327,9 +327,9 @@ agent:restart
 
 agent:upgrade
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
-- :api-ref:`GET /agents/{agent_id}/upgrade_result <operation/api.controllers.agent_controller.get_agent_upgrade>` (`agent:id`_, `agent:group`_)
-- :api-ref:`PUT /agents/{agent_id}/upgrade <operation/api.controllers.agent_controller.put_upgrade_agent>` (`agent:id`_, `agent:group`_)
-- :api-ref:`PUT /agents/{agent_id}/upgrade_custom <operation/api.controllers.agent_controller.put_upgrade_custom_agent>` (`agent:id`_, `agent:group`_)
+- :api-ref:`GET /agents/upgrade_result <operation/api.controllers.agent_controller.get_agent_upgrade>` (`agent:id`_, `agent:group`_)
+- :api-ref:`PUT /agents/upgrade <operation/api.controllers.agent_controller.put_upgrade_agents>` (`agent:id`_, `agent:group`_)
+- :api-ref:`PUT /agents/upgrade_custom <operation/api.controllers.agent_controller.put_upgrade_custom_agents>` (`agent:id`_, `agent:group`_)
 
 
 Ciscat


### PR DESCRIPTION

## Description

This PR propagates changes made in #4649 [initially to 4.1] to 4.2.
Description from original PR:

> This pull request adds a minor change to the API RBAC reference.
> 
> When the upgrade API endpoints were changed to use a list of agents instead of only an agent ID, a pull request to the documentation repository was created and merged. This PR added this change, among others:
> 
> a4e4341
> 
> Related issue: wazuh/wazuh#5536
> 
> After a merge, the endpoints were changed again to the old ones in the RBAC reference: a9859fa#diff-65941c75de5a5309aadbcb6be5f41fc0841498264276439160b57eaa1f54d9e2
> 
> This pull request reverts the last change mentioned.
> 

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->


