### PR TITLE
Updated API tag version to 4.3 in conf.py

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -29,13 +29,13 @@ author = u'Wazuh, Inc.'
 copyright = u'&copy; ' + str(datetime.datetime.now().year) + u' &middot; Wazuh Inc.'
 
 # The short X.Y version
-version = '4.2'
+version = '4.3'
 is_latest_release = True
 
 # The full version, including alpha/beta/rc tags
 # Important: use a valid branch (4.0) or, preferably, tag name (v4.0.0)
-release = '4.2'
-api_tag = 'master'
+release = '4.3'
+api_tag = '4.3'
 apiURL = 'https://raw.githubusercontent.com/wazuh/wazuh/'+api_tag+'/api/api/spec/spec.yaml'
 
 # -- General configuration ------------------------------------------------


### PR DESCRIPTION

## Description

This PR closes #4705 and aims at revamping to 4.3 version so the API reference works correctly and according to the release version. 

## Checks
- [x] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

Regards,
