### PR TITLE
Fix typo error on Python package, bash execution and wcloud-cli version

### DIFF
--- a/source/cloud-service/cli/index.rst
+++ b/source/cloud-service/cli/index.rst
@@ -17,7 +17,7 @@ To use ``wcloud-cli``, you need to install the following components:
 
 - Python 3.x
 - ``boto3`` Python package
-- ``request`` Python package
+- ``requests`` Python package
   
 Installation
 ------------
@@ -32,12 +32,12 @@ Installation
 
   .. code-block:: console
 
-    # wcloud-cli version
+    # ./wcloud-cli version
 
   .. code-block:: none
     :class: output
 
-    Wazuh Cloud CLI - "version": "1.1.1"
+    Wazuh Cloud CLI - "version": "1.0.0"
 
 
 Configuration


### PR DESCRIPTION
Hi team

## Description

This PR closes #4792 and fixes some typos found in the _source/cloud-service/cli/index_ section of the documentation.

## Checks
- [x] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

Regards,
Mariel