### PR TITLE
[4.3] Fixed meta tag "robots" and the list of documents

### DIFF
--- a/source/_themes/wazuh_doc_theme/api-redoc.html
+++ b/source/_themes/wazuh_doc_theme/api-redoc.html
@@ -29,7 +29,9 @@
     <meta name="twitter:title" content="{{ pagetitle|e + titlesuffix }}" />
     <meta name="twitter:description" content="User manual, installation and configuration guides. Learn how to get the most out of the Wazuh platform." />
     <meta name="twitter:image" content="{{ theme_wazuh_doc_url + '/' + version + '/_static/images/wazuh-docs-card.png' }}" />
-    {% if not is_latest_release %}
+    {% if is_latest_release %}
+    <meta name="robots" content="index" />
+    {% else %}
     <meta name="robots" content="noindex" />
     {% endif %}
     <!--

--- a/source/_themes/wazuh_doc_theme/cloud-api-redoc.html
+++ b/source/_themes/wazuh_doc_theme/cloud-api-redoc.html
@@ -29,7 +29,9 @@
     <meta name="twitter:title" content="{{ pagetitle|e + titlesuffix }}" />
     <meta name="twitter:description" content="User manual, installation and configuration guides. Learn how to get the most out of the Wazuh platform." />
     <meta name="twitter:image" content="{{ theme_wazuh_doc_url + '/' + version + '/_static/images/wazuh-docs-card.png' }}" />
-    {% if not is_latest_release %}
+    {% if is_latest_release %}
+    <meta name="robots" content="index" />
+    {% else %}
     <meta name="robots" content="noindex" />
     {% endif %}
     <!--

--- a/source/_themes/wazuh_doc_theme/layout.html
+++ b/source/_themes/wazuh_doc_theme/layout.html
@@ -63,7 +63,9 @@
 <meta name="twitter:title" content="{{ pagetitle|e + titlesuffix }}" />
 <meta name="twitter:description" content="User manual, installation and configuration guides. Learn how to get the most out of the Wazuh platform." />
 <meta name="twitter:image" content="{{ theme_wazuh_doc_url + '/current/_static/images/wazuh-docs-card.png' }}" />
-{% if not is_latest_release %}
+{% if is_latest_release %}
+<meta name="robots" content="index" />
+{% else %}
 <meta name="robots" content="noindex" />
 {% endif %}
 

--- a/source/_themes/wazuh_doc_theme/layout.html
+++ b/source/_themes/wazuh_doc_theme/layout.html
@@ -63,7 +63,8 @@
 <meta name="twitter:title" content="{{ pagetitle|e + titlesuffix }}" />
 <meta name="twitter:description" content="User manual, installation and configuration guides. Learn how to get the most out of the Wazuh platform." />
 <meta name="twitter:image" content="{{ theme_wazuh_doc_url + '/current/_static/images/wazuh-docs-card.png' }}" />
-{% if is_latest_release %}
+{% set is_orphan = meta and meta.orphan is defined %}
+{% if is_latest_release and not is_orphan %}
 <meta name="robots" content="index" />
 {% else %}
 <meta name="robots" content="noindex" />

--- a/source/_themes/wazuh_doc_theme_v3/layout.html
+++ b/source/_themes/wazuh_doc_theme_v3/layout.html
@@ -128,7 +128,8 @@
 <html lang="{{ language }}">
   <head>
     {% block head -%}
-    {% if is_latest_release and  pagename != 'moved-content' and pagename != 'not_found' and pagename != 'search' %}
+    {% set is_orphan = meta and meta.orphan is defined %}
+    {% if is_latest_release and  pagename != 'moved-content' and pagename != 'not_found' and pagename != 'search' and not is_orphan %}
     <meta name="robots" content="index" />
     {% else %}
     <meta name="robots" content="noindex" />

--- a/source/_themes/wazuh_doc_theme_v3/layout.html
+++ b/source/_themes/wazuh_doc_theme_v3/layout.html
@@ -128,9 +128,11 @@
 <html lang="{{ language }}">
   <head>
     {% block head -%}
-    {%- if not is_latest_release -%}
-    <meta name="robots" content="noindex">
-    {%- endif %}
+    {% if is_latest_release and  pagename != 'moved-content' and pagename != 'not_found' and pagename != 'search' %}
+    <meta name="robots" content="index" />
+    {% else %}
+    <meta name="robots" content="noindex" />
+    {% endif %}
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="UTF-8">
     <meta name="author" content="Wazuh">

--- a/source/conf.py
+++ b/source/conf.py
@@ -689,9 +689,11 @@ def finish_and_clean(app, exception):
                 os.remove(app.srcdir + '/_static/' + mini_asset)
 
 def collect_compiled_pagename(app, pagename, templatename, context, doctree):
-    ''' Runs once per page, storing the pagename (full page path) extracted from the context '''
+    ''' Runs once per page, storing the pagename (full page path) extracted from the context
+        It store the path of all compiled documents except the orphans and the ones in exclude_doc'''
     if templatename == "page.html" and pagename not in exclude_doc:
-        list_compiled_html.append(context['pagename']+'.html')
+        if not context['meta'] or ( context['meta']['orphan'] ):
+            list_compiled_html.append(context['pagename']+'.html')
     else:
         pass
 


### PR DESCRIPTION
## Description

This PR properly adjust the value of the meta tag "robots" depending on whether the release is the latest one or not.
In addition, it fixes the list of documents, that is used to create the sitemap.

## Checks
- [x] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
