### PR TITLE
Replaced branch with tag in packages generation guide

### DIFF
--- a/source/development/packaging/generate-aix-package.rst
+++ b/source/development/packaging/generate-aix-package.rst
@@ -18,7 +18,7 @@ Download our wazuh-packages repository from GitHub and go to the aix directory.
 
 .. code-block:: console
 
- $ curl -L https://github.com/wazuh/wazuh-packages/tarball/|WAZUH_PACKAGES_BRANCH| | tar zx
+ $ curl -L https://github.com/wazuh/wazuh-packages/tarball/v|WAZUH_LATEST| | tar zx
  $ cd wazuh-wazuh-packages-*
  $ cd aix
 
@@ -33,7 +33,7 @@ Execute the ``generate_wazuh_packages.sh`` script, with the different options yo
 
   Usage: ./generate_wazuh_packages.sh [OPTIONS]
 
-      -b, --branch <branch>               Select Git branch or tag e.g. |WAZUH_PACKAGES_BRANCH|
+      -b, --branch <branch>               Select Git branch or tag e.g. v|WAZUH_LATEST|
       -e, --environment                   Install all the packages necessaries to build the RPM package
       -s, --store  <rpm_directory>        Directory to store the resulting RPM package. By default: /tmp/build
       -p, --install-path <rpm_home>       Installation path for the package. By default: /var

--- a/source/development/packaging/generate-deb-package.rst
+++ b/source/development/packaging/generate-deb-package.rst
@@ -19,7 +19,7 @@ Download our wazuh-packages repository from GitHub and go to the debs directory.
 
 .. code-block:: console
 
- $ git clone https://github.com/wazuh/wazuh-packages && cd wazuh-packages/debs && git checkout v|WAZUH_LATEST_PACKAGES|
+ $ git clone https://github.com/wazuh/wazuh-packages && cd wazuh-packages/debs && git checkout v|WAZUH_LATEST|
 
 Execute the ``generate_debian_package.sh`` script, with the different options you desire. This script will build a Docker image with all the necessary tools to create the DEB and run a container that will build it:
 
@@ -52,18 +52,18 @@ Below, you will find some examples of how to build a DEB package.
 
 .. code-block:: console
 
-  # ./generate_debian_package.sh -b v|WAZUH_LATEST| --packages-branch v|WAZUH_LATEST_PACKAGES| -s /tmp -t manager -a amd64 -r my_rev.
+  # ./generate_debian_package.sh -b v|WAZUH_LATEST| --packages-branch v|WAZUH_LATEST| -s /tmp -t manager -a amd64 -r my_rev.
 
 This will generate a |WAZUH_LATEST| Wazuh manager package DEB with revision ``my_rev`` for ``amd64`` systems.
 
 .. code-block:: console
 
-  # ./generate_debian_package.sh -b v|WAZUH_LATEST| --packages-branch v|WAZUH_LATEST_PACKAGES| -s /tmp -t api -a i386 -r my_rev
+  # ./generate_debian_package.sh -b v|WAZUH_LATEST| --packages-branch v|WAZUH_LATEST| -s /tmp -t api -a i386 -r my_rev
 
 This will generate a |WAZUH_LATEST| Wazuh api package DEB with revision ``my_rev`` for ``i386`` systems and store it in ``/tmp``.
 
 .. code-block:: console
 
-  # ./generate_debian_package.sh -b v|WAZUH_LATEST| --packages-branch v|WAZUH_LATEST_PACKAGES| -t agent -a amd64 -p /opt/ossec
+  # ./generate_debian_package.sh -b v|WAZUH_LATEST| --packages-branch v|WAZUH_LATEST| -t agent -a amd64 -p /opt/ossec
 
 This will generate a |WAZUH_LATEST| Wazuh agent DEB package with ``/opt/ossec`` as installation directory for ``amd64`` systems.

--- a/source/development/packaging/generate-deb-package.rst
+++ b/source/development/packaging/generate-deb-package.rst
@@ -19,7 +19,7 @@ Download our wazuh-packages repository from GitHub and go to the debs directory.
 
 .. code-block:: console
 
- $ git clone https://github.com/wazuh/wazuh-packages && cd wazuh-packages/debs && git checkout |WAZUH_PACKAGES_BRANCH|
+ $ git clone https://github.com/wazuh/wazuh-packages && cd wazuh-packages/debs && git checkout v|WAZUH_LATEST_PACKAGES|
 
 Execute the ``generate_debian_package.sh`` script, with the different options you desire. This script will build a Docker image with all the necessary tools to create the DEB and run a container that will build it:
 
@@ -31,7 +31,7 @@ Execute the ``generate_debian_package.sh`` script, with the different options yo
   :class: output
 
   Usage: ./generate_debian_package.sh [OPTIONS]
-  
+
       -b, --branch <branch>      [Required] Select Git branch.
       --packages-branch <branch> [Required] Select Git branch or tag from wazuh-packages repository.
       -t, --target <target>      [Required] Target package to build: manager or agent.
@@ -52,18 +52,18 @@ Below, you will find some examples of how to build a DEB package.
 
 .. code-block:: console
 
-  # ./generate_debian_package.sh -b v|WAZUH_LATEST| --packages-branch |WAZUH_PACKAGES_BRANCH| -s /tmp -t manager -a amd64 -r my_rev.
+  # ./generate_debian_package.sh -b v|WAZUH_LATEST| --packages-branch v|WAZUH_LATEST_PACKAGES| -s /tmp -t manager -a amd64 -r my_rev.
 
 This will generate a |WAZUH_LATEST| Wazuh manager package DEB with revision ``my_rev`` for ``amd64`` systems.
 
 .. code-block:: console
 
-  # ./generate_debian_package.sh -b v|WAZUH_LATEST| --packages-branch |WAZUH_PACKAGES_BRANCH| -s /tmp -t api -a i386 -r my_rev
+  # ./generate_debian_package.sh -b v|WAZUH_LATEST| --packages-branch v|WAZUH_LATEST_PACKAGES| -s /tmp -t api -a i386 -r my_rev
 
 This will generate a |WAZUH_LATEST| Wazuh api package DEB with revision ``my_rev`` for ``i386`` systems and store it in ``/tmp``.
 
 .. code-block:: console
 
-  # ./generate_debian_package.sh -b v|WAZUH_LATEST| --packages-branch |WAZUH_PACKAGES_BRANCH| -t agent -a amd64 -p /opt/ossec
+  # ./generate_debian_package.sh -b v|WAZUH_LATEST| --packages-branch v|WAZUH_LATEST_PACKAGES| -t agent -a amd64 -p /opt/ossec
 
 This will generate a |WAZUH_LATEST| Wazuh agent DEB package with ``/opt/ossec`` as installation directory for ``amd64`` systems.

--- a/source/development/packaging/generate-hpux-package.rst
+++ b/source/development/packaging/generate-hpux-package.rst
@@ -19,7 +19,7 @@ Download our wazuh-packages repository from GitHub and go to the ``hpux`` direct
 
 .. code-block:: console
 
- $ curl -L https://github.com/wazuh/wazuh-packages/tarball/|WAZUH_PACKAGES_BRANCH| | tar zx
+ $ curl -L https://github.com/wazuh/wazuh-packages/tarball/v|WAZUH_LATEST| | tar zx
  $ cd wazuh-wazuh-packages-*
  $ cd hp-ux
 

--- a/source/development/packaging/generate-osx-package.rst
+++ b/source/development/packaging/generate-osx-package.rst
@@ -18,11 +18,11 @@ Requirements
 
 If ``Packages`` and ``Brew`` are not already installed in your system, they can be installed using the generate_wazuh_packages.sh script
 
-Download our wazuh-packages repository from GitHub and go to the macos directory of the |WAZUH_PACKAGES_BRANCH| branch.
+Download our wazuh-packages repository from GitHub and go to the macos directory.
 
 .. code-block:: console
 
-  $ git clone https://github.com/wazuh/wazuh-packages && cd wazuh-packages/macos && git checkout |WAZUH_PACKAGES_BRANCH|
+  $ git clone https://github.com/wazuh/wazuh-packages && cd wazuh-packages/macos && git checkout v|WAZUH_LATEST|
 
 Execute the ``generate_wazuh_packages.sh`` script, with the different options you desire.
 
@@ -34,9 +34,9 @@ Execute the ``generate_wazuh_packages.sh`` script, with the different options yo
   :class: output
 
   Usage: ./generate_wazuh_packages.sh [OPTIONS]
-  
+
     Build options:
-      -b, --branch <branch>         [Required] Select Git branch or tag. 
+      -b, --branch <branch>         [Required] Select Git branch or tag.
       -s, --store-path <path>       [Optional] Set the destination absolute path of package.
       -j, --jobs <number>           [Optional] Number of parallel jobs when compiling.
       -r, --revision <rev>          [Optional] Package revision that append to version e.g. x.x.x-rev
@@ -45,7 +45,7 @@ Execute the ``generate_wazuh_packages.sh`` script, with the different options yo
       -i, --install-deps            [  Util  ] Install build dependencies (Packages).
       -x, --install-xcode           [  Util  ] Install X-Code and brew. Can't be executed as root.
       -v, --verbose                 [  Util  ] Show additional information during the package generation.
-  
+
     Signing options:
       --keychain                    [Optional] Keychain where the Certificates are installed.
       --keychain-password           [Optional] Password of the keychain.

--- a/source/development/packaging/generate-ova.rst
+++ b/source/development/packaging/generate-ova.rst
@@ -17,7 +17,7 @@ Requirements
  * `Git <https://git-scm.com/book/en/v2/Getting-Started-Installing-Git>`_
  * `Python <https://www.python.org/download/releases/2.7/>`_
 
-Download our wazuh-packages repository from GitHub and go to the ova directory of the |WAZUH_PACKAGES_BRANCH| branch.
+Download our wazuh-packages repository from GitHub and go to the ova directory.
 
 .. code-block:: console
 

--- a/source/development/packaging/generate-rpm-package.rst
+++ b/source/development/packaging/generate-rpm-package.rst
@@ -19,7 +19,7 @@ Download our wazuh-packages repository from GitHub and go to the rpms directory.
 
 .. code-block:: console
 
- $ git clone https://github.com/wazuh/wazuh-packages && cd wazuh-packages/rpms && git checkout |WAZUH_PACKAGES_BRANCH|
+ $ git clone https://github.com/wazuh/wazuh-packages && cd wazuh-packages/rpms && git checkout v|WAZUH_LATEST|
 
 Execute the ``generate_rpm_package.sh`` script, with the different options you desire. This script will build a Docker image with all the necessary tools to create the RPM and run a container that will build it:
 
@@ -31,7 +31,7 @@ Execute the ``generate_rpm_package.sh`` script, with the different options you d
   :class: output
 
   Usage: ./generate_rpm_package.sh [OPTIONS]
-  
+
       -b, --branch <branch>        [Required] Select Git branch or tag.
       --packages-branch <branch>   [Required] Select Git branch or tag from wazuh-packages repository.
       -t, --target <target>        [Required] Target package to build [manager/api/agent].
@@ -54,18 +54,18 @@ Below, you will find some examples of how to build an RPM package.
 
 .. code-block:: console
 
-  # ./generate_rpm_package.sh -b v|WAZUH_LATEST| --packages-branch |WAZUH_PACKAGES_BRANCH| -s /tmp -t manager -a x86_64 -r my_rev.
+  # ./generate_rpm_package.sh -b v|WAZUH_LATEST| --packages-branch v|WAZUH_LATEST| -s /tmp -t manager -a x86_64 -r my_rev.
 
 This will generate a |WAZUH_LATEST| Wazuh manager RPM package with revision ``my_rev`` for ``x86_64`` systems.
 
 .. code-block:: console
 
-  # ./generate_rpm_package.sh -b v|WAZUH_LATEST| --packages-branch |WAZUH_PACKAGES_BRANCH| -s /tmp -t api -a i386 -r my_rev
+  # ./generate_rpm_package.sh -b v|WAZUH_LATEST| --packages-branch v|WAZUH_LATEST| -s /tmp -t api -a i386 -r my_rev
 
 This will generate a |WAZUH_LATEST| Wazuh api RPM package with revision ``my_rev`` for ``i386`` systems and store it in ``/tmp``.
 
 .. code-block:: console
 
-  # ./generate_rpm_package.sh -b v|WAZUH_LATEST| --packages-branch |WAZUH_PACKAGES_BRANCH| -t agent -a x86_64 -p /opt/ossec
+  # ./generate_rpm_package.sh -b v|WAZUH_LATEST| --packages-branch v|WAZUH_LATEST| -t agent -a x86_64 -p /opt/ossec
 
 This will generate a |WAZUH_LATEST| Wazuh agent RPM package with ``/opt/ossec`` as installation directory for ``x86_64`` systems.

--- a/source/development/packaging/generate-sol-package.rst
+++ b/source/development/packaging/generate-sol-package.rst
@@ -14,11 +14,11 @@ Requirements
 
  * Git
 
-Download our wazuh-packages repository from GitHub and go to the ``solaris`` directory of the |WAZUH_PACKAGES_BRANCH| branch.
+Download our wazuh-packages repository from GitHub and go to the ``solaris`` directory.
 
 .. code-block:: console
 
-  $ git clone https://github.com/wazuh/wazuh-packages && cd wazuh-packages/solaris && git checkout |WAZUH_PACKAGES_BRANCH|
+  $ git clone https://github.com/wazuh/wazuh-packages && cd wazuh-packages/solaris && git checkout v|WAZUH_LATEST|
 
 Choose the version of solaris you want to build the package for and go to that directory.
 
@@ -32,7 +32,7 @@ Run the ``generate_wazuh_packages.sh`` script to build the package. Here you can
  :class: output
 
  Usage: ./generate_wazuh_packages.sh [OPTIONS]
- 
+
     -b, --branch <branch>               Select Git branch or tag.
     -e, --environment                   Install all the packages necessaries to build the pkg package.
     -s, --store  <pkg_directory>        Directory to store the resulting pkg package. By default, an output folder will be created.
@@ -110,7 +110,7 @@ Clone our wazuh-packages repository from GitHub and switch to your target branch
 
     .. code-block:: console
 
-      $ git clone https://github.com/wazuh/wazuh-packages && cd wazuh-packages/solaris && git checkout |WAZUH_PACKAGES_BRANCH|
+      $ git clone https://github.com/wazuh/wazuh-packages && cd wazuh-packages/solaris && git checkout v|WAZUH_LATEST|
       $ cp solaris10 package_generation/src/
       $ cd package_generation
 
@@ -118,7 +118,7 @@ Clone our wazuh-packages repository from GitHub and switch to your target branch
 
     .. code-block:: console
 
-      $ git clone https://github.com/wazuh/wazuh-packages && cd wazuh-packages/solaris && git checkout |WAZUH_PACKAGES_BRANCH|
+      $ git clone https://github.com/wazuh/wazuh-packages && cd wazuh-packages/solaris && git checkout v|WAZUH_LATEST|
       $ cp solaris11 package_generation/src/
       $ cd package_generation
 

--- a/source/development/packaging/generate-wazuh-kibana-app.rst
+++ b/source/development/packaging/generate-wazuh-kibana-app.rst
@@ -1,8 +1,8 @@
 .. Copyright (C) 2022 Wazuh, Inc.
 
 .. meta::
-  :description: Wazuh provides an automated way of building our Wazuh Kibana plugin packages. Check out this step-by-step guide and learn how to create this package. 
-  
+  :description: Wazuh provides an automated way of building our Wazuh Kibana plugin packages. Check out this step-by-step guide and learn how to create this package.
+
 .. _create-kibana-app:
 
 Wazuh Kibana plugin
@@ -22,7 +22,7 @@ Download our wazuh-packages repository from GitHub and go to the wazuhapp direct
 
 .. code-block:: console
 
-  $ git clone https://github.com/wazuh/wazuh-packages && cd wazuh-packages/wazuhapp/kibana && git checkout |WAZUH_PACKAGES_BRANCH|
+  $ git clone https://github.com/wazuh/wazuh-packages && cd wazuh-packages/wazuhapp/kibana && git checkout v|WAZUH_LATEST|
 
 Execute the ``generate_wazuh_app.sh`` script, with the different options you desire. This script will build a Docker image with all the necessary tools to create the Wazuh Kibana plugin package and run a container that will build it:
 
@@ -34,7 +34,7 @@ Execute the ``generate_wazuh_app.sh`` script, with the different options you des
   :class: output
 
   Usage: ./generate_wazuh_app.sh [OPTIONS]
-  
+
       -b, --branch <branch>     [Required] Select Git branch or tag.
       -s, --store <path>        [Optional] Set the destination path of package, by defauly /tmp/wazuh-app.
       -r, --revision <rev>      [Optional] Package revision that append to version e.g. x.x.x-rev

--- a/source/development/packaging/generate-wazuh-splunk-app.rst
+++ b/source/development/packaging/generate-wazuh-splunk-app.rst
@@ -19,7 +19,7 @@ Download our wazuh-packages repository from GitHub and go to the splunkapp direc
 
 .. code-block:: console
 
-  $ git clone https://github.com/wazuh/wazuh-packages && cd wazuh-packages/splunkapp && git checkout |WAZUH_PACKAGES_BRANCH|
+  $ git clone https://github.com/wazuh/wazuh-packages && cd wazuh-packages/splunkapp && git checkout v|WAZUH_LATEST|
 
 Execute the ``generate_wazuh_splunk_app.sh`` script, with the different options you desire. This script will build a Docker image with all the necessary tools to create the Wazuh Splunk App package and run a container that will build it:
 
@@ -31,7 +31,7 @@ Execute the ``generate_wazuh_splunk_app.sh`` script, with the different options 
   :class: output
 
   Usage: ./generate_wazuh_splunk_app.sh [OPTIONS]
-  
+
       -b, --branch <branch>     [Required] Select Git branch or tag.
       -s, --store <directory>   [Optional] Destination directory by default /home/vagrant/wazuh-wazuh-packages-26460eb/splunkapp/output
       -r, --revision            [Optional] Package revision that append to version e.g. x.x.x-y.y.y_rev

--- a/source/development/packaging/generate-windows-package.rst
+++ b/source/development/packaging/generate-windows-package.rst
@@ -28,7 +28,7 @@ Download our wazuh-packages repository from GitHub and go to the ``windows`` dir
 
 .. code-block:: console
 
-    $ git clone https://github.com/wazuh/wazuh-packages && cd wazuh-packages/windows && git checkout |WAZUH_PACKAGES_BRANCH|
+    $ git clone https://github.com/wazuh/wazuh-packages && cd wazuh-packages/windows && git checkout v|WAZUH_LATEST|
 
 Execute the ``generate_compiled_windows_agent.sh`` script, with the different options you desire. This script will build a Docker
 image with all the necessary tools to compile and obtain the Windows agent compiled in a zip file :
@@ -41,7 +41,7 @@ image with all the necessary tools to compile and obtain the Windows agent compi
   :class: output
 
   Usage: ./generate_compiled_windows_agent.sh [OPTIONS]
-  
+
       -b, --branch <branch>     [Required] Select Git branch.
       -j, --jobs <number>       [Optional] Change number of parallel jobs when compiling the Windows agent. By default: 4.
       -r, --revision <rev>      [Optional] Package revision. By default: 1.

--- a/source/development/packaging/generate-wpk-package.rst
+++ b/source/development/packaging/generate-wpk-package.rst
@@ -23,7 +23,7 @@ Download our wazuh-packages repository from GitHub and go to the wpk directory.
 
 .. code-block:: console
 
- $ git clone https://github.com/wazuh/wazuh-packages && cd wazuh-packages/wpk && git checkout |WAZUH_PACKAGES_BRANCH|
+ $ git clone https://github.com/wazuh/wazuh-packages && cd wazuh-packages/wpk && git checkout v|WAZUH_LATEST|
 
 Execute the ``generate_wpk_package.sh`` script, with the different options you desire. This script will build a Docker image with all the necessary tools to create the WPK and run a container that will build it:
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

This PR replaces all branch references to tag in the packages generation guide. (4.3 -> v4.3.0)

## Checks
- [x] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

```
╰─➤  make html                                                                                                                                                                                                 
sphinx-build -b html -d build/doctrees   source build/html
Running Sphinx v3.2.0
loading translations [en-US]... not available for built-in messages
loading pickled environment... done
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 610 source files that are out of date
updating environment: 0 added, 15 changed, 0 removed
reading sources... [100%] migration-guide/wazuh-indexer                                                                                                                                                            
Copying static files for wazuh-doc-images...[100%] img/loading.gif                                                                                                                                                 
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] user-manual/wazuh-dashboard/troubleshooting                                                                                                                                               
generating indices... done
writing additional pages...  not_found user-manual/api/reference cloud-service/apis/reference moved-content searchdone
copying images... [100%] user-manual/wazuh-dashboard/../../images/kibana-app/features/settings/about.png                                                                                                           
copying static files... ... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded.

The HTML pages are in build/html.
Copying tabs assets

Build finished. The HTML pages are in build/html.
```
