### PR TITLE
Installation guide improvements

### DIFF
--- a/source/installation-guide/wazuh-dashboard/installation-assistant.rst
+++ b/source/installation-guide/wazuh-dashboard/installation-assistant.rst
@@ -19,13 +19,13 @@ Wazuh dashboard installation
 
 
 
-#. Run the assistant with the option ``-wd`` and the node name to install and configure the Wazuh dashboard. The node name must be the same used in ``config.yml`` for the initial configuration, for example, ``dashboard``.
+#. Run the assistant with the option ``--wazuh-dashboard`` and the node name to install and configure the Wazuh dashboard. The node name must be the same used in ``config.yml`` for the initial configuration, for example, ``dashboard``.
    
    .. note:: Make sure that a copy of ``wazuh-install-files.tar``, created during the Wazuh indexer installation, is placed in your working directory.
 
    .. code-block:: console
 
-      # bash ./wazuh-install.sh -wd dashboard
+      # bash wazuh-install.sh --wazuh-dashboard dashboard
 
     
 

--- a/source/installation-guide/wazuh-indexer/installation-assistant.rst
+++ b/source/installation-guide/wazuh-indexer/installation-assistant.rst
@@ -63,11 +63,11 @@ Indicate your deployment configuration, create the SSL certificates to encrypt c
              - name: dashboard
                ip: <dashboard-node-ip>
 
-#. Run the assistant with the option ``-g`` to generate the  Wazuh cluster key, certificates, and passwords necessary for installation. 
+#. Run the assistant with the option ``--generate-config-files`` to generate the  Wazuh cluster key, certificates, and passwords necessary for installation. 
 
       .. code-block:: console
 
-        # bash ./wazuh-install.sh -g
+        # bash wazuh-install.sh --generate-config-files
 
 
 #.  Copy the ``wazuh-install-files.tar`` file to all the servers of the distributed deployment, including the Wazuh server, the Wazuh indexer, and the Wazuh dashboard nodes. This can be done by using, for example, ``scp``.
@@ -86,13 +86,13 @@ Install and configure the Wazuh indexer nodes.
         # curl -sO https://packages.wazuh.com/|WAZUH_LATEST_MINOR|/wazuh-install.sh
 
 
-#. Run the assistant with the option ``-wi`` and the node name to install and configure the Wazuh indexer. The node name must be the same used in ``config.yml`` for the initial configuration, for example, ``node-1``.
+#. Run the assistant with the option ``--wazuh-indexer`` and the node name to install and configure the Wazuh indexer. The node name must be the same used in ``config.yml`` for the initial configuration, for example, ``node-1``.
       
       .. note:: Make sure that a copy of ``wazuh-install-files.tar``, created during the initial configuration step, is placed in your working directory.
 
       .. code-block:: console
 
-        # bash ./wazuh-install.sh -wi node-1 
+        # bash wazuh-install.sh --wazuh-indexer node-1 
 
 
 Repeat this process on each Wazuh indexer node and proceed with initializing the cluster.             
@@ -104,12 +104,13 @@ Repeat this process on each Wazuh indexer node and proceed with initializing the
 
 The final stage of the process for installing the Wazuh indexer cluster consists in running the security admin script. 
 
-Run the Wazuh installation assistant with option ``-s`` on any Wazuh indexer node to load the new certificates information and start the cluster. 
+#. Run the Wazuh installation assistant with option ``--start-cluster`` on `any` Wazuh indexer node to load the new certificates information and start the cluster. 
 
-  .. code-block:: console
-
-    # bash ./wazuh-install.sh -s
-
+   .. code-block:: console
+ 
+     # bash wazuh-install.sh --start-cluster
+ 
+   .. note:: You only have to initialize the cluster `once`, there is no need to run this command on every node. 
 
 Next steps
 ----------

--- a/source/installation-guide/wazuh-indexer/step-by-step.rst
+++ b/source/installation-guide/wazuh-indexer/step-by-step.rst
@@ -98,12 +98,13 @@ Repeat this stage of the installation process for every Wazuh indexer node in yo
     <div class="accordion-section open">
 
 
-#. Run the Wazuh indexer ``indexer-security-init.sh`` script on any Wazuh indexer node to load the new certificates information and start the cluster. 
+#. Run the Wazuh indexer ``indexer-security-init.sh`` script on `any` Wazuh indexer node to load the new certificates information and start the cluster. 
     
-    .. code-block:: console
+   .. code-block:: console
 
       # /usr/share/wazuh-indexer/bin/indexer-security-init.sh
 
+   .. note:: You only have to initialize the cluster `once`, there is no need to run this command on every node. 
       
 Testing the cluster installation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/installation-guide/wazuh-server/installation-assistant.rst
+++ b/source/installation-guide/wazuh-server/installation-assistant.rst
@@ -18,13 +18,13 @@ Wazuh server cluster installation
    
        # curl -sO https://packages.wazuh.com/|WAZUH_LATEST_MINOR|/wazuh-install.sh
 
-#. Run the assistant with the option ``-ws`` followed by the node name to install the Wazuh server. The node name must be the same used in ``config.yml`` for the initial configuration, for example, ``wazuh-1``.
+#. Run the assistant with the option ``--wazuh-server`` followed by the node name to install the Wazuh server. The node name must be the same used in ``config.yml`` for the initial configuration, for example, ``wazuh-1``.
  
    .. note:: Make sure that a copy of ``wazuh-install-files.tar``, created during the Wazuh indexer installation, is placed in your working directory.
 
    .. code-block:: console
   
-       # bash ./wazuh-install.sh -ws wazuh-1
+       # bash wazuh-install.sh --wazuh-server wazuh-1
 
 
 Your Wazuh server is now successfully installed. 


### PR DESCRIPTION
## Description

This PR includes the following improvements:

- The Wazuh installation assistant commands now include the full description to make it easier for users to understand what they are doing at each step.

   Old commands: 
   ![image](https://user-images.githubusercontent.com/61882981/167597381-9047be62-7203-443b-9b6d-0309495099be.png)
   New commands: 
   ![image](https://user-images.githubusercontent.com/61882981/167597601-21e639a7-9549-4e74-bcd5-69b031b3b92a.png)

- A note is included indicating that the cluster only has to be initialized once. It is emphasized that it can be started on _any_ Wazuh indexer node. 

   ![image](https://user-images.githubusercontent.com/61882981/167597880-9c01c4c1-2ab7-4ff7-9c41-ecaec34c752d.png)


## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).


## Note to the reviewer

This PR includes changes to the `redirect.js` script that need to be included in all production branches.
