### PR TITLE
Add ipv6 support

### DIFF
--- a/source/user-manual/reference/ossec-conf/auth.rst
+++ b/source/user-manual/reference/ossec-conf/auth.rst
@@ -27,6 +27,7 @@ Options
 - `disabled`_
 - `remote_enrollment`_
 - `port`_
+- `ipv6`_
 - `use_source_ip`_
 - `force`_
 - `purge`_
@@ -74,6 +75,19 @@ Defines the TCP port number for listening to connections.
 +--------------------+---------------------+
 
 .. _auth_use_source_ip:
+
+ipv6
+^^^^^^^^^^^
+
+.. versionadded:: 4.4.0
+
+Enable IPv6 support.
+
++--------------------+------------------+
+| **Default value**  | no               |
++--------------------+------------------+
+| **Allowed values** | yes, no          |
++--------------------+------------------+
 
 use_source_ip
 ^^^^^^^^^^^^^

--- a/source/user-manual/reference/ossec-conf/global.rst
+++ b/source/user-manual/reference/ossec-conf/global.rst
@@ -259,9 +259,7 @@ This sets the memory size for the event correlation engine.
 white_list
 ^^^^^^^^^^
 
-This specifies an IPv4/IPv6 address, netblock, or hostname for which Active Responses will not be triggered. Only one of those
-values may be specified for each ``<while_list>`` tag, but several values may be used by including multiple
-``<white_list>`` tags. This configuration is compared against the extracted **srcip** field in the alert.
+This specifies an IPv4/IPv6 address, netblock, or hostname that will not trigger an active response. Only one of those values may be specified for each ``<while_list>`` tag, but several values may be used by including multiple ``<white_list>`` tags. This configuration is compared against the extracted **srcip** field in the alert.
 
 +--------------------+--------------------------------------------------------------------+
 | **Default value**  | n/a                                                                |

--- a/source/user-manual/reference/ossec-conf/global.rst
+++ b/source/user-manual/reference/ossec-conf/global.rst
@@ -259,20 +259,19 @@ This sets the memory size for the event correlation engine.
 white_list
 ^^^^^^^^^^
 
-This specifies an IPv4 address, netblock, or hostname for which Active Responses will not be triggered. Only one of those
+This specifies an IPv4/IPv6 address, netblock, or hostname for which Active Responses will not be triggered. Only one of those
 values may be specified for each ``<while_list>`` tag, but several values may be used by including multiple
 ``<white_list>`` tags. This configuration is compared against the extracted **srcip** field in the alert.
 
-+--------------------+---------------------------------------------------------------+
-| **Default value**  | n/a                                                           |
-+--------------------+---------------------------------------------------------------+
-| **Allowed values** | Any IPv4 address, netblock (i.e.: 192.168.0.0/16) or hostname |
-+--------------------+---------------------------------------------------------------+
++--------------------+--------------------------------------------------------------------+
+| **Default value**  | n/a                                                                |
++--------------------+--------------------------------------------------------------------+
+| **Allowed values** | Any IPv4/IPv6 address, netblock (i.e.: 192.168.0.0/16) or hostname |
++--------------------+--------------------------------------------------------------------+
 
 .. note::
 
-  This option is only valid in server and local installs. IPv4-mapped IPv6 addresses will be compared against any configured
-  IPv4 or netblock.
+  This option is only valid in server and local installs.
 
 host_information
 ^^^^^^^^^^^^^^^^

--- a/source/user-manual/reference/ossec-conf/remote.rst
+++ b/source/user-manual/reference/ossec-conf/remote.rst
@@ -110,19 +110,13 @@ Local ip address to use to listen for connections.
 ipv6
 ^^^^^^^^^^^
 
-Whether the local IP address is IPv6
+Enable IPv6 support.
 
 +--------------------+------------------+
 | **Default value**  | no               |
 +--------------------+------------------+
 | **Allowed values** | yes, no          |
 +--------------------+------------------+
-
-.. note::
-
-  At the moment it's not possible to set both *local_ip* and *ipv6*.
-
-  IPv6 is not available for secure connections.
 
 queue_size
 ^^^^^^^^^^^^


### PR DESCRIPTION
## Description

This PR includes these changes:

- All references saying that IPv6 is not supported have been removed.
- A new configuration option to enable/disable IPv6 support has been included in `auth` block.

## Configuration options

```xml
<remote>
    <ipv6>yes/no</ipv6>
</remote>

<auth>
    <ipv6>yes/no</ipv6>
</auth>
```

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
