### PR TITLE
Update default value of 'disabled' tag in cluster reference page

### DIFF
--- a/source/user-manual/reference/ossec-conf/cluster.rst
+++ b/source/user-manual/reference/ossec-conf/cluster.rst
@@ -152,7 +152,7 @@ disabled
 Toggles whether the cluster is enabled or not. If this value is set to **yes**, the cluster won't start.
 
 +--------------------+-----------------------------------------+
-| **Default value**  | yes                                     |
+| **Default value**  | no                                      |
 +--------------------+-----------------------------------------+
 | **Allowed values** | yes, no                                 |
 +--------------------+-----------------------------------------+
@@ -174,4 +174,5 @@ Sample configuration
         <node>master</node>
       </nodes>
       <hidden>no</hidden>
+      <disabled>no</disabled>
     </cluster>


### PR DESCRIPTION
| Related PR |
|--|
|https://github.com/wazuh/wazuh/pull/13367|

## Description

This PR updates the default value of `disabled` tag in Cluster reference page so it shows the real default value.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
