### PR TITLE
Improve the Wazuh dashboard migration guide

### DIFF
--- a/source/migration-guide/wazuh-dashboard.rst
+++ b/source/migration-guide/wazuh-dashboard.rst
@@ -122,6 +122,7 @@ To guarantee a correct operation of Wazuh, make sure to also migrate from Open D
 
 #.  Port your settings from ``/usr/share/kibana/data/wazuh/config/wazuh.yml`` to ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml``. It is recommended to copy the content from ``/usr/share/kibana/data/wazuh/downloads/`` as well.
 
+#. Access the Wazuh web interface at ``https://<dashboard_ip>`` with your credentials and make sure that everything is working as expected. 
 
 #. Uninstall Kibana.
 

--- a/source/migration-guide/wazuh-dashboard.rst
+++ b/source/migration-guide/wazuh-dashboard.rst
@@ -66,7 +66,7 @@ Follow this guide to migrate from Open Distro for Elasticsearch Kibana 1.13 to t
               .. include:: /_templates/installations/dashboard/apt/install_dashboard.rst
 
 
-    ..  note:: Make sure that your Wazuh manager is updated to the latest version. 
+    ..  note:: Make sure that your Wazuh manager is updated to the latest version. To learn more, see the :doc:`Upgrading the Wazuh manager </upgrade-guide/upgrading-wazuh>` documentation. 
 
 #. Create the ``/etc/wazuh-dashboard/certs`` directory, copy your old certificates to the new location and change ownership and permissions.    
 

--- a/source/migration-guide/wazuh-dashboard.rst
+++ b/source/migration-guide/wazuh-dashboard.rst
@@ -10,6 +10,8 @@ Migrating to the Wazuh dashboard
 
 Follow this guide to migrate from Open Distro for Elasticsearch Kibana 1.13 to the Wazuh dashboard. These instructions are intended for a standard Wazuh installation, you may need to make some changes to adapt them to your environment.
 
+To guarantee a correct operation of Wazuh, make sure to also migrate from Open Distro for Elasticsearch to the Wazuh indexer. To learn more, see the :doc:`Migrating to the Wazuh indexer </migration-guide/wazuh-indexer>` documentation. 
+
 
 .. note:: Root user privileges are required to execute all the commands described below.
 

--- a/source/migration-guide/wazuh-indexer.rst
+++ b/source/migration-guide/wazuh-indexer.rst
@@ -243,4 +243,4 @@ Follow this guide to migrate from Open Distro for Elasticsearch 1.13 to the Wazu
 Next steps
 ----------
 
-Your cluster is now updated. If you want to migrate from Kibana to the Wazuh dashboard, see the :doc:`wazuh-dashboard` section.
+Your cluster is now updated. To guarantee a correct operation of Wazuh, make sure to also migrate from Kibana to the Wazuh dashboard.  To learn more, see the :doc:`wazuh-dashboard` section.


### PR DESCRIPTION
## Description

This PR adds the following improvements to the "Migrating to the Wazuh dashboard" document: 

- Adds a note recommending also migrating from Open Distro for Elasticsearch to the Wazuh indexer to guarantee the correct operation of Wazuh. 
- Adds a step to enter the web interface and verify that everything is working as expected before uninstalling Kibana. 
- Adds a link to the "Upgrading the Wazuh manager" documentation. 

This PR closes #5131.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

## Note to the reviewer

This PR includes changes to the `redirect.js` script that need to be included in all production branches.
