### PR TITLE
[3.13] Fixed the compilation using Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,9 @@ test
 node_modules
 __pycache__
 .eslintrc
-package-lock.json
 package.json
+package-lock.json
+!source/_themes/wazuh_doc_theme_v3/package.json
 !source/_themes/wazuh_doc_theme_v3/package-lock.json
 source/_themes/wazuh_doc_theme/static/css/dist/*.min.css
 source/_themes/wazuh_doc_theme/static/js/dist/*.min.js
@@ -15,3 +16,5 @@ source/_themes/wazuh_doc_theme_v3/src/css/*.css
 source/_themes/wazuh_doc_theme_v3/src/css/*.css.map
 source/_themes/wazuh_doc_theme_v3/src/js/*.js
 source/_themes/wazuh_doc_theme_v3/src/js/*.js.map
+source/_static/css/*.min.css
+source/_static/js/*.min.js

--- a/source/conf.py
+++ b/source/conf.py
@@ -558,7 +558,7 @@ def setup(app):
 
 def insert_inline_style(app, pagename, templatename, context, doctree):
     ''' Runs once per page, inserting the content of the compiled style for Google Fonts into the context '''
-    google_fonts_path = os.path.join('source/',theme_assets_path, 'static', 'css', 'google-fonts.min.css')
+    google_fonts_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), theme_assets_path, 'static', 'css', 'google-fonts.min.css')
     # Fonts to be preloaded
     with open(google_fonts_path, 'r') as reader:
         google_fonts = reader.read()


### PR DESCRIPTION
## Description

This PR fixes an error occurring only during the compilation using Docker.
In addition, I included some changes in the file `.gitignore` that were not related to this problem but necessary in this branch.

## Checks
- [x] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
