### PR TITLE
Correcting the path for the Kibana reports

### DIFF
--- a/source/user-manual/kibana-app/features/reporting.rst
+++ b/source/user-manual/kibana-app/features/reporting.rst
@@ -5,7 +5,7 @@
 Reporting
 =========
 
-When you're navigating through the *Overview* or *Agents* tabs, you can generate a report of the current section when clicking on the printer icon button, on the top right corner in the interface. These reports are stored on the same machine where Kibana is installed, in the ``/usr/share/kibana/wazuh/downloads/reports`` folder. A status message will indicate if the report was generated successfully, or if the process was aborted.
+When you're navigating through the *Overview* or *Agents* tabs, you can generate a report of the current section when clicking on the printer icon button, on the top right corner in the interface. These reports are stored on the same machine where Kibana is installed, in the ``/usr/share/kibana/data/wazuh/downloads/reports/`` folder. A status message will indicate if the report was generated successfully, or if the process was aborted.
 
 .. thumbnail:: ../../../images/kibana-app/features/reporting/generate-report.png
   :align: center


### PR DESCRIPTION

## Description
A minor edit to fix the path where the Reports from the Wazuh Kibana app are stored
<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
