### PR TITLE
Update the Python version required by the external integrations

### DIFF
--- a/source/amazon/services/prerequisites/dependencies.rst
+++ b/source/amazon/services/prerequisites/dependencies.rst
@@ -18,7 +18,7 @@ Installing dependencies
 Python
 ------
 
-The AWS module requires Python 3.9. Future Python releases should maintain compatibility although it cannot be guaranteed.
+The AWS module requires Python 3. It is compatible with Python 3.6 to Python 3.9. Future Python releases should maintain compatibility although it cannot be guaranteed.
 
 a) For CentOS/RHEL/Fedora operating systems:
 
@@ -47,6 +47,11 @@ b) For Debian/Ubuntu operating systems:
 
   # apt-get update && apt-get install python3-pip
 
+It is recommended to use a pip version greater than or equal to 19.0 to ease the installation of the required dependencies.
+
+.. code-block:: console
+
+  # pip3 install --upgrade pip
 
 Boto3
 -----

--- a/source/azure/dependencies.rst
+++ b/source/azure/dependencies.rst
@@ -17,7 +17,7 @@ Installing dependencies
 Python
 ------
 
-The Azure module requires Python 3.9. Future Python releases should maintain compatibility although it cannot be guaranteed.
+The Azure module requires Python 3. It is compatible with Python 3.6 to Python 3.9. Future Python releases should maintain compatibility although it cannot be guaranteed.
 
 a) For CentOS/RHEL/Fedora operating systems:
 
@@ -46,6 +46,11 @@ b) For Debian/Ubuntu operating systems:
 
   # apt-get update && apt-get install python3-pip
 
+It is recommended to use a pip version greater than or equal to 19.0 to ease the installation of the required dependencies.
+
+.. code-block:: console
+
+  # pip3 install --upgrade pip
 
 Azure Storage Blobs client library for Python
 ---------------------------------------------

--- a/source/docker-monitor/dependencies.rst
+++ b/source/docker-monitor/dependencies.rst
@@ -17,7 +17,7 @@ Installing dependencies
 Python
 ------
 
-The Docker listener module requires Python 3.9. Future Python releases should maintain compatibility although it cannot be guaranteed.
+The Docker listener module requires Python 3. It is compatible with Python 3.6 to Python 3.9. Future Python releases should maintain compatibility although it cannot be guaranteed.
 
 a) For CentOS/RHEL/Fedora operating systems:
 
@@ -31,6 +31,11 @@ b) For Debian/Ubuntu operating systems:
 
   # apt-get update && apt-get install python3
 
+It is recommended to use a pip version greater than or equal to 19.0 to ease the installation of the required dependencies.
+
+.. code-block:: console
+
+  # pip3 install --upgrade pip
 
 Pip
 ---

--- a/source/gcp/prerequisites/dependencies.rst
+++ b/source/gcp/prerequisites/dependencies.rst
@@ -17,7 +17,7 @@ Installing dependencies
 Python
 ------
 
-The GCP module requires Python 3.9. Future Python releases should maintain compatibility although it cannot be guaranteed.
+The GCP module requires Python 3. It is compatible with Python 3.6 to Python 3.9. Future Python releases should maintain compatibility although it cannot be guaranteed.
 
 a) For CentOS/RHEL/Fedora operating systems:
 
@@ -46,6 +46,11 @@ b) For Debian/Ubuntu operating systems:
 
   # apt-get update && apt-get install python3-pip
 
+It is recommended to use a pip version greater than or equal to 19.0 to ease the installation of the required dependencies.
+
+.. code-block:: console
+
+  # pip3 install --upgrade pip
 
 Google Cloud pip dependencies
 -----------------------------


### PR DESCRIPTION
|Related issue|
|--|
|Closes #4838|

## Description
In this PR we update the documentation to make it clear that the external integration modules can be executed with Python versions 3.6 onward. This is in line with the work performed for wazuh/wazuh#12235.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
