### PR TITLE
Changes warning message in macOS localfile

### DIFF
--- a/source/user-manual/reference/ossec-conf/localfile.rst
+++ b/source/user-manual/reference/ossec-conf/localfile.rst
@@ -1,7 +1,7 @@
 .. Copyright (C) 2022 Wazuh, Inc.
 .. meta::
   :description: Learn more about how to configure the collection of log data from files, Windows events, and from the output of commands with Wazuh. 
-  
+
 .. _reference_ossec_localfile:
 
 localfile
@@ -174,7 +174,7 @@ The attributes below are optional.
 +-------------+---------------------------------------+--------------+---------------+
 
 .. warning::
-  If collecting logs with ``<log_format>`` set as ``macos``, then ``max-size`` is ignored. 
+  If collecting logs with ``<log_format>`` set as ``macos``, then ``max-size`` is ignored.
 
 .. note::
   If the log rotates while ``wazuh-logcollector`` is stopped and ``only-future-events`` is set to ``no``, it will start reading from the beginning of the log. 
@@ -376,7 +376,7 @@ Set the format of the log to be read. **field is required**
 
 .. warning::
 
-    Only one configuration block with ``log_format`` set as ``macos`` is allowed.
+    Only one configuration block with ``log_format`` set as ``macos`` is allowed. If more blocks are added, the last one will be used.
 
 .. warning::
 


### PR DESCRIPTION
## Description
Currently, in the documentation, we warn the user that only a single block can be placed in the macOS localfile. 

With the development of the pull request **Fix verify-agent-conf for MacOS ULS [#13035 ](https://github.com/wazuh/wazuh/pull/13035)**, multiple blocks are allowed, although only the last valid block will be used.

This should be reflected in our documentation.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

