### PR TITLE
[3.1] Fixed the depth of the global TOC

### DIFF
--- a/source/_themes/wazuh_doc_theme/theme.conf
+++ b/source/_themes/wazuh_doc_theme/theme.conf
@@ -14,4 +14,4 @@ display_version = True
 prev_next_buttons_location = bottom
 wazuh_web_url = https://wazuh.com
 wazuh_doc_url = https://documentation.wazuh.com
-globaltoc_depth = 4
+globaltoc_depth = 5

--- a/source/conf.py
+++ b/source/conf.py
@@ -122,10 +122,7 @@ html_theme = 'wazuh_doc_theme'
 html_theme_options = {
     'wazuh_web_url': 'https://wazuh.com',
     'wazuh_doc_url': 'https://documentation.wazuh.com',
-    'globaltoc_depth': 5, # Only for Wazuh documentation theme v2.0
-    'includehidden': True, # Only for Wazuh documentation theme v2.0v
     'collapse_navigation': False, # Only for Wazuh documentation theme v2.0v
-    'prev_next_buttons_location': 'bottom' # Only for Wazuh documentation theme v2.0v
 }
 
 


### PR DESCRIPTION

## Description

Adjusted the configuration to solve a problem with the depth of the menu in the sidebar.

## Checks
- [x] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
