### PR TITLE
Fix GCC download URL for Solaris installation from sources

### DIFF
--- a/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-agent/index.rst
+++ b/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-agent/index.rst
@@ -632,7 +632,7 @@ Installing Wazuh agent from sources
 
           .. code-block:: console
 
-            # curl -k -O https://packages.wazuh.com/utils/gcc/gcc-5.5.0/gcc-5.5.0.tar.gz && gtar xzf gcc-5.5.0.tar.gz
+            # curl -k -O https://packages.wazuh.com/utils/gcc/gcc-5.5.0.tar.gz && gtar xzf gcc-5.5.0.tar.gz
             # ln -sf gcc-5.5.0 gcc
             # cd gcc
             # wget https://packages.wazuh.com/utils/gcc/mpfr-2.4.2.tar.bz2 && gtar xjf mpfr-2.4.2.tar.bz2 && ln -sf mpfr-2.4.2 mpfr

--- a/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-agent/index.rst
+++ b/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-agent/index.rst
@@ -822,7 +822,7 @@ Installing Wazuh agent from sources
 
            .. code-block:: console
 
-            # curl -O https://packages.wazuh.com/utils/gcc/gcc-5.5.0/gcc-5.5.0.tar.gz && gtar xzf gcc-5.5.0.tar.gz
+            # curl -O https://packages.wazuh.com/utils/gcc/gcc-5.5.0.tar.gz && gtar xzf gcc-5.5.0.tar.gz
             # ln -sf gcc-5.5.0 gcc
             # cd gcc && ./contrib/download_prerequisites
             # cd .. && mkdir -p gcc-build && cd gcc-build


### PR DESCRIPTION
|Related issue|
|---|
|Closes #4399|

## Description

Hi team!

This PR fixes invalid GCC download URL during Solaris Agent Installation from sources

## Checks
- [X] It compiles without warnings.
- [X] Spelling and grammar. 
- [X] Used impersonal speech. 
- [X] Used uppercase only on nouns. 
- [X] ~Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).~

Regards,
Nico