### PR TITLE
Review descriptions that only mention buckets in AWS integration

### DIFF
--- a/source/amazon/services/prerequisites/credentials.rst
+++ b/source/amazon/services/prerequisites/credentials.rst
@@ -21,7 +21,7 @@ There are multiple ways to configure the AWS credentials:
 Create an IAM User
 ------------------
 
-Wazuh will need a user with permissions to pull log data from the S3 bucket. The easiest way to accomplish this is by creating a new IAM user for your account. We will only allow it to read data from the bucket.
+Wazuh will need a user with permissions to pull log data from the different services. The easiest way to accomplish this is by creating a new IAM user in the account. This section will show how to create a sample user with permissions to only read data from a bucket.
 
 1. Create new user:
 
@@ -135,7 +135,7 @@ IAM Roles
 .. warning::
   This authentication method requires some credentials to be previously added to the configuration using any other authentication method.
 
-IAM Roles can also be used to access the S3 bucket. Follow these steps to create one:
+IAM Roles can also be used to interact with the different AWS services. This section will show how to create a sample IAM role with permissions to only read data from a bucket:
 
 1. Go to Services > Security, Identity & Compliance > IAM.
 

--- a/source/amazon/services/prerequisites/credentials.rst
+++ b/source/amazon/services/prerequisites/credentials.rst
@@ -21,7 +21,7 @@ There are multiple ways to configure the AWS credentials:
 Create an IAM User
 ------------------
 
-Wazuh will need a user with permissions to pull log data from the different services. The easiest way to accomplish this is by creating a new IAM user in the account. This section will show how to create a sample user with permissions to only read data from a bucket.
+Wazuh requires a user with permissions to pull log data from the different services. The easiest way to accomplish this is by creating a new IAM user in the AWS account. This section shows how to create a sample user with read-only permissions to pull data from a bucket
 
 1. Create new user:
 
@@ -135,7 +135,7 @@ IAM Roles
 .. warning::
   This authentication method requires some credentials to be previously added to the configuration using any other authentication method.
 
-IAM Roles can also be used to interact with the different AWS services. This section will show how to create a sample IAM role with permissions to only read data from a bucket:
+IAM Roles can also be used to interact with the different AWS services. This section shows how to create a sample IAM role with read-only permissions to pull data from a bucket:
 
 1. Go to Services > Security, Identity & Compliance > IAM.
 

--- a/source/amazon/services/prerequisites/dependencies.rst
+++ b/source/amazon/services/prerequisites/dependencies.rst
@@ -51,7 +51,7 @@ b) For Debian/Ubuntu operating systems:
 Boto3
 -----
 
-`Boto3 <https://boto3.readthedocs.io/>`_ is the official package supported by Amazon to manage AWS resources. It will be used to download the log messages from the S3 Bucket or the log groups for the CloudWatch Logs service integration. The module is compatible with boto3 from ``1.13.1`` to ``1.17.76``. Future boto3 releases should maintain compatibility although it cannot be guaranteed.
+`Boto3 <https://boto3.readthedocs.io/>`_ is the official package supported by Amazon to manage AWS resources. It will be used to download the log messages from the different AWS services supported by Wazuh. The module is compatible with boto3 from ``1.13.1`` to ``1.17.76``. Future boto3 releases should maintain compatibility although it cannot be guaranteed.
 
 To install boto3, execute the following command:
 

--- a/source/amazon/services/prerequisites/dependencies.rst
+++ b/source/amazon/services/prerequisites/dependencies.rst
@@ -51,7 +51,7 @@ b) For Debian/Ubuntu operating systems:
 Boto3
 -----
 
-`Boto3 <https://boto3.readthedocs.io/>`_ is the official package supported by Amazon to manage AWS resources. It will be used to download the log messages from the different AWS services supported by Wazuh. The module is compatible with boto3 from ``1.13.1`` to ``1.17.76``. Future boto3 releases should maintain compatibility although it cannot be guaranteed.
+`Boto3 <https://boto3.readthedocs.io/>`_ is the official package supported by Amazon to manage AWS resources. It is used to download the log messages from the different AWS services supported by Wazuh. The module is compatible with boto3 from ``1.13.1`` to ``1.17.76``. Future boto3 releases should maintain compatibility although it cannot be guaranteed.
 
 To install boto3, execute the following command:
 

--- a/source/amazon/services/supported-services/cloudwatchlogs.rst
+++ b/source/amazon/services/supported-services/cloudwatchlogs.rst
@@ -22,7 +22,7 @@ AWS CloudWatch Logs
 AWS configuration
 -----------------
 
-AWS CloudWatch logs can be accessed by configuring CloudWatch to store them into a bucket or by using the CloudWatch Logs Agent. The AWS API allows Wazuh to retrieve those logs, analyze them, and raise alerts if applicable.
+AWS CloudWatch logs can be accessed by using the Wazuh CloudWatch Logs integration. The AWS API allows Wazuh to retrieve those logs, analyze them, and raise alerts if applicable.
 
 
 Wazuh configuration

--- a/source/amazon/services/troubleshooting.rst
+++ b/source/amazon/services/troubleshooting.rst
@@ -40,8 +40,6 @@ Common errors
 
     When an error occurs when trying to collect and parse logs for an AWS service, the ``ossec.log`` will output an error such as below:
 
-    The number is the AWS Account ID provided for the CloudTrail, and the name in the parenthesis is the AWS Account Alias (if provided).
-
     .. code-block:: none
         :class: output
 

--- a/source/user-manual/reference/ossec-conf/wodle-s3.rst
+++ b/source/user-manual/reference/ossec-conf/wodle-s3.rst
@@ -65,7 +65,7 @@ Disables the AWS-S3 wodle.
 skip_on_error
 ^^^^^^^^^^^^^
 
-When unable to process and parse a CloudTrail log, skip the log and continue processing
+When unable to process and parse a log, skip it and continue processing. If set to no, the module will abort the execution once it encounters an error.
 
 +--------------------+---------+
 | **Default value**  | yes     |
@@ -364,7 +364,7 @@ Run evaluation immediately when service is started.
 interval
 ^^^^^^^^
 
-Frequency for reading from the S3 bucket.
+Time the module will wait for before being executed again.
 
 +--------------------+------------------------------------------------------------------------------------------------------------------------------------------------------+
 | **Default value**  | 10m                                                                                                                                                  |

--- a/source/user-manual/reference/ossec-conf/wodle-s3.rst
+++ b/source/user-manual/reference/ossec-conf/wodle-s3.rst
@@ -364,7 +364,7 @@ Run evaluation immediately when service is started.
 interval
 ^^^^^^^^
 
-Time the module will wait for before being executed again.
+The amount of time the module will wait for before running again.
 
 +--------------------+------------------------------------------------------------------------------------------------------------------------------------------------------+
 | **Default value**  | 10m                                                                                                                                                  |


### PR DESCRIPTION
|Related issue|
|---|
|Closes #4690|

## Description
In this PR we change the description of items that could affect and buckets but only mentioned buckets, since that was misleading.

We also correct the CloudWatch Logs section were it said that the module could work with buckets too when
that is wrong. Also, we removed a section of the `troubleshooting` file which had a paragraph totally unrelated with anything surrounding it.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
