### PR TITLE
Add note to HPUX upgrade process related to the user and group

### DIFF
--- a/source/upgrade-guide/upgrading-agent.rst
+++ b/source/upgrade-guide/upgrading-agent.rst
@@ -269,6 +269,9 @@ To perform the upgrade locally, follow the instructions for the operating system
 
       The Wazuh agent upgrading process for HP-UX systems requires to download the latest `HP-UX installer <https://packages.wazuh.com/|CURRENT_MAJOR|/hp-ux/wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_HPUX|-hpux-11v3-ia64.tar>`_.
 
+      .. note::
+        Steps 3 and 4 are only required if the agent is upgraded from a version lower than 4.3.0 to a version greater than or equal to 4.3.0. Otherwise, the user and group must not be modified.
+
       #. Stop the Wazuh agent:
 
           .. code-block:: console

--- a/source/upgrade-guide/upgrading-agent.rst
+++ b/source/upgrade-guide/upgrading-agent.rst
@@ -269,9 +269,6 @@ To perform the upgrade locally, follow the instructions for the operating system
 
       The Wazuh agent upgrading process for HP-UX systems requires to download the latest `HP-UX installer <https://packages.wazuh.com/|CURRENT_MAJOR|/hp-ux/wazuh-agent-|WAZUH_LATEST|-|WAZUH_REVISION_HPUX|-hpux-11v3-ia64.tar>`_.
 
-      .. note::
-        Steps 3 and 4 are only required if the agent is upgraded from a version lower than 4.3.0 to a version greater than or equal to 4.3.0. Otherwise, the user and group must not be modified.
-
       #. Stop the Wazuh agent:
 
           .. code-block:: console
@@ -287,19 +284,21 @@ To perform the upgrade locally, follow the instructions for the operating system
             # cp /var/ossec/etc/client.keys ~/client.keys.bk
 
 
-      #. Delete ossec user and group:
+      #. **Only for upgrades from version 4.2.6 or lower**:  
+      
+         #. Delete ossec user and group:
 
-          .. code-block:: console
+            .. code-block:: console
 
-            # groupdel ossec
-            # userdel ossec
+              # groupdel ossec
+              # userdel ossec
 
-      #. Create the wazuh user and group:
+         #. Create the wazuh user and group:
 
-          .. code-block:: console
+            .. code-block:: console
 
-            # groupadd wazuh
-            # useradd -G wazuh wazuh
+              # groupadd wazuh
+              # useradd -G wazuh wazuh
 
       #. Deploy the Wazuh agent files:
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

This issue closes #5235.

It has been added a note in the upgrade process for HP-UX to avoid replacing the user and group when upgrading between versions with the same user and group.

It has been added at the beginning of the steps because introducing the note in the middle of them breaks the sequence.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

