### PR TITLE
Removing wrong title added in Deploying a Wazuh cluster section

### DIFF
--- a/source/user-manual/configuring-cluster/index.rst
+++ b/source/user-manual/configuring-cluster/index.rst
@@ -16,7 +16,6 @@ Deploying a Wazuh cluster
     advanced-settings
     cluster-management
 
-.. title:: Getting started
 
 .. _gt-cluster:
 


### PR DESCRIPTION
Hi team,

## Description

This PR closes #4730 and removes an incorrect title labeled "Getting Started" in the Deploying a Wazuh cluster section of the user manual. 

## Checks
- [x] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).


