### PR TITLE
Fix docker deployment variable version

### DIFF
--- a/source/deployment-options/docker/wazuh-container.rst
+++ b/source/deployment-options/docker/wazuh-container.rst
@@ -32,7 +32,7 @@ Single-node Deployment
 
     .. code-block:: console
 
-      $ git clone https://github.com/wazuh/wazuh-docker.git -b |WAZUH_LATEST_MINOR| --depth=1
+      $ git clone https://github.com/wazuh/wazuh-docker.git -b v|WAZUH_LATEST_DOCKER| --depth=1
 
 
     Then enter into the ``single-node`` directory, all the commands described below are executed within this directory. For :ref:`additional security <customize-default-users>`, the default password for the Wazuh indexer administrator user can be changed.
@@ -114,7 +114,7 @@ Multi-node deployment
 
     .. code-block:: console
 
-      $ git clone https://github.com/wazuh/wazuh-docker.git -b |WAZUH_LATEST_MINOR| --depth=1
+      $ git clone https://github.com/wazuh/wazuh-docker.git -b v|WAZUH_LATEST_DOCKER| --depth=1
 
    
   Then enter into the ``multi-node`` directory, all the commands described below are executed within this directory. For :ref:`additional security <customize-default-users>`, the default password for the Wazuh Indexer admin user can be changed.
@@ -199,7 +199,7 @@ The Wazuh manager, indexer, and dashboard images can be modified and built local
 
 .. code-block:: console
   
-   $ git clone https://github.com/wazuh/wazuh-docker.git -b |WAZUH_LATEST_MINOR| --depth=1
+   $ git clone https://github.com/wazuh/wazuh-docker.git -b v|WAZUH_LATEST_DOCKER| --depth=1
 
 
 2. Enter into the ``build-docker-images`` directory and build the Wazuh manager, indexer, and dashboard images:


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

Hello team, this PR change the docker deployment variable when cloning the wazuh-docker repostory to use the v4.3.0 tag

![image](https://user-images.githubusercontent.com/14913942/168092952-6a0e3193-14cb-407a-9dd8-65ddf671eb07.png)


<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

## Checks
- [x] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

```
╰─➤  make html                                                                                                                                    
sphinx-build -b html -d build/doctrees   source build/html
Running Sphinx v3.2.0
loading translations [en-US]... not available for built-in messages
loading pickled environment... done
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 610 source files that are out of date
updating environment: 0 added, 0 changed, 0 removed
Copying static files for wazuh-doc-images...[100%] img/loading.gif                                                                                                                                                 
looking for now-outdated files... none found
preparing documents... done
writing output... [100%] user-manual/wazuh-dashboard/troubleshooting                                                                                                                                               
generating indices... done
writing additional pages...  not_found user-manual/api/reference cloud-service/apis/reference moved-content searchdone
copying images... [100%] user-manual/wazuh-dashboard/../../images/kibana-app/features/settings/about.png                                                                                                           
copying static files... ... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded.

The HTML pages are in build/html.
Copying tabs assets

Build finished. The HTML pages are in build/html.
```