### PR TITLE
Fix elasticsearch memory locking curl command

### DIFF
--- a/source/user-manual/elasticsearch/elastic-tuning.rst
+++ b/source/user-manual/elasticsearch/elastic-tuning.rst
@@ -107,7 +107,7 @@ After starting Elasticsearch, run the following request to verify that the setti
 
 .. code-block:: console
 
-    # curl "http://localhost:9200/_nodes?filter_path=**.mlockall&pretty"
+    # curl -k -u admin:{admin_password} "https://localhost:9200/_nodes?filter_path=**.mlockall&pretty"
 
 .. code-block:: json
     :class: output

--- a/source/user-manual/elasticsearch/elastic-tuning.rst
+++ b/source/user-manual/elasticsearch/elastic-tuning.rst
@@ -2,13 +2,13 @@
 
 .. meta::
   :description: In this section of the Wazuh documentation, you will find more information on how to tune Elasticsearch: changing user passwords, memory locking, and shards and replicas.
-  
+
 .. _elastic_tuning:
 
 Elasticsearch tuning
 ====================
 
-This guide summarizes the relevant settings that enable Elasticsearch optimization. To change the default passwords, see the :doc:`/user-manual/securing-wazuh/index` section. 
+This guide summarizes the relevant settings that enable Elasticsearch optimization. To change the default passwords, see the :doc:`/user-manual/securing-wazuh/index` section.
 
 - `Memory locking`_
 - `Shards and replicas`_
@@ -49,7 +49,7 @@ Elasticsearch malfunctions when the system is swapping memory. It is crucial for
             # cat > /etc/systemd/system/elasticsearch.service.d/elasticsearch.conf << EOF
             [Service]
             LimitMEMLOCK=infinity
-            EOF            
+            EOF
 
         .. group-tab:: SysV Init
 
@@ -107,7 +107,7 @@ After starting Elasticsearch, run the following request to verify that the setti
 
 .. code-block:: console
 
-    # curl -k -u admin:{admin_password} "https://localhost:9200/_nodes?filter_path=**.mlockall&pretty"
+    # curl -k -u {user}:{password} "https://localhost:9200/_nodes?filter_path=**.mlockall&pretty"
 
 .. code-block:: json
     :class: output
@@ -154,7 +154,7 @@ In addition, Elasticsearch allows the user to make one or more copies of the ind
 
 .. warning::
 
-  The number of shards and replicas can be defined per index at the time of their creation. Once the index is created, the number of replicas must be changed dynamically, whereas the number of fragments cannot be changed afterward. 
+  The number of shards and replicas can be defined per index at the time of their creation. Once the index is created, the number of replicas must be changed dynamically, whereas the number of fragments cannot be changed afterward.
 
 How many shards should an index have?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/user-manual/elasticsearch/elastic-tuning.rst
+++ b/source/user-manual/elasticsearch/elastic-tuning.rst
@@ -107,7 +107,7 @@ After starting Elasticsearch, run the following request to verify that the setti
 
 .. code-block:: console
 
-    # curl -k -u {user}:{password} "https://localhost:9200/_nodes?filter_path=**.mlockall&pretty"
+    # curl -k -u <username>:<password> "https://localhost:9200/_nodes?filter_path=**.mlockall&pretty"
 
 .. code-block:: json
     :class: output


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

This PR fix the Elasticsearch curl command which check the memory locking value

![image](https://user-images.githubusercontent.com/14913942/168870721-81c803c4-9ca0-47f3-929f-bc228df76486.png)


<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

## Checks
- [x] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

```
╰─➤  make html
sphinx-build -b html -d build/doctrees   source build/html
Running Sphinx v3.2.0
loading translations [en-US]... not available for built-in messages
loading pickled environment... done
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 610 source files that are out of date
updating environment: 0 added, 3 changed, 0 removed
reading sources... [100%] user-manual/elasticsearch/elastic-tuning                                                                                                                                                 
Copying static files for wazuh-doc-images...[100%] img/loading.gif                                                                                                                                                 
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] user-manual/wazuh-dashboard/troubleshooting                                                                                                                                               
generating indices... done
writing additional pages...  not_found user-manual/api/reference cloud-service/apis/reference moved-content searchdone
copying images... [100%] user-manual/wazuh-dashboard/../../images/kibana-app/features/settings/about.png                                                                                                           
copying static files... ... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded.

The HTML pages are in build/html.
Copying tabs assets

Build finished. The HTML pages are in build/html.
```