### PR TITLE
Typo in FTS example fixed

### DIFF
--- a/source/user-manual/ruleset/ruleset-xml-syntax/decoders.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/decoders.rst
@@ -389,7 +389,7 @@ The following decoder will extract the user who generated the alert and the loca
 
 .. code-block:: xml
 
-  </decoder>
+  <decoder name="fts-decoder">
     <fts>srcuser, location</fts>
     ...
   </decoder>


### PR DESCRIPTION
|Related issue|
|---|
| #4722 |


## Description
This PR fixes a typo in the FTS decoder example.

How it is:

![image](https://user-images.githubusercontent.com/1891958/148229476-91333f85-51e2-401e-bd2b-60d7d971a9d5.png)

How it should be:

![image](https://user-images.githubusercontent.com/1891958/148232035-a15a9fb1-bf23-44d7-915b-b74b1716e276.png)


## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
