### PR TITLE
Improve AWS integration's ossec.conf reference

### DIFF
--- a/source/user-manual/reference/ossec-conf/wodle-s3.rst
+++ b/source/user-manual/reference/ossec-conf/wodle-s3.rst
@@ -1,7 +1,7 @@
 .. Copyright (C) 2022 Wazuh, Inc.
 
 .. meta::
-    :description: Learn more about the local configuration of Wazuh. In this section of the documentation you can check out more about the wodle name “aws-s3”. 
+    :description: Learn more about the local configuration of Wazuh. In this section of the documentation you can learn more about the configuration options of the Wazuh integration with AWS.
 
 .. _wodle_s3:
 
@@ -15,44 +15,12 @@ wodle name="aws-s3"
 		<wodle name="aws-s3">
 		</wodle>
 
-Configuration options of the AWS-S3 wodle.
+After adding an ``aws-s3`` section, it is mandatory to define at least one :ref:`bucket<buckets>` or :ref:`service <services>`. It is possible to configure multiple buckets and services inside the same ``aws-s3`` section.
 
-
-Options
--------
-
-Main options
-^^^^^^^^^^^^
-
-- `disabled`_
-- `interval`_
-- `run_on_start`_
-- `skip_on_error`_
-- `bucket type`_
-- `service type`_
-
-
-+-----------------------+-----------------------------+--------------------+
-| Main options          | Allowed values              | Mandatory/Optional |
-+=======================+=============================+====================+
-| `disabled`_           | yes, no                     | Mandatory          |
-+-----------------------+-----------------------------+--------------------+
-| `skip_on_error`_      | yes, no                     | Optional           |
-+-----------------------+-----------------------------+--------------------+
-| `bucket type`_        | N/A                         | Mandatory          |
-+-----------------------+-----------------------------+--------------------+
-
-Scheduling options
-^^^^^^^^^^^^^^^^^^
-
-- `run_on_start`_
-- `interval`_
-- `day`_
-- `wday`_
-- `time`_
+The options available to use inside the ``aws-s3`` section are the following:
 
 disabled
-^^^^^^^^
+~~~~~~~~
 
 Disables the AWS-S3 wodle.
 
@@ -61,9 +29,11 @@ Disables the AWS-S3 wodle.
 +--------------------+-----------------------------+
 | **Allowed values** | yes, no                     |
 +--------------------+-----------------------------+
+| **Mandatory**      | yes                         |
++--------------------+-----------------------------+
 
 skip_on_error
-^^^^^^^^^^^^^
+~~~~~~~~~~~~~
 
 When unable to process and parse a log, skip it and continue processing. If set to no, the module will abort the execution once it encounters an error.
 
@@ -72,88 +42,166 @@ When unable to process and parse a log, skip it and continue processing. If set 
 +--------------------+---------+
 | **Allowed values** | yes, no |
 +--------------------+---------+
+| **Mandatory**      | no      |
++--------------------+---------+
 
-bucket type
-^^^^^^^^^^^
+run_on_start
+~~~~~~~~~~~~
 
-Defines a bucket to process. It must have its ``type`` attribute defined. It supports multiple instances of this option.
+Run the module immediately after the Wazuh service starts.
 
-Bucket options
-~~~~~~~~~~~~~~
++--------------------+---------+
+| **Default value**  | yes     |
++--------------------+---------+
+| **Allowed values** | yes, no |
++--------------------+---------+
+| **Mandatory**      | no      |
++--------------------+---------+
 
-- `bucket\\name`_
-- `bucket\\aws_account_id`_
-- `bucket\\aws_account_alias`_
-- `bucket\\access_key`_
-- `bucket\\secret_key`_
-- `bucket\\aws_profile`_
-- `bucket\\iam_role_arn`_
-- `bucket\\iam_role_duration`_
-- `bucket\\path`_
-- `bucket\\path_suffix`_
-- `bucket\\only_logs_after`_
-- `bucket\\regions`_
-- `bucket\\aws_organization_id`_
-- `bucket\\discard_regex`_
-- `bucket\\sts_endpoint`_
-- `bucket\\service_endpoint`_
+interval
+~~~~~~~~
 
+The amount of time the module will wait for before running again.
 
-+----------------------------------+-------------------------------------------------------------+-----------------------------------------------+
-| Options                          | Allowed values                                              | Mandatory/Optional                            |
-+==================================+=============================================================+===============================================+
-| `type`_                          | cloudtrail, guardduty, vpcflow, config, custom              | Mandatory                                     |
-+----------------------------------+-------------------------------------------------------------+-----------------------------------------------+
-| `bucket\\name`_                  | Any valid bucket name                                       | Mandatory                                     |
-+----------------------------------+-------------------------------------------------------------+-----------------------------------------------+
-| `bucket\\aws_account_id`_        | Comma list of AWS Accounts                                  | Optional (only works with CloudTrail buckets) |
-+----------------------------------+-------------------------------------------------------------+-----------------------------------------------+
-| `bucket\\aws_account_alias`_     | Any string                                                  | Optional                                      |
-+----------------------------------+-------------------------------------------------------------+-----------------------------------------------+
-| `bucket\\access_key`_            | Alphanumerical key                                          | Optional                                      |
-+----------------------------------+-------------------------------------------------------------+-----------------------------------------------+
-| `bucket\\secret_key`_            | Alphanumerical key                                          | Optional                                      |
-+----------------------------------+-------------------------------------------------------------+-----------------------------------------------+
-| `bucket\\aws_profile`_           | Any string                                                  | Optional                                      |
-+----------------------------------+-------------------------------------------------------------+-----------------------------------------------+
-| `bucket\\iam_role_arn`_          | IAM role ARN                                                | Optional                                      |
-+----------------------------------+-------------------------------------------------------------+-----------------------------------------------+
-| `bucket\\iam_role_duration`_     | Number of seconds between 900 and 3600                      | Optional (if set, it requires an iam_role_arn |
-|                                  |                                                             | to be provided)                               |
-+----------------------------------+-------------------------------------------------------------+-----------------------------------------------+
-| `bucket\\path`_                  | Prefix for S3 bucket key                                    | Optional                                      |
-+----------------------------------+-------------------------------------------------------------+-----------------------------------------------+
-| `bucket\\path_suffix`_           | Suffix for S3 bucket key                                    | Optional                                      |
-+----------------------------------+-------------------------------------------------------------+-----------------------------------------------+
-| `bucket\\only_logs_after`_       | Date (YYYY-MMM-DDD, for example 2018-AUG-21)                | Optional                                      |
-+----------------------------------+-------------------------------------------------------------+-----------------------------------------------+
-| `bucket\\regions`_               | Comma list of AWS regions                                   | Optional (only works with CloudTrail buckets) |
-+----------------------------------+-------------------------------------------------------------+-----------------------------------------------+
-| `bucket\\aws_organization_id`_   | Name of AWS organization                                    | Optional (only works with CloudTrail buckets) |
-+----------------------------------+-------------------------------------------------------------+-----------------------------------------------+
-| `bucket\\discard_regex`_         | A regex value to determine if an event should be discarded. | Optional                                      |
-+----------------------------------+-------------------------------------------------------------+-----------------------------------------------+
-| `bucket\\sts_endpoint`_          | The AWS Security Token Service VPC endpoint URL.            | Optional                                      |
-+----------------------------------+-------------------------------------------------------------+-----------------------------------------------+
-| `bucket\\service_endpoint`_      | The AWS S3 endpoint URL.                                    | Optional                                      |
-+----------------------------------+-------------------------------------------------------------+-----------------------------------------------+
++--------------------+------------------------------------------------------------------------------------------------------------------------------------------------------+
+| **Default value**  | 10m                                                                                                                                                  |
++--------------------+------------------------------------------------------------------------------------------------------------------------------------------------------+
+| **Allowed values** | A positive number that must contain a suffix character indicating a time unit, such as, s (seconds), m (minutes), h (hours), d (days), M (months).   |
++--------------------+------------------------------------------------------------------------------------------------------------------------------------------------------+
+| **Mandatory**      | no                                                                                                                                                   +
++--------------------+------------------------------------------------------------------------------------------------------------------------------------------------------+
 
-type
-^^^^
+day
+~~~
 
-Specifies type of bucket. It is an attribute of the ``bucket`` tag.
+Day of the month to run the scan.
 
-+--------------------+------------------------------------------------+
-| **Default value**  | N/A                                            |
-+--------------------+------------------------------------------------+
-| **Allowed values** | cloudtrail, guardduty, vpcflow, config, custom |
-+--------------------+------------------------------------------------+
++--------------------+--------------------------+
+| **Default value**  | N/A                      |
++--------------------+--------------------------+
+| **Allowed values** | Day of the month [1..31] |
++--------------------+--------------------------+
+| **Mandatory**      | no                       |
++--------------------+--------------------------+
 
 .. note::
-    Different configurations as ``macie`` has ``custom`` type.
 
-bucket\\name
-^^^^^^^^^^^^
+	When the ``day`` option is set, the interval value must be a multiple of months. By default, the interval is set to a month.
+
+wday
+~~~~
+
+Day of the week to run the scan. This option is **not compatible** with the ``day`` option.
+
++--------------------+--------------------------+
+| **Default value**  | N/A                      |
++--------------------+--------------------------+
+| **Allowed values** | Day of the week:         |
+|                    |  - sunday/sun            |
+|                    |  - monday/mon            |
+|                    |  - tuesday/tue           |
+|                    |  - wednesday/wed         |
+|                    |  - thursday/thu          |
+|                    |  - friday/fri            |
+|                    |  - saturday/sat          |
++--------------------+--------------------------+
+| **Mandatory**      | no                       |
++--------------------+--------------------------+
+
+
+.. note::
+
+	When the ``wday`` option is set, the interval value must be a multiple of weeks. By default, the interval is set to a week.
+
+time
+~~~~
+
+Time of the day to run the scan. It has to be in the hh:mm format.
+
++--------------------+-----------------------+
+| **Default value**  | N/A                   |
++--------------------+-----------------------+
+| **Allowed values** | Time of day *[hh:mm]* |
++--------------------+-----------------------+
+| **Mandatory**      | no                    |
++--------------------+-----------------------+
+
+.. note::
+
+	When only the ``time`` option is set, the interval value must be a multiple of days or weeks. By default, the interval is set to a day.
+
+remove_from_bucket
+~~~~~~~~~~~~~~~~~~
+
+Delete each log file from the S3 bucket once it has been collected by the module.
+
++--------------------+-----------------------+
+| **Default value**  | no                    |
++--------------------+-----------------------+
+| **Allowed values** | yes, no               |
++--------------------+-----------------------+
+| **Mandatory**      | no                    |
++--------------------+-----------------------+
+
+.. _buckets:
+
+Buckets
+~~~~~~~
+
+It is necessary to specify the type as an attribute of the ``bucket`` tag, for example:
+
+	.. code-block:: xml
+
+		<bucket type="cloudtrail">
+
+		</bucket>
+
+The available types are:  ``cloudtrail``, ``guardduty``, ``vpcflow``, ``config``, ``custom``, ``cisco_umbrella``, ``waf``, ``alb``, ``clb``, ``nlb``, and ``server_access``.
+
+.. note::
+    The type that must be used depends on the service configured. More information about the supported services and their associated types on :ref:`AWS supported services <amazon_supported_services>`.
+
++----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
+| Options                                | Allowed values                                              | Mandatory/Optional                            |
++========================================+=============================================================+===============================================+
+| :ref:`bucket_name`                     | Any valid bucket name                                       | Mandatory                                     |
++----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
+| :ref:`bucket_aws_account_id`           | Comma list of AWS Accounts                                  | Optional (only works with CloudTrail buckets) |
++----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
+| :ref:`bucket_account_alias`            | Any string                                                  | Optional                                      |
++----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
+| :ref:`bucket_access_key`               | Alphanumerical key                                          | Optional                                      |
++----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
+| :ref:`bucket_secret_key`               | Alphanumerical key                                          | Optional                                      |
++----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
+| :ref:`bucket_aws_profile`              | Any string                                                  | Optional                                      |
++----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
+| :ref:`bucket_iam_role_arn`             | IAM role ARN                                                | Optional                                      |
++----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
+| :ref:`bucket_iam_role_duration`        | Number of seconds between 900 and 3600                      | Optional (if set, it requires an iam_role_arn |
+|                                        |                                                             | to be provided)                               |
++----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
+| :ref:`bucket_path`                     | Prefix for S3 bucket key                                    | Optional                                      |
++----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
+| :ref:`bucket_path_suffix`              | Suffix for S3 bucket key                                    | Optional                                      |
++----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
+| :ref:`only_logs_aws_buckets`           | Date (YYYY-MMM-DDD, for example 2018-AUG-21)                | Optional                                      |
++----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
+| :ref:`bucket_regions`                  | Comma list of AWS regions                                   | Optional (only works with CloudTrail buckets) |
++----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
+| :ref:`bucket_aws_organization_id`      | Name of AWS organization                                    | Optional (only works with CloudTrail buckets) |
++----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
+| :ref:`bucket_discard_regex`            | A regex value to determine if an event should be discarded  | Optional                                      |
++----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
+| :ref:`bucket_sts_endpoint`             | The AWS Security Token Service VPC endpoint URL             | Optional                                      |
++----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
+| :ref:`bucket_service_endpoint`         | The AWS S3 endpoint URL                                     | Optional                                      |
++----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
+
+.. _bucket_name:
+
+name
+^^^^
 
 Name of the S3 bucket from where logs are read.
 
@@ -163,20 +211,24 @@ Name of the S3 bucket from where logs are read.
 | **Allowed values** | Any valid bucket name       |
 +--------------------+-----------------------------+
 
-bucket\\aws_account_id
-^^^^^^^^^^^^^^^^^^^^^^
+.. _bucket_aws_account_id:
+
+aws_account_id
+^^^^^^^^^^^^^^
 
 The AWS Account ID for the bucket logs. Only works with CloudTrail buckets.
 
 +--------------------+-------------------------------------------+
-| **Default value**  | All accounts.                             |
+| **Default value**  | All accounts                              |
 +--------------------+-------------------------------------------+
 | **Allowed values** | Comma list of 12 digit AWS Account ID     |
 +--------------------+-------------------------------------------+
 
 
-bucket\\aws_account_alias
-^^^^^^^^^^^^^^^^^^^^^^^^^
+.. _bucket_account_alias:
+
+aws_account_alias
+^^^^^^^^^^^^^^^^^
 
 A user-friendly name for the AWS account.
 
@@ -186,30 +238,36 @@ A user-friendly name for the AWS account.
 | **Allowed values** | Any string                  |
 +--------------------+-----------------------------+
 
-bucket\\access_key
-^^^^^^^^^^^^^^^^^^
+.. _bucket_access_key:
+
+access_key
+^^^^^^^^^^
 
 The access key ID for the IAM user with the permission to read logs from the bucket.
 
 +--------------------+--------------------------+
 | **Default value**  | N/A                      |
 +--------------------+--------------------------+
-| **Allowed values** | Any alphanumerical key.  |
+| **Allowed values** | Any alphanumerical key   |
 +--------------------+--------------------------+
 
-bucket\\secret_key
-^^^^^^^^^^^^^^^^^^
+.. _bucket_secret_key:
+
+secret_key
+^^^^^^^^^^
 
 The secret key created for the IAM user with the permission to read logs from the bucket.
 
 +--------------------+--------------------------+
 | **Default value**  | N/A                      |
 +--------------------+--------------------------+
-| **Allowed values** | Any alphanumerical key.  |
+| **Allowed values** | Any alphanumerical key   |
 +--------------------+--------------------------+
 
-bucket\\aws_profile
-^^^^^^^^^^^^^^^^^^^
+.. _bucket_aws_profile:
+
+aws_profile
+^^^^^^^^^^^
 
 A valid profile name from a Shared Credential File or AWS Config File with the permission to read logs from the bucket.
 
@@ -221,19 +279,21 @@ A valid profile name from a Shared Credential File or AWS Config File with the p
 
 .. _bucket_iam_role_arn:
 
-bucket\\iam_role_arn
-^^^^^^^^^^^^^^^^^^^^
+iam_role_arn
+^^^^^^^^^^^^
 
-A valid role arn with permission to read logs from the bucket.
+A valid role ARN with permission to read logs from the bucket.
 
 +--------------------+----------------+
 | **Default value**  | N/A            |
 +--------------------+----------------+
-| **Allowed values** | Valid role arn |
+| **Allowed values** | Valid role ARN |
 +--------------------+----------------+
 
-bucket\\iam_role_duration
-^^^^^^^^^^^^^^^^^^^^^^^^^
+.. _bucket_iam_role_duration:
+
+iam_role_duration
+^^^^^^^^^^^^^^^^^
 
 A valid number of seconds that defines the duration of the session assumed when using the provided :ref:`iam_role_arn<bucket_iam_role_arn>`.
 
@@ -243,8 +303,10 @@ A valid number of seconds that defines the duration of the session assumed when 
 | **Allowed values** | Number of seconds between 900 and 3600   |
 +--------------------+------------------------------------------+
 
-bucket\\path
-^^^^^^^^^^^^
+.. _bucket_path:
+
+path
+^^^^
 
 If defined, the path or prefix for the bucket.
 
@@ -254,8 +316,10 @@ If defined, the path or prefix for the bucket.
 | **Allowed values** | Valid path    |
 +--------------------+---------------+
 
-bucket\\path_suffix
-^^^^^^^^^^^^^^^^^^^
+.. _bucket_path_suffix:
+
+path_suffix
+^^^^^^^^^^^
 
 If defined, the suffix for the bucket. Only works with buckets which contain the folder named AWSLogs (Cloudtrail, VPC and Macie).
 
@@ -267,8 +331,8 @@ If defined, the suffix for the bucket. Only works with buckets which contain the
 
 .. _only_logs_aws_buckets:
 
-bucket\\only_logs_after
-^^^^^^^^^^^^^^^^^^^^^^^
+only_logs_after
+^^^^^^^^^^^^^^^
 
 A valid date, in YYYY-MMM-DD format. Only logs from that date onwards will be parsed.
 
@@ -278,8 +342,10 @@ A valid date, in YYYY-MMM-DD format. Only logs from that date onwards will be pa
 | **Allowed values** | Valid date                        |
 +--------------------+-----------------------------------+
 
-bucket\\regions
-^^^^^^^^^^^^^^^
+.. _bucket_regions:
+
+regions
+^^^^^^^
 
 A comma-delimited list of regions to limit parsing of logs. Only works with CloudTrail buckets.
 
@@ -289,8 +355,10 @@ A comma-delimited list of regions to limit parsing of logs. Only works with Clou
 | **Allowed values** | Comma-delimited list of valid regions  |
 +--------------------+----------------------------------------+
 
-bucket\\aws_organization_id
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. _bucket_aws_organization_id:
+
+aws_organization_id
+^^^^^^^^^^^^^^^^^^^
 
 Name of AWS organization. Only works with CloudTrail buckets.
 
@@ -300,8 +368,10 @@ Name of AWS organization. Only works with CloudTrail buckets.
 | **Allowed values** | Valid AWS organization name            |
 +--------------------+----------------------------------------+
 
-bucket\\discard_regex
-^^^^^^^^^^^^^^^^^^^^^
+.. _bucket_discard_regex:
+
+discard_regex
+^^^^^^^^^^^^^
 
 A regex value to determine if an event should be discarded. It requires a `field` attribute used to specify the field of the event where the regex should be applied.
 
@@ -314,7 +384,7 @@ A regex value to determine if an event should be discarded. It requires a `field
 Attributes:
 
 +-----------+------------------------------------------------------------------------------------------------------+
-| **field** | The event's field on which the regex should be applied to determine if the event should be skipped.  |
+| **field** | The event's field on which the regex should be applied to determine if the event should be skipped   |
 |           +------------------+-----------------------------------------------------------------------------------+
 |           | Default value    | N/A                                                                               |
 |           +------------------+-----------------------------------------------------------------------------------+
@@ -328,8 +398,10 @@ Usage example:
     <discard_regex field="data.configurationItemStatus">REJECT</discard_regex>
 
 
-bucket\\sts_endpoint
-^^^^^^^^^^^^^^^^^^^^
+.. _bucket_sts_endpoint:
+
+sts_endpoint
+^^^^^^^^^^^^
 
 The AWS Security Token Service VPC endpoint URL to be used when an IAM role is provided as the authentication method. Check the :ref:`Considerations for configuration <amazon_considerations>` page to learn more about VPC endpoints.
 
@@ -339,8 +411,10 @@ The AWS Security Token Service VPC endpoint URL to be used when an IAM role is p
 | **Allowed values** | Any valid VPC endpoint URL for STS     |
 +--------------------+----------------------------------------+
 
-bucket\\service_endpoint
-^^^^^^^^^^^^^^^^^^^^^^^^
+.. _bucket_service_endpoint:
+
+service_endpoint
+^^^^^^^^^^^^^^^^
 
 The AWS S3 endpoint URL to be used to download the data from the bucket. Check the :ref:`Considerations for configuration <amazon_considerations>` page to learn more about VPC and FIPS endpoints.
 
@@ -350,118 +424,72 @@ The AWS S3 endpoint URL to be used to download the data from the bucket. Check t
 | **Allowed values** | Any valid endpoint URL for S3          |
 +--------------------+----------------------------------------+
 
-run_on_start
-^^^^^^^^^^^^
+.. _services:
 
-Run evaluation immediately when service is started.
+Services
+~~~~~~~~
 
-+--------------------+---------+
-| **Default value**  | yes     |
-+--------------------+---------+
-| **Allowed values** | yes, no |
-+--------------------+---------+
+It is necessary to specify the type as an attribute of the ``service`` tag, for example:
 
-interval
-^^^^^^^^
+	.. code-block:: xml
 
-The amount of time the module will wait for before running again.
+		<service type="cloudwatchlogs">
 
-+--------------------+------------------------------------------------------------------------------------------------------------------------------------------------------+
-| **Default value**  | 10m                                                                                                                                                  |
-+--------------------+------------------------------------------------------------------------------------------------------------------------------------------------------+
-| **Allowed values** | A positive number that should contain a suffix character indicating a time unit, such as, s (seconds), m (minutes), h (hours), d (days), M (months). |
-+--------------------+------------------------------------------------------------------------------------------------------------------------------------------------------+
+		</service>
 
-day
-^^^
-
-Day of the month to run the scan.
-
-+--------------------+--------------------------+
-| **Default value**  | n/a                      |
-+--------------------+--------------------------+
-| **Allowed values** | Day of the month [1..31] |
-+--------------------+--------------------------+
+The available types are: ``cloudwatchlogs``, and ``inspector``.
 
 .. note::
+    The type that must be used depends on the service configured. More information about the supported services and their associated types on :ref:`AWS supported services <amazon_supported_services>`.
 
-	When the ``day`` option is set, the interval value must be a multiple of months. By default, the interval is set to a month.
++----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
+| Options                                | Allowed values                                              | Mandatory/Optional                            |
++========================================+=============================================================+===============================================+
+| :ref:`service_aws_account_id`          | Comma-delimited list of 12 digit AWS Account ID             | Optional                                      |
++----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
+| :ref:`service_aws_account_alias`       | Any string                                                  | Optional                                      |
++----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
+| :ref:`service_aws_log_groups`          | Comma-delimited list of valid log group names               | Mandatory for CloudWatch Logs                 |
++----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
+| :ref:`service_access_key`              | Any alphanumerical key                                      | Optional                                      |
++----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
+| :ref:`service_secret_key`              | Any alphanumerical key                                      | Optional                                      |       
++----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
+| :ref:`service_aws_profile`             | Valid profile name                                          | Optional                                      |
++----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
+| :ref:`service_iam_role_arn`            | Valid role ARN                                              | Optional                                      |
++----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
+| :ref:`service_iam_role_duration`       | Number of seconds between 900 and 3600                      | Optional (if set, it requires an iam_role_arn |
+|                                        |                                                             | to be provided)                               |
++----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
+| :ref:`service_only_logs_after`         | Valid date in YYYY-MMM-DD format                            | Optional                                      |
++----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
+| :ref:`service_regions`                 | Comma-delimited list of valid regions                       | Optional                                      |
++----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
+| :ref:`service_remove_log_streams`      | yes, no                                                     | Optional                                      |
++----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
+| :ref:`service_sts_endpoint`            | Any valid VPC endpoint URL for STS                          | Optional                                      |
++----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
+| :ref:`service_service_endpoint`        | Any valid endpoint URL for the AWS Service                  | Optional                                      |
++----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
 
-wday
-^^^^
+.. _service_aws_account_id:
 
-Day of the week to run the scan. This option is **not compatible** with the ``day`` option.
-
-+--------------------+--------------------------+
-| **Default value**  | n/a                      |
-+--------------------+--------------------------+
-| **Allowed values** | Day of the week:         |
-|                    |  - sunday/sun            |
-|                    |  - monday/mon            |
-|                    |  - tuesday/tue           |
-|                    |  - wednesday/wed         |
-|                    |  - thursday/thu          |
-|                    |  - friday/fri            |
-|                    |  - saturday/sat          |
-+--------------------+--------------------------+
-
-.. note::
-
-	When the ``wday`` option is set, the interval value must be a multiple of weeks. By default, the interval is set to a week.
-
-time
-^^^^
-
-Time of the day to run the scan. It has to be represented in the format *hh:mm*.
-
-+--------------------+-----------------------+
-| **Default value**  | n/a                   |
-+--------------------+-----------------------+
-| **Allowed values** | Time of day *[hh:mm]* |
-+--------------------+-----------------------+
-
-.. note::
-
-	When only the ``time`` option is set, the interval value must be a multiple of days or weeks. By default, the interval is set to a day.
-
-
-service type
-^^^^^^^^^^^^
-
-Define a service to process. Must have the attribute ``type`` defined. (Supports multiple instances of this option).
-
-Service options
-~~~~~~~~~~~~~~~
-
-- `Service\\aws_account_id`_
-- `Service\\aws_account_alias`_
-- `Service\\aws_log_groups`_
-- `Service\\access_key`_
-- `Service\\secret_key`_
-- `Service\\aws_profile`_
-- `Service\\iam_role_arn`_
-- `Service\\iam_role_duration`_
-- `Service\\only_logs_after`_
-- `Service\\regions`_
-- `Service\\remove_log_streams`_
-- `Service\\sts_endpoint`_
-- `Service\\service_endpoint`_
-
-
-Service\\aws_account_id
-^^^^^^^^^^^^^^^^^^^^^^^
+aws_account_id
+^^^^^^^^^^^^^^
 
 The AWS Account ID for accessing the service.
 
 +--------------------+-----------------------------------------------------+
-| **Default value**  | All accounts.                                       |
+| **Default value**  | All accounts                                        |
 +--------------------+-----------------------------------------------------+
 | **Allowed values** | Comma-delimited list of 12 digit AWS Account ID     |
 +--------------------+-----------------------------------------------------+
 
+.. _service_aws_account_alias:
 
-Service\\aws_account_alias
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+aws_account_alias
+^^^^^^^^^^^^^^^^^
 
 A user-friendly name for the AWS account.
 
@@ -471,43 +499,51 @@ A user-friendly name for the AWS account.
 | **Allowed values** | Any string                  |
 +--------------------+-----------------------------+
 
-Service\\access_key
-^^^^^^^^^^^^^^^^^^^
+.. _service_access_key:
+
+access_key
+^^^^^^^^^^
 
 The access key ID for the IAM user with the permission to access the service.
 
 +--------------------+--------------------------+
 | **Default value**  | N/A                      |
 +--------------------+--------------------------+
-| **Allowed values** | Any alphanumerical key.  |
+| **Allowed values** | Any alphanumerical key   |
 +--------------------+--------------------------+
 
-Service\\aws_log_groups
-^^^^^^^^^^^^^^^^^^^^^^^
+.. _service_aws_log_groups:
+
+aws_log_groups
+^^^^^^^^^^^^^^
 
 .. versionadded:: 4.0.0
 
-A comma-delimited list of log group names from where the logs should be extracted. Only works for CloudWatch Logs service.
+A comma-delimited list of log group names from where the logs should be extracted. This option is mandatory for CloudWatch Logs, and only works with that service.
 
 +--------------------+------------------------------------------------+
-| **Default value**  | All regions                                    |
+| **Default value**  | N/A                                            |
 +--------------------+------------------------------------------------+
 | **Allowed values** | Comma-delimited list of valid log group names  |
 +--------------------+------------------------------------------------+
 
-Service\\secret_key
-^^^^^^^^^^^^^^^^^^^
+.. _service_secret_key:
+
+secret_key
+^^^^^^^^^^
 
 The secret key created for the IAM user with the permission to access the service.
 
 +--------------------+--------------------------+
 | **Default value**  | N/A                      |
 +--------------------+--------------------------+
-| **Allowed values** | Any alphanumerical key.  |
+| **Allowed values** | Any alphanumerical key   |
 +--------------------+--------------------------+
 
-Service\\aws_profile
-^^^^^^^^^^^^^^^^^^^^
+.. _service_aws_profile:
+
+aws_profile
+^^^^^^^^^^^
 
 A valid profile name from a Shared Credential File or AWS Config File with the permission to access the service.
 
@@ -519,19 +555,21 @@ A valid profile name from a Shared Credential File or AWS Config File with the p
 
 .. _service_iam_role_arn:
 
-Service\\iam_role_arn
-^^^^^^^^^^^^^^^^^^^^^
+iam_role_arn
+^^^^^^^^^^^^
 
-A valid role arn with permission to access the service.
+A valid role ARN with permission to access the service.
 
 +--------------------+----------------+
 | **Default value**  | N/A            |
 +--------------------+----------------+
-| **Allowed values** | Valid role arn |
+| **Allowed values** | Valid role ARN |
 +--------------------+----------------+
 
-Service\\iam_role_duration
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. _service_iam_role_duration:
+
+iam_role_duration
+^^^^^^^^^^^^^^^^^
 
 A valid number of seconds that defines the duration of the session assumed when using the provided :ref:`iam_role_arn<service_iam_role_arn>`.
 
@@ -541,8 +579,10 @@ A valid number of seconds that defines the duration of the session assumed when 
 | **Allowed values** | Number of seconds between 900 and 3600   |
 +--------------------+------------------------------------------+
 
-Service\\only_logs_after
-^^^^^^^^^^^^^^^^^^^^^^^^
+.. _service_only_logs_after:
+
+only_logs_after
+^^^^^^^^^^^^^^^
 
 .. versionadded:: 4.0.0
 
@@ -551,15 +591,17 @@ A valid date, in YYYY-MMM-DD format. Only logs from that date onwards will be pa
 +--------------------+-----------------------------------+
 | **Default value**  | Date of execution at ``00:00:00`` |
 +--------------------+-----------------------------------+
-| **Allowed values** | Valid date                        |
+| **Allowed values** | Valid date in YYYY-MMM-DD format  |
 +--------------------+-----------------------------------+
 
-Service\\regions
-^^^^^^^^^^^^^^^^
+.. _service_regions:
+
+regions
+^^^^^^^
 
 .. versionadded:: 4.0.0
 
-A comma-delimited list of regions to limit parsing of logs. Only works for CloudWatch Logs service.
+A comma-delimited list of regions to limit parsing of logs.
 
 +--------------------+----------------------------------------+
 | **Default value**  | All regions                            |
@@ -567,8 +609,10 @@ A comma-delimited list of regions to limit parsing of logs. Only works for Cloud
 | **Allowed values** | Comma-delimited list of valid regions  |
 +--------------------+----------------------------------------+
 
-Service\\remove_log_streams
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. _service_remove_log_streams:
+
+remove_log_streams
+^^^^^^^^^^^^^^^^^^
 
 .. versionadded:: 4.0.0
 
@@ -580,8 +624,34 @@ Define whether or not to remove the log streams from the log groups after they a
 | **Allowed values** | yes, no |
 +--------------------+---------+
 
+.. _service_sts_endpoint:
+
+sts_endpoint
+^^^^^^^^^^^^
+
+The AWS Security Token Service VPC endpoint URL to be used when an IAM role is provided as the authentication method. Check the :ref:`Considerations for configuration <amazon_considerations>` page to learn more about VPC endpoints.
+
++--------------------+----------------------------------------+
+| **Default value**  | N/A                                    |
++--------------------+----------------------------------------+
+| **Allowed values** | Any valid VPC endpoint URL for STS     |
++--------------------+----------------------------------------+
+
+.. _service_service_endpoint:
+
+service_endpoint
+^^^^^^^^^^^^^^^^
+
+The endpoint URL for the required AWS Service to be used to download the data from it. Check the :ref:`Considerations for configuration <amazon_considerations>` page to learn more about VPC and FIPS endpoints.
+
++--------------------+------------------------------------------------+
+| **Default value**  | N/A                                            |
++--------------------+------------------------------------------------+
+| **Allowed values** | Any valid endpoint URL for the AWS Service     |
++--------------------+------------------------------------------------+
+
 Example of configuration
-------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: xml
 
@@ -638,27 +708,3 @@ Example of configuration
           <discard_regex field="data.configurationItemStatus">REJECT</discard_regex>
       </service>
   </wodle>
-
-
-Service\\sts_endpoint
-^^^^^^^^^^^^^^^^^^^^^
-
-The AWS Security Token Service VPC endpoint URL to be used when an IAM role is provided as the authentication method. Check the :ref:`Considerations for configuration <amazon_considerations>` page to learn more about VPC endpoints.
-
-+--------------------+----------------------------------------+
-| **Default value**  | N/A                                    |
-+--------------------+----------------------------------------+
-| **Allowed values** | Any valid VPC endpoint URL for STS     |
-+--------------------+----------------------------------------+
-
-Service\\service_endpoint
-^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The endpoint URL for the required AWS Service to be used to download the data from it. Check the :ref:`Considerations for configuration <amazon_considerations>` page to learn more about VPC and FIPS endpoints.
-
-+--------------------+------------------------------------------------+
-| **Default value**  | N/A                                            |
-+--------------------+------------------------------------------------+
-| **Allowed values** | Any valid endpoint URL for the AWS Service     |
-+--------------------+------------------------------------------------+
-

--- a/source/user-manual/reference/ossec-conf/wodle-s3.rst
+++ b/source/user-manual/reference/ossec-conf/wodle-s3.rst
@@ -148,7 +148,7 @@ Delete each log file from the S3 bucket once it has been collected by the module
 Buckets
 ~~~~~~~
 
-It is necessary to specify the type as an attribute of the ``bucket`` tag, for example:
+It is necessary to specify the type as an attribute of the ``bucket`` tag to indicate the service configured. More information about the supported services and their associated types on :ref:`AWS supported services <amazon_supported_services>`.
 
 	.. code-block:: xml
 
@@ -157,9 +157,6 @@ It is necessary to specify the type as an attribute of the ``bucket`` tag, for e
 		</bucket>
 
 The available types are:  ``cloudtrail``, ``guardduty``, ``vpcflow``, ``config``, ``custom``, ``cisco_umbrella``, ``waf``, ``alb``, ``clb``, ``nlb``, and ``server_access``.
-
-.. note::
-    The type that must be used depends on the service configured. More information about the supported services and their associated types on :ref:`AWS supported services <amazon_supported_services>`.
 
 +----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
 | Options                                | Allowed values                                              | Mandatory/Optional                            |
@@ -429,7 +426,7 @@ The AWS S3 endpoint URL to be used to download the data from the bucket. Check t
 Services
 ~~~~~~~~
 
-It is necessary to specify the type as an attribute of the ``service`` tag, for example:
+It is necessary to specify the type as an attribute of the ``service`` tag to indicate the service configured. More information about the supported services and their associated types on :ref:`AWS supported services <amazon_supported_services>`.
 
 	.. code-block:: xml
 
@@ -440,7 +437,6 @@ It is necessary to specify the type as an attribute of the ``service`` tag, for 
 The available types are: ``cloudwatchlogs``, and ``inspector``.
 
 .. note::
-    The type that must be used depends on the service configured. More information about the supported services and their associated types on :ref:`AWS supported services <amazon_supported_services>`.
 
 +----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
 | Options                                | Allowed values                                              | Mandatory/Optional                            |


### PR DESCRIPTION
| Related issue |
|---|
| Closes #4852 |
## Description
In this PR we restructure the AWS integration's `ossec.conf` reference to make it easier to follow. We defined three sections:

1. One with global parameters that might affect every integration defined.
2. One with the parameters that may be used inside the `<bucket>` tag.
3. One with the parameters that may be used inside the `<service>` tag.

The indices that were at the top of each subsection have been removed. For the first one, since the number of options is very low, we will rely on accessing every parameter either using the right-side index. For the second and third subsections, there is a table with every option along with how to configure it to make it easier to have all the information at a glimpse. The one for the third section has been written from scratch.

Some paragraphs have been reworded, and the hierarchy of each subsection has changed to make them more coherent.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
