### PR TITLE
Fix link to SCA examples in repo

### DIFF
--- a/source/user-manual/capabilities/sec-config-assessment/creating-custom-policies.rst
+++ b/source/user-manual/capabilities/sec-config-assessment/creating-custom-policies.rst
@@ -357,7 +357,7 @@ Examples
 
 The following sections cover each rule type, illustrating them with several examples. It is also recommended to check
 the actual policies and, for minimalistic although complete examples, the `SCA test suite policies
-<https://github.com/wazuh/wazuh-qa/tree/master/tests/integration/test_sca/test_basic_usage/data>`_.
+<https://github.com/wazuh/wazuh-qa/tree/master/tests/legacy/test_sca/test_basic_usage/data>`_.
 
 Rule syntax for files
 :::::::::::::::::::::::::::::::::::


### PR DESCRIPTION
## Description

This PR fixes the broken link:
* https://github.com/wazuh/wazuh-qa/tree/master/tests/integration/test_sca/test_basic_usage/data
found in page https://documentation.wazuh.com/current/user-manual/capabilities/sec-config-assessment/creating-custom-policies.html#examples and replaces it with:
* https://github.com/wazuh/wazuh-qa/tree/master/tests/legacy/test_sca/test_basic_usage/data

## Checks
- [X] It compiles without warnings.
- [X] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [X] Used uppercase only on nouns. 
- [X] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).