### PR TITLE
Adust agent enrollment troubleshooting ul style

### DIFF
--- a/source/_themes/wazuh_doc_theme/css-src/style.css
+++ b/source/_themes/wazuh_doc_theme/css-src/style.css
@@ -404,6 +404,10 @@ header .menuweb-bar .menu-item a {
   padding-right: 1em;
 }
 
+#troubleshooting ul ul {
+  margin-bottom: 0;
+}
+
 #capabilities > p {
   margin-bottom: 1rem;
 }

--- a/source/user-manual/agent-enrollment/index.rst
+++ b/source/user-manual/agent-enrollment/index.rst
@@ -38,7 +38,7 @@ The following has to be in place to ensure the Wazuh agent enrollment is done:
 
 #. An installed and running Wazuh agent on the endpoint that the user needs to enroll. 
 
-#. Outbound connectivity between the Wazuh agent and the Wazuh manager services. The following ports are configurable:
+#. Outbound connectivity from the Wazuh agent to the Wazuh manager services. The following ports are configurable:
 
    - 1514/TCP for agent communication.
    - 1515/TCP for enrollment via automatic agent request.

--- a/source/user-manual/agent-enrollment/security-options/using-password-authentication.rst
+++ b/source/user-manual/agent-enrollment/security-options/using-password-authentication.rst
@@ -106,27 +106,26 @@ The following steps serve as a guide on how to enroll a Linux/Unix endpoint with
 #. Launch the terminal as a root user.
 #. Create the file ``/var/ossec/etc/authd.pass`` with the enrollment password in it.
 
-   .. code-block:: console
+       .. code-block:: console
 
-       # echo "<password>" > /var/ossec/etc/authd.pass
+          # echo "<custom_password>" > /var/ossec/etc/authd.pass
 
 
-   .. note::
-     #. You have to replace ``<password>`` with the agents enrollment password created on the manager.
-     #. File permissions for the ``authd.pass`` file should be set to 644 and the owner should be root. The permissions and ownership can be configured by running the commands below:
+    #. You have to replace ``<custom_password>`` with the agents enrollment password created on the manager.
+    #. File permissions for the ``authd.pass`` file should be set to 644 and the owner should be root. The permissions and ownership can be configured by running the commands below:
 
-         .. code-block:: console
+       .. code-block:: console
 
-               # chmod 644 /var/ossec/etc/authd.pass
-               # chown root:wazuh /var/ossec/etc/authd.pass
+          # chmod 644 /var/ossec/etc/authd.pass
+          # chown root:wazuh /var/ossec/etc/authd.pass
 
 
     The output below shows the recommended file owner and permissions.
 
-         .. code-block:: xml
-            :class: output 
+       .. code-block:: xml
+        :class: output 
 
-            -rw-r--r-- 1 root wazuh 18 Jan 11 13:03 /var/ossec/etc/authd.pass
+          -rw-r--r-- 1 root wazuh 18 Jan 11 13:03 /var/ossec/etc/authd.pass
 
 #. Add the Wazuh manager IP address or DNS name in the ``<client><server><address>`` section of the manager configuration file ``/var/ossec/etc/ossec.conf``.
 
@@ -194,7 +193,7 @@ The Wazuh agent installation directory depends on the architecture of the host.
       
         # ``echo “<custom_password>” > "C:\Program Files (x86)\ossec-agent\authd.pass"``.
 
-   Note that you have to replace ``<password>`` with the agents enrollment password created on the manager.
+   Note that you have to replace ``<custom_password>`` with the agents enrollment password created on the manager.
 
 
 #. Add the Wazuh manager IP address or DNS name in the ``<client><server><address>`` section of ``C:\Program Files (x86)\ossec-agent\ossec.conf``:
@@ -247,29 +246,24 @@ The following steps serve as a guide on how to enroll a macOS endpoint with pass
 
 #. Create a file called ``/Library/Ossec/etc/authd.pass`` and save the password to it.
 
+       .. code-block:: console
 
-   .. code-block:: console
+          # echo "<custom_password>" > /Library/Ossec/etc/authd.pass
 
-     # echo "<custom_password>" > /Library/Ossec/etc/authd.pass
-
-
-
-   .. note::
-    #. You have to replace ``<password>`` with the agents enrollment password created on the manager.
+    #. You have to replace ``<custom_password>`` with the agents enrollment password created on the manager.
     #. File permissions for the ``authd.pass`` file should be set to 644 and the owner should be root. The permissions and ownership can be configured by running the commands below:
 
-            .. code-block:: console 
+       .. code-block:: console 
 
-                  # chmod 644 /Library/Ossec/etc/authd.pass
-                  # chown root:wazuh /Library/Ossec/etc/authd.pass
+          # chmod 644 /Library/Ossec/etc/authd.pass
+          # chown root:wazuh /Library/Ossec/etc/authd.pass
 
+    The output below shows the recommended file owner and permissions:
 
-      The output below shows the recommended file owner and permissions:
+       .. code-block:: xml
+           :class: output 
 
-            .. code-block:: xml
-               :class: output 
-
-               -rw-r--r-- 1 root wazuh 18 Jan 11 13:03 /Library/Ossec/etc/authd.pass
+            -rw-r--r-- 1 root wazuh 18 Jan 11 13:03 /Library/Ossec/etc/authd.pass
 
 #. Add the Wazuh manager IP address or DNS name in the ``<client><server><address>`` section of ``/Library/Ossec/etc/ossec.conf``:
 

--- a/source/user-manual/agent-enrollment/troubleshooting.rst
+++ b/source/user-manual/agent-enrollment/troubleshooting.rst
@@ -14,8 +14,8 @@ The location of the agent log file is dependent on the operating system:
 
 - For Linux-based systems, the log file is located at ``/var/ossec/logs/ossec.log``
 - For Windows endpoints, the location of the log file is dependent on its architecture:
-   - For a 64-bit endpoint, it is located at ``C:\Program Files (x86)\ossec-agent\ossec.log``
-   - For a 32-bit endpoint, it is located at ``C:\Program Files\ossec-agent\ossec.logs``
+     - For a 64-bit endpoint, it is located at ``C:\Program Files (x86)\ossec-agent\ossec.log``
+     - For a 32-bit endpoint, it is located at ``C:\Program Files\ossec-agent\ossec.logs``
 - For a macOS endpoint, the log file is located at ``/Library/Ossec/logs/ossec.log``
 
 


### PR DESCRIPTION
This PR aims to adust the ul style in the section: `Wazuh agent enrollment > Troubleshooting` and other fixes.

From:
![image (1)](https://user-images.githubusercontent.com/85168963/155395214-68e7a95f-1912-479c-88f4-361e00197a0e.png)

to:
![image](https://user-images.githubusercontent.com/85168963/155393779-f86c2225-2a58-4dbc-9dcc-fbaf9c15b07c.png)

##  Tasks
- [x] Work on the branch `Agent-enrollment-troubleshooting-ul-style`

## Checks
- [ ] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

Regards,
Damian Furfuro