### PR TITLE
Restructure the AWS documentation

### DIFF
--- a/source/_static/js/redirects.js
+++ b/source/_static/js/redirects.js
@@ -4,6 +4,7 @@ const redirections = [];
 
 /* Note: new release versions must always be inserted in the first position of the array "versions" */
 const versions = [
+  '4.4',
   '4.3',
   '4.2',
   '4.1',
@@ -56,6 +57,35 @@ removedUrls['x.y'] = [
   '/old-url',
 ];
 */
+
+/* *** RELEASE 4.4 ****/
+
+/* Redirections from 4.3 to 4.4  */
+
+redirections.push(
+    {
+      'target': ['4.3=>4.4', '4.4=>4.3'],
+      '4.3': '/amazon/services/supported-services/alb.html',
+      '4.4': '/amazon/services/supported-services/elastic-load-balancing/alb.html',
+    },
+    {
+      'target': ['4.3=>4.4', '4.4=>4.3'],
+      '4.3': '/amazon/services/supported-services/nlb.html',
+      '4.4': '/amazon/services/supported-services/elastic-load-balancing/nlb.html',
+    },
+    {
+      'target': ['4.3=>4.4', '4.4=>4.3'],
+      '4.3': '/amazon/services/supported-services/clb.html',
+      '4.4': '/amazon/services/supported-services/elastic-load-balancing/clb.html',
+    }
+);
+*/
+
+/* Pages added in 4.4 */
+
+newUrls['4.4'] = [
+  '/amazon/services/supported-services/elastic-load-balancing/index.html',
+];
 
 /* *** RELEASE 4.3 ****/
 

--- a/source/amazon/services/supported-services/cloudwatchlogs.rst
+++ b/source/amazon/services/supported-services/cloudwatchlogs.rst
@@ -5,8 +5,8 @@
 
 .. _aws_cloudwatchlogs:
 
-AWS CloudWatch Logs
-===================
+Amazon CloudWatch Logs
+======================
 
 .. versionadded:: 4.0.0
 

--- a/source/amazon/services/supported-services/elastic-load-balancing/alb.rst
+++ b/source/amazon/services/supported-services/elastic-load-balancing/alb.rst
@@ -17,19 +17,19 @@ Amazon configuration
 
 #. Go to Services > Compute > EC2:
 
-    .. thumbnail:: ../../../images/aws/aws-create-vpc-1.png
+    .. thumbnail:: ../../../../images/aws/aws-create-vpc-1.png
       :align: center
       :width: 70%
 
 #. Go to Load Balancing > Load Balancers on the left menu. Create a new load balancer or select one or more load balancers and select *Edit attributes* on the *Actions* menu:
 
-    .. thumbnail:: ../../../images/aws/aws-create-elb-1.png
+    .. thumbnail:: ../../../../images/aws/aws-create-elb-1.png
       :align: center
       :width: 70%
 
 #. In this tab we will define our S3 and the path where the logs will be stored:
 
-    .. thumbnail:: ../../../images/aws/aws-create-elb-2.png
+    .. thumbnail:: ../../../../images/aws/aws-create-elb-2.png
       :align: center
       :width: 70%
 

--- a/source/amazon/services/supported-services/elastic-load-balancing/clb.rst
+++ b/source/amazon/services/supported-services/elastic-load-balancing/clb.rst
@@ -3,12 +3,12 @@
 .. meta::
   :description: AWS Classic Load Balancer is a service that distributes incoming application traffic across multiple targets. Learn how to configure and monitor it with Wazuh.
 
-.. _amazon_nlb:
+.. _amazon_clb:
 
-Amazon NLB
+Amazon CLB
 ==========
 
-`Network Load Balancers <https://docs.aws.amazon.com/elasticloadbalancing/latest/network/introduction.html>`_ (Amazon NLB) Elastic Load Balancing automatically distributes the incoming traffic across multiple targets, such as EC2 instances, containers, and IP addresses, in one or more Availability Zones. It monitors the health of its registered targets and routes traffic only to the healthy targets. Users can select the type of load balancer that best suits their needs. A Network Load Balancer functions at the fourth layer of the Open Systems Interconnection (OSI) model. It can handle millions of requests per second. After the load balancer receives a connection request, it selects a target from the target group for the default rule. It attempts to open a TCP connection to the selected target on the port specified in the listener configuration.
+`Classic Load Balancers <https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/introduction.html>`_ (Amazon CLB) Elastic Load Balancing automatically distributes the incoming traffic across multiple targets, such as EC2 instances, containers, and IP addresses, in one or more Availability Zones. It monitors the health of its registered targets and routes traffic only to the healthy targets. Users can select the type of load balancer that best suits their needs. A Classic Load Balancer makes routing decisions at either the transport layer (TCP/SSL) or the application layer (HTTP/HTTPS). Classic Load Balancers currently require a fixed relationship between the load balancer port and the container instance port.
 
 Amazon configuration
 --------------------
@@ -17,32 +17,32 @@ Amazon configuration
 
 #. Go to Services > Compute > EC2:
 
-    .. thumbnail:: ../../../images/aws/aws-create-vpc-1.png
+    .. thumbnail:: ../../../../images/aws/aws-create-vpc-1.png
       :align: center
       :width: 70%
 
 #. Go to Load Balancing > Load Balancers on the left menu. Create a new load balancer or select one or more load balancers and select *Edit attributes* on the *Actions* menu:
 
-    .. thumbnail:: ../../../images/aws/aws-create-elb-1.png
+    .. thumbnail:: ../../../../images/aws/aws-create-elb-1.png
       :align: center
       :width: 70%
 
 #. In this tab we will define our S3 and the path where the logs will be stored:
 
-    .. thumbnail:: ../../../images/aws/aws-create-elb-2.png
+    .. thumbnail:: ../../../../images/aws/aws-create-elb-2.png
       :align: center
       :width: 70%
 
     .. note::
-      To enable access logs for NLB (Network Load Balancers), check the following link:
+      To enable access logs for CLB (Classic Load Balancers), check the following link:
 
-        * `Network Load Balancer. <https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-access-logs.html>`_
+        * `Classic Load Balancer. <https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html>`_
 
 
 Wazuh configuration
 -------------------
 
-#. Open the Wazuh configuration file (``/var/ossec/etc/ossec.conf``) and add the following block for NLB:
+#. Open the Wazuh configuration file (``/var/ossec/etc/ossec.conf``) and add the following block for CLB:
 
     .. code-block:: xml
 
@@ -51,9 +51,9 @@ Wazuh configuration
         <interval>10m</interval>
         <run_on_start>yes</run_on_start>
         <skip_on_error>yes</skip_on_error>
-        <bucket type="nlb">
+        <bucket type="clb">
           <name>wazuh-aws-wodle</name>
-          <path>NLB</path>
+          <path>CLB</path>
           <aws_profile>default</aws_profile>
         </bucket>
       </wodle>

--- a/source/amazon/services/supported-services/elastic-load-balancing/index.rst
+++ b/source/amazon/services/supported-services/elastic-load-balancing/index.rst
@@ -1,0 +1,19 @@
+.. Copyright (C) 2022 Wazuh, Inc.
+
+.. meta::
+   :description: AWS Elastic Load Balancers are services that distribute incoming traffic across multiple targets. Learn how to configure and monitor them with Wazuh.
+
+.. _elastic_load_balancing:
+
+======================
+Elastic Load Balancers
+======================
+
+AWS Elastic Load Balancers are services that distribute incoming traffic across multiple targets. The following sections will explain the different types of load balancers available and how to configure and monitor them with Wazuh:
+
+.. toctree::
+   :titlesonly:
+
+   Amazon Application Load Balancer (ALB)<alb>
+   Amazon Classic Load Balancer (CLB)<clb>
+   Amazon Network Load Balancer (NLB)<nlb>

--- a/source/amazon/services/supported-services/elastic-load-balancing/index.rst
+++ b/source/amazon/services/supported-services/elastic-load-balancing/index.rst
@@ -9,7 +9,7 @@
 Elastic Load Balancers
 ======================
 
-AWS Elastic Load Balancers are services that distribute incoming traffic across multiple targets. The following sections will explain the different types of load balancers available and how to configure and monitor them with Wazuh:
+AWS Elastic Load Balancers are services that distribute incoming traffic across multiple targets. The following sections explain the different types of load balancers available and how to configure and monitor them with Wazuh:
 
 .. toctree::
    :titlesonly:

--- a/source/amazon/services/supported-services/elastic-load-balancing/nlb.rst
+++ b/source/amazon/services/supported-services/elastic-load-balancing/nlb.rst
@@ -3,12 +3,12 @@
 .. meta::
   :description: AWS Classic Load Balancer is a service that distributes incoming application traffic across multiple targets. Learn how to configure and monitor it with Wazuh.
 
-.. _amazon_clb:
+.. _amazon_nlb:
 
-Amazon CLB
+Amazon NLB
 ==========
 
-`Classic Load Balancers <https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/introduction.html>`_ (Amazon CLB) Elastic Load Balancing automatically distributes the incoming traffic across multiple targets, such as EC2 instances, containers, and IP addresses, in one or more Availability Zones. It monitors the health of its registered targets and routes traffic only to the healthy targets. Users can select the type of load balancer that best suits their needs. A Classic Load Balancer makes routing decisions at either the transport layer (TCP/SSL) or the application layer (HTTP/HTTPS). Classic Load Balancers currently require a fixed relationship between the load balancer port and the container instance port.
+`Network Load Balancers <https://docs.aws.amazon.com/elasticloadbalancing/latest/network/introduction.html>`_ (Amazon NLB) Elastic Load Balancing automatically distributes the incoming traffic across multiple targets, such as EC2 instances, containers, and IP addresses, in one or more Availability Zones. It monitors the health of its registered targets and routes traffic only to the healthy targets. Users can select the type of load balancer that best suits their needs. A Network Load Balancer functions at the fourth layer of the Open Systems Interconnection (OSI) model. It can handle millions of requests per second. After the load balancer receives a connection request, it selects a target from the target group for the default rule. It attempts to open a TCP connection to the selected target on the port specified in the listener configuration.
 
 Amazon configuration
 --------------------
@@ -17,32 +17,32 @@ Amazon configuration
 
 #. Go to Services > Compute > EC2:
 
-    .. thumbnail:: ../../../images/aws/aws-create-vpc-1.png
+    .. thumbnail:: ../../../../images/aws/aws-create-vpc-1.png
       :align: center
       :width: 70%
 
 #. Go to Load Balancing > Load Balancers on the left menu. Create a new load balancer or select one or more load balancers and select *Edit attributes* on the *Actions* menu:
 
-    .. thumbnail:: ../../../images/aws/aws-create-elb-1.png
+    .. thumbnail:: ../../../../images/aws/aws-create-elb-1.png
       :align: center
       :width: 70%
 
 #. In this tab we will define our S3 and the path where the logs will be stored:
 
-    .. thumbnail:: ../../../images/aws/aws-create-elb-2.png
+    .. thumbnail:: ../../../../images/aws/aws-create-elb-2.png
       :align: center
       :width: 70%
 
     .. note::
-      To enable access logs for CLB (Classic Load Balancers), check the following link:
+      To enable access logs for NLB (Network Load Balancers), check the following link:
 
-        * `Classic Load Balancer. <https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html>`_
+        * `Network Load Balancer. <https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-access-logs.html>`_
 
 
 Wazuh configuration
 -------------------
 
-#. Open the Wazuh configuration file (``/var/ossec/etc/ossec.conf``) and add the following block for CLB:
+#. Open the Wazuh configuration file (``/var/ossec/etc/ossec.conf``) and add the following block for NLB:
 
     .. code-block:: xml
 
@@ -51,9 +51,9 @@ Wazuh configuration
         <interval>10m</interval>
         <run_on_start>yes</run_on_start>
         <skip_on_error>yes</skip_on_error>
-        <bucket type="clb">
+        <bucket type="nlb">
           <name>wazuh-aws-wodle</name>
-          <path>CLB</path>
+          <path>NLB</path>
           <aws_profile>default</aws_profile>
         </bucket>
       </wodle>

--- a/source/amazon/services/supported-services/index.rst
+++ b/source/amazon/services/supported-services/index.rst
@@ -55,9 +55,6 @@ The next table contains the most relevant information about configuring each ser
     cloudtrail
     vpc
     config
-    alb
-    clb
-    nlb
     kms
     macie
     trusted-advisor
@@ -68,3 +65,4 @@ The next table contains the most relevant information about configuring each ser
     cloudwatchlogs
     ecr-image-scanning
     cisco-umbrella
+    elastic-load-balancing/index

--- a/source/amazon/services/supported-services/inspector.rst
+++ b/source/amazon/services/supported-services/inspector.rst
@@ -5,8 +5,8 @@
 
 .. _amazon_inspector:
 
-Amazon Inspector
-================
+Amazon Inspector Classic
+========================
 
 `Amazon Inspector <https://aws.amazon.com/inspector/>`_ is an automated security assessment service that helps improve the security and compliance of applications deployed on AWS. Amazon Inspector automatically assesses applications for exposure, vulnerabilities, and deviations from best practices. After performing an assessment, Amazon Inspector produces a detailed list of security findings prioritized by level of severity. These findings can be reviewed directly or as part of detailed assessment reports which are available via the Amazon Inspector console or API.
 

--- a/source/amazon/services/supported-services/kms.rst
+++ b/source/amazon/services/supported-services/kms.rst
@@ -5,8 +5,8 @@
 
 .. _amazon_kms:
 
-AWS Key Management Service
-==========================
+AWS Key Management Service (KMS)
+================================
 
 `AWS Key Management Service <https://aws.amazon.com/kms/>`_ (KMS) makes it easy for users to create and manage keys and control the use of encryption across a wide range of AWS services and in their applications. AWS KMS is a secure and resilient service that uses FIPS 140-2 validated hardware security modules to protect their keys. AWS KMS is integrated with AWS CloudTrail to provide users with logs of all key usage to help meet their regulatory and compliance needs.
 

--- a/source/amazon/services/supported-services/server-access.rst
+++ b/source/amazon/services/supported-services/server-access.rst
@@ -6,8 +6,8 @@
 
 .. _amazon_server_access:
 
-S3 Server Access
-================
+Amazon S3 Server Access
+=======================
 
 `Amazon S3 Server Access Logging <https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerLogs.html>`_ provides detailed records for the requests that are made to a bucket. Server access logs are useful for many applications. For example, access log information can be useful in security and access audits. It can also help you learn about your customer base and understand your Amazon S3 bill.
 

--- a/source/amazon/services/supported-services/vpc.rst
+++ b/source/amazon/services/supported-services/vpc.rst
@@ -5,8 +5,8 @@
 
 .. _amazon_vpc:
 
-Amazon VPC
-==========
+Amazon Virtual Private Cloud (VPC)
+==================================
 
 `Amazon Virtual Private Cloud <https://aws.amazon.com/vpc/?nc1=h_ls>`_ (Amazon VPC) lets users provision a logically isolated section of the AWS Cloud where they can launch AWS resources in a virtual network that they define. Users have complete control over their virtual networking environment, including selection of their own IP address range, creation of subnets, and configuration of route tables and network gateways. Users can use both IPv4 and IPv6 in their VPC for secure and easy access to resources and applications.
 

--- a/source/amazon/services/supported-services/waf.rst
+++ b/source/amazon/services/supported-services/waf.rst
@@ -5,8 +5,8 @@
 
 .. _amazon_waf:
 
-Amazon WAF
-==========
+Amazon Web Application Firewall (WAF)
+=====================================
 
 `Amazon WAF <https://aws.amazon.com/waf/>`_ is a web application firewall that helps protect your web applications from common web exploits that could affect application availability, compromise security, or consume excessive resources. ``AWS WAF`` gives you control over which traffic to allow or block to your web applications by defining customizable web security rules. 
 


### PR DESCRIPTION
|Related issue|
|--|
|Closes #4688 |

## Description
This PR changes the name of some sections of the AWS integration to make them match the ones used by the AWS documentation. Also, the `Elastic Load Balancers` section was added to group the `ALB`, `CLB` and `NLB` sections, which were hanging from `Supported services` directly in earlier versions.

Currently, the moved sections don't appear in the sidebar:
![current](https://user-images.githubusercontent.com/72474806/155124637-32ed9732-a427-4285-bbbf-596ed30895c4.png)

However, they were correctly added by the toctree, like the following screenshot shows:
![toctree](https://user-images.githubusercontent.com/72474806/155124782-68ffd7cf-44b5-4914-9eb4-9c21fee2d7f3.png)


After investigating the issue, we concluded that it was due to how the [globaltoc_depth](https://github.com/wazuh/wazuh-documentation/blob/ee2ff8351625e7d27a1190854fafdcc479b43b35/source/conf.py#L130) is set because of older releases. Modifying it returns the expected result:
![after changes in theme](https://user-images.githubusercontent.com/72474806/155124567-2788919f-78e5-499c-8e6e-a55346367ca8.png) 

That problem will be fixed in the next version of the Wazuh theme, so we will leave it unchanged in this PR.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

## Note to the reviewer

This PR includes changes to the `redirect.js` script that need to be included in all production branches.
