### PR TITLE
Update the minimum Ubuntu version to build the Windows agent from sources

### DIFF
--- a/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-agent/index.rst
+++ b/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-agent/index.rst
@@ -198,7 +198,7 @@ Installing Wazuh agent from sources
 
   .. group-tab:: Windows
 
-    .. note:: The following procedure has been tested on Ubuntu 16.04 and other Debian based distributions and may work with other Debian/Ubuntu versions as well.
+    .. note:: The following procedure has been tested on Ubuntu 20.04 and other Debian based distributions and may work with other Debian/Ubuntu versions as well.
 
     1. Set up the Ubuntu build environment. Install these dependencies to build the Windows Wazuh agent installer on Ubuntu:
 


### PR DESCRIPTION
## Related issue

This PR closes https://github.com/wazuh/wazuh/issues/11642.

## Description

Currently, the documentation states that the Windows agent build procedure works on Ubuntu 16.04. As of Wazuh 4.2, we require:

- MinGW 7+.
- CMake 3.12.4+.

So, we have two easy options:

- Use Ubuntu 18.04+, and install CMake 3.18 as shown above.
- Use Ubuntu 20.04. No extra steps are needed.

In addition, our package build procedure is based on Ubuntu 20.04 ([Dockerfile](https://github.com/wazuh/wazuh-packages/blob/37e14c0e3e25eb8add6d5716d64f2fa23b29ecd0/windows/Dockerfile#L1)). Since the Ubuntu version where the agent gets compiled is irrelevant, I propose to change "Ubuntu 16.04" with "Ubuntu 20.04". 

## Checks
- [ ] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).