### PR TITLE
[4.3] Avoid auto-generated links to image resources

### DIFF
--- a/source/_exts/wazuh-doc-images.py
+++ b/source/_exts/wazuh-doc-images.py
@@ -272,7 +272,7 @@ def setup(app):
     app.connect('env-updated', manage_static_files)
 
     return {
-        'version': '0.1',
+        'version': '0.2',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
     }

--- a/source/conf.py
+++ b/source/conf.py
@@ -356,6 +356,8 @@ wazuh_images_config = {
   'show_caption': True
 }
 
+html_scaled_image_link = False
+
 # -- Options for intersphinx extension ---------------------------------------
 
 # Example configuration for intersphinx: refer to the Python standard library.


### PR DESCRIPTION
## Description

This PR turns off the scaled_image_link option to avoid the links to image resources that are automatically added by Sphinx. This is required after the latest changes to our custom extension `wazuh-doc-images` (v0.1) and will not affect the branches that still use the old version of the extension (v0.2).

## Checks
- [x] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
