### PR TITLE
Change installation packages to latest 4.2 version

### DIFF
--- a/source/_templates/installations/basic/wazuh/deb/deploy_wazuh_agent.rst
+++ b/source/_templates/installations/basic/wazuh/deb/deploy_wazuh_agent.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # WAZUH_MANAGER="10.0.0.2" apt-get install wazuh-agent=|WAZUH_LATEST|-|WAZUH_REVISION_DEB_AGENT_X86|
+  # WAZUH_MANAGER="10.0.0.2" apt-get install wazuh-agent=4.2.6-1
 
 .. End of include file

--- a/source/_templates/installations/basic/wazuh/deb/deploy_wazuh_agent.rst
+++ b/source/_templates/installations/basic/wazuh/deb/deploy_wazuh_agent.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # WAZUH_MANAGER="10.0.0.2" apt-get install wazuh-agent
+  # WAZUH_MANAGER="10.0.0.2" apt-get install wazuh-agent=|WAZUH_LATEST|-|WAZUH_REVISION_DEB_AGENT_X86|
 
 .. End of include file

--- a/source/_templates/installations/basic/wazuh/deb/install_wazuh_agent.rst
+++ b/source/_templates/installations/basic/wazuh/deb/install_wazuh_agent.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # apt-get install wazuh-agent=|WAZUH_LATEST|-|WAZUH_REVISION_DEB_AGENT_X86|
+  # apt-get install wazuh-agent=4.2.6-1
 
 .. End of include file

--- a/source/_templates/installations/basic/wazuh/deb/install_wazuh_agent.rst
+++ b/source/_templates/installations/basic/wazuh/deb/install_wazuh_agent.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # apt-get install wazuh-agent
+  # apt-get install wazuh-agent=|WAZUH_LATEST|-|WAZUH_REVISION_DEB_AGENT_X86|
 
 .. End of include file

--- a/source/_templates/installations/basic/wazuh/deb/install_wazuh_manager.rst
+++ b/source/_templates/installations/basic/wazuh/deb/install_wazuh_manager.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # apt-get install wazuh-manager=|WAZUH_LATEST|-|WAZUH_REVISION_DEB_MANAGER_X86|
+  # apt-get install wazuh-manager=4.2.6-1
 
 .. End of include file

--- a/source/_templates/installations/basic/wazuh/deb/install_wazuh_manager.rst
+++ b/source/_templates/installations/basic/wazuh/deb/install_wazuh_manager.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # apt-get install wazuh-manager
+  # apt-get install wazuh-manager=|WAZUH_LATEST|-|WAZUH_REVISION_DEB_MANAGER_X86|
 
 .. End of include file

--- a/source/_templates/installations/basic/wazuh/yum/deploy_wazuh_agent.rst
+++ b/source/_templates/installations/basic/wazuh/yum/deploy_wazuh_agent.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # WAZUH_MANAGER="10.0.0.2" yum install wazuh-agent
+  # WAZUH_MANAGER="10.0.0.2" yum install wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_YUM_AGENT_X86|
 
 .. End of include file

--- a/source/_templates/installations/basic/wazuh/yum/deploy_wazuh_agent.rst
+++ b/source/_templates/installations/basic/wazuh/yum/deploy_wazuh_agent.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # WAZUH_MANAGER="10.0.0.2" yum install wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_YUM_AGENT_X86|
+  # WAZUH_MANAGER="10.0.0.2" yum install wazuh-agent-4.2.6-1
 
 .. End of include file

--- a/source/_templates/installations/basic/wazuh/yum/install_wazuh_agent.rst
+++ b/source/_templates/installations/basic/wazuh/yum/install_wazuh_agent.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # yum install wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_YUM_AGENT_X86|
+  # yum install wazuh-agent-4.2.6-1
 
 .. End of include file

--- a/source/_templates/installations/basic/wazuh/yum/install_wazuh_agent.rst
+++ b/source/_templates/installations/basic/wazuh/yum/install_wazuh_agent.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # yum install wazuh-agent
+  # yum install wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_YUM_AGENT_X86|
 
 .. End of include file

--- a/source/_templates/installations/basic/wazuh/yum/install_wazuh_manager.rst
+++ b/source/_templates/installations/basic/wazuh/yum/install_wazuh_manager.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # yum install wazuh-manager
+  # yum install wazuh-manager-|WAZUH_LATEST|-|WAZUH_REVISION_YUM_MANAGER_X86|
 
 .. End of include file

--- a/source/_templates/installations/basic/wazuh/yum/install_wazuh_manager.rst
+++ b/source/_templates/installations/basic/wazuh/yum/install_wazuh_manager.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # yum install wazuh-manager-|WAZUH_LATEST|-|WAZUH_REVISION_YUM_MANAGER_X86|
+  # yum install wazuh-manager-4.2.6-1
 
 .. End of include file

--- a/source/_templates/installations/basic/wazuh/zypp/deploy_wazuh_agent.rst
+++ b/source/_templates/installations/basic/wazuh/zypp/deploy_wazuh_agent.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # WAZUH_MANAGER="10.0.0.2" zypper install wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_YUM_AGENT_X86|
+  # WAZUH_MANAGER="10.0.0.2" zypper install wazuh-agent-4.2.6-1
 
 .. End of include file

--- a/source/_templates/installations/basic/wazuh/zypp/deploy_wazuh_agent.rst
+++ b/source/_templates/installations/basic/wazuh/zypp/deploy_wazuh_agent.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # WAZUH_MANAGER="10.0.0.2" zypper install wazuh-agent
+  # WAZUH_MANAGER="10.0.0.2" zypper install wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_YUM_AGENT_X86|
 
 .. End of include file

--- a/source/_templates/installations/basic/wazuh/zypp/install_wazuh_agent.rst
+++ b/source/_templates/installations/basic/wazuh/zypp/install_wazuh_agent.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # zypper install wazuh-agent
+  # zypper install wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_YUM_AGENT_X86|
 
 .. End of include file

--- a/source/_templates/installations/basic/wazuh/zypp/install_wazuh_agent.rst
+++ b/source/_templates/installations/basic/wazuh/zypp/install_wazuh_agent.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # zypper install wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_YUM_AGENT_X86|
+  # zypper install wazuh-agent-4.2.6-1
 
 .. End of include file

--- a/source/_templates/installations/basic/wazuh/zypp/install_wazuh_manager.rst
+++ b/source/_templates/installations/basic/wazuh/zypp/install_wazuh_manager.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # zypper install wazuh-manager
+  # zypper install wazuh-manager-|WAZUH_LATEST|-|WAZUH_REVISION_YUM_MANAGER_X86|
 
 .. End of include file

--- a/source/_templates/installations/basic/wazuh/zypp/install_wazuh_manager.rst
+++ b/source/_templates/installations/basic/wazuh/zypp/install_wazuh_manager.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # zypper install wazuh-manager-|WAZUH_LATEST|-|WAZUH_REVISION_YUM_MANAGER_X86|
+  # zypper install wazuh-manager-4.2.6-1
 
 .. End of include file

--- a/source/_templates/installations/wazuh/deb/deploy_wazuh_agent.rst
+++ b/source/_templates/installations/wazuh/deb/deploy_wazuh_agent.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # WAZUH_MANAGER="10.0.0.2" apt-get install wazuh-agent=|WAZUH_LATEST|-|WAZUH_REVISION_DEB_AGENT_X86|
+  # WAZUH_MANAGER="10.0.0.2" apt-get install wazuh-agent=4.2.6-1
 
 .. End of include file

--- a/source/_templates/installations/wazuh/deb/deploy_wazuh_agent.rst
+++ b/source/_templates/installations/wazuh/deb/deploy_wazuh_agent.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # WAZUH_MANAGER="10.0.0.2" apt-get install wazuh-agent
+  # WAZUH_MANAGER="10.0.0.2" apt-get install wazuh-agent=|WAZUH_LATEST|-|WAZUH_REVISION_DEB_AGENT_X86|
 
 .. End of include file

--- a/source/_templates/installations/wazuh/deb/install_wazuh_agent.rst
+++ b/source/_templates/installations/wazuh/deb/install_wazuh_agent.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # apt-get install wazuh-agent=|WAZUH_LATEST|-|WAZUH_REVISION_DEB_AGENT_X86|
+  # apt-get install wazuh-agent=4.2.6-1
 
 .. End of include file

--- a/source/_templates/installations/wazuh/deb/install_wazuh_agent.rst
+++ b/source/_templates/installations/wazuh/deb/install_wazuh_agent.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # apt-get install wazuh-agent
+  # apt-get install wazuh-agent=|WAZUH_LATEST|-|WAZUH_REVISION_DEB_AGENT_X86|
 
 .. End of include file

--- a/source/_templates/installations/wazuh/deb/install_wazuh_manager.rst
+++ b/source/_templates/installations/wazuh/deb/install_wazuh_manager.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # apt-get install wazuh-manager=|WAZUH_LATEST|-|WAZUH_REVISION_DEB_MANAGER_X86|
+  # apt-get install wazuh-manager=4.2.6-1
 
 .. End of include file

--- a/source/_templates/installations/wazuh/deb/install_wazuh_manager.rst
+++ b/source/_templates/installations/wazuh/deb/install_wazuh_manager.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # apt-get install wazuh-manager
+  # apt-get install wazuh-manager=|WAZUH_LATEST|-|WAZUH_REVISION_DEB_MANAGER_X86|
 
 .. End of include file

--- a/source/_templates/installations/wazuh/yum/deploy_wazuh_agent.rst
+++ b/source/_templates/installations/wazuh/yum/deploy_wazuh_agent.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # WAZUH_MANAGER="10.0.0.2" yum install wazuh-agent
+  # WAZUH_MANAGER="10.0.0.2" yum install wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_YUM_AGENT_X86|
 
 .. End of include file

--- a/source/_templates/installations/wazuh/yum/deploy_wazuh_agent.rst
+++ b/source/_templates/installations/wazuh/yum/deploy_wazuh_agent.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # WAZUH_MANAGER="10.0.0.2" yum install wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_YUM_AGENT_X86|
+  # WAZUH_MANAGER="10.0.0.2" yum install wazuh-agent-4.2.6-1
 
 .. End of include file

--- a/source/_templates/installations/wazuh/yum/install_wazuh_agent.rst
+++ b/source/_templates/installations/wazuh/yum/install_wazuh_agent.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # yum install wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_YUM_AGENT_X86|
+  # yum install wazuh-agent-4.2.6-1
 
 .. End of include file

--- a/source/_templates/installations/wazuh/yum/install_wazuh_agent.rst
+++ b/source/_templates/installations/wazuh/yum/install_wazuh_agent.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # yum install wazuh-agent
+  # yum install wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_YUM_AGENT_X86|
 
 .. End of include file

--- a/source/_templates/installations/wazuh/yum/install_wazuh_manager.rst
+++ b/source/_templates/installations/wazuh/yum/install_wazuh_manager.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # yum install wazuh-manager
+  # yum install wazuh-manager-|WAZUH_LATEST|-|WAZUH_REVISION_YUM_MANAGER_X86|
 
 .. End of include file

--- a/source/_templates/installations/wazuh/yum/install_wazuh_manager.rst
+++ b/source/_templates/installations/wazuh/yum/install_wazuh_manager.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # yum install wazuh-manager-|WAZUH_LATEST|-|WAZUH_REVISION_YUM_MANAGER_X86|
+  # yum install wazuh-manager-4.2.6-1
 
 .. End of include file

--- a/source/_templates/installations/wazuh/zypp/deploy_wazuh_agent.rst
+++ b/source/_templates/installations/wazuh/zypp/deploy_wazuh_agent.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # WAZUH_MANAGER="10.0.0.2" zypper install wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_YUM_AGENT_X86|
+  # WAZUH_MANAGER="10.0.0.2" zypper install wazuh-agent-4.2.6-1
 
 .. End of include file

--- a/source/_templates/installations/wazuh/zypp/deploy_wazuh_agent.rst
+++ b/source/_templates/installations/wazuh/zypp/deploy_wazuh_agent.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # WAZUH_MANAGER="10.0.0.2" zypper install wazuh-agent
+  # WAZUH_MANAGER="10.0.0.2" zypper install wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_YUM_AGENT_X86|
 
 .. End of include file

--- a/source/_templates/installations/wazuh/zypp/install_wazuh_agent.rst
+++ b/source/_templates/installations/wazuh/zypp/install_wazuh_agent.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # zypper install wazuh-agent
+  # zypper install wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_YUM_AGENT_X86|
 
 .. End of include file

--- a/source/_templates/installations/wazuh/zypp/install_wazuh_agent.rst
+++ b/source/_templates/installations/wazuh/zypp/install_wazuh_agent.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # zypper install wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_YUM_AGENT_X86|
+  # zypper install wazuh-agent-4.2.6-1
 
 .. End of include file

--- a/source/_templates/installations/wazuh/zypp/install_wazuh_manager.rst
+++ b/source/_templates/installations/wazuh/zypp/install_wazuh_manager.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # zypper install wazuh-manager
+  # zypper install wazuh-manager-|WAZUH_LATEST|-|WAZUH_REVISION_YUM_MANAGER_X86|
 
 .. End of include file

--- a/source/_templates/installations/wazuh/zypp/install_wazuh_manager.rst
+++ b/source/_templates/installations/wazuh/zypp/install_wazuh_manager.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # zypper install wazuh-manager-|WAZUH_LATEST|-|WAZUH_REVISION_YUM_MANAGER_X86|
+  # zypper install wazuh-manager-4.2.6-1
 
 .. End of include file

--- a/source/cloud-service/your-environment/agents-without-internet.rst
+++ b/source/cloud-service/your-environment/agents-without-internet.rst
@@ -76,7 +76,7 @@ To achieve this configuration, follow these steps:
 
          WAZUH_MANAGER_IP=nginx_ip WAZUH_PROTOCOL="tcp" \
          WAZUH_PASSWORD="xxxx" \
-         yum install wazuh-agent
+         yum install wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_YUM_AGENT_X86|
          
       In this example, make sure to replace ``<xxxx>`` with your actual password.
 
@@ -113,6 +113,6 @@ In case your agents are located in AWS, you can access our Wazuh Cloud service s
 
       WAZUH_MANAGER_IP=vpce-<aws-endpoint-id>.vpce-svc-<aws-service-id>.<region>.vpce.amazonaws.com WAZUH_PROTOCOL="tcp" \
       WAZUH_PASSWORD="xxxx" \
-      yum install wazuh-agent
+      yum install wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_YUM_AGENT_X86|
 
    In this example, make sure to replace ``<xxxx>`` with your actual password.

--- a/source/conf.py
+++ b/source/conf.py
@@ -32,7 +32,7 @@ copyright = u'&copy; ' + str(datetime.datetime.now().year) + u' &middot; Wazuh I
 
 # The short X.Y version
 version = '4.2'
-is_latest_release = True
+is_latest_release = False
 
 # The full version, including alpha/beta/rc tags
 # Important: use a valid branch (4.0) or, preferably, tag name (v4.0.0)

--- a/source/installation-guide/wazuh-agent/deployment-variables/deployment-variables-linux.rst
+++ b/source/installation-guide/wazuh-agent/deployment-variables/deployment-variables-linux.rst
@@ -56,42 +56,42 @@ Examples:
         .. code-block:: console
         
              # WAZUH_MANAGER="10.0.0.2" WAZUH_REGISTRATION_PASSWORD="TopSecret" \
-                  WAZUH_AGENT_NAME="yum-agent" yum install wazuh-agent
+                  WAZUH_AGENT_NAME="yum-agent" yum install wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_YUM_AGENT_X86|
         
         * Registration with password and assigning a group:
         
         .. code-block:: console
         
              # WAZUH_MANAGER="10.0.0.2" WAZUH_REGISTRATION_SERVER="10.0.0.2" WAZUH_REGISTRATION_PASSWORD="TopSecret" \
-                  WAZUH_AGENT_GROUP="my-group" yum install wazuh-agent
+                  WAZUH_AGENT_GROUP="my-group" yum install wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_YUM_AGENT_X86|
         
         * Registration with relative path to CA. It will be searched at your Wazuh installation folder:
         
         .. code-block:: console
         
              # WAZUH_MANAGER="10.0.0.2" WAZUH_REGISTRATION_SERVER="10.0.0.2" WAZUH_AGENT_NAME="yum-agent" \
-                  WAZUH_REGISTRATION_CA="rootCA.pem" yum install wazuh-agent
+                  WAZUH_REGISTRATION_CA="rootCA.pem" yum install wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_YUM_AGENT_X86|
         
         * Registration with protocol:
         
         .. code-block:: console
         
              # WAZUH_MANAGER="10.0.0.2" WAZUH_REGISTRATION_SERVER="10.0.0.2" WAZUH_AGENT_NAME="yum-agent" \
-                  WAZUH_PROTOCOL="udp" yum install wazuh-agent
+                  WAZUH_PROTOCOL="udp" yum install wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_YUM_AGENT_X86|
         
         * Registration and adding multiple address:
         
         .. code-block:: console
         
              # WAZUH_MANAGER="10.0.0.2,10.0.0.3" WAZUH_REGISTRATION_SERVER="10.0.0.2" \
-                  WAZUH_AGENT_NAME="yum-agent" yum install wazuh-agent
+                  WAZUH_AGENT_NAME="yum-agent" yum install wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_YUM_AGENT_X86|
         
         * Absolute paths to CA, certificate or key that contain spaces can be written as shown below:
         
         .. code-block:: console
         
              # WAZUH_MANAGER "10.0.0.2" WAZUH_REGISTRATION_SERVER "10.0.0.2" WAZUH_REGISTRATION_KEY "/var/ossec/etc/sslagent.key" \
-                  WAZUH_REGISTRATION_CERTIFICATE "/var/ossec/etc/sslagent.cert" yum install wazuh-agent
+                  WAZUH_REGISTRATION_CERTIFICATE "/var/ossec/etc/sslagent.cert" yum install wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_YUM_AGENT_X86|
         
         .. note:: To verify agents identity with the registration server, it's necessary to use both KEY and PEM options. See the    :ref:`Registration Service with host verification - Agent verification with host validation <enrollment_additional_security>` section.
      
@@ -104,42 +104,42 @@ Examples:
         .. code-block:: console
         
              # WAZUH_MANAGER="10.0.0.2" WAZUH_REGISTRATION_PASSWORD="TopSecret" \
-                  WAZUH_AGENT_NAME="apt-agent" apt-get install wazuh-agent
+                  WAZUH_AGENT_NAME="apt-agent" apt-get install wazuh-agent=|WAZUH_LATEST|-|WAZUH_REVISION_DEB_AGENT_X86|
         
         * Registration with password and assigning a group:
         
         .. code-block:: console
         
              # WAZUH_MANAGER="10.0.0.2" WAZUH_REGISTRATION_SERVER="10.0.0.2" WAZUH_REGISTRATION_PASSWORD="TopSecret" \
-                  WAZUH_AGENT_GROUP="my-group" apt-get install wazuh-agent
+                  WAZUH_AGENT_GROUP="my-group" apt-get install wazuh-agent=|WAZUH_LATEST|-|WAZUH_REVISION_DEB_AGENT_X86|
         
         * Registration with relative path to CA. It will be searched at your Wazuh installation folder:
         
         .. code-block:: console
         
              # WAZUH_MANAGER="10.0.0.2" WAZUH_REGISTRATION_SERVER="10.0.0.2" WAZUH_AGENT_NAME="apt-agent" \
-                  WAZUH_REGISTRATION_CA="rootCA.pem" apt-get install wazuh-agent
+                  WAZUH_REGISTRATION_CA="rootCA.pem" apt-get install wazuh-agent=|WAZUH_LATEST|-|WAZUH_REVISION_DEB_AGENT_X86|
         
         * Registration with protocol:
         
         .. code-block:: console
         
              # WAZUH_MANAGER="10.0.0.2" WAZUH_REGISTRATION_SERVER="10.0.0.2" WAZUH_AGENT_NAME="apt-agent" \
-                  WAZUH_PROTOCOL="udp" apt-get install wazuh-agent
+                  WAZUH_PROTOCOL="udp" apt-get install wazuh-agent=|WAZUH_LATEST|-|WAZUH_REVISION_DEB_AGENT_X86|
         
         * Registration and adding multiple addresses:
         
         .. code-block:: console
         
              # WAZUH_MANAGER="10.0.0.2,10.0.0.3" WAZUH_REGISTRATION_SERVER="10.0.0.2" \
-                  WAZUH_AGENT_NAME="apt-agent" apt-get install wazuh-agent
+                  WAZUH_AGENT_NAME="apt-agent" apt-get install wazuh-agent=|WAZUH_LATEST|-|WAZUH_REVISION_DEB_AGENT_X86|
         
         * Absolute paths to CA, certificate or key that contain spaces can be written as shown below:
         
         .. code-block:: console
         
              # WAZUH_MANAGER "10.0.0.2" WAZUH_REGISTRATION_SERVER "10.0.0.2" WAZUH_REGISTRATION_KEY "/var/ossec/etc/sslagent.key" \
-                  WAZUH_REGISTRATION_CERTIFICATE "/var/ossec/etc/sslagent.cert" apt-get install wazuh-agent
+                  WAZUH_REGISTRATION_CERTIFICATE "/var/ossec/etc/sslagent.cert" apt-get install wazuh-agent=|WAZUH_LATEST|-|WAZUH_REVISION_DEB_AGENT_X86|
         
         .. note:: To verify agents identity with the registration server, it's necessary to use both KEY and PEM options. See the    :ref:`Registration Service with host verification - Agent verification with host validation <enrollment_additional_security>` section.
      
@@ -155,44 +155,41 @@ Examples:
         .. code-block:: console
         
              # WAZUH_MANAGER="10.0.0.2" WAZUH_REGISTRATION_PASSWORD="TopSecret" \
-                  WAZUH_AGENT_NAME="zypper-agent" zypper install wazuh-agent
+                  WAZUH_AGENT_NAME="zypper-agent" zypper install wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_YUM_AGENT_X86|
         
         * Registration with password and assigning a group:
         
         .. code-block:: console
         
              # WAZUH_MANAGER="10.0.0.2" WAZUH_REGISTRATION_SERVER="10.0.0.2" WAZUH_REGISTRATION_PASSWORD="TopSecret" \
-                  WAZUH_AGENT_GROUP="my-group" zypper install wazuh-agent
+                  WAZUH_AGENT_GROUP="my-group" zypper install wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_YUM_AGENT_X86|
         
         * Registration with relative path to CA. It will be searched at your Wazuh installation folder:
         
         .. code-block:: console
         
              # WAZUH_MANAGER="10.0.0.2" WAZUH_REGISTRATION_SERVER="10.0.0.2" WAZUH_AGENT_NAME="zypper-agent" \
-                  WAZUH_REGISTRATION_CA="rootCA.pem" zypper install wazuh-agent
+                  WAZUH_REGISTRATION_CA="rootCA.pem" zypper install wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_YUM_AGENT_X86|
         
         * Registration with protocol:
         
         .. code-block:: console
         
              # WAZUH_MANAGER="10.0.0.2" WAZUH_REGISTRATION_SERVER="10.0.0.2" WAZUH_AGENT_NAME="zypper-agent" \
-                  WAZUH_PROTOCOL="udp" zypper install wazuh-agent
+                  WAZUH_PROTOCOL="udp" zypper install wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_YUM_AGENT_X86|
         
         * Registration and adding multiple address:
         
         .. code-block:: console
         
              # WAZUH_MANAGER="10.0.0.2,10.0.0.3" WAZUH_REGISTRATION_SERVER="10.0.0.2" \
-                  WAZUH_AGENT_NAME="zypper-agent" zypper install wazuh-agent
+                  WAZUH_AGENT_NAME="zypper-agent" zypper install wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_YUM_AGENT_X86|
         
         * Absolute paths to CA, certificate or key that contain spaces can be written as shown below:
         
         .. code-block:: console
         
              # WAZUH_MANAGER "10.0.0.2" WAZUH_REGISTRATION_SERVER "10.0.0.2" WAZUH_REGISTRATION_KEY "/var/ossec/etc/sslagent.key" \
-                  WAZUH_REGISTRATION_CERTIFICATE "/var/ossec/etc/sslagent.cert" zypper install wazuh-agent
+                  WAZUH_REGISTRATION_CERTIFICATE "/var/ossec/etc/sslagent.cert" zypper install wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_YUM_AGENT_X86|
         
         .. note:: To verify agents identity with the registration server, it's necessary to use both KEY and PEM options. See the    :ref:`Registration Service with host verification - Agent verification with host validation <enrollment_additional_security>` section.
-
-
-

--- a/source/learning-wazuh/build-lab/install-linux-agents.rst
+++ b/source/learning-wazuh/build-lab/install-linux-agents.rst
@@ -48,7 +48,7 @@ Install and start the Wazuh agent software
   .. code-block:: console
 
     # WAZUH_MANAGER="172.30.0.10" WAZUH_REGISTRATION_PASSWORD="please123" \
-    WAZUH_PROTOCOL="tcp" yum -y install wazuh-agent
+    WAZUH_PROTOCOL="tcp" yum -y install wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_YUM_AGENT_X86|
     # systemctl start wazuh-agent
 
 Verify the agent has properly connected:

--- a/source/learning-wazuh/build-lab/install-wazuh-manager.rst
+++ b/source/learning-wazuh/build-lab/install-wazuh-manager.rst
@@ -46,7 +46,7 @@ Install the Wazuh manager software and start its service:
 
   .. code-block:: console
 
-    # yum -y install wazuh-manager
+    # yum -y install wazuh-manager-|WAZUH_LATEST|-|WAZUH_REVISION_YUM_MANAGER_X86|
     # systemctl start wazuh-manager
 
 Configure Wazuh manager to allow self registration of new agents with authentication:

--- a/source/upgrade-guide/legacy/upgrading-agent/from-2.x-to-3.x.rst
+++ b/source/upgrade-guide/legacy/upgrading-agent/from-2.x-to-3.x.rst
@@ -35,7 +35,7 @@ To upgrade the Wazuh agent choose the appropriate tab for the desired operating 
 
         .. code-block:: console
 
-          # yum install wazuh-agent
+          # yum install wazuh-agent-3.13.3-1
 
         It is recommended to disable the Wazuh repository in order to avoid undesired upgrades and compatibility issues as the Wazuh agent should always be in the same or lower version than the Wazuh manager:
 
@@ -56,7 +56,7 @@ To upgrade the Wazuh agent choose the appropriate tab for the desired operating 
         .. code-block:: console
 
           # apt-get update
-          # apt-get install wazuh-agent
+          # apt-get install wazuh-agent=3.13.3-1
 
         It is recommended to disable the Wazuh repository in order to avoid undesired upgrades and compatibility issues as the Wazuh agent should always be in the same or lower version than the Wazuh manager:
 

--- a/source/upgrade-guide/legacy/upgrading-wazuh-server/from-2.x-to-3.x.rst
+++ b/source/upgrade-guide/legacy/upgrading-wazuh-server/from-2.x-to-3.x.rst
@@ -57,14 +57,14 @@ To upgrade the Wazuh server choose the the appropriate tab for the desired packa
 
         .. code-block:: console
 
-          # yum install wazuh-manager wazuh-api
+          # yum install wazuh-manager-3.13.3-1 wazuh-api
 
       .. group-tab:: APT
 
         .. code-block:: console
 
           # apt-get update
-          # apt-get install wazuh-manager wazuh-api
+          # apt-get install wazuh-manager=3.13.3-1 wazuh-api
 
       .. group-tab:: ZYpp
 

--- a/source/upgrade-guide/upgrading-agent.rst
+++ b/source/upgrade-guide/upgrading-agent.rst
@@ -76,7 +76,7 @@ To perform the upgrade locally, follow the instructions for the operating system
         .. code-block:: console
 
           # apt-get update
-          # apt-get install wazuh-agent
+          # apt-get install wazuh-agent=|WAZUH_LATEST|-|WAZUH_REVISION_DEB_AGENT_X86|
 
 
     #. It is recommended to disable the Wazuh repository in order to avoid undesired upgrades and compatibility issues as the Wazuh agent should always be in the same or an older version than the Wazuh manager. Skip this step if the package is set to a ``hold`` state:

--- a/source/upgrade-guide/upgrading-wazuh.rst
+++ b/source/upgrade-guide/upgrading-wazuh.rst
@@ -83,7 +83,7 @@ To upgrade the Wazuh manager, choose your package manager and follow the instruc
 
           .. code-block:: console
 
-              # apt-get install wazuh-manager
+              # apt-get install wazuh-manager=|WAZUH_LATEST|-|WAZUH_REVISION_DEB_MANAGER_X86|
 
 
 

--- a/source/user-manual/registering/agent-enrollment.rst
+++ b/source/user-manual/registering/agent-enrollment.rst
@@ -97,7 +97,7 @@ In the following example, we show how an Ubuntu Wazuh agent can be installed, co
 
     .. code-block:: console  
 
-          # apt-get install wazuh-agent
+          # apt-get install wazuh-agent=|WAZUH_LATEST|-|WAZUH_REVISION_DEB_AGENT_X86|
 
 
 #. Edit ``/var/ossec/etc/ossec.conf`` to include the manager IP address and, optional, any desired enrollment configuration:


### PR DESCRIPTION
## Description

Replace Wazuh manager and Wazuh agent with latest 4.2 packages

## Checks
- [X] It compiles without warnings.
- [X] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [X] Used uppercase only on nouns. 
- [X] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).