### PR TITLE
Fix CPE helper introduction in Vulnerability Detector

### DIFF
--- a/source/user-manual/capabilities/vulnerability-detection/cpe-helper.rst
+++ b/source/user-manual/capabilities/vulnerability-detection/cpe-helper.rst
@@ -8,15 +8,11 @@
 CPE Helper
 ==========
 
-Since Wazuh 3.11.0, Vulnerability Detector relies on the National Vulnerability Database to analyze vulnerabilities on Windows agents.
-In a future release, this integration is attempted to be extended to the rest of operating systems.
+Since Wazuh 3.11.0, Vulnerability Detector relies on the National Vulnerability Database to report vulnerabilities affecting the software inventory of Windows agents.
 
-The package inventory of agents is stored in Wazuh DB and used by Vulnerability Detector directly.
-This inventory is contrasted against vulnerability feeds, generating alerts if vulnerabilities are detected. However,
-program names submitted by Syscollector from Windows agents are not valid to look for vulnerabilities in the feed of the National Vulnerability Database.
+To achieve this goal, an auxiliary dictionary is included in order to translate the gathered program names to the standard format used by the NVD, which is called `CPE (Common Platform Enumeration) <https://nvd.nist.gov/products/cpe>`_.
 
-For this reason, an auxiliary dictionary has been created, that could convert the software inventory of Windows agents to the standard format used by this
-provider: `CPE (Common Platform Enumeration) <https://nvd.nist.gov/products/cpe>`_.
+Every single program in the Windows agents must be covered in this dictionary to be scanned for vulnerabilities.
 
 - `CPE Helper Schema`_
 - `Dictionary schema`_


### PR DESCRIPTION
## Description

This pull request clarifies the introduction of the CPE helper dictionary in Vulnerability Detector. This is mainly motivated by this statement:
```
In a future release, this integration is attempted to be extended to the rest of operating systems.
```
which is outdated since several versions ago.

This is a fix of the current documentation so it would be great to merge it directly in the production branch.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
