### PR TITLE
Fix yum, apt and zypper documentation(build from sources)

### DIFF
--- a/source/deployment-options/wazuh-from-sources/wazuh-agent/index.rst
+++ b/source/deployment-options/wazuh-from-sources/wazuh-agent/index.rst
@@ -48,8 +48,9 @@ Installing Wazuh agent from sources
 
             .. code-block:: console
 
-              # yum install make gcc gcc-c++ python3 python3-policycoreutils automake autoconf libtool openssl-devel cmake
-              # rpm -i $(rpm -q libstdc++-devel --queryformat "http://mirror.centos.org/centos/8/PowerTools/x86_64/os/Packages/libstdc++-static-%{VERSION}-%{RELEASE}.%{arch}.rpm\n")
+              # yum install make gcc gcc-c++ python3 python3-policycoreutils automake autoconf libtool openssl-devel yum-utils cmake -y
+              # yum-config-manager --enable powertools
+              # yum install libstdc++-static -y
 
             **Optional** CMake 3.18 installation from sources
 
@@ -66,7 +67,7 @@ Installing Wazuh agent from sources
 
         .. code-block:: console
 
-         # apt-get install python gcc g++ make libc6-dev curl policycoreutils automake autoconf libtool
+         # apt-get install python gcc g++ make libc6-dev curl policycoreutils automake autoconf libtool libssl-dev
 
 
         CMake 3.18 installation
@@ -84,7 +85,7 @@ Installing Wazuh agent from sources
 
         .. code-block:: console
 
-         # zypper install make gcc gcc-c++ policycoreutils-python automake autoconf libtool
+         # zypper install make gcc gcc-c++ policycoreutils-python automake autoconf libtool curl libopenssl-devel
 
         CMake 3.18 installation
 

--- a/source/deployment-options/wazuh-from-sources/wazuh-server/index.rst
+++ b/source/deployment-options/wazuh-from-sources/wazuh-server/index.rst
@@ -71,7 +71,7 @@ Installing the Wazuh manager
 
     .. code-block:: console
 
-      # apt-get install python gcc g++ make libc6-dev curl policycoreutils automake autoconf libtool cmake
+      # apt-get install python gcc g++ make libc6-dev curl policycoreutils automake autoconf libtool cmake libssl-dev
 
 
     **Optional** CMake 3.18 installation
@@ -88,7 +88,7 @@ Installing the Wazuh manager
 
     .. code-block:: console
 
-        # zypper install make cmake gcc gcc-c++ policycoreutils-python automake autoconf libtool
+        # zypper install make cmake gcc gcc-c++ policycoreutils-python automake autoconf libtool curl libopenssl-devel
 
     CMake 3.18 installation
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #4983  |
|Closes #4984  |

## Description
This PR aims to solve several errors in the current documentation page.
1- The need to install the OpenSSL devel.
2- Dependency on a third-party URL.
3- cURL as an openSUSE dependency


<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
