### PR TITLE
Update Logs Analytics query reference section

### DIFF
--- a/source/user-manual/reference/ossec-conf/wodle-azure-logs.rst
+++ b/source/user-manual/reference/ossec-conf/wodle-azure-logs.rst
@@ -365,7 +365,7 @@ For more information on Log Analytics query's language, check the `Azure documen
 +--------------------+-----------------------------------+
 | **Default value**  | N/A                               |
 +--------------------+-----------------------------------+
-| **Allowed values** | Any String without double quotes. |
+| **Allowed values** | Any String without double quotes  |
 +--------------------+-----------------------------------+
 
 log_analytics\\request\\workspace

--- a/source/user-manual/reference/ossec-conf/wodle-azure-logs.rst
+++ b/source/user-manual/reference/ossec-conf/wodle-azure-logs.rst
@@ -85,7 +85,7 @@ Options
 +----------------------------------------+----------------------------------------------+
 | `log_analytics\\request\\tag`_         | Any string                                   |
 +----------------------------------------+----------------------------------------------+
-| `log_analytics\\request\\query`_       | Any string                                   |
+| `log_analytics\\request\\query`_       | Any string without double quotes             |
 +----------------------------------------+----------------------------------------------+
 | `log_analytics\\request\\workspace`_   | Any string                                   |
 +----------------------------------------+----------------------------------------------+
@@ -327,7 +327,7 @@ request options
 +=========================================+==============================================+
 | `log_analytics\\request\\tag`_          | Any string                                   |
 +-----------------------------------------+----------------------------------------------+
-| `log_analytics\\request\\query`_        | Any string                                   |
+| `log_analytics\\request\\query`_        | Any string without double quotes             |
 +-----------------------------------------+----------------------------------------------+
 | `log_analytics\\request\\workspace`_    | Any string                                   |
 +-----------------------------------------+----------------------------------------------+
@@ -350,13 +350,23 @@ Defines a tag that we will add to the query. This entry is optional and can be u
 log_analytics\\request\\query
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This is the query made to the Azure Log Analytics API. This option is ready to use any query that we can make in the Log Analytics portal. For more information on the language, check the `Azure documentation <https://docs.microsoft.com/en-us/azure/azure-monitor/logs/get-started-queries>`_.
+This is the query made to the Azure Log Analytics API. This option is compatible with any valid query accepted by the Log Analytics portal, as long as it does not contains double quotes (``"``). If you need to use double quotes, you must replace them with single ones (``'``) or escape them by using the backslash character (``\"``).
 
-+--------------------+--------------------+
-| **Default value**  | N/A                |
-+--------------------+--------------------+
-| **Allowed values** | Any String         |
-+--------------------+--------------------+
+Here are some examples of valid queries:
+
+.. code-block:: xml
+
+    AuditLogs | where OperationVersion contains '1'
+    AuditLogs | where OperationVersion contains \"1\"
+
+
+For more information on Log Analytics query's language, check the `Azure documentation <https://docs.microsoft.com/en-us/azure/azure-monitor/logs/get-started-queries>`_.
+
++--------------------+-----------------------------------+
+| **Default value**  | N/A                               |
++--------------------+-----------------------------------+
+| **Allowed values** | Any String without double quotes. |
++--------------------+-----------------------------------+
 
 log_analytics\\request\\workspace
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION

## Description

This PR updates the Azure reference documentation to expand the description of the Log Analytics `query` parameter to specify that it does not support the usage of double quoutes (`"`) and explaining how to avoid this issue.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
