### PR TITLE
Update docker-listener python3 requirement

### DIFF
--- a/source/docker-monitor/dependencies.rst
+++ b/source/docker-monitor/dependencies.rst
@@ -17,7 +17,7 @@ Installing dependencies
 Python
 ------
 
-The Docker listener module requires python 3. It is compatible with python versions from `3.6.0` to `3.9.5`. Future python releases should maintain compatibility although it cannot be guaranteed.
+The Docker listener module requires Python 3.9. Future Python releases should maintain compatibility although it cannot be guaranteed.
 
 a) For CentOS/RHEL/Fedora operating systems:
 


### PR DESCRIPTION
## Description

This PR updates the `Docker-listener` dependencies page to make it consistent with the content of the pages for the AWS and GCP modules.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

