### PR TITLE
Remove bucket reference from CloudWatchLogs documentation

### DIFF
--- a/source/amazon/services/supported-services/cloudwatchlogs.rst
+++ b/source/amazon/services/supported-services/cloudwatchlogs.rst
@@ -22,7 +22,7 @@ AWS CloudWatch Logs
 AWS configuration
 -----------------
 
-AWS CloudWatch logs can be accessed by configuring CloudWatch to store them into a bucket or by using the CloudWatch Logs Agent. The AWS API allows Wazuh to retrieve those logs, analyze them, and raise alerts if applicable.
+AWS CloudWatch logs can be accessed by using the Wazuh CloudWatch Logs integration. The AWS API allows Wazuh to retrieve those logs, analyze them, and raise alerts if applicable.
 
 
 Wazuh configuration


### PR DESCRIPTION
|Related issue|
|---|
|Closes #4991|

## Description
In this PR we have applied the correction for the CloudWatch Logs section were it said that the module could work with buckets too. This fix was already applied in #4690 for the future 4.4 release. 

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
