### PR TITLE
[4.3] Updated requirements to specify Jinja2 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Sphinx==3.2.0
 sphinx_tabs==1.2.1
 docutils==0.16
 jsmin==3.0.1
+Jinja2<3.1


### PR DESCRIPTION

## Description

Since the new versions of Jinja2 will cause errors during compilation, this PR updates requirements.txt to specify the Jinja2 version that needs to be installed to avoid errors.

## Checks
- [x] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
