### PR TITLE
[4.2] Hide release note link from navigation

### DIFF
--- a/source/_static/js/redirects.js
+++ b/source/_static/js/redirects.js
@@ -356,8 +356,6 @@ removedUrls['4.2'] = [
   '/release-notes/release_4_1_3.html',
   '/release-notes/release_4_1_4.html',
   '/release-notes/release_4_1_5.html',
-  '/release-notes/release_4_2_0.html',
-  '/release-notes/release_4_2_1.html',
   '/user-manual/api/securing_api.html',
   '/user-manual/configuring-cluster/cluster_management.html',
   '/user-manual/manager/manual-email-report/smtp_authentication.html',

--- a/source/_static/js/release-note-redirect.js
+++ b/source/_static/js/release-note-redirect.js
@@ -7,3 +7,9 @@ let currentPath = window.location.pathname;
         newUrl = currentPath.replaceAll('_', '-');
         window.location.replace(newUrl);   
     }
+
+/* Remove element from navigation */
+
+let releaseNoteNavLink = document.querySelectorAll("a[href='release_4_2_0.html']")[0];
+let releaseNoteNavLinkParent = releaseNoteNavLink.parentNode;
+releaseNoteNavLinkParent.remove();

--- a/source/_static/js/release-note-redirect.js
+++ b/source/_static/js/release-note-redirect.js
@@ -11,5 +11,7 @@ let currentPath = window.location.pathname;
 /* Remove element from navigation */
 
 let releaseNoteNavLink = document.querySelectorAll("a[href='release_4_2_0.html']")[0];
-let releaseNoteNavLinkParent = releaseNoteNavLink.parentNode;
-releaseNoteNavLinkParent.remove();
+if(releaseNoteNavLink) {
+    let releaseNoteNavLinkParent = releaseNoteNavLink.parentNode;
+    releaseNoteNavLinkParent.remove();
+}

--- a/source/release-notes/index.rst
+++ b/source/release-notes/index.rst
@@ -13,12 +13,6 @@ This section summarizes the most important features of each Wazuh release.
 
     .. toctree::
         :maxdepth: 2
-        :hidden:
-        
-        release_4_2_0
-
-    .. toctree::
-        :maxdepth: 2
         
         release-4-2-5
         release-4-2-4
@@ -79,3 +73,9 @@ This section summarizes the most important features of each Wazuh release.
         release-3-1-0
         release-3-0-0
         release-2-1
+
+    .. toctree::
+        :maxdepth: 1
+        :hidden:
+        
+        release_4_2_0


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description
This PR hides the hidden 4.2.0 release note link from navigation.
<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

## Checks
- [ ] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).