### PR TITLE
Fix SCA example rule

### DIFF
--- a/source/user-manual/capabilities/sec-config-assessment/creating-custom-policies.rst
+++ b/source/user-manual/capabilities/sec-config-assessment/creating-custom-policies.rst
@@ -410,7 +410,7 @@ Other examples
 - Check if a file exists: ``f:/proc/sys/net/ipv4/ip_forward``
 - Check if a process is running: ``p:avahi-daemon``
 - Check value of registry: ``r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters -> MaximumPasswordAge -> 0``
-- Check if a directory contains files: ``d:/home/* -> ^.mysql_history$``
+- Check if a directory contains files: ``d:/home -> ^.mysql_history$``
 - Check if a directory exists: ``d:/etc/mysql``
 - Check the running configuration of sshd for the maximum authentication tries allowed: ``c:sshd -T -> !r:^\s*maxauthtries\s+4\s*$``
 - Check if root is the only account with UID 0: ``f:/etc/passwd -> !r:^# && !r:^root: && r:^\w+:\w+:0:``


### PR DESCRIPTION
## Description

Hi team,

I fixed an SCA example that uses a wildcard to define a directory path, which is not supported in the current version of SCA.

Right now we can search for files recursively just specifying the directory itself.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

## Note to the reviewer

This PR goes to 4.2 since it is a bug in the current documentation.