### PR TITLE
Review AWS integration's meta descriptions

### DIFF
--- a/source/amazon/services/prerequisites/S3-bucket.rst
+++ b/source/amazon/services/prerequisites/S3-bucket.rst
@@ -1,7 +1,7 @@
 .. Copyright (C) 2022 Wazuh, Inc.
 
 .. meta::
-  :description: Learn how to configure an Amazon S3, an object storage service that delivers scalability, data availability, security, and performance.
+  :description: Learn how to configure an Amazon S3 bucket, an object storage service that delivers scalability, data availability, security, and performance.
   
 .. _s3_bucket:
 

--- a/source/amazon/services/prerequisites/considerations.rst
+++ b/source/amazon/services/prerequisites/considerations.rst
@@ -1,7 +1,7 @@
 .. Copyright (C) 2022 Wazuh, Inc.
 
 .. meta::
-  :description: In this section, we show you some considerations that must be taken into account when configuring the Wazuh module for AWS.
+  :description: Learn about some considerations that must be taken into account when configuring the Wazuh module for AWS.
   
 .. _amazon_considerations:
 

--- a/source/amazon/services/prerequisites/credentials.rst
+++ b/source/amazon/services/prerequisites/credentials.rst
@@ -1,7 +1,7 @@
 .. Copyright (C) 2022 Wazuh, Inc.
 
 .. meta::
-  :description: Learn more about Wazuh AWS module configuration. In this section of the Wazuh documentation, you can find multiple ways to configure AWS credentials.
+  :description: Learn about the different ways that could be used to configure your AWS credentials when monitoring AWS services with Wazuh.
   
 .. _amazon_credentials:
 

--- a/source/amazon/services/prerequisites/dependencies.rst
+++ b/source/amazon/services/prerequisites/dependencies.rst
@@ -1,7 +1,7 @@
 .. Copyright (C) 2022 Wazuh, Inc.
 
 .. meta::
-  :description: Learn more about how to monitor AWS based services with Wazuh. In this section, you will learn more about installing dependencies. 
+  :description: Learn about the required dependencies for using the AWS integration in a Wazuh agent.
   
 .. _amazon_dependencies:
 

--- a/source/amazon/services/supported-services/alb.rst
+++ b/source/amazon/services/supported-services/alb.rst
@@ -1,5 +1,8 @@
 .. Copyright (C) 2022 Wazuh, Inc.
 
+.. meta::
+  :description: AWS Application Load Balancer is a service that distributes incoming application traffic across multiple targets. Learn how to configure and monitor it with Wazuh.
+
 .. _amazon_alb:
 
 Amazon ALB

--- a/source/amazon/services/supported-services/cisco-umbrella.rst
+++ b/source/amazon/services/supported-services/cisco-umbrella.rst
@@ -1,5 +1,8 @@
 .. Copyright (C) 2022 Wazuh, Inc.
 
+.. meta::
+  :description: Cisco Umbrella is a cloud-based Secure Internet Gateway platform that provides you with multiple levels of defense against internet-based threats. Learn how to configure and monitor it with Wazuh.
+
 .. _cisco_umbrella:
 
 Cisco Umbrella

--- a/source/amazon/services/supported-services/clb.rst
+++ b/source/amazon/services/supported-services/clb.rst
@@ -1,5 +1,8 @@
 .. Copyright (C) 2022 Wazuh, Inc.
 
+.. meta::
+  :description: AWS Classic Load Balancer is a service that distributes incoming application traffic across multiple targets. Learn how to configure and monitor it with Wazuh.
+
 .. _amazon_clb:
 
 Amazon CLB

--- a/source/amazon/services/supported-services/config.rst
+++ b/source/amazon/services/supported-services/config.rst
@@ -1,5 +1,8 @@
 .. Copyright (C) 2022 Wazuh, Inc.
 
+.. meta::
+  :description: AWS Config is a service that records the configuration of AWS resources easing auditing tasks. Learn how to configure and monitor it with Wazuh.
+
 .. _amazon_config:
 
 AWS Config

--- a/source/amazon/services/supported-services/index.rst
+++ b/source/amazon/services/supported-services/index.rst
@@ -6,7 +6,7 @@ Supported services
 ==================
 
 .. meta::
-  :description: Supported services
+  :description: Learn more about all the different AWS services that Wazuh is able to monitor here.
 
 All the services except ``Inspector`` and ``CloudWatch Logs`` get their data from log files stored in an ``S3`` bucket. These services store their data into log files which are configured inside ``<bucket type='TYPE'> </bucket>`` tags, while ``Inspector`` and ``CloudWatch Logs`` services are configured inside ``<service type='inspector'> </service>`` and ``<service type='cloudwatchlogs'> </service>`` tags, respectively.
 

--- a/source/amazon/services/supported-services/inspector.rst
+++ b/source/amazon/services/supported-services/inspector.rst
@@ -1,5 +1,8 @@
 .. Copyright (C) 2022 Wazuh, Inc.
 
+.. meta::
+  :description: Amazon Inspector Classic is an automated security assessments service that improves the security of applications deployed on AWS. Learn how to configure and monitor its findings with Wazuh.
+
 .. _amazon_inspector:
 
 Amazon Inspector

--- a/source/amazon/services/supported-services/kms.rst
+++ b/source/amazon/services/supported-services/kms.rst
@@ -1,5 +1,8 @@
 .. Copyright (C) 2022 Wazuh, Inc.
 
+.. meta::
+  :description: AWS KMS is key management service that allows to create and control keys used to encrypt and sign data. Learn how to configure and monitor it with Wazuh.
+
 .. _amazon_kms:
 
 AWS Key Management Service

--- a/source/amazon/services/supported-services/macie.rst
+++ b/source/amazon/services/supported-services/macie.rst
@@ -1,5 +1,8 @@
 .. Copyright (C) 2022 Wazuh, Inc.
 
+.. meta::
+  :description: Amazon Macie is a service that uses machine learning and pattern matching to protect sensitive data. Learn how to configure and monitor it with Wazuh.
+
 .. _amazon_macie:
 
 Amazon Macie

--- a/source/amazon/services/supported-services/nlb.rst
+++ b/source/amazon/services/supported-services/nlb.rst
@@ -1,5 +1,8 @@
 .. Copyright (C) 2022 Wazuh, Inc.
 
+.. meta::
+  :description: AWS Classic Load Balancer is a service that distributes incoming application traffic across multiple targets. Learn how to configure and monitor it with Wazuh.
+
 .. _amazon_nlb:
 
 Amazon NLB

--- a/source/amazon/services/supported-services/server-access.rst
+++ b/source/amazon/services/supported-services/server-access.rst
@@ -1,6 +1,9 @@
 
 .. Copyright (C) 2021 Wazuh, Inc.
 
+.. meta::
+  :description: AWS Server Access Logging is a service that provides detailed records for the requests made to a bucket. Learn how to configure and monitor it with Wazuh.
+
 .. _amazon_server_access:
 
 S3 Server Access

--- a/source/amazon/services/supported-services/trusted-advisor.rst
+++ b/source/amazon/services/supported-services/trusted-advisor.rst
@@ -1,5 +1,8 @@
 .. Copyright (C) 2022 Wazuh, Inc.
 
+.. meta::
+  :description: AWS Trusted Advisor is a service that helps users reduce cost by optimizing their AWS environment. Learn how to configure and monitor it with Wazuh.
+
 .. _amazon_trusted_advisor:
 
 AWS Trusted Advisor

--- a/source/amazon/services/supported-services/vpc.rst
+++ b/source/amazon/services/supported-services/vpc.rst
@@ -1,5 +1,8 @@
 .. Copyright (C) 2022 Wazuh, Inc.
 
+.. meta::
+  :description: Amazon VPC is a service that allows user to launch AWS resources in a logically isolated section of the AWS Cloud. Learn how to configure and monitor its changes with Wazuh.
+
 .. _amazon_vpc:
 
 Amazon VPC

--- a/source/amazon/services/supported-services/waf.rst
+++ b/source/amazon/services/supported-services/waf.rst
@@ -1,5 +1,7 @@
-
 .. Copyright (C) 2022 Wazuh, Inc.
+
+.. meta::
+  :description: Amazon WAF is web application firewall that helps protecting web applications from common web exploits. Learn how to configure and monitor it with Wazuh.
 
 .. _amazon_waf:
 

--- a/source/amazon/services/troubleshooting.rst
+++ b/source/amazon/services/troubleshooting.rst
@@ -6,7 +6,7 @@ Troubleshooting
 ===============
 
 .. meta::
-  :description: Frequently asked questions about the Wazuh module for Amazon.
+  :description: Learn more about how to fix the most frequent issues when using the Wazuh AWS integration.
 
 The below information is intended to assist in troubleshooting issues.
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #4795|

## Description
In this PR we add the missing meta descriptions to the following AWS integration documentation files:

```
services/supported-services/kms.rst
services/supported-services/server-access.rst
services/supported-services/macie.rst
services/supported-services/inspector.rst
services/supported-services/config.rst
services/supported-services/alb.rst
services/supported-services/clb.rst
services/supported-services/vpc.rst
services/supported-services/nlb.rst
services/supported-services/waf.rst
services/supported-services/trusted-advisor.rst
services/supported-services/cisco-umbrella.rst
```

After this, running `grep -RL "\.\. meta::" source/amazon` doesn't show any results, so the rest of the sites of the Amazon integration's documentation have their meta description.

We also review some meta descriptions that were incomplete or incorrect.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

