### PR TITLE
Update securing API section referencing Kibana configuration file

### DIFF
--- a/source/user-manual/api/securing-api.rst
+++ b/source/user-manual/api/securing-api.rst
@@ -64,7 +64,7 @@ Recommended changes to securize Wazuh API
     After changing the password, there is no need to restart the Wazuh API but a new :api-ref:`authentication <operation/api.controllers.security_controller.login_user>` will be required for the affected users.
 
     .. warning::
-      Changing the **wazuh-wui** user password will affect the Wazuh UI. You will have to update the ``wazuh.yml`` file accordingly with the new credentials. For further information, please visit the :ref:`Wazuh Kibana plugin configuration file section <kibana_config_file>`.
+      Changing the **wazuh-wui** user password will affect the Wazuh UI. You will have to update the ``/usr/share/kibana/data/wazuh/config/wazuh.yml`` configuration file accordingly with the new credentials. To learn more, see the :ref:`Wazuh Kibana plugin configuration file section <kibana_config_file>`.
 
 #. Change the default host and port:
 

--- a/source/user-manual/api/securing-api.rst
+++ b/source/user-manual/api/securing-api.rst
@@ -63,6 +63,9 @@ Recommended changes to securize Wazuh API
 
     After changing the password, there is no need to restart the Wazuh API but a new :api-ref:`authentication <operation/api.controllers.security_controller.login_user>` will be required for the affected users.
 
+    .. warning::
+      Changing the **wazuh-wui** user password will affect the Wazuh UI. You will have to update the ``wazuh.yml`` file accordingly with the new credentials. For further information, please visit the :ref:`Wazuh Kibana plugin configuration file section <kibana_config_file>`.
+
 #. Change the default host and port:
 
     The *host* is set to ``0.0.0.0`` by default, which means the Wazuh API will accept any incoming connection. It is possible to restrict it editing the Wazuh API configuration in ``WAZUH_PATH/api/configuration/api.yaml``:


### PR DESCRIPTION

## Description

This PR closes #4889 and adds some clarity about the repercussion for Kibana when changing the `wazuh-wui` API user credentials.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).


## Note to the reviewer

This PR is pointing to the production branch. Later versions must be updated as well.
