### PR TITLE
Modify the description of the baseline scan type for Vulnerability Detector

### DIFF
--- a/source/user-manual/capabilities/vulnerability-detection/how-it-works.rst
+++ b/source/user-manual/capabilities/vulnerability-detection/how-it-works.rst
@@ -1,7 +1,7 @@
 .. Copyright (C) 2022 Wazuh, Inc.
 .. meta::
-  :description: Vulnerability Detection is one of the Wazuh capabilities. Learn more about how it works and the repositories it uses. 
-  
+  :description: Vulnerability Detection is one of the Wazuh capabilities. Learn more about how it works and the repositories it uses.
+
 .. vu_how_it_works:
 
 How it works
@@ -34,7 +34,7 @@ There is only one case in which the packages and the operating system will be re
 
 We have then three different types of scan:
 
-- `Baseline`: This scan type will be triggered the first time after `Vulnerability Detector` is enabled. It performs a full scan for every single package installed as well as the operating system. As a result, the CVE inventory will have the information of the vulnerabilities detected but no alerts will be generated.
+- `Baseline`: This scan type will be triggered the first time after `Vulnerability Detector` is enabled. It performs a full scan for every single package installed as well as the operating system. As a result, the CVE inventory will have the information of the vulnerabilities detected and an alert will be generated for each vulnerability.
 - `Full scan`: In this scan type, every single package installed as well as the operating system are scanned. It runs only when the configured :ref:`min_full_scan_interval <vuln_det_min_full_scan_interval>` expires and the CVEs database is updated with new information. As a result, any update/change in the vulnerability inventory will be alerted.
 - `Partial scan`: Only new packages are scanned. As a result, any update/change in the vulnerability inventory will be alerted.
 


### PR DESCRIPTION
## Description

This PR closes #4919

Due to the modifications made for the issue: https://github.com/wazuh/wazuh/issues/12588 ([PR](https://github.com/wazuh/wazuh/pull/12618)), it has been necessary to modify the description of the baseline scan type.

For this, the change made in the description has been to change the sentence from `no alerts are generated`, to `an alert is generated for each vulnerability`.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 