### PR TITLE
Change all MD5 references in cluster pages

### DIFF
--- a/source/development/wazuh-cluster.rst
+++ b/source/development/wazuh-cluster.rst
@@ -86,7 +86,7 @@ The image below shows a schema of how a master node and a worker node interact w
     :align: center
     :width: 80%
 
-    
+
 Threads
 ^^^^^^^
 The following tasks can be found in the cluster, depending on the type of node they are running on:
@@ -127,9 +127,9 @@ This thread is in charge of synchronizing master's integrity information among a
 
     * Path
     * Modification time
-    * MD5 checksum
+    * Blake2b checksum
     * Whether the file is a merged file or not. And if it's merged:
-    
+
         * The merge type
         * The filename
 
@@ -513,8 +513,8 @@ If the log error message isn't clarifying enough, the traceback can be logged se
     2019/04/10 15:50:37 wazuh-clusterd: ERROR: [Cluster] [Main] Could not get checksum of file client.keys: [Errno 13] Permission denied: '/var/ossec/etc/client.keys'
     Traceback (most recent call last):
     File "/var/ossec/framework/python/lib/python3.9/site-packages/wazuh-|WAZUH_LATEST|-py3.7.egg/wazuh/core/cluster/cluster.py", line 217, in walk_dir
-        entry_metadata['md5'] = md5(os.path.join(common.ossec_path, full_path))
-    File "/var/ossec/framework/python/lib/python3.9/site-packages/wazuh-|WAZUH_LATEST|-py3.7.egg/wazuh/core/utils.py", line 555, in md5
+        entry_metadata['blake2b'] = blake2b(os.path.join(common.ossec_path, full_path))
+    File "/var/ossec/framework/python/lib/python3.9/site-packages/wazuh-|WAZUH_LATEST|-py3.7.egg/wazuh/core/utils.py", line 555, in blake2b
         with open(fname, "rb") as f:
     PermissionError: [Errno 13] Permission denied: '/var/ossec/etc/client.keys'
 

--- a/source/user-manual/configuring-cluster/basics.rst
+++ b/source/user-manual/configuring-cluster/basics.rst
@@ -1,8 +1,8 @@
 .. Copyright (C) 2022 Wazuh, Inc.
 
 .. meta::
-    :description: A Wazuh cluster is a group of Wazuh managers that work together to enhance the availability and scalability of the service. Learn more about it here. 
-    
+    :description: A Wazuh cluster is a group of Wazuh managers that work together to enhance the availability and scalability of the service. Learn more about it here.
+
 .. _wazuh-cluster-introduction:
 
 Basics
@@ -109,4 +109,4 @@ Integrity thread
 File Integrity Thread
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-    The integrity of each file is calculated using its MD5 checksum and its modification time. To avoid calculating the integrity with each worker connection, the integrity is calculated in a different thread, called *File integrity thread*, in the master node every so often.
+    The integrity of each file is calculated using its Blake2b checksum and its modification time. To avoid calculating the integrity with each worker connection, the integrity is calculated in a different thread, called *File integrity thread*, in the master node every so often.


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

This PR closes #5092. In this PR we have changed all references to the MD5 algorithm related to the cluster as our intention is to use the Blake2b algorithm in Wazuh version 4.4.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->
