### PR TITLE
Windows agent is not started after installation with deployment variables

### DIFF
--- a/source/installation-guide/wazuh-agent/wazuh-agent-package-windows.rst
+++ b/source/installation-guide/wazuh-agent/wazuh-agent-package-windows.rst
@@ -37,7 +37,7 @@ The agent runs on the host you want to monitor and communicates with the Wazuh m
 
               For additional deployment options such as agent name, agent group, and registration password, see the :ref:`Deployment variables for Windows <deployment_variables_windows>` section.
 
-              The installation process is now complete and the Wazuh agent is successfully installed, registered, and configured, running on your Windows system.
+              The installation process is now complete and the Wazuh agent is successfully installed, registered, and configured.
 
               .. note:: Alternatively, if you want to install an agent without registering it, omit the deployment variables. To learn more about the different registration methods, see the :ref:`Registering Wazuh agents <register_agents>` section.
                

--- a/source/installation-guide/wazuh-agent/wazuh-agent-package-windows.rst
+++ b/source/installation-guide/wazuh-agent/wazuh-agent-package-windows.rst
@@ -20,7 +20,7 @@ The agent runs on the host you want to monitor and communicates with the Wazuh m
     
           .. group-tab:: CLI
 
-             To deploy the Wazuh agent to your system, choose one of the command shell alternatives and edit the ``WAZUH_MANAGER`` and ``WAZUH_REGISTRATION_SERVER`` variables so that they contain the Wazuh manager IP address or hostname.
+             To deploy the Wazuh agent to your system, choose one of the command shell alternatives and edit the ``WAZUH_MANAGER`` variable so that it contains the Wazuh manager IP address or hostname.
 
              - Using CMD:
 
@@ -43,7 +43,7 @@ The agent runs on the host you want to monitor and communicates with the Wazuh m
 
                 NET START WazuhSvc
 
-             Once started the Wazuh agent will start the enrollment process and register to the manager.
+             Once started, the Wazuh agent will start the enrollment process and register to the manager.
 
               .. note:: Alternatively, if you want to install an agent without registering it, omit the deployment variables. To learn more about the different registration methods, see the :ref:`Registering Wazuh agents <register_agents>` section.
 

--- a/source/installation-guide/wazuh-agent/wazuh-agent-package-windows.rst
+++ b/source/installation-guide/wazuh-agent/wazuh-agent-package-windows.rst
@@ -19,40 +19,46 @@ The agent runs on the host you want to monitor and communicates with the Wazuh m
         .. tabs::
     
           .. group-tab:: CLI
-    
+
              To deploy the Wazuh agent to your system, choose one of the command shell alternatives and edit the ``WAZUH_MANAGER`` and ``WAZUH_REGISTRATION_SERVER`` variables so that they contain the Wazuh manager IP address or hostname.
- 
+
              - Using CMD:
 
                .. code-block:: none
 
-                  wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_WINDOWS|.msi /q WAZUH_MANAGER="10.0.0.2" WAZUH_REGISTRATION_SERVER="10.0.0.2"
- 
+                  wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_WINDOWS|.msi /q WAZUH_MANAGER="10.0.0.2"
+
              -  Using PowerShell:
 
                 .. code-block:: none
- 
-                  .\wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_WINDOWS|.msi /q WAZUH_MANAGER="10.0.0.2" WAZUH_REGISTRATION_SERVER="10.0.0.2"
+
+                  .\wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_WINDOWS|.msi /q WAZUH_MANAGER="10.0.0.2"
 
 
               For additional deployment options such as agent name, agent group, and registration password, see the :ref:`Deployment variables for Windows <deployment_variables_windows>` section.
 
-              The installation process is now complete and the Wazuh agent is successfully installed, registered, and configured.
+              The installation process is now complete and the Wazuh agent is successfully installed and configured. You can start the Wazuh agent from the GUI or by running:
+
+              .. code-block:: none
+
+                NET START WazuhSvc
+
+             Once started the Wazuh agent will start the enrollment process and register to the manager.
 
               .. note:: Alternatively, if you want to install an agent without registering it, omit the deployment variables. To learn more about the different registration methods, see the :ref:`Registering Wazuh agents <register_agents>` section.
-               
 
-            
+
+
           .. group-tab:: GUI
 
                 To install the Wazuh agent on your system, run the Windows installer and follow the steps in the installation wizard. If you are not sure how to answer some of the prompts, use the default answers. Once installed, the agent uses a GUI for configuration, opening the log file, and starting or stopping the service.
-            
+
                     .. thumbnail:: ../../images/installation/windows-agent.png
                         :align: center
                         :width: 50%
-            
+
               The installation process is now complete and the Wazuh agent is successfully installed on your Windows system. The next step is to register and configure the agent to communicate with the Wazuh manager. To perform this action, see the :ref:`Registering Wazuh agents <register_agents>` section.                 
- 
+
 
  By default, all agent files are stored in ``C:\Program Files (x86)\ossec-agent`` after the installation.
 


### PR DESCRIPTION


<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description
This PR modifies the Windows agent installation guide to reflect the changes in this PR:
https://github.com/wazuh/wazuh/pull/12271
<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

## Note to the reviewer

This PR includes changes to the `redirect.js` script that need to be included in all production branches.
