### PR TITLE
Change the Canonical OVAL link in Vulnerability Detector

### DIFF
--- a/source/user-manual/capabilities/vulnerability-detection/offline-update.rst
+++ b/source/user-manual/capabilities/vulnerability-detection/offline-update.rst
@@ -1,7 +1,7 @@
 .. Copyright (C) 2022 Wazuh, Inc.
 
 .. meta::
-    :description: Learn more about how to perform the offline update of the Wazuh Vulnerability Detector in this section of our documentation. 
+    :description: Learn more about how to perform the offline update of the Wazuh Vulnerability Detector in this section of our documentation.
 
 .. vu_offline_update:
 
@@ -28,13 +28,13 @@ To perform an offline update of the Canonical feeds, you must download the corre
 +------------+--------------------------------------------------------------------------------------------+
 | OS         | Link                                                                                       |
 +============+============================================================================================+
-| Focal      | `<https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.focal.cve.oval.xml.bz2>`_  |
+| Focal      | `<https://security-metadata.canonical.com/oval/com.ubuntu.focal.cve.oval.xml.bz2>`_        |
 +------------+--------------------------------------------------------------------------------------------+
-| Bionic     | `<https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.bionic.cve.oval.xml.bz2>`_ |
+| Bionic     | `<https://security-metadata.canonical.com/oval/com.ubuntu.bionic.cve.oval.xml.bz2>`_       |
 +------------+--------------------------------------------------------------------------------------------+
-| Xenial     | `<https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.xenial.cve.oval.xml.bz2>`_ |
+| Xenial     | `<https://security-metadata.canonical.com/oval/com.ubuntu.xenial.cve.oval.xml.bz2>`_       |
 +------------+--------------------------------------------------------------------------------------------+
-| Trusty     | `<https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.trusty.cve.oval.xml.bz2>`_ |
+| Trusty     | `<https://security-metadata.canonical.com/oval/com.ubuntu.trusty.cve.oval.xml.bz2>`_       |
 +------------+--------------------------------------------------------------------------------------------+
 
 To fetch the vulnerability feeds from an alternative repository, the configuration is similar to the following:


### PR DESCRIPTION
## Description

As of 16 November 2021, the repository at the following URL is no longer supported:
`https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.$(lsb_release -cs).cve.oval.xml.bz2`

And it seems that because they have changed the URL where the repository is located, so that it has been modified by the following link:
`https://security-metadata.canonical.com/oval/com.ubuntu.$(lsb_release -cs).cve.oval.xml.bz2`

In this PR, all the old links have been replaced to modify them by the new one.

This change affects all versions that have _offline updates_ in Wazuh.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
