### PR TITLE
Remote enrollment typo

### DIFF
--- a/source/user-manual/reference/ossec-conf/auth.rst
+++ b/source/user-manual/reference/ossec-conf/auth.rst
@@ -213,7 +213,7 @@ Default configuration
 
   <auth>
     <disabled>no</disabled>
-    <remote_enrollment>yes<remote_enrollment>
+    <remote_enrollment>yes</remote_enrollment>
     <port>1515</port>
     <use_source_ip>no</use_source_ip>
     <force_insert>yes</force_insert>


### PR DESCRIPTION
| Related issue |
| -- |
|closes #4891 |

## Description

This PR fixes  a typo error in [user-manual/reference/ossec-conf/auth.html](https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/auth.html)

4.2:
```
<auth>
  <disabled>no</disabled>
  <remote_enrollment>yes<remote_enrollment>
```

PR:
```
<auth>
  <disabled>no</disabled>
  <remote_enrollment>yes</remote_enrollment>
```

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).


