### PR TITLE
Deprecate GCP integration's logging parameter

### DIFF
--- a/source/gcp/prerequisites/considerations.rst
+++ b/source/gcp/prerequisites/considerations.rst
@@ -23,6 +23,11 @@ When using the ``only_logs_after`` tag, the Wazuh module checks the creation tim
 
 Any date in the file's name is ignored and only the creation date is used to determine whether or not a file should be processed.
 
+Logging level
+-------------
+
+To switch between different logging levels for debugging and troubleshooting purposes, the Google Cloud integration uses the :ref:`wazuh_modules debug level<wazuh_modules_options>` to set its verbosity level.
+
 
 Configuring multiple Google Cloud Storage bucket
 ------------------------------------------------
@@ -34,7 +39,6 @@ Below there is an example of a configuration that uses more than one bucket:
  <gcp-bucket>
     <run_on_start>yes</run_on_start>
     <interval>1m</interval>
-    <logging>debug</logging>
 
     <bucket type="access_logs">
         <name>wazuh-test-bucket</name>

--- a/source/gcp/prerequisites/considerations.rst
+++ b/source/gcp/prerequisites/considerations.rst
@@ -26,7 +26,7 @@ Any date in the file's name is ignored and only the creation date is used to det
 Logging level
 -------------
 
-To switch between different logging levels for debugging and troubleshooting purposes, the Google Cloud integration uses the :ref:`wazuh_modules debug level<wazuh_modules_options>` to set its verbosity level.
+To switch between different logging levels for debugging and troubleshooting purposes, the Google Cloud integration uses the :ref:`wazuh_modules.debug <wazuh_modules_options>` level to set its verbosity level.
 
 
 Configuring multiple Google Cloud Storage bucket

--- a/source/gcp/supported-services/access_logs.rst
+++ b/source/gcp/supported-services/access_logs.rst
@@ -26,7 +26,6 @@ Example of configuration
  <gcp-bucket>
     <run_on_start>yes</run_on_start>
     <interval>1m</interval>
-    <logging>debug</logging>
     <bucket type="access_logs">
         <name>wazuh-test-bucket</name>
         <credentials_file>credentials.json</credentials_file>

--- a/source/user-manual/reference/internal-options.rst
+++ b/source/user-manual/reference/internal-options.rst
@@ -1019,6 +1019,8 @@ Once these settings have been adjusted, the file must be saved followed by a res
 |                                               | Allowed value | Any integer between 0 and 2147483647.                                               |
 +-----------------------------------------------+---------------+-------------------------------------------------------------------------------------+
 
+.. _wazuh_modules_options:
+
 Wazuh Modules
 -------------
 

--- a/source/user-manual/reference/ossec-conf/gcp-bucket.rst
+++ b/source/user-manual/reference/ossec-conf/gcp-bucket.rst
@@ -25,7 +25,6 @@ Main options
 ^^^^^^^^^^^^
 
 - `enabled`_
-- `logging`_
 - `bucket type`_
 
 Scheduling options
@@ -52,13 +51,10 @@ This indicates if the module is enabled or disabled.
 logging
 ^^^^^^^^
 
-Toggle between the different logging levels.
+.. deprecated:: 4.4
 
-+--------------------+--------------------------------------------+
-| **Default value**  | info                                       |
-+--------------------+--------------------------------------------+
-| **Allowed values** | disabled/info/debug/warning/error/critical |
-+--------------------+--------------------------------------------+
+This option has no effect. The module now uses the :ref:`wazuh_modules debug level<wazuh_modules_options>` to set its logging level.
+
 
 bucket type
 ^^^^^^^^^^^
@@ -230,6 +226,5 @@ Linux configuration:
         <interval>1m</interval>
         <project_id>wazuh-dev</project_id>
         <subscription_name>wazuhdns</subscription_name>
-        <logging>debug</logging>
         <credentials_file>wodles/gcp-bucket/credentials.json</credentials_file>
     </gcp-bucket>

--- a/source/user-manual/reference/ossec-conf/gcp-bucket.rst
+++ b/source/user-manual/reference/ossec-conf/gcp-bucket.rst
@@ -53,7 +53,7 @@ logging
 
 .. deprecated:: 4.4
 
-This option has no effect. The module now uses the :ref:`wazuh_modules debug level<wazuh_modules_options>` to set its logging level.
+This option has no effect. The module now uses the :ref:`wazuh_modules.debug <wazuh_modules_options>` level to set its logging level.
 
 
 bucket type

--- a/source/user-manual/reference/ossec-conf/gcp-pubsub.rst
+++ b/source/user-manual/reference/ossec-conf/gcp-pubsub.rst
@@ -28,7 +28,6 @@ Main options
 - `credentials_file`_
 - `max_messages`_
 - `num_threads`_
-- `logging`_
 
 Scheduling options
 ^^^^^^^^^^^^^^^^^^
@@ -119,14 +118,9 @@ Number of threads used to pull in each iteration. The number of maximum messages
 logging
 ^^^^^^^^
 
-Toggle between the different logging levels.
+.. deprecated:: 4.4
 
-+--------------------+--------------------------------------------+
-| **Default value**  | info                                       |
-+--------------------+--------------------------------------------+
-| **Allowed values** | disabled/info/debug/warning/error/critical |
-+--------------------+--------------------------------------------+
-
+This option has no effect. The module now uses the :ref:`wazuh_modules debug level<wazuh_modules_options>` to set its logging level.
 
 pull_on_start
 ^^^^^^^^^^^^^
@@ -215,6 +209,5 @@ Linux configuration:
         <interval>1m</interval>
         <project_id>wazuh-dev</project_id>
         <subscription_name>wazuhdns</subscription_name>
-        <logging>debug</logging>
         <credentials_file>wodles/gcp-pubsub/credentials.json</credentials_file>
     </gcp-pubsub>

--- a/source/user-manual/reference/ossec-conf/gcp-pubsub.rst
+++ b/source/user-manual/reference/ossec-conf/gcp-pubsub.rst
@@ -120,7 +120,7 @@ logging
 
 .. deprecated:: 4.4
 
-This option has no effect. The module now uses the :ref:`wazuh_modules debug level<wazuh_modules_options>` to set its logging level.
+This option has no effect. The module now uses the :ref:`wazuh_modules.debug <wazuh_modules_options>` level to set its logging level.
 
 pull_on_start
 ^^^^^^^^^^^^^


### PR DESCRIPTION
|Related issue|
|----|
|Closes #4942|


## Description
In this PR we add information regarding the deprecation of the GCP integration's debug parameter. 

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->