### PR TITLE
Remove ossec ownership from Wazuh documentation

### DIFF
--- a/source/deployment-options/wazuh-from-sources/wazuh-agent/index.rst
+++ b/source/deployment-options/wazuh-from-sources/wazuh-agent/index.rst
@@ -187,7 +187,7 @@ Installing Wazuh agent from sources
         # find /etc/systemd/system -name "wazuh*" | xargs rm -f
         # systemctl daemon-reload
 
-    Remove users:
+    Remove user and group:
 
     .. code-block:: console
 
@@ -352,7 +352,7 @@ Installing Wazuh agent from sources
 
      # rm -rf /Library/StartupItems/OSSEC
 
-    Remove users:
+    Remove user and group:
 
     .. code-block:: console
 
@@ -468,7 +468,7 @@ Installing Wazuh agent from sources
 
      # find /etc/rc.d -name "*wazuh*" | xargs rm -f
 
-    Remove users:
+    Remove user and group:
 
     .. code-block:: console
 
@@ -587,7 +587,7 @@ Installing Wazuh agent from sources
 
      # find /sbin/{init.d,rc*.d} -name "*wazuh*" | xargs rm -f
 
-    Remove users:
+    Remove user and group:
 
     .. code-block:: console
 
@@ -773,7 +773,7 @@ Installing Wazuh agent from sources
 
          # find /sbin/{init.d,rc*.d} -name "*wazuh*" | xargs rm -f
 
-        Remove users:
+        Remove user and group:
 
         .. code-block:: console
 
@@ -913,7 +913,7 @@ Installing Wazuh agent from sources
 
          # find /sbin/{init.d,rc*.d} -name "*wazuh*" | xargs rm -f
 
-        Remove users:
+        Remove user and group:
 
         .. code-block:: console
 

--- a/source/deployment-options/wazuh-from-sources/wazuh-server/index.rst
+++ b/source/deployment-options/wazuh-from-sources/wazuh-server/index.rst
@@ -276,7 +276,7 @@ Delete the service:
         # find /etc/systemd/system -name "wazuh*" | xargs rm -f
         # systemctl daemon-reload
 
-Remove users:
+Remove user and group:
 
   .. code-block:: console
 

--- a/source/installation-guide/wazuh-agent/wazuh-agent-package-hpux.rst
+++ b/source/installation-guide/wazuh-agent/wazuh-agent-package-hpux.rst
@@ -14,12 +14,12 @@ The installed agent runs on the host you want to monitor and communicates with t
 
 #. To start the installation process, download the `HP-UX installer <https://packages.wazuh.com/|CURRENT_MAJOR|/hp-ux/wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_HPUX|-hpux-11v3-ia64.tar>`_. 
 
-#. Create the ``ossec`` user and group.
+#. Create the ``wazuh`` user and group.
    
    .. code-block:: console
    
-       # groupadd ossec
-       # useradd -G ossec ossec
+       # groupadd wazuh
+       # useradd -G wazuh wazuh
    
 #. Unzip the package in ``/``.
 

--- a/source/proof-of-concept-guide/block-malicious-actor-ip-reputation.rst
+++ b/source/proof-of-concept-guide/block-malicious-actor-ip-reputation.rst
@@ -63,7 +63,7 @@ Configure your environment as follows to test the POC.
 
     .. code-block:: console
 
-        # chown ossec:ossec /var/ossec/etc/lists/blacklist-alienvault
+        # chown wazuh:wazuh /var/ossec/etc/lists/blacklist-alienvault
         # chmod 660 /var/ossec/etc/lists/blacklist-alienvault
 
 #. Add a custom rule to trigger the active response. This can be done in the ``/var/ossec/etc/rules/local_rules.xml`` file at the Wazuh manager.

--- a/source/proof-of-concept-guide/detect-malware-yara-integration.rst
+++ b/source/proof-of-concept-guide/detect-malware-yara-integration.rst
@@ -168,11 +168,11 @@ Configure your environment as follows to test the POC.
 
 
 
-#. Change ``yara.sh`` file owner to ``root:ossec`` and file permissions to ``0750``.
+#. Change ``yara.sh`` file owner to ``root:wazuh`` and file permissions to ``0750``.
 
     .. code-block:: console
 
-        # chown root:ossec /var/ossec/active-response/bin/yara.sh
+        # chown root:wazuh /var/ossec/active-response/bin/yara.sh
         # chmod 750 /var/ossec/active-response/bin/yara.sh
 
 #. Run ``yum install jq`` if jq is missing. This allows the ``yara.sh`` script to process the JSON input.

--- a/source/proof-of-concept-guide/detect-remove-malware-virustotal.rst
+++ b/source/proof-of-concept-guide/detect-remove-malware-virustotal.rst
@@ -107,7 +107,7 @@ Configure your environment as follows to test the POC.
     .. code-block:: console
 
         # chmod 750 /var/ossec/active-response/bin/remove-threat.sh
-        # chown root:ossec /var/ossec/active-response/bin/remove-threat.sh
+        # chown root:wazuh /var/ossec/active-response/bin/remove-threat.sh
 
 #. Run ``yum install jq`` if jq is missing. This allows the ``remove-threat.sh`` script to process the JSON input.
 

--- a/source/user-manual/capabilities/active-response/ar-use-cases/removing-malware.rst
+++ b/source/user-manual/capabilities/active-response/ar-use-cases/removing-malware.rst
@@ -172,7 +172,7 @@ Change ``/var/ossec/active-response/bin/remove-threat.sh`` owner and permissions
 .. code-block:: none 
 
   chmod 750 /var/ossec/active-response/bin/remove-threat.sh
-  chown root:ossec /var/ossec/active-response/bin/remove-threat.sh
+  chown root:wazuh /var/ossec/active-response/bin/remove-threat.sh
 
   
 Restart Wazuh agent to apply configuration changes. 

--- a/source/user-manual/capabilities/active-response/ar-use-cases/wazuh-with-yara.rst
+++ b/source/user-manual/capabilities/active-response/ar-use-cases/wazuh-with-yara.rst
@@ -208,7 +208,7 @@ The script configured to run as part of the active response settings defined on 
   exit 1;
   
   
-.. note:: Make sure that you have `jq <https://stedolan.github.io/jq/>`_ installed, and that the ``yara.sh`` file ownership is ``root:ossec`` and the permissions are ``750``.
+.. note:: Make sure that you have `jq <https://stedolan.github.io/jq/>`_ installed, and that the ``yara.sh`` file ownership is ``root:wazuh`` and the permissions are ``750``.
   
 The script receives these paths:
   

--- a/source/user-manual/capabilities/agentless-monitoring/how-it-works.rst
+++ b/source/user-manual/capabilities/agentless-monitoring/how-it-works.rst
@@ -27,7 +27,7 @@ Public key authentication can be used with the following command:
 
 .. code-block:: console
 
-  # sudo -u ossec ssh-keygen
+  # sudo -u wazuh ssh-keygen
 
 Once created, the public key must be copied into the remote device.
 


### PR DESCRIPTION
## Description

This pull request closes #5012.

4.3.0 includes the replacement of the user and group `ossec` to `wazuh` for Unix installations. Some sections in the documentation developed in parallel to this change had remaining references to the deprecated user and group.

These references have been updated as well as the whole documentation has been reviewed again looking for similar cases.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
