### PR TITLE
Fix required Python version in Azure and AWS modules (#4774)

### DIFF
--- a/source/amazon/services/prerequisites/dependencies.rst
+++ b/source/amazon/services/prerequisites/dependencies.rst
@@ -32,10 +32,6 @@ b) For Debian/Ubuntu operating systems:
 
   # apt-get update && apt-get install python3
 
-
-Pip
----
-
 The required modules can be installed with Pip, the Python package manager. Most of UNIX distributions have this tool available in their software repositories:
 
 a) For CentOS/RHEL/Fedora operating systems:

--- a/source/amazon/services/prerequisites/dependencies.rst
+++ b/source/amazon/services/prerequisites/dependencies.rst
@@ -18,7 +18,7 @@ Installing dependencies
 Python
 ------
 
-The AWS S3 integration requires python 3. It is compatible with python versions from `3.6.0` to `3.9.5`. Future python releases should maintain compatibility although it cannot be guaranteed.
+The AWS module requires Python 3.9. Future Python releases should maintain compatibility although it cannot be guaranteed.
 
 a) For CentOS/RHEL/Fedora operating systems:
 

--- a/source/azure/dependencies.rst
+++ b/source/azure/dependencies.rst
@@ -17,7 +17,7 @@ Installing dependencies
 Python
 ------
 
-The Azure monitoring module requires python 3. It is compatible with python versions from `3.6.0` to `3.9.5`. Future python releases should maintain compatibility although it cannot be guaranteed.
+The Azure module requires Python 3.9. Future Python releases should maintain compatibility although it cannot be guaranteed.
 
 a) For CentOS/RHEL/Fedora operating systems:
 

--- a/source/azure/dependencies.rst
+++ b/source/azure/dependencies.rst
@@ -31,10 +31,6 @@ b) For Debian/Ubuntu operating systems:
 
   # apt-get update && apt-get install python3
 
-
-Pip
----
-
 The required modules can be installed with Pip, the Python package manager. Most of UNIX distributions have this tool available in their software repositories:
 
 a) For CentOS/RHEL/Fedora operating systems:


### PR DESCRIPTION
| Related issue |
|----|
| Closes #4774 |

## Description
In this PR we change the Python required Python version that was set in the Azure and AWS dependencies files from `3.6-3.9` to `3.9` in a style similar to the one used in the GCP module.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
