### PR TITLE
Fix GCP pip dependencies

### DIFF
--- a/source/gcp/prerequisites/dependencies.rst
+++ b/source/gcp/prerequisites/dependencies.rst
@@ -57,22 +57,8 @@ Google Cloud pip dependencies
 
 `google-cloud-pubsub <https://pypi.org/project/google-cloud-pubsub/>`_ is the official python library supported by Google to manage Google Cloud Pub/Sub resources. It is used to pull the log messages from the Pub/Sub queue. 
 
-- Depending on the Wazuh version used, it is necessary to install a different ``google-cloud-pubsub`` version.
-
-    - For Wazuh versions later or equal to 4.2.2:
-
-    .. code-block:: console
-
-      # pip3 install google-cloud-pubsub==2.7.1
-
-    - For older versions:
-
-    .. code-block:: console
-
-      # pip3 install google-cloud-pubsub==1.4.3
-
-- To install the rest of the dependencies, execute the following command:
+To install the dependencies, execute the following command:
 
   .. code-block:: console
 
-    # pip3 install google-api-core==1.30.0 google-auth==1.28.0 google-cloud-core==1.7.1 google-cloud-storage==1.39.0 google-crc32c==1.1.2 google-resumable-media==1.3.1 googleapis-common-protos==1.51.0 grpc-google-iam-v1==0.12.3 grpcio==1.38.1 pytz==2020.1
+    # pip3 install cachetools==4.1.0 certifi==2020.4.5.1 cffi==1.14.4 chardet==3.0.4 charset-normalizer==2.0.4 google-api-core==1.30.0 google-auth==1.28.0 google-cloud-core==1.7.1 google-cloud-pubsub==2.7.1 google-cloud-storage==1.39.0 google-crc32c==1.1.2 google-resumable-media==1.3.1 googleapis-common-protos==1.51.0 grpc-google-iam-v1==0.12.3 grpcio==1.38.1 idna==2.9 libcst==0.3.20 mypy-extensions==0.4.3 packaging==20.9 proto-plus==1.19.0 protobuf==3.17.3 pyasn1-modules==0.2.8 pyasn1==0.4.8 pycparser==2.20 pyparsing==2.4.7 pytz==2020.1 PyYAML==5.4.1 requests==2.25.1 rsa==4.7.2 setuptools==59.6.0 six==1.14.0 typing-extensions==3.10.0.2 typing-inspect==0.7.1 urllib3==1.26.5


### PR DESCRIPTION

## Description

As described in https://github.com/wazuh/wazuh-documentation/issues/4994 the documentation did not show the proper steps to install the pip dependencies for the gcp module. In particular, the problem was the order in which to do the installations. When installing the `pubsub` package first, it applied its own dependencies automatically, which could later result in warnings and errors when trying to install the rest of the recommended dependencies, in some cases requiring a downgrade.

This PR solves the problem by unifying the installation of the different PIP requirements in a single command, as well as indicating exactly each and every one of the necessary requirements.


Specifically, the pip dependencies to be installed are the following ones:

```
cachetools==4.1.0
certifi==2020.4.5.1
cffi==1.14.4
chardet==3.0.4
charset-normalizer==2.0.4
google-api-core==1.30.0
google-auth==1.28.0
google-cloud-core==1.7.1
google-cloud-pubsub==2.7.1
google-cloud-storage==1.39.0
google-crc32c==1.1.2
google-resumable-media==1.3.1
googleapis-common-protos==1.51.0
grpc-google-iam-v1==0.12.3
grpcio==1.38.1
idna==2.9
libcst==0.3.20
mypy-extensions==0.4.3
packaging==20.9
proto-plus==1.19.0
protobuf==3.17.3
pyasn1-modules==0.2.8
pyasn1==0.4.8
pycparser==2.20
pyparsing==2.4.7
pytz==2020.1
PyYAML==5.4.1
requests==2.25.1
rsa==4.7.2
setuptools==59.6.0
six==1.14.0
typing-extensions==3.10.0.2
typing-inspect==0.7.1
urllib3==1.26.5
```

These versions match those found in the [wazuh/wazuh](https://github.com/wazuh/wazuh) [requirements.txt](https://github.com/wazuh/wazuh/blob/4.3/framework/requirements.txt) file, except for `setuptools`, which is not present in that file.

The steps followed to test this were as follows, on a clean Ubuntu 18.04 machine:

```
apt-get update && apt-get install python3
apt-get update && apt-get install python3-pip
pip3 install --upgrade pip
pip3 install cachetools==4.1.0 certifi==2020.4.5.1 cffi==1.14.4 chardet==3.0.4 charset-normalizer==2.0.4 google-api-core==1.30.0 google-auth==1.28.0 google-cloud-core==1.7.1 google-cloud-pubsub==2.7.1 google-cloud-storage==1.39.0 google-crc32c==1.1.2 google-resumable-media==1.3.1 googleapis-common-protos==1.51.0 grpc-google-iam-v1==0.12.3 grpcio==1.38.1 idna==2.9 libcst==0.3.20 mypy-extensions==0.4.3 packaging==20.9 proto-plus==1.19.0 protobuf==3.17.3 pyasn1-modules==0.2.8 pyasn1==0.4.8 pycparser==2.20 pyparsing==2.4.7 pytz==2020.1 PyYAML==5.4.1 requests==2.25.1 rsa==4.7.2 setuptools==59.6.0 six==1.14.0 typing-extensions==3.10.0.2 typing-inspect==0.7.1 urllib3==1.26.5 
```
The following is the `pip` output when installing the dependencies in a completely clean Ubuntu 18.04 environment:

```
pip3 install cachetools==4.1.0 certifi==2020.4.5.1 cffi==1.14.4 chardet==3.0.4 charset-normalizer==2.0.4 google-api-core==1.30.0 google-auth==1.28.0 google-cloud-core==1.7.1 google-cloud-pubsub==2.7.1 google-cloud-storage==1.39.0 google-crc32c==1.1.2 google-resumable-media==1.3.1 googleapis-common-protos==1.51.0 grpc-google-iam-v1==0.12.3 grpcio==1.38.1 idna==2.9 libcst==0.3.20 mypy-extensions==0.4.3 packaging==20.9 proto-plus==1.19.0 protobuf==3.17.3 pyasn1-modules==0.2.8 pyasn1==0.4.8 pycparser==2.20 pyparsing==2.4.7 pytz==2020.1 PyYAML==5.4.1 requests==2.25.1 rsa==4.7.2 setuptools==59.6.0 six==1.14.0 typing-extensions==3.10.0.2 typing-inspect==0.7.1 urllib3==1.26.5 
Collecting cachetools==4.1.0
  Downloading cachetools-4.1.0-py3-none-any.whl (10 kB)
Collecting certifi==2020.4.5.1
  Downloading certifi-2020.4.5.1-py2.py3-none-any.whl (157 kB)
     |################################| 157 kB 4.3 MB/s            
Collecting cffi==1.14.4
  Downloading cffi-1.14.4-cp36-cp36m-manylinux1_x86_64.whl (401 kB)
     |################################| 401 kB 18.3 MB/s            
Collecting chardet==3.0.4
  Downloading chardet-3.0.4-py2.py3-none-any.whl (133 kB)
     |################################| 133 kB 28.0 MB/s            
Collecting charset-normalizer==2.0.4
  Downloading charset_normalizer-2.0.4-py3-none-any.whl (36 kB)
Collecting google-api-core==1.30.0
  Downloading google_api_core-1.30.0-py2.py3-none-any.whl (93 kB)
     |################################| 93 kB 1.3 MB/s             
Collecting google-auth==1.28.0
  Downloading google_auth-1.28.0-py2.py3-none-any.whl (136 kB)
     |################################| 136 kB 31.6 MB/s            
Collecting google-cloud-core==1.7.1
  Downloading google_cloud_core-1.7.1-py2.py3-none-any.whl (28 kB)
Collecting google-cloud-pubsub==2.7.1
  Downloading google_cloud_pubsub-2.7.1-py2.py3-none-any.whl (217 kB)
     |################################| 217 kB 20.1 MB/s            
Collecting google-cloud-storage==1.39.0
  Downloading google_cloud_storage-1.39.0-py2.py3-none-any.whl (103 kB)
     |################################| 103 kB 7.0 MB/s            
Collecting google-crc32c==1.1.2
  Downloading google_crc32c-1.1.2-cp36-cp36m-manylinux2014_x86_64.whl (38 kB)
Collecting google-resumable-media==1.3.1
  Downloading google_resumable_media-1.3.1-py2.py3-none-any.whl (75 kB)
     |################################| 75 kB 2.5 MB/s             
Collecting googleapis-common-protos==1.51.0
  Downloading googleapis-common-protos-1.51.0.tar.gz (35 kB)
  Preparing metadata (setup.py) ... done
Collecting grpc-google-iam-v1==0.12.3
  Downloading grpc-google-iam-v1-0.12.3.tar.gz (13 kB)
  Preparing metadata (setup.py) ... done
Collecting grpcio==1.38.1
  Downloading grpcio-1.38.1-cp36-cp36m-manylinux2014_x86_64.whl (4.2 MB)
     |################################| 4.2 MB 14.6 MB/s            
Collecting idna==2.9
  Downloading idna-2.9-py2.py3-none-any.whl (58 kB)
     |################################| 58 kB 3.1 MB/s             
Collecting libcst==0.3.20
  Downloading libcst-0.3.20-py3-none-any.whl (514 kB)
     |################################| 514 kB 12.8 MB/s            
Collecting mypy-extensions==0.4.3
  Downloading mypy_extensions-0.4.3-py2.py3-none-any.whl (4.5 kB)
Collecting packaging==20.9
  Downloading packaging-20.9-py2.py3-none-any.whl (40 kB)
     |################################| 40 kB 2.4 MB/s             
Collecting proto-plus==1.19.0
  Downloading proto_plus-1.19.0-py3-none-any.whl (42 kB)
     |################################| 42 kB 1.2 MB/s             
Collecting protobuf==3.17.3
  Downloading protobuf-3.17.3-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl (1.0 MB)
     |################################| 1.0 MB 19.7 MB/s            
Collecting pyasn1-modules==0.2.8
  Downloading pyasn1_modules-0.2.8-py2.py3-none-any.whl (155 kB)
     |################################| 155 kB 17.4 MB/s            
Collecting pyasn1==0.4.8
  Downloading pyasn1-0.4.8-py2.py3-none-any.whl (77 kB)
     |################################| 77 kB 3.5 MB/s             
Collecting pycparser==2.20
  Downloading pycparser-2.20-py2.py3-none-any.whl (112 kB)
     |################################| 112 kB 5.3 MB/s            
Collecting pyparsing==2.4.7
  Downloading pyparsing-2.4.7-py2.py3-none-any.whl (67 kB)
     |################################| 67 kB 4.2 MB/s             
Collecting pytz==2020.1
  Downloading pytz-2020.1-py2.py3-none-any.whl (510 kB)
     |################################| 510 kB 17.0 MB/s            
Collecting PyYAML==5.4.1
  Downloading PyYAML-5.4.1-cp36-cp36m-manylinux1_x86_64.whl (640 kB)
     |################################| 640 kB 20.3 MB/s            
Collecting requests==2.25.1
  Downloading requests-2.25.1-py2.py3-none-any.whl (61 kB)
     |################################| 61 kB 3.7 MB/s             
Collecting rsa==4.7.2
  Downloading rsa-4.7.2-py3-none-any.whl (34 kB)
Collecting setuptools==59.6.0
  Downloading setuptools-59.6.0-py3-none-any.whl (952 kB)
     |################################| 952 kB 19.4 MB/s            
Collecting six==1.14.0
  Downloading six-1.14.0-py2.py3-none-any.whl (10 kB)
Collecting typing-extensions==3.10.0.2
  Downloading typing_extensions-3.10.0.2-py3-none-any.whl (26 kB)
Collecting typing-inspect==0.7.1
  Downloading typing_inspect-0.7.1-py3-none-any.whl (8.4 kB)
Collecting urllib3==1.26.5
  Downloading urllib3-1.26.5-py2.py3-none-any.whl (138 kB)
     |################################| 138 kB 29.5 MB/s            
Collecting google-api-core[grpc]<3.0.0dev,>=1.26.0
  Downloading google_api_core-2.7.1-py3-none-any.whl (114 kB)
     |################################| 114 kB 25.9 MB/s            
Collecting googleapis-common-protos[grpc]<2.0.0dev,>=1.5.2
  Downloading googleapis_common_protos-1.56.0-py2.py3-none-any.whl (241 kB)
     |################################| 241 kB 31.8 MB/s            
Collecting dataclasses>=0.6.0
  Downloading dataclasses-0.8-py3-none-any.whl (19 kB)
Collecting google-api-core[grpc]<3.0.0dev,>=1.26.0
  Downloading google_api_core-2.7.0-py3-none-any.whl (114 kB)
     |################################| 114 kB 24.9 MB/s            
  Downloading google_api_core-2.6.1-py3-none-any.whl (114 kB)
     |################################| 114 kB 9.4 MB/s            
  Downloading google_api_core-2.6.0-py2.py3-none-any.whl (114 kB)
     |################################| 114 kB 6.3 MB/s            
  Downloading google_api_core-2.5.0-py2.py3-none-any.whl (111 kB)
     |################################| 111 kB 5.6 MB/s            
  Downloading google_api_core-2.4.0-py2.py3-none-any.whl (111 kB)
     |################################| 111 kB 6.1 MB/s            
  Downloading google_api_core-2.3.2-py2.py3-none-any.whl (109 kB)
     |################################| 109 kB 5.8 MB/s            
  Downloading google_api_core-2.3.0-py2.py3-none-any.whl (109 kB)
     |################################| 109 kB 5.3 MB/s            
  Downloading google_api_core-2.2.2-py2.py3-none-any.whl (95 kB)
     |################################| 95 kB 3.1 MB/s             
  Downloading google_api_core-2.2.1-py2.py3-none-any.whl (95 kB)
     |################################| 95 kB 2.9 MB/s             
  Downloading google_api_core-2.2.0-py2.py3-none-any.whl (95 kB)
     |################################| 95 kB 2.7 MB/s             
  Downloading google_api_core-2.1.1-py2.py3-none-any.whl (95 kB)
     |################################| 95 kB 2.8 MB/s             
  Downloading google_api_core-2.1.0-py2.py3-none-any.whl (94 kB)
     |################################| 94 kB 4.1 MB/s             
  Downloading google_api_core-2.0.1-py2.py3-none-any.whl (92 kB)
     |################################| 92 kB 511 kB/s             
  Downloading google_api_core-2.0.0-py2.py3-none-any.whl (92 kB)
     |################################| 92 kB 313 kB/s             
  Downloading google_api_core-1.31.5-py2.py3-none-any.whl (93 kB)
     |################################| 93 kB 278 kB/s             
  Downloading google_api_core-1.31.4-py2.py3-none-any.whl (93 kB)
     |################################| 93 kB 1.4 MB/s             
  Downloading google_api_core-1.31.3-py2.py3-none-any.whl (93 kB)
     |################################| 93 kB 1.5 MB/s             
  Downloading google_api_core-1.31.2-py2.py3-none-any.whl (93 kB)
     |################################| 93 kB 1.1 MB/s             
  Downloading google_api_core-1.31.1-py2.py3-none-any.whl (93 kB)
     |################################| 93 kB 1.2 MB/s             
  Downloading google_api_core-1.31.0-py2.py3-none-any.whl (93 kB)
     |################################| 93 kB 1.3 MB/s             
Collecting googleapis-common-protos[grpc]<2.0.0dev,>=1.5.2
  Downloading googleapis_common_protos-1.55.0-py2.py3-none-any.whl (212 kB)
     |################################| 212 kB 65.6 MB/s            
  Downloading googleapis_common_protos-1.54.0-py2.py3-none-any.whl (207 kB)
     |################################| 207 kB 19.4 MB/s            
  Downloading googleapis_common_protos-1.53.0-py2.py3-none-any.whl (198 kB)
     |################################| 198 kB 21.8 MB/s            
  Downloading googleapis_common_protos-1.52.0-py2.py3-none-any.whl (100 kB)
     |################################| 100 kB 10.2 MB/s           
Building wheels for collected packages: googleapis-common-protos, grpc-google-iam-v1
  Building wheel for googleapis-common-protos (setup.py) ... done
  Created wheel for googleapis-common-protos: filename=googleapis_common_protos-1.51.0-py3-none-any.whl size=74511 sha256=6b39c5257aca8d2651396e172949c08b572e5ba0a12f504e8df183e52152e80f
  Stored in directory: /root/.cache/pip/wheels/35/8d/af/a922cb18800b31fadac3523cadf6c1efdf233b788fe7a4da70
  Building wheel for grpc-google-iam-v1 (setup.py) ... done
  Created wheel for grpc-google-iam-v1: filename=grpc_google_iam_v1-0.12.3-py3-none-any.whl size=15418 sha256=beca05a894b0b02bb330e85210c69e0eca1f43a47317596d3386c7909836aa7d
  Stored in directory: /root/.cache/pip/wheels/76/65/cd/392da05e43270f143b6c5076ba88d39144abff586792593e7c
Successfully built googleapis-common-protos grpc-google-iam-v1
Installing collected packages: six, pyasn1, urllib3, setuptools, rsa, pyparsing, pycparser, pyasn1-modules, protobuf, idna, chardet, certifi, cachetools, typing-extensions, requests, pytz, packaging, mypy-extensions, grpcio, googleapis-common-protos, google-auth, cffi, typing-inspect, PyYAML, google-crc32c, google-api-core, dataclasses, proto-plus, libcst, grpc-google-iam-v1, google-resumable-media, google-cloud-core, google-cloud-storage, google-cloud-pubsub, charset-normalizer
  Attempting uninstall: six
    Found existing installation: six 1.11.0
    Uninstalling six-1.11.0:
      Successfully uninstalled six-1.11.0
  Attempting uninstall: setuptools
    Found existing installation: setuptools 39.0.1
    Uninstalling setuptools-39.0.1:
      Successfully uninstalled setuptools-39.0.1
  Attempting uninstall: idna
    Found existing installation: idna 2.6
    Uninstalling idna-2.6:
      Successfully uninstalled idna-2.6
Successfully installed PyYAML-5.4.1 cachetools-4.1.0 certifi-2020.4.5.1 cffi-1.14.4 chardet-3.0.4 charset-normalizer-2.0.4 dataclasses-0.8 google-api-core-1.30.0 google-auth-1.28.0 google-cloud-core-1.7.1 google-cloud-pubsub-2.7.1 google-cloud-storage-1.39.0 google-crc32c-1.1.2 google-resumable-media-1.3.1 googleapis-common-protos-1.51.0 grpc-google-iam-v1-0.12.3 grpcio-1.38.1 idna-2.9 libcst-0.3.20 mypy-extensions-0.4.3 packaging-20.9 proto-plus-1.19.0 protobuf-3.17.3 pyasn1-0.4.8 pyasn1-modules-0.2.8 pycparser-2.20 pyparsing-2.4.7 pytz-2020.1 requests-2.25.1 rsa-4.7.2 setuptools-59.6.0 six-1.14.0 typing-extensions-3.10.0.2 typing-inspect-0.7.1 urllib3-1.26.5
```
## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
