### PR TITLE
Add new cluster command in cluster development page

### DIFF
--- a/source/development/wazuh-cluster.rst
+++ b/source/development/wazuh-cluster.rst
@@ -327,34 +327,37 @@ Common messages
 
 As said before, all protocols are built from a common abstract base. This base defines some messages to manage connections, keep alives, etc. These commands are defined in ``wazuh.core.cluster.common.Handler.process_request``, ``wazuh.core.cluster.server.AbstractServerHandler.process_request`` and ``wazuh.core.cluster.client.AbstractClient.process_request``.
 
-+---------------+-------------+--------------------+--------------------------------------------------------------------------+
-| Message       | Received in | Arguments          | Description                                                              |
-+===============+=============+====================+==========================================================================+
-| ``new_str``   | Both        | String length<int> | Used to start the sending long strings process.                          |
-+---------------+-------------+--------------------+--------------------------------------------------------------------------+
-| ``str_upd``   | Both        | String Id<str>,    | Used to send a string chunk during the sending long strings process.     |
-|               |             | Data chunk<str>    |                                                                          |
-+---------------+-------------+--------------------+--------------------------------------------------------------------------+
-| ``err_str``   | Both        | String length<int> | Used to notify an error while sending a string so the reserved space is  |
-|               |             |                    | freed.                                                                   |
-+---------------+-------------+--------------------+--------------------------------------------------------------------------+
-| ``new_file``  | Both        | Filename<str>      | Used to start the sending file process.                                  |
-+---------------+-------------+--------------------+--------------------------------------------------------------------------+
-| ``file_upd``  | Both        | Filename<str>,     | Used to send a file chunk during the sending file process.               |
-|               |             | Data chunk<str>    |                                                                          |
-+---------------+-------------+--------------------+--------------------------------------------------------------------------+
-| ``file_end``  | Both        | Filename<str>,     | Used to finish the sending file process.                                 |
-|               |             | File checksum<str> |                                                                          |
-+---------------+-------------+--------------------+--------------------------------------------------------------------------+
-| ``echo``      | Both        | Message<str>       | Used to send keep alives to the peer. Replies the same received message. |
-+---------------+-------------+--------------------+--------------------------------------------------------------------------+
-| ``echo-c``    | Server      | Message<str>       | Used by the client to send keep alives to the server.                    |
-+---------------+-------------+--------------------+--------------------------------------------------------------------------+
-| ``echo-m``    | Client      | Message<str>       | Used by the server to send keep alives to the client.                    |
-+---------------+-------------+--------------------+--------------------------------------------------------------------------+
-| ``hello``     | Server      | Client name<str>   | First message sent by a client to the server on its first connection.    |
-|               |             |                    | The wazuh protocol modifies this command to add extra arguments.         |
-+---------------+-------------+--------------------+--------------------------------------------------------------------------+
++-----------------+-------------+--------------------+--------------------------------------------------------------------------+
+| Message         | Received in | Arguments          | Description                                                              |
++=================+=============+====================+==========================================================================+
+| ``new_str``     | Both        | String length<int> | Used to start the sending long strings process.                          |
++-----------------+-------------+--------------------+--------------------------------------------------------------------------+
+| ``str_upd``     | Both        | String Id<str>,    | Used to send a string chunk during the sending long strings process.     |
+|                 |             | Data chunk<str>    |                                                                          |
++-----------------+-------------+--------------------+--------------------------------------------------------------------------+
+| ``err_str``     | Both        | String length<int> | Used to notify an error while sending a string so the reserved space is  |
+|                 |             |                    | freed.                                                                   |
++-----------------+-------------+--------------------+--------------------------------------------------------------------------+
+| ``new_file``    | Both        | Filename<str>      | Used to start the sending file process.                                  |
++-----------------+-------------+--------------------+--------------------------------------------------------------------------+
+| ``file_upd``    | Both        | Filename<str>,     | Used to send a file chunk during the sending file process.               |
+|                 |             | Data chunk<str>    |                                                                          |
++-----------------+-------------+--------------------+--------------------------------------------------------------------------+
+| ``file_end``    | Both        | Filename<str>,     | Used to finish the sending file process.                                 |
+|                 |             | File checksum<str> |                                                                          |
++-----------------+-------------+--------------------+--------------------------------------------------------------------------+
+| ``cancel_task`` | Both        | Task name<str>,    | Used to cancel the task in progress in the sending node.                 |
+|                 |             | Error msg<str>     |                                                                          |
++-----------------+-------------+--------------------+--------------------------------------------------------------------------+
+| ``echo``        | Both        | Message<str>       | Used to send keep alives to the peer. Replies the same received message. |
++-----------------+-------------+--------------------+--------------------------------------------------------------------------+
+| ``echo-c``      | Server      | Message<str>       | Used by the client to send keep alives to the server.                    |
++-----------------+-------------+--------------------+--------------------------------------------------------------------------+
+| ``echo-m``      | Client      | Message<str>       | Used by the server to send keep alives to the client.                    |
++-----------------+-------------+--------------------+--------------------------------------------------------------------------+
+| ``hello``       | Server      | Client name<str>   | First message sent by a client to the server on its first connection.    |
+|                 |             |                    | The wazuh protocol modifies this command to add extra arguments.         |
++-----------------+-------------+--------------------+--------------------------------------------------------------------------+
 
 
 Cluster performance

--- a/source/development/wazuh-cluster.rst
+++ b/source/development/wazuh-cluster.rst
@@ -349,14 +349,14 @@ As said before, all protocols are built from a common abstract base. This base d
 | ``cancel_task`` | Both        | Task name<str>,    | Used to cancel the task in progress in the sending node.                 |
 |                 |             | Error msg<str>     |                                                                          |
 +-----------------+-------------+--------------------+--------------------------------------------------------------------------+
-| ``echo``        | Both        | Message<str>       | Used to send keep alives to the peer. Replies the same received message. |
+| ``echo``        | Both        | Message<str>       | Used to send keepalives to the peer. Replies the same received message.  |
 +-----------------+-------------+--------------------+--------------------------------------------------------------------------+
-| ``echo-c``      | Server      | Message<str>       | Used by the client to send keep alives to the server.                    |
+| ``echo-c``      | Server      | Message<str>       | Used by the client to send keepalives to the server.                     |
 +-----------------+-------------+--------------------+--------------------------------------------------------------------------+
-| ``echo-m``      | Client      | Message<str>       | Used by the server to send keep alives to the client.                    |
+| ``echo-m``      | Client      | Message<str>       | Used by the server to send keepalives to the client.                     |
 +-----------------+-------------+--------------------+--------------------------------------------------------------------------+
 | ``hello``       | Server      | Client name<str>   | First message sent by a client to the server on its first connection.    |
-|                 |             |                    | The wazuh protocol modifies this command to add extra arguments.         |
+|                 |             |                    | The Wazuh protocol modifies this command to add extra arguments.         |
 +-----------------+-------------+--------------------+--------------------------------------------------------------------------+
 
 


### PR DESCRIPTION
## Description

This PR closes #4770. A new cluster command (`cancel_task`) is now mentioned on the Cluster development page.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

## Note to the reviewer

This PR includes changes to the `redirect.js` script that need to be included in all production branches.
