### PR TITLE
Review installation from sources section

### DIFF
--- a/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-server/index.rst
+++ b/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-server/index.rst
@@ -163,6 +163,9 @@ To install the required dependencies to build the python interpreter, follow the
           # zypper install epel-release yum-utils -y
           # zypper-builddep python34 -y
 
+  .. group-tab:: Pacman
+
+        Arch-Linux-based operating systems do not require any additional steps.
 
 
 .. note:: The Python version from the previous command may change depending on the OS used to build the binaries. More information in `Install dependencies <https://devguide.python.org/setup/#install-dependencies>`_.

--- a/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-server/index.rst
+++ b/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-server/index.rst
@@ -50,8 +50,9 @@ Installing Wazuh manager
 
           .. code-block:: console
 
-            # yum install make cmake gcc gcc-c++ python3 python3-policycoreutils automake autoconf libtool openssl-devel cmake
-            # rpm -i $(rpm -q libstdc++-devel --queryformat "http://mirror.centos.org/centos/8/PowerTools/x86_64/os/Packages/libstdc++-static-%{VERSION}-%{RELEASE}.%{arch}.rpm\n")
+            # yum install make gcc gcc-c++ python3 python3-policycoreutils automake autoconf libtool openssl-devel cmake yum-utils -y
+            # yum-config-manager --enable powertools
+            # yum install libstdc++-static -y
 
 
           **Optional** CMake 3.18 installation from sources
@@ -70,10 +71,10 @@ Installing Wazuh manager
 
     .. code-block:: console
 
-      # apt-get install python gcc g++ make libc6-dev curl policycoreutils automake autoconf libtool
+      # apt-get install python gcc g++ make libc6-dev curl policycoreutils automake autoconf libtool cmake
 
 
-    CMake 3.18 installation
+    **Optional** CMake 3.18 installation
 
     .. code-block:: console
 
@@ -117,20 +118,41 @@ To install the required dependencies to build the python interpreter, follow the
 
   .. group-tab:: Yum
 
-    .. code-block:: console
+    .. tabs::
 
-        # yum install epel-release yum-utils -y
-        # yum-builddep python34 -y
+	.. tab:: CentOS 6/7
 
+	    .. code-block:: console
+
+		# yum install epel-release yum-utils -y
+		# yum-builddep python34 -y
+
+	.. tab:: CentOS 8
+
+	    .. code-block:: console
+
+		# yum-builddep python3 -y
 
   .. group-tab:: APT
 
+    .. tabs::
 
-    .. code-block:: console
+       .. tab:: Ubuntu
 
-        # sed -Ei 's/^# deb-src /deb-src /' /etc/apt/sources.list
-        # apt-get update
-        # apt-get build-dep python3.9 -y
+	.. code-block:: console
+
+	    # sed -Ei 's/^# deb-src /deb-src /' /etc/apt/sources.list
+	    # apt-get update
+	    # apt-get build-dep python3.9 -y
+
+       .. tab:: Debian
+
+	.. code-block:: console
+
+	    # apt-get install lsb-release -y
+            # echo "deb-src http://deb.debian.org/debian $(lsb_release -cs) main" >> /etc/apt/sources.list
+	    # apt-get update
+	    # apt-get build-dep python3.9 -y
 
 
   .. group-tab:: ZYpp

--- a/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-server/index.rst
+++ b/source/installation-guide/more-installation-alternatives/wazuh-from-sources/wazuh-server/index.rst
@@ -120,39 +120,39 @@ To install the required dependencies to build the python interpreter, follow the
 
     .. tabs::
 
-	.. tab:: CentOS 6/7
+    	.. tab:: CentOS 6/7
 
-	    .. code-block:: console
+  	    .. code-block:: console
 
-		# yum install epel-release yum-utils -y
-		# yum-builddep python34 -y
+      		# yum install epel-release yum-utils -y
+      		# yum-builddep python34 -y
 
-	.. tab:: CentOS 8
+    	.. tab:: CentOS 8
 
-	    .. code-block:: console
+  	    .. code-block:: console
 
-		# yum-builddep python3 -y
+      		# yum-builddep python3 -y
 
   .. group-tab:: APT
 
     .. tabs::
 
-       .. tab:: Ubuntu
+      .. tab:: Ubuntu
 
-	.. code-block:: console
+      	.. code-block:: console
 
-	    # sed -Ei 's/^# deb-src /deb-src /' /etc/apt/sources.list
-	    # apt-get update
-	    # apt-get build-dep python3.9 -y
+      	    # sed -Ei 's/^# deb-src /deb-src /' /etc/apt/sources.list
+      	    # apt-get update
+      	    # apt-get build-dep python3.9 -y
 
-       .. tab:: Debian
+      .. tab:: Debian
 
-	.. code-block:: console
+      	.. code-block:: console
 
-	    # apt-get install lsb-release -y
+      	    # apt-get install lsb-release -y
             # echo "deb-src http://deb.debian.org/debian $(lsb_release -cs) main" >> /etc/apt/sources.list
-	    # apt-get update
-	    # apt-get build-dep python3.9 -y
+      	    # apt-get update
+      	    # apt-get build-dep python3.9 -y
 
 
   .. group-tab:: ZYpp
@@ -160,8 +160,8 @@ To install the required dependencies to build the python interpreter, follow the
 
     .. code-block:: console
 
-          # zypper install epel-release yum-utils -y
-          # zypper-builddep python34 -y
+        # zypper install epel-release yum-utils -y
+        # zypper-builddep python34 -y
 
   .. group-tab:: Pacman
 


### PR DESCRIPTION
| Related issue |
|----|
| Closes #4803 |

## Description
In this PR we fix the Wazuh installation from sources site, updating the `CentOS8` section, which was currently broken; and separating APT-based OSs in two categories in the *additional dependencies for compiling Python* table, since the commands that should be run change based on if the user has a `Debian` or `Ubuntu` machine.

We also add a note to clarify that Arch-based-OSs don't need to install additional packages to compile Python along with Wazuh.

### Tests performed
Compiling Wazuh and Python following the new installation instructions shows that the installation process is now working as expected.

#### Installation in CentOS 7
```
[root@b6696dc095dc wazuh]# /var/ossec/framework/python/bin/python3
Python 3.9.9 (main, Feb 10 2022, 10:41:41) 
[GCC 7.3.1 20180303 (Red Hat 7.3.1-5)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from wazuh import *
>>> 
[root@b6696dc095dc wazuh]# lsb_release -a
LSB Version:	:core-4.1-amd64:core-4.1-noarch
Distributor ID:	CentOS
Description:	CentOS Linux release 7.9.2009 (Core)
Release:	7.9.2009
Codename:	Core
```

#### Installation in Debian
```
root@c08f6706f6e5:/wazuh# cd /var/ossec/framework/python/bin/
root@c08f6706f6e5:/var/ossec/framework/python/bin# ./python3
Python 3.9.9 (main, Feb  9 2022, 18:03:14) 
[GCC 10.2.1 20210110] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from wazuh import *
>>> 
root@c08f6706f6e5:/var/ossec/framework/python/bin# lsb_release -a
No LSB modules are available.
Distributor ID:	Debian
Description:	Debian GNU/Linux 11 (bullseye)
Release:	11
Codename:	bullseye
```

#### Installation in Ubuntu
```
root@df5096eb21b7:/wazuh# /var/ossec/framework/python/bin/python3
Python 3.9.9 (main, Feb 10 2022, 10:21:26) 
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from wazuh import *
>>> 
root@df5096eb21b7:/wazuh# lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 20.04.3 LTS
Release:	20.04
Codename:	focal
```

#### Installation in Arch Linux
```
[root@e7ce9d3f7f92 /]# /var/ossec/framework/python/bin/python3
Python 3.9.9 (main, Feb 10 2022, 15:35:21) 
[GCC 11.1.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from wazuh import *
[root@e7ce9d3f7f92 /]# lsb_release -a
LSB Version:	1.4
Distributor ID:	Arch
Description:	Arch Linux
Release:	rolling
Codename:	n/a
```

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
