### PR TITLE
Replace packages URLs with new shortened dev URLs

### DIFF
--- a/source/_templates/installations/basic/elastic/common/configure_kibana.rst
+++ b/source/_templates/installations/basic/elastic/common/configure_kibana.rst
@@ -2,7 +2,7 @@
 
 .. code-block:: console
 
-  # curl -so /etc/kibana/kibana.yml https://packages.wazuh.com/resources/4.2/elastic-stack/kibana/7.x/kibana.yml
+  # curl -so /etc/kibana/kibana.yml https://packages-dev.wazuh.com/4.3/tpl/elastic-basic/kibana.yml
 
 
 Edit the ``/etc/kibana/kibana.yml`` file:

--- a/source/_templates/installations/basic/elastic/common/configure_kibana_all_in_one.rst
+++ b/source/_templates/installations/basic/elastic/common/configure_kibana_all_in_one.rst
@@ -2,7 +2,7 @@
 
 .. code-block:: console
 
-  # curl -so /etc/kibana/kibana.yml https://packages.wazuh.com/resources/4.2/elastic-stack/kibana/7.x/kibana_all_in_one.yml
+  # curl -so /etc/kibana/kibana.yml https://packages-dev.wazuh.com/4.3/tpl/elastic-basic/kibana_all_in_one.yml
 
 Edit the ``/etc/kibana/kibana.yml`` file:
 

--- a/source/_templates/installations/basic/elastic/common/elastic-multi-node/configure_elasticsearch.rst
+++ b/source/_templates/installations/basic/elastic/common/elastic-multi-node/configure_elasticsearch.rst
@@ -2,7 +2,7 @@
 
 .. code-block:: console
 
-  # curl -so /etc/elasticsearch/elasticsearch.yml https://packages.wazuh.com/resources/4.2/elastic-stack/elasticsearch/7.x/elasticsearch_cluster.yml
+  # curl -so /etc/elasticsearch/elasticsearch.yml https://packages-dev.wazuh.com/4.3/tpl/elastic-basic/elasticsearch_cluster.yml
 
 
 The file ``/etc/elasticsearch/elasticsearch.yml`` has to be edited:

--- a/source/_templates/installations/basic/elastic/common/elastic-multi-node/configure_elasticsearch_initial_node.rst
+++ b/source/_templates/installations/basic/elastic/common/elastic-multi-node/configure_elasticsearch_initial_node.rst
@@ -2,7 +2,7 @@
 
 .. code-block:: console
 
-  # curl -so /etc/elasticsearch/elasticsearch.yml https://packages.wazuh.com/resources/4.2/elastic-stack/elasticsearch/7.x/elasticsearch_cluster_initial_node.yml
+  # curl -so /etc/elasticsearch/elasticsearch.yml https://packages-dev.wazuh.com/4.3/tpl/elastic-basic/elasticsearch_cluster_initial_node.yml
 
 The file ``/etc/elasticsearch/elasticsearch.yml`` has to be edited:
 

--- a/source/_templates/installations/basic/elastic/common/elastic-multi-node/configure_elasticsearch_subsequent_nodes.rst
+++ b/source/_templates/installations/basic/elastic/common/elastic-multi-node/configure_elasticsearch_subsequent_nodes.rst
@@ -2,7 +2,7 @@
 
 .. code-block:: console
 
-  # curl -so /etc/elasticsearch/elasticsearch.yml https://packages.wazuh.com/resources/4.2/elastic-stack/elasticsearch/7.x/elasticsearch_cluster_subsequent_nodes.yml
+  # curl -so /etc/elasticsearch/elasticsearch.yml https://packages-dev.wazuh.com/4.3/tpl/elastic-basic/elasticsearch_cluster_subsequent_nodes.yml
 
 The file ``/etc/elasticsearch/elasticsearch.yml`` has to be edited:
 

--- a/source/_templates/installations/basic/elastic/common/elastic-single-node/configure_elasticsearch.rst
+++ b/source/_templates/installations/basic/elastic/common/elastic-single-node/configure_elasticsearch.rst
@@ -4,6 +4,6 @@ Once Elasticsearch is installed it can be configured by downloading the file ``/
 
 .. code-block:: console
 
-  # curl -so /etc/elasticsearch/elasticsearch.yml https://packages.wazuh.com/resources/4.2/elastic-stack/elasticsearch/7.x/elasticsearch.yml
+  # curl -so /etc/elasticsearch/elasticsearch.yml https://packages-dev.wazuh.com/4.3/tpl/elastic-basic/elasticsearch.yml
 
 .. End of include file

--- a/source/_templates/installations/basic/elastic/common/elastic-single-node/configure_elasticsearch_aio.rst
+++ b/source/_templates/installations/basic/elastic/common/elastic-single-node/configure_elasticsearch_aio.rst
@@ -4,6 +4,6 @@ Download the configuration file ``/etc/elasticsearch/elasticsearch.yml`` as foll
 
 .. code-block:: console
 
-  # curl -so /etc/elasticsearch/elasticsearch.yml https://packages.wazuh.com/resources/4.2/elastic-stack/elasticsearch/7.x/elasticsearch_all_in_one.yml
+  # curl -so /etc/elasticsearch/elasticsearch.yml https://packages-dev.wazuh.com/4.3/tpl/elastic-basic/elasticsearch_all_in_one.yml
 
 .. End of include file

--- a/source/_templates/installations/elastic/common/certificates-aio.rst
+++ b/source/_templates/installations/elastic/common/certificates-aio.rst
@@ -4,7 +4,7 @@
 
   .. code-block:: console
 
-    # curl -so ~/wazuh-cert-tool.sh https://packages.wazuh.com/resources/4.2/open-distro/tools/certificate-utility/wazuh-cert-tool.sh
+    # curl -so ~/wazuh-cert-tool.sh https://packages-dev.wazuh.com/4.3/wazuh-cert-tool.sh
     # curl -so ~/instances.yml https://packages.wazuh.com/resources/4.2/open-distro/tools/certificate-utility/instances_aio.yml
 
 * Run the  ``wazuh-cert-tool.sh`` to create the certificates:

--- a/source/_templates/installations/elastic/common/elastic-multi-node/generate_certificates.rst
+++ b/source/_templates/installations/elastic/common/elastic-multi-node/generate_certificates.rst
@@ -4,7 +4,7 @@
 
    .. code-block:: console
 
-     # curl -sO https://s3.us-west-1.amazonaws.com/packages-dev.wazuh.com/resources/4.2/tools/wazuh-cert-tool.sh
+     # curl -sO https://packages-dev.wazuh.com/4.3/wazuh-cert-tool.sh
      # curl -sO https://s3.us-west-1.amazonaws.com/packages-dev.wazuh.com/resources/4.2/config/opendistro/certificate/instances.yml
 
 #. Edit ``./instances.yml`` and replace the node names and IP values with the corresponding names and IP addresses. Add as many node fields as needed.

--- a/source/_templates/installations/elastic/common/elastic-single-node/generate_deploy_certificates.rst
+++ b/source/_templates/installations/elastic/common/elastic-single-node/generate_deploy_certificates.rst
@@ -5,7 +5,7 @@
 
    .. code-block:: console
  
-     # curl -so ~/wazuh-cert-tool.sh https://packages.wazuh.com/resources/4.2/open-distro/tools/certificate-utility/wazuh-cert-tool.sh
+     # curl -so ~/wazuh-cert-tool.sh https://packages-dev.wazuh.com/4.3/wazuh-cert-tool.sh
      # curl -so ~/instances.yml https://packages.wazuh.com/resources/4.2/open-distro/tools/certificate-utility/instances.yml
 
 #. Edit ``~/instances.yml`` and replace the values ``<node-name>`` and ``node-IP``  with the corresponding names and IP addresses. Add as many nodes fields as needed:

--- a/source/_templates/installations/indexer/common/generate_certificates.rst
+++ b/source/_templates/installations/indexer/common/generate_certificates.rst
@@ -4,8 +4,8 @@
 
    .. code-block:: console
 
-    # curl -sO https://packages-dev.wazuh.com/resources/4.3/install_functions/opendistro/wazuh-cert-tool.sh
-    # curl -sO https://packages-dev.wazuh.com/resources/4.3/config/opendistro/certificate/config.yml
+    # curl -sO https://packages-dev.wazuh.com/4.3/wazuh-cert-tool.sh
+    # curl -sO https://packages-dev.wazuh.com/4.3/config.yml
 
 #. Edit ``./config.yml`` and replace the node names and IP values with the corresponding names and IP addresses. You need to do this for all the Wazuh server, the Wazuh indexer, and the Wazuh dashboard nodes. Add as many node fields as needed.
 

--- a/source/deployment-options/elastic-stack/all-in-one-deployment/all-in-one.rst
+++ b/source/deployment-options/elastic-stack/all-in-one-deployment/all-in-one.rst
@@ -75,7 +75,7 @@ Certificates creation and deployment
 
     .. code-block:: console
 
-        # curl -so /usr/share/elasticsearch/instances.yml https://packages.wazuh.com/resources/|WAZUH_LATEST_MINOR|/elastic-stack/instances_aio.yml
+        # curl -so /usr/share/elasticsearch/instances.yml https://packages-dev.wazuh.com/|WAZUH_LATEST_MINOR|/tpl/elastic-basic/instances_aio.yml
     
     
     In the following steps, a file that contains a folder named after the instance defined here will be created. This folder will contain the certificates and the keys necessary to communicate with the Elasticsearch node using SSL.
@@ -236,7 +236,7 @@ Filebeat installation and configuration
 
     .. code-block:: console
 
-      # curl -so /etc/filebeat/filebeat.yml https://packages.wazuh.com/resources/|WAZUH_LATEST_MINOR|/elastic-stack/filebeat/7.x/filebeat_all_in_one.yml
+      # curl -so /etc/filebeat/filebeat.yml https://packages-dev.wazuh.com/|WAZUH_LATEST_MINOR|/tpl/elastic-basic/filebeat_all_in_one.yml
 
 #. Download the alerts template for Elasticsearch:
 

--- a/source/deployment-options/elastic-stack/distributed-deployment/step-by-step-installation/wazuh-cluster/wazuh-multi-node-cluster.rst
+++ b/source/deployment-options/elastic-stack/distributed-deployment/step-by-step-installation/wazuh-cluster/wazuh-multi-node-cluster.rst
@@ -160,7 +160,7 @@ Filebeat installation and configuration
 
     .. code-block:: console
 
-      # curl -so /etc/filebeat/filebeat.yml https://packages.wazuh.com/resources/|WAZUH_LATEST_MINOR|/elastic-stack/filebeat/7.x/filebeat.yml
+      # curl -so /etc/filebeat/filebeat.yml https://packages-dev.wazuh.com/|WAZUH_LATEST_MINOR|/tpl/elastic-basic/filebeat.yml
 
 #. Download the alerts template for Elasticsearch:
 

--- a/source/deployment-options/elastic-stack/distributed-deployment/step-by-step-installation/wazuh-cluster/wazuh-single-node-cluster.rst
+++ b/source/deployment-options/elastic-stack/distributed-deployment/step-by-step-installation/wazuh-cluster/wazuh-single-node-cluster.rst
@@ -131,7 +131,7 @@ Filebeat installation and configuration
 
     .. code-block:: console
 
-      # curl -so /etc/filebeat/filebeat.yml https://packages.wazuh.com/resources/|WAZUH_LATEST_MINOR|/elastic-stack/filebeat/7.x/filebeat.yml
+      # curl -so /etc/filebeat/filebeat.yml https://packages-dev.wazuh.com/|WAZUH_LATEST_MINOR|/tpl/elastic-basic/filebeat.yml
 
 #. Download the alerts template for Elasticsearch:
 

--- a/source/deployment-options/elastic-stack/distributed-deployment/unattended/unattended-elasticsearch-cluster-installation.rst
+++ b/source/deployment-options/elastic-stack/distributed-deployment/unattended/unattended-elasticsearch-cluster-installation.rst
@@ -47,7 +47,7 @@ Download the script and the configuration file. After downloading them, configur
       .. code-block:: console
 
           # curl -so ~/elastic-stack-installation.sh https://packages.wazuh.com/resources/|WAZUH_LATEST_MINOR|/elastic-stack/unattended-installation/distributed/elastic-stack-installation.sh 
-          # curl -so ~/config.yml https://packages.wazuh.com/resources/|WAZUH_LATEST_MINOR|/elastic-stack/unattended-installation/distributed/templates/config.yml
+          # curl -so ~/config.yml https://packages-dev.wazuh.com/|WAZUH_LATEST_MINOR|/config.yml
 
     **Configure the installation** 
       

--- a/source/installation-guide/wazuh-dashboard/unattended.rst
+++ b/source/installation-guide/wazuh-dashboard/unattended.rst
@@ -20,7 +20,7 @@ You can install and configure the Wazuh dashboard using an automated script.
 
     .. code-block:: console
 
-      # curl -sO https://s3.us-west-1.amazonaws.com/packages-dev.wazuh.com/resources/4.3/wazuh_install.sh
+      # curl -sO https://packages-dev.wazuh.com/|WAZUH_LATEST_MINOR|/wazuh-install.sh
 
 
 
@@ -28,7 +28,7 @@ You can install and configure the Wazuh dashboard using an automated script.
    
     .. code-block:: console
 
-      # bash ./wazuh_install.sh -wd dashboard
+      # bash ./wazuh-install.sh -wd dashboard
 
     
 

--- a/source/installation-guide/wazuh-indexer/unattended.rst
+++ b/source/installation-guide/wazuh-indexer/unattended.rst
@@ -33,8 +33,8 @@ Indicate your deployment configuration, create the SSL certificates to encrypt c
 
       .. code-block:: console
 
-          # curl -sO https://s3.us-west-1.amazonaws.com/packages-dev.wazuh.com/resources/4.3/wazuh_install.sh
-          # curl -sO https://s3.us-west-1.amazonaws.com/packages-dev.wazuh.com/resources/4.3/config.yml
+          # curl -sO https://packages-dev.wazuh.com/|WAZUH_LATEST_MINOR|/wazuh-install.sh
+          # curl -sO https://packages-dev.wazuh.com/|WAZUH_LATEST_MINOR|/config.yml
        
 #. Edit ``./config.yml`` and replace the node names and IP values with the corresponding names and IP addresses. You need to do this for all the Wazuh server, the Wazuh indexer, and the Wazuh dashboard nodes. Add as many node fields as needed.
 
@@ -69,7 +69,7 @@ Indicate your deployment configuration, create the SSL certificates to encrypt c
 
       .. code-block:: console
 
-        # bash ./wazuh_install.sh -c
+        # bash ./wazuh-install.sh -c
 
 
 #.  Copy the ``configurations.tar`` file to all the servers of the distributed deployment, including the Wazuh server, the Wazuh indexer, and the Wazuh dashboard nodes. This can be done by using, for example, ``scp``.
@@ -85,14 +85,14 @@ Install and configure the Wazuh indexer nodes. Make sure that a copy of ``config
 
       .. code-block:: console
 
-        # curl -sO https://s3.us-west-1.amazonaws.com/packages-dev.wazuh.com/resources/4.3/wazuh_install.sh
+        # curl -sO https://packages-dev.wazuh.com/|WAZUH_LATEST_MINOR|/wazuh-install.sh
 
 
 #. Run the script with the option ``-wi`` and the node name to install and configure the Wazuh indexer. The node name must be the same used in ``config.yml`` for the initial configuration, for example, ``node-1``.
 
       .. code-block:: console
 
-        # bash ./wazuh_install.sh -wi node-1 
+        # bash ./wazuh-install.sh -wi node-1 
 
 
 Repeat this process on each Wazuh indexer node and proceed with initializing the cluster.             
@@ -108,7 +108,7 @@ Run the unattended script with option ``-s`` to load the new certificates inform
 
   .. code-block:: console
 
-    # bash ./wazuh_install.sh -s
+    # bash ./wazuh-install.sh -s
 
 
 Next steps

--- a/source/installation-guide/wazuh-server/unattended.rst
+++ b/source/installation-guide/wazuh-server/unattended.rst
@@ -18,7 +18,7 @@ Install the Wazuh server as a single-node or multi-node cluster according to you
 
    .. code-block:: console
    
-       # curl -sO https://s3.us-west-1.amazonaws.com/packages-dev.wazuh.com/resources/4.3/wazuh_install.sh
+       # curl -sO https://packages-dev.wazuh.com/|WAZUH_LATEST_MINOR|/wazuh-install.sh
 
 #. Run the script with the option ``-ws`` followed by the node name to install the Wazuh server. The node name must be the same used in ``config.yml`` for the initial configuration, for example, ``wazuh-master``.
  

--- a/source/quickstart.rst
+++ b/source/quickstart.rst
@@ -76,7 +76,7 @@ Installing Wazuh
 
    .. code-block:: console
 
-     # curl -sO https://s3.us-west-1.amazonaws.com/packages-dev.wazuh.com/resources/4.3/wazuh_install.sh && sudo bash ./wazuh_install.sh -a
+     # curl -sO https://packages-dev.wazuh.com/|WAZUH_LATEST_MINOR|/wazuh-install.sh && sudo bash ./wazuh-install.sh -a
 
    After executing the installer, the output shows the access credentials and a message that confirms that the installation was successful.
    

--- a/source/user-manual/elasticsearch/elastic-tuning.rst
+++ b/source/user-manual/elasticsearch/elastic-tuning.rst
@@ -31,7 +31,7 @@ Changing the default passwords of Elasticsearch is highly recommended in order t
     
       .. code-block:: console
       
-        # curl -so wazuh-passwords-tool.sh https://packages.wazuh.com/resources/4.2/open-distro/tools/wazuh-passwords-tool.sh
+        # curl -so wazuh-passwords-tool.sh https://packages-dev.wazuh.com/|WAZUH_LATEST_MINOR|/wazuh-passwords-tool.sh
 
     - Run the script:
 


### PR DESCRIPTION
## Description

This PR closes issue #4922 . It replaces packages and scripts URLs with the new shortened versions. This uses the development `packages-dev` URLs and will need to be replaced with the `packages` production URLs when available and published.

## Checks
- [X] It compiles without warnings.
- [X] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [X] Used uppercase only on nouns. 
- [X] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).