### PR TITLE
Fix centOS 8 installation from sources

### DIFF
--- a/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-agent/index.rst
+++ b/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-agent/index.rst
@@ -49,7 +49,7 @@ Installing Wazuh agent from sources
             .. code-block:: console
 
               # yum install make gcc gcc-c++ python3 python3-policycoreutils automake autoconf libtool openssl-devel cmake
-              # rpm -i $(rpm -q libstdc++-devel --queryformat "http://mirror.centos.org/centos/8/PowerTools/x86_64/os/Packages/libstdc++-static-%{VERSION}-%{RELEASE}.%{arch}.rpm")
+              # rpm -i $(rpm -q libstdc++-devel --queryformat "http://mirror.centos.org/centos/8/PowerTools/x86_64/os/Packages/libstdc++-static-%{VERSION}-%{RELEASE}.%{arch}.rpm\n")
 
             **Optional** CMake 3.18 installation from sources
 

--- a/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-agent/index.rst
+++ b/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-agent/index.rst
@@ -49,7 +49,7 @@ Installing Wazuh agent from sources
             .. code-block:: console
 
               # yum install make gcc gcc-c++ python3 python3-policycoreutils automake autoconf libtool openssl-devel cmake
-              # rpm -i $(rpm --eval https://packages.wazuh.com/utils/libstdc%2B%2B/libstdc%2B%2B-static-8.4.1-1.el8.'%{_arch}'.rpm)
+              # rpm -i $(rpm -q libstdc++-devel --queryformat "http://mirror.centos.org/centos/8/PowerTools/x86_64/os/Packages/libstdc++-static-%{VERSION}-%{RELEASE}.%{arch}.rpm")
 
             **Optional** CMake 3.18 installation from sources
 

--- a/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-server/index.rst
+++ b/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-server/index.rst
@@ -51,7 +51,7 @@ Installing Wazuh manager
           .. code-block:: console
 
             # yum install make cmake gcc gcc-c++ python3 python3-policycoreutils automake autoconf libtool openssl-devel cmake
-            # rpm -i $(rpm --eval https://packages.wazuh.com/utils/libstdc%2B%2B/libstdc%2B%2B-static-8.4.1-1.el8.'%{_arch}'.rpm)
+            # rpm -i $(rpm -q libstdc++-devel --queryformat "http://mirror.centos.org/centos/8/PowerTools/x86_64/os/Packages/libstdc++-static-%{VERSION}-%{RELEASE}.%{arch}.rpm")
 
 
           **Optional** CMake 3.18 installation from sources

--- a/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-server/index.rst
+++ b/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-server/index.rst
@@ -51,7 +51,7 @@ Installing Wazuh manager
           .. code-block:: console
 
             # yum install make cmake gcc gcc-c++ python3 python3-policycoreutils automake autoconf libtool openssl-devel cmake
-            # rpm -i $(rpm -q libstdc++-devel --queryformat "http://mirror.centos.org/centos/8/PowerTools/x86_64/os/Packages/libstdc++-static-%{VERSION}-%{RELEASE}.%{arch}.rpm")
+            # rpm -i $(rpm -q libstdc++-devel --queryformat "http://mirror.centos.org/centos/8/PowerTools/x86_64/os/Packages/libstdc++-static-%{VERSION}-%{RELEASE}.%{arch}.rpm\n")
 
 
           **Optional** CMake 3.18 installation from sources


### PR DESCRIPTION
|Related issue|
|---|
|#4712|

## Description

Hi team,

This PR aims to solve centOS install from sources, broken since centOS 8.5 due to libstdc++-static dependency

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 

Regards,
Nico
