### PR TITLE
Fix default password on kubernetes installation alternative.

### DIFF
--- a/source/deployment-options/deploying-with-kubernetes/kubernetes-deployment.rst
+++ b/source/deployment-options/deploying-with-kubernetes/kubernetes-deployment.rst
@@ -188,7 +188,7 @@ In case you created domain names for the services, you should be able to access 
   
 The Wazuh dashboard will be accessible on ``https://localhost:8443``.
 
-The default credentials are ``admin:admin``.
+The default credentials are ``admin:SecretPassword``.
 
 
 Agents


### PR DESCRIPTION
## Description
|Related issue|
|---|
|Closes #5226 |

# Description
This issue solves a problem in the documentation of the Wazuh installation guide, in which the password indicated by default is incorrect.

## Current
![image](https://user-images.githubusercontent.com/14300208/168502576-1d6dcb68-82c3-48e3-8c0f-16c4c8daef41.png)

## Expected
![image](https://user-images.githubusercontent.com/14300208/168502620-add00359-0d17-4758-892a-466a4df2a974.png)


## Checks
- [X] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

