### PR TITLE
specifying Jinja2 version in requirements.txt - issue #5009

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Sphinx==3.2.0
 sphinx_tabs==1.2.1
 docutils==0.16
 jsmin==3.0.1
+Jinja2<3.1


### PR DESCRIPTION
Community contribution.

<!--
This is my first ever PR; apologies if I did this wrong.
-->

## Description

Closes issue #5009. 

Python grabs the most recent version of Jinja2 when grabbing the dependencies from requirements.txt when not specified otherwise. The most recent version of Jinja2 breaks the `make html` command, so the last working version of Jinja2 is now specified in requirements.txt.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
