### PR TITLE
Fix wcloud-cli version

### DIFF
--- a/source/cloud-service/cli/index.rst
+++ b/source/cloud-service/cli/index.rst
@@ -37,7 +37,7 @@ Installation
   .. code-block:: none
     :class: output
 
-    Wazuh Cloud CLI - "version": "1.0.0"
+    Wazuh Cloud CLI - "version": "1.0.1"
 
 
 Configuration


### PR DESCRIPTION
# Related

⚠️ ⚠️ Please this PR should close #4898

|Related issue|
|--|
|Closes #4898  |

## Description


In PR  #4897 I forgot to update the Wazuh cli version output from 1.0.0 to 1.0.1

### Before changes

![Captura de pantalla 2022-03-15 a las 12 52 54](https://user-images.githubusercontent.com/14912971/158372356-02715115-adbd-49e6-87d0-869fb6cbcd2e.png)


### After changes



![Captura de pantalla 2022-03-15 a las 12 46 11](https://user-images.githubusercontent.com/14912971/158372255-6bcce2d9-2bdf-4da8-8d38-d2dc2ca8b26f.png)



## Checks
- [x] It compiles without warnings.


- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).


## Note to the reviewer

This PR DOES NOT includes changes to the `redirect.js` script
