### PR TITLE
Fix code line highlight out-of-range warnings

### DIFF
--- a/source/_templates/installations/elastic/common/elastic-multi-node/configure_elasticsearch_initial.rst
+++ b/source/_templates/installations/elastic/common/elastic-multi-node/configure_elasticsearch_initial.rst
@@ -35,7 +35,6 @@
   
 
     .. code-block:: yaml
-        :emphasize-lines: 5
 
         opendistro_security.nodes_dn:
             - CN=node-1,OU=Docu,O=Wazuh,L=California,C=US

--- a/source/_templates/installations/elastic/common/elastic-multi-node/configure_elasticsearch_subsequent.rst
+++ b/source/_templates/installations/elastic/common/elastic-multi-node/configure_elasticsearch_subsequent.rst
@@ -35,7 +35,6 @@
       ``CN=<common_name>,OU=<operational_unit>,O=<organization_name>,L=<locality>,C=<country_code>``
   
         .. code-block:: yaml
-            :emphasize-lines: 5
 
             opendistro_security.nodes_dn:
                 - CN=node-1,OU=Docu,O=Wazuh,L=California,C=US


### PR DESCRIPTION
## Description

This PR removes code highlighting lines that were previously removed.

## Checks
- [X] It compiles without warnings.
- [X] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [X] Used uppercase only on nouns. 
- [X] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).