### PR TITLE
Add Windows core dumps guide

### DIFF
--- a/source/development/core-dumps-generation.rst
+++ b/source/development/core-dumps-generation.rst
@@ -158,3 +158,31 @@ Lastly, a core dump can also be analyzed if we have debugging symbols embedded i
 ``DISABLE_STRIP_SYMBOLS=1`` make flag). More info about building Wazuh can be found :ref:`here<wazuh_makefile>`.
 
 .. [2] When compiling, binaries and dSYM bundles are created with a matching UUID identifier, this – and search methods including Spotlight – is what allows ``lldb`` to automatically match them.
+
+Windows
+*******
+
+Windows use PDB as format for symbols files. Wazuh agent PDBs are compressed and can be found :ref:`here<win-dbg-symbols-packages>`.
+
+Wazuh agent dumps generation is enabled by default during installation for Windows versions newer than Windows Server 2008 and Windows Vista with Service Pack 1 due Windows Error Reporting support.
+Dumps will be created on ``<INSTALLDIR>\dumps`` folder.
+
+
+To know more about Windows dumps enabling see `Collecting User-Mode Dumps
+<https://docs.microsoft.com/en-us/windows/win32/wer/collecting-user-mode-dumps>`_.
+
+
+Post-mortem analysis
+--------------------
+
+Core dumps could be analyzed using WinDbg following the next steps:
+
+#. Select crash dump by picking ``<INSTALLDIR>\dumps\<process-name>.<process-PID>`` on `File > Open Crash Dump` menu.
+#. Download Wazuh Windows symbols, uncompress ZIP file and select it on `File > Symbol File Path`, appending ``;srv*`` to also load Windows symbols.
+#. [Optional] Download Wazuh source code and add its path on `File > Source File Path`.
+
+The last step is to run the analysis of the core dump
+
+   .. code-block:: console
+
+    !analyze -v


### PR DESCRIPTION
| Related issue |
|---|
| Closes #5152 | 

## Description

This PR aims to add a little explanation about core dumps in Windows environments

## Checks
- [X] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

## Note to the reviewer

This PR includes changes to the `redirect.js` script that need to be included in all production branches.
