### PR TITLE
Add uninstall central components guide

### DIFF
--- a/source/_static/js/redirects.js
+++ b/source/_static/js/redirects.js
@@ -81,6 +81,7 @@ newUrls['4.3'] = [
   '/office365/monitoring-office365-activity.html',
   '/user-manual/reference/ossec-conf/office365-module.html',
   '/user-manual/capabilities/log-data-collection/how-to-collect-macoslogs.html',
+  '/user-manual/uninstall/central-components.html',
   '/azure/activity-services/index.html',
   '/azure/activity-services/active-directory/index.html',
   '/azure/activity-services/active-directory/graph.html',

--- a/source/deployment-options/elastic-stack/distributed-deployment/step-by-step-installation/wazuh-cluster/wazuh-multi-node-cluster.rst
+++ b/source/deployment-options/elastic-stack/distributed-deployment/step-by-step-installation/wazuh-cluster/wazuh-multi-node-cluster.rst
@@ -218,7 +218,7 @@ Disabling repositories
 
 
 
-To uninstall Wazuh and Filebeat, visit the :ref:`uninstalling section <user_manual_uninstall_wazuh_installation_open_distro>`.
+To uninstall Wazuh and Filebeat, visit the :ref:`uninstalling section <user_manual_uninstall_wazuh_installation_basic>`.
 
 Next steps
 ----------

--- a/source/deployment-options/offline-installation.rst
+++ b/source/deployment-options/offline-installation.rst
@@ -349,7 +349,7 @@ Upon the first access to Kibana, the browser shows a warning message stating tha
   * It is highly recommended to change the default passwords of Elasticsearch for the users' passwords. To perform this action, see the :ref:`Change users' password <change_elastic_pass>` section.
   * It is also recommended to customize the file ``/etc/elasticsearch/jvm.options`` to improve the performance of Elasticsearch. Learn more about this process in the :ref:`memory_locking` section.
 
-To uninstall all the components of the all-in-one installation, see the :ref:`Uninstalling Wazuh <user_manual_uninstall_wazuh_installation_open_distro>` section.
+To uninstall all the components of the all-in-one installation, see the :doc:`/user-manual/uninstall/central-components` section.
 
 Next steps
 ----------

--- a/source/installation-guide/wazuh-dashboard/step-by-step.rst
+++ b/source/installation-guide/wazuh-dashboard/step-by-step.rst
@@ -148,4 +148,4 @@ All the Wazuh central components are successfully installed.
 
 The Wazuh environment is now ready and you can proceed with installing the Wazuh agent on the endpoints to be monitored. To perform this action, see the :ref:`Wazuh agent <installation_agents>` section.
 
-If you want to uninstall the Wazuh dashboard, see the :ref:`uninstalling <uninstall_kibana>` section. 
+If you want to uninstall the Wazuh dashboard, see :ref:`uninstall_dashboard`.

--- a/source/installation-guide/wazuh-indexer/step-by-step.rst
+++ b/source/installation-guide/wazuh-indexer/step-by-step.rst
@@ -148,4 +148,4 @@ Next steps
 
 The Wazuh indexer is now successfully installed on your single-node or multi-node cluster and you can proceed with installing the Wazuh server. To perform this action, see the :doc:`../wazuh-server/step-by-step` section.
 
-If you want to uninstall the Wazuh indexer, see the :ref:`Uninstalling <uninstall_elasticsearch>` section.
+If you want to uninstall the Wazuh indexer, see :ref:`uninstall_indexer`.

--- a/source/installation-guide/wazuh-server/step-by-step.rst
+++ b/source/installation-guide/wazuh-server/step-by-step.rst
@@ -234,4 +234,4 @@ Next steps
 
 The Wazuh server installation is now complete and you can proceed with :doc:`../wazuh-dashboard/step-by-step`.
 
-If you want to uninstall the Wazuh server, see the :doc:`/user-manual/uninstall/central-components` section.
+If you want to uninstall the Wazuh server, see the :ref:`uninstall_manager` and :ref:`uninstall_filebeat` sections.

--- a/source/installation-guide/wazuh-server/step-by-step.rst
+++ b/source/installation-guide/wazuh-server/step-by-step.rst
@@ -234,4 +234,4 @@ Next steps
 
 The Wazuh server installation is now complete and you can proceed with :doc:`../wazuh-dashboard/step-by-step`.
 
-If you want to uninstall the Wazuh server, see the :ref:`uninstall_manager` and :ref:`uninstall_filebeat` sections.
+If you want to uninstall the Wazuh server, see :ref:`uninstall_server`.

--- a/source/installation-guide/wazuh-server/step-by-step.rst
+++ b/source/installation-guide/wazuh-server/step-by-step.rst
@@ -234,4 +234,4 @@ Next steps
 
 The Wazuh server installation is now complete and you can proceed with :doc:`../wazuh-dashboard/step-by-step`.
 
-If you want to uninstall the Wazuh server, see the :ref:`uninstalling section <user_manual_uninstall_wazuh_installation_open_distro>`.
+If you want to uninstall the Wazuh server, see the :doc:`/user-manual/uninstall/central-components` section.

--- a/source/user-manual/uninstall/central-components.rst
+++ b/source/user-manual/uninstall/central-components.rst
@@ -18,10 +18,10 @@ If you want to uninstall one specific central component, you need to follow the 
 
 .. note:: Root user privileges are required to execute all the commands described below.
 
-.. _uninstall_manager:
+.. _uninstall_server:
 
-Uninstall the Wazuh manager
----------------------------
+Uninstall the Wazuh server
+--------------------------
 
 #. Remove the Wazuh repository and the Wauh manager package.
 
@@ -47,13 +47,6 @@ Uninstall the Wazuh manager
 
       # rm -rf /var/ossec/
       # rm -rf /etc/systemd/system/multi-user.target.wants/wazuh-manager.service
-
-
-.. _uninstall_filebeat:
-      
-Uninstall Filebeat
-------------------
-
 
 #. Remove the Filebeat package.
 

--- a/source/user-manual/uninstall/central-components.rst
+++ b/source/user-manual/uninstall/central-components.rst
@@ -6,9 +6,9 @@
 Uninstalling the Wazuh central components
 =========================================
 
-You can uninstall all the Wazuh central components using the Wazuh installer.
+You can uninstall all the Wazuh central components using the `Wazuh installation assistant <https://packages-dev.wazuh.com/|WAZUH_LATEST_MINOR|/wazuh-install.sh>`_.
 
-Run the Wazuh installer with the option ``-u`` or ``--uninstall`` as follows:
+Run the assistant with the option ``-u`` or ``--uninstall`` as follows:
 
     .. code-block:: console
 
@@ -16,7 +16,7 @@ Run the Wazuh installer with the option ``-u`` or ``--uninstall`` as follows:
 
 This will remove Wazuh indexer, Wazuh server, and Wazuh dashboard from your cluster node.
 
-If you want to uninstall one specific central component, you need to follow the instructions below.
+If you want to uninstall one specific central component, follow the instructions below.
 
 .. note:: Root user privileges are required to execute all the commands described below.
 
@@ -25,23 +25,7 @@ If you want to uninstall one specific central component, you need to follow the 
 Uninstall the Wazuh dashboard
 -----------------------------
 
-#. Remove the Wazuh repository if not done already.
-
-    .. tabs::
-
-      .. group-tab:: Yum
-
-        .. code-block:: console
-          
-          # rm /etc/yum.repos.d/wazuh.repo
-
-      .. group-tab:: APT
-
-        .. code-block:: console
-        
-          # rm /etc/apt/sources.list.d/wazuh.list
-
-#. Clean the Wazuh dashboard installation.
+#. Remove the Wazuh dashboard installation.
 
     .. tabs::
 
@@ -65,23 +49,7 @@ Uninstall the Wazuh dashboard
 Uninstall the Wazuh server
 --------------------------
 
-#. Remove the Wazuh repository if not done already.
-
-    .. tabs::
-
-      .. group-tab:: Yum
-
-        .. code-block:: console
-          
-          # rm /etc/yum.repos.d/wazuh.repo
-
-      .. group-tab:: APT
-
-        .. code-block:: console
-        
-          # rm /etc/apt/sources.list.d/wazuh.list
-
-#. Clean the Wazuh manager installation.
+#. Remove the Wazuh manager installation.
 
     .. tabs::
 
@@ -98,7 +66,7 @@ Uninstall the Wazuh server
         
           # apt remove --purge wazuh-manager -y
 
-#. Clean the Filebeat installation.
+#. Remove the Filebeat installation.
 
     .. tabs::
 
@@ -123,23 +91,7 @@ Uninstall the Wazuh server
 Uninstall the Wazuh indexer
 ---------------------------
 
-#. Remove the Wazuh repository if not done already.
-
-    .. tabs::
-
-      .. group-tab:: Yum
-
-        .. code-block:: console
-          
-          # rm /etc/yum.repos.d/wazuh.repo
-
-      .. group-tab:: APT
-
-        .. code-block:: console
-        
-          # rm /etc/apt/sources.list.d/wazuh.list
-
-#. Clean the Wazuh indexer installation.
+#. Remove the Wazuh indexer installation.
 
     .. tabs::
 

--- a/source/user-manual/uninstall/central-components.rst
+++ b/source/user-manual/uninstall/central-components.rst
@@ -14,7 +14,7 @@ Run the assistant with the option ``-u`` or ``--uninstall`` as follows:
 
       $ sudo bash wazuh-install.sh --uninstall
 
-This will remove Wazuh indexer, Wazuh server, and Wazuh dashboard from your cluster node.
+This will remove the Wazuh indexer, the Wazuh server, and the Wazuh dashboard.
 
 If you want to uninstall one specific central component, follow the instructions below.
 

--- a/source/user-manual/uninstall/central-components.rst
+++ b/source/user-manual/uninstall/central-components.rst
@@ -6,7 +6,7 @@
 Uninstalling the Wazuh central components
 =========================================
 
-You can uninstall all the Wazuh central components using the Wazuh installer. Run it with the option ``-u | --uninstall`` as follows.
+You can uninstall all the Wazuh central components using the Wazuh installer. Run the Wazuh installer with the option ``-u`` or ``--uninstall`` as follows:
 
     .. code-block:: console
 
@@ -17,6 +17,8 @@ This will remove Wazuh indexer, Wazuh server, and Wazuh dashboard from your clus
 If you want to uninstall one specific central component, you need to follow the instructions below.
 
 .. note:: Root user privileges are required to execute all the commands described below.
+
+.. _uninstall_manager:
 
 Uninstall the Wazuh manager
 ---------------------------
@@ -39,18 +41,21 @@ Uninstall the Wazuh manager
           # rm /etc/apt/sources.list.d/wazuh.list
           # apt remove --purge wazuh-manager -y
 
-#. Remove related installation files.
+#. Clean the Wazuh manager installation.
 
     .. code-block:: console
 
       # rm -rf /var/ossec/
+      # rm -rf /etc/systemd/system/multi-user.target.wants/wazuh-manager.service
 
 
+.. _uninstall_filebeat:
+      
 Uninstall Filebeat
 ------------------
 
 
-#. Remove Filebeat package.
+#. Remove the Filebeat package.
 
     .. tabs::
 
@@ -66,13 +71,16 @@ Uninstall Filebeat
       
           # apt remove --purge filebeat -y
 
-#. Remove related installation files.
+#. Clean the Filebeat installation.
 
     .. code:: console
     
       # rm -rf /var/lib/filebeat/
       # rm -rf /usr/share/filebeat/
       # rm -rf /etc/filebeat/
+      # rm -rf /var/log/filebeat/
+      # rm -rf /etc/systemd/system/multi-user.target.wants/filebeat.service
+
 
 .. _uninstall_indexer:
 
@@ -95,13 +103,18 @@ Uninstall the Wazuh indexer
 
           # apt remove --purge wazuh-indexer -y
           
-#. Remove related installation files.
+#. Clean the Wazuh indexer installation.
 
     .. code:: console
     
       # rm -rf /var/lib/wazuh-indexer/
       # rm -rf /usr/share/wazuh-indexer/
       # rm -rf /etc/wazuh-indexer/
+      # rm -rf /var/log/wazuh-indexer/
+      # rm -rf /securityadmin_demo.sh
+      # rm -rf /etc/systemd/system/opensearch.service.wants/
+      # rm -rf /etc/systemd/system/multi-user.target.wants/opensearch.service
+      # rm -rf /lib/firewalld/services/opensearch.xml
 
 .. _uninstall_dashboard:
 
@@ -124,7 +137,7 @@ Uninstall the Wazuh dashboard
 
           # apt remove --purge wazuh-dashboard -y
           
-#. Remove related installation files.
+#. Clean the Wazuh dashboard installation.
 
     .. code:: console
     
@@ -132,3 +145,6 @@ Uninstall the Wazuh dashboard
       # rm -rf /usr/share/wazuh-dashboard/
       # rm -rf /etc/wazuh-dashboard/
       # rm -rf /run/wazuh-dashboard/
+      # rm -rf /etc/systemd/system/multi-user.target.wants/wazuh-dashboard.service
+      # rm -rf /etc/systemd/system/wazuh-dashboard.service
+      # rm -rf /lib/firewalld/services/dashboard.xml

--- a/source/user-manual/uninstall/central-components.rst
+++ b/source/user-manual/uninstall/central-components.rst
@@ -6,7 +6,9 @@
 Uninstalling the Wazuh central components
 =========================================
 
-You can uninstall all the Wazuh central components using the Wazuh installer. Run the Wazuh installer with the option ``-u`` or ``--uninstall`` as follows:
+You can uninstall all the Wazuh central components using the Wazuh installer.
+
+Run the Wazuh installer with the option ``-u`` or ``--uninstall`` as follows:
 
     .. code-block:: console
 
@@ -18,12 +20,12 @@ If you want to uninstall one specific central component, you need to follow the 
 
 .. note:: Root user privileges are required to execute all the commands described below.
 
-.. _uninstall_server:
+.. _uninstall_dashboard:
 
-Uninstall the Wazuh server
---------------------------
+Uninstall the Wazuh dashboard
+-----------------------------
 
-#. Remove the Wazuh repository and the Wauh manager package.
+#. Remove the Wazuh repository if not done already.
 
     .. tabs::
 
@@ -32,89 +34,14 @@ Uninstall the Wazuh server
         .. code-block:: console
           
           # rm /etc/yum.repos.d/wazuh.repo
-          # yum remove wazuh-manager -y
 
       .. group-tab:: APT
 
         .. code-block:: console
         
           # rm /etc/apt/sources.list.d/wazuh.list
-          # apt remove --purge wazuh-manager -y
 
-#. Clean the Wazuh manager installation.
-
-    .. code-block:: console
-
-      # rm -rf /var/ossec/
-      # rm -rf /etc/systemd/system/multi-user.target.wants/wazuh-manager.service
-
-#. Remove the Filebeat package.
-
-    .. tabs::
-
-      .. group-tab:: Yum
-
-        .. code:: console
-        
-          # yum remove filebeat -y
-
-      .. group-tab:: APT
-
-        .. code:: console
-      
-          # apt remove --purge filebeat -y
-
-#. Clean the Filebeat installation.
-
-    .. code:: console
-    
-      # rm -rf /var/lib/filebeat/
-      # rm -rf /usr/share/filebeat/
-      # rm -rf /etc/filebeat/
-      # rm -rf /var/log/filebeat/
-      # rm -rf /etc/systemd/system/multi-user.target.wants/filebeat.service
-
-
-.. _uninstall_indexer:
-
-Uninstall the Wazuh indexer
----------------------------
-
-#. Remove the Wazuh indexer package.
-
-    .. tabs::
-
-      .. group-tab:: Yum
-
-        .. code:: console
-        
-          # yum remove wazuh-indexer -y
-
-      .. group-tab:: APT
-
-        .. code:: console
-
-          # apt remove --purge wazuh-indexer -y
-          
-#. Clean the Wazuh indexer installation.
-
-    .. code:: console
-    
-      # rm -rf /var/lib/wazuh-indexer/
-      # rm -rf /usr/share/wazuh-indexer/
-      # rm -rf /etc/wazuh-indexer/
-      # rm -rf /var/log/wazuh-indexer/
-      # rm -rf /securityadmin_demo.sh
-      # rm -rf /etc/systemd/system/opensearch.service.wants/
-      # rm -rf /etc/systemd/system/multi-user.target.wants/opensearch.service
-      # rm -rf /lib/firewalld/services/opensearch.xml
-
-.. _uninstall_dashboard:
-
-Uninstall the Wazuh dashboard
------------------------------
-
-#. Remove the Wazuh dashboard package.
+#. Clean the Wazuh dashboard installation.
 
     .. tabs::
 
@@ -123,21 +50,112 @@ Uninstall the Wazuh dashboard
         .. code:: console
         
           # yum remove wazuh-dashboard -y
+          # rm -rf /var/lib/wazuh-dashboard/
+          # rm -rf /usr/share/wazuh-dashboard/
+          # rm -rf /etc/wazuh-dashboard/
 
       .. group-tab:: APT
 
         .. code:: console
 
           # apt remove --purge wazuh-dashboard -y
-          
-#. Clean the Wazuh dashboard installation.
 
-    .. code:: console
-    
-      # rm -rf /var/lib/wazuh-dashboard/
-      # rm -rf /usr/share/wazuh-dashboard/
-      # rm -rf /etc/wazuh-dashboard/
-      # rm -rf /run/wazuh-dashboard/
-      # rm -rf /etc/systemd/system/multi-user.target.wants/wazuh-dashboard.service
-      # rm -rf /etc/systemd/system/wazuh-dashboard.service
-      # rm -rf /lib/firewalld/services/dashboard.xml
+.. _uninstall_server:
+
+Uninstall the Wazuh server
+--------------------------
+
+#. Remove the Wazuh repository if not done already.
+
+    .. tabs::
+
+      .. group-tab:: Yum
+
+        .. code-block:: console
+          
+          # rm /etc/yum.repos.d/wazuh.repo
+
+      .. group-tab:: APT
+
+        .. code-block:: console
+        
+          # rm /etc/apt/sources.list.d/wazuh.list
+
+#. Clean the Wazuh manager installation.
+
+    .. tabs::
+
+      .. group-tab:: Yum
+
+        .. code-block:: console
+          
+          # yum remove wazuh-manager -y
+          # rm -rf /var/ossec/
+
+      .. group-tab:: APT
+
+        .. code-block:: console
+        
+          # apt remove --purge wazuh-manager -y
+
+#. Clean the Filebeat installation.
+
+    .. tabs::
+
+      .. group-tab:: Yum
+
+        .. code:: console
+        
+          # yum remove filebeat -y
+          # rm -rf /var/lib/filebeat/
+          # rm -rf /usr/share/filebeat/
+          # rm -rf /etc/filebeat/
+
+      .. group-tab:: APT
+
+        .. code:: console
+      
+          # apt remove --purge filebeat -y
+
+
+.. _uninstall_indexer:
+
+Uninstall the Wazuh indexer
+---------------------------
+
+#. Remove the Wazuh repository if not done already.
+
+    .. tabs::
+
+      .. group-tab:: Yum
+
+        .. code-block:: console
+          
+          # rm /etc/yum.repos.d/wazuh.repo
+
+      .. group-tab:: APT
+
+        .. code-block:: console
+        
+          # rm /etc/apt/sources.list.d/wazuh.list
+
+#. Clean the Wazuh indexer installation.
+
+    .. tabs::
+
+      .. group-tab:: Yum
+
+        .. code:: console
+        
+          # yum remove wazuh-indexer -y
+          # rm -rf /var/lib/wazuh-indexer/
+          # rm -rf /usr/share/wazuh-indexer/
+          # rm -rf /etc/wazuh-indexer/
+
+      .. group-tab:: APT
+
+        .. code:: console
+
+          # apt remove --purge wazuh-indexer -y
+          
+#. Remove the ``wazuh-certs-tool.sh`` and ``config.yml`` files downloaded previously.

--- a/source/user-manual/uninstall/central-components.rst
+++ b/source/user-manual/uninstall/central-components.rst
@@ -1,0 +1,134 @@
+.. Copyright (C) 2015-2022 Wazuh, Inc.
+
+.. meta::
+  :description: Learn how to uninstall each Wazuh central component.
+  
+Uninstalling the Wazuh central components
+=========================================
+
+You can uninstall all the Wazuh central components using the Wazuh installer. Run it with the option ``-u | --uninstall`` as follows.
+
+    .. code-block:: console
+
+      $ sudo bash wazuh-install.sh --uninstall
+
+This will remove Wazuh indexer, Wazuh server, and Wazuh dashboard from your cluster node.
+
+If you want to uninstall one specific central component, you need to follow the instructions below.
+
+.. note:: Root user privileges are required to execute all the commands described below.
+
+Uninstall the Wazuh manager
+---------------------------
+
+#. Remove the Wazuh repository and the Wauh manager package.
+
+    .. tabs::
+
+      .. group-tab:: Yum
+
+        .. code-block:: console
+          
+          # rm /etc/yum.repos.d/wazuh.repo
+          # yum remove wazuh-manager -y
+
+      .. group-tab:: APT
+
+        .. code-block:: console
+        
+          # rm /etc/apt/sources.list.d/wazuh.list
+          # apt remove --purge wazuh-manager -y
+
+#. Remove related installation files.
+
+    .. code-block:: console
+
+      # rm -rf /var/ossec/
+
+
+Uninstall Filebeat
+------------------
+
+
+#. Remove Filebeat package.
+
+    .. tabs::
+
+      .. group-tab:: Yum
+
+        .. code:: console
+        
+          # yum remove filebeat -y
+
+      .. group-tab:: APT
+
+        .. code:: console
+      
+          # apt remove --purge filebeat -y
+
+#. Remove related installation files.
+
+    .. code:: console
+    
+      # rm -rf /var/lib/filebeat/
+      # rm -rf /usr/share/filebeat/
+      # rm -rf /etc/filebeat/
+
+.. _uninstall_indexer:
+
+Uninstall the Wazuh indexer
+---------------------------
+
+#. Remove the Wazuh indexer package.
+
+    .. tabs::
+
+      .. group-tab:: Yum
+
+        .. code:: console
+        
+          # yum remove wazuh-indexer -y
+
+      .. group-tab:: APT
+
+        .. code:: console
+
+          # apt remove --purge wazuh-indexer -y
+          
+#. Remove related installation files.
+
+    .. code:: console
+    
+      # rm -rf /var/lib/wazuh-indexer/
+      # rm -rf /usr/share/wazuh-indexer/
+      # rm -rf /etc/wazuh-indexer/
+
+.. _uninstall_dashboard:
+
+Uninstall the Wazuh dashboard
+-----------------------------
+
+#. Remove the Wazuh dashboard package.
+
+    .. tabs::
+
+      .. group-tab:: Yum
+
+        .. code:: console
+        
+          # yum remove wazuh-dashboard -y
+
+      .. group-tab:: APT
+
+        .. code:: console
+
+          # apt remove --purge wazuh-dashboard -y
+          
+#. Remove related installation files.
+
+    .. code:: console
+    
+      # rm -rf /var/lib/wazuh-dashboard/
+      # rm -rf /usr/share/wazuh-dashboard/
+      # rm -rf /etc/wazuh-dashboard/
+      # rm -rf /run/wazuh-dashboard/

--- a/source/user-manual/uninstall/central-components.rst
+++ b/source/user-manual/uninstall/central-components.rst
@@ -157,5 +157,3 @@ Uninstall the Wazuh indexer
         .. code:: console
 
           # apt remove --purge wazuh-indexer -y
-          
-#. Remove the ``wazuh-certs-tool.sh`` and ``config.yml`` files downloaded previously.

--- a/source/user-manual/uninstall/index.rst
+++ b/source/user-manual/uninstall/index.rst
@@ -13,6 +13,7 @@ This document will give instructions to uninstall each Wazuh component.
     .. toctree::
         :maxdepth: 1
 
+        central-components
         open-distro       
         elastic-stack
 

--- a/source/user-manual/uninstall/open-distro.rst
+++ b/source/user-manual/uninstall/open-distro.rst
@@ -10,8 +10,6 @@ Uninstalling Wazuh with Open Distro for Elasticsearch
 
 This document will give instructions to uninstall each Wazuh component. 
 
-.. _uninstall_manager:
-
 Uninstall the Wazuh manager
 ---------------------------
 
@@ -126,7 +124,3 @@ Uninstall Kibana
 
 
     .. include:: ../../_templates/installations/elastic/zypp/uninstall_kibana.rst   
-
-
-
-

--- a/source/user-manual/uninstall/open-distro.rst
+++ b/source/user-manual/uninstall/open-distro.rst
@@ -3,8 +3,6 @@
 .. meta::
   :description: In this section of the Wazuh documentation, you will find the instructions to uninstall each Wazuh component. Learn more here. 
   
-.. _user_manual_uninstall_wazuh_installation_open_distro:
-
 Uninstalling Wazuh with Open Distro for Elasticsearch
 =====================================================
 
@@ -35,7 +33,6 @@ Uninstall the Wazuh manager
 
     .. include:: ../../_templates/installations/wazuh/zypp/uninstall_wazuh_manager_api.rst
 
-.. _uninstall_filebeat:
 
 Uninstall Filebeat
 ---------------------
@@ -65,8 +62,6 @@ Uninstall Filebeat
     .. include:: ../../_templates/installations/elastic/deb/uninstall_filebeat.rst
 
 
-.. _uninstall_elasticsearch:
-
 Uninstall Elasticsearch
 -----------------------
 
@@ -93,12 +88,6 @@ Uninstall Elasticsearch
 
     .. include:: ../../_templates/installations/elastic/zypp/uninstall_elasticsearch.rst
 
-   
-
-
-
-
-.. _uninstall_kibana:
 
 Uninstall Kibana
 ----------------


### PR DESCRIPTION
## Description

This PR adds a page to the user manual on uninstalling Wazuh central components.

## Checks
- [X] It compiles without warnings.
- [X] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [X] Used uppercase only on nouns. 
- [X] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

## Note to the reviewer

This PR includes changes to the `redirect.js` script that need to be included in all production branches.
