### PR TITLE
Add instructions to secure the Wazuh installation

### DIFF
--- a/source/_templates/common/restart_dashboard.rst
+++ b/source/_templates/common/restart_dashboard.rst
@@ -1,0 +1,17 @@
+.. Copyright (C) 2022 Wazuh, Inc.
+
+.. tabs::
+
+ .. group-tab:: Systemd
+
+  .. code-block:: console
+
+   # systemctl restart wazuh-dashboard
+
+ .. group-tab:: SysV init
+
+  .. code-block:: console
+
+   # service wazuh-dashboard restart
+
+.. End of include file

--- a/source/_templates/common/restart_filebeat.rst
+++ b/source/_templates/common/restart_filebeat.rst
@@ -1,0 +1,17 @@
+.. Copyright (C) 2022 Wazuh, Inc.
+
+.. tabs::
+
+ .. group-tab:: Systemd
+
+  .. code-block:: console
+
+   # systemctl restart filebeat
+
+ .. group-tab:: SysV init
+
+  .. code-block:: console
+
+   # service filebeat restart
+
+.. End of include file

--- a/source/installation-guide/wazuh-dashboard/step-by-step.rst
+++ b/source/installation-guide/wazuh-dashboard/step-by-step.rst
@@ -127,7 +127,10 @@ Starting the Wazuh dashboard service
 Securing your Wazuh installation
 --------------------------------
 
-Change the default credentials to protect your Wazuh solution. 
+
+You have now installed and configured all the Wazuh central components. We recommend changing the default credentials to protect your infrastructure from possible attacks. 
+
+Follow the instructions below to change the passwords for both the Wazuh API and the Wazuh indexer users.  
 
 Change the default Wazuh API credentials
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -171,8 +174,6 @@ Change the default password of the admin users: `wazuh` and `wazuh-wui`. Note th
 
    See the :doc:`Securing the Wazuh API </user-manual/api/securing-api>` section for additional security configurations. 
 
-   .. note:: Remember to store these passwords securely. 
-
 #. In your `Wazuh dashboard` server, update ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` with your new password.  
 
    .. code-block:: yaml
@@ -195,53 +196,73 @@ Change the default password of the admin users: `wazuh` and `wazuh-wui`. Note th
 Change the default Wazuh indexer credentials
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Run the following command on any Wazuh indexer node to change all the default Wazuh indexer passwords. 
+Select your deployment type and follow the instructions to change the default Wazuh indexer passwords. 
 
-#. Use the Wazuh password tool to change all the internal users passwords. 
 
-   .. code-block:: console
-  
-     # /usr/share/wazuh-indexer/plugins/opensearch-security/tools/wazuh-passwords-tool.sh --change-all
-  
-   .. code-block:: console
-     :class: output
+.. tabs::
 
-     INFO: The password for user admin is o5XWBs044S5PJ1edYgw4R4MOM7r00Hjm
-     INFO: The password for user kibanaserver is mqhbijWWw8vVyuOBDtFQvqoLYwMdrcXP
-     INFO: The password for user kibanaro is jTbFvrCSQ4LaLmcNtcFOzVUvCL24nYtN
-     INFO: The password for user logstash is bmtERx0schYGoANyGiWnyed6044CYGQv
-     INFO: The password for user readall is j9JOe7nEhKZhjyfUWVXhI2FNaM5A7eT6
-     INFO: The password for user snapshotrestore is tYyAqG9U72RURf0svrvJ8rtiVEzqjdmg
-     INFO: The password for user wazuh_admin is NHJMpiJkeBgjwNSJnoPV1KD9XMD7a98N
-     INFO: The password for user wazuh_user is N364F1kSkgKfUkVPzRxnCKwszaDVLqu0
-     WARNING: Passwords changed. Remember to update the password in the Wazuh dashboard and Filebeat nodes if necessary, and restart the services.
+   .. group-tab:: All-in-one deployment
 
-   .. note:: Remember to store these passwords securely. 
-
-If you have an all-in-one deployment, the ``wazuh-passwords-tool.sh`` automatically updates the credentials in your Filebeat and Wazuh dashboard keystores. For a distributed deployment, you need to update them manually following the steps below. 
-
-**Only for distributed deployments**
-
-#. On your `Wazuh server`, update the `admin` password in the Filebeat keystore. Replace ``<admin-password>`` with the random password generated in the previous step and run the following command:  
+       #. Use the Wazuh password tool to change all the internal users passwords. 
       
-    .. code-block:: console
+          .. code-block:: console
+         
+            # /usr/share/wazuh-indexer/plugins/opensearch-security/tools/wazuh-passwords-tool.sh --change-all
+         
+          .. code-block:: console
+            :class: output
+       
+            INFO: The password for user admin is o5XWBs044S5PJ1edYgw4R4MOM7r00Hjm
+            INFO: The password for user kibanaserver is mqhbijWWw8vVyuOBDtFQvqoLYwMdrcXP
+            INFO: The password for user kibanaro is jTbFvrCSQ4LaLmcNtcFOzVUvCL24nYtN
+            INFO: The password for user logstash is bmtERx0schYGoANyGiWnyed6044CYGQv
+            INFO: The password for user readall is j9JOe7nEhKZhjyfUWVXhI2FNaM5A7eT6
+            INFO: The password for user snapshotrestore is tYyAqG9U72RURf0svrvJ8rtiVEzqjdmg
+            INFO: The password for user wazuh_admin is NHJMpiJkeBgjwNSJnoPV1KD9XMD7a98N
+            INFO: The password for user wazuh_user is N364F1kSkgKfUkVPzRxnCKwszaDVLqu0
+            WARNING: Passwords changed. Remember to update the password in the Wazuh dashboard and Filebeat nodes if necessary, and restart the services.
+       
+    
+   .. group-tab:: Distributed deployment
 
-      # echo <admin-password> | filebeat keystore add password --stdin --force
+       #. Use the Wazuh password tool on `any Wazuh indexer node` to change all the internal users passwords. 
 
-#. Restart Filebeat.
+          .. code-block:: console
+  
+             # /usr/share/wazuh-indexer/plugins/opensearch-security/tools/wazuh-passwords-tool.sh --change-all
+  
+          .. code-block:: console
+            :class: output
 
-   .. include:: /_templates/common/restart_filebeat.rst
+             INFO: The password for user admin is o5XWBs044S5PJ1edYgw4R4MOM7r00Hjm
+             INFO: The password for user kibanaserver is mqhbijWWw8vVyuOBDtFQvqoLYwMdrcXP
+             INFO: The password for user kibanaro is jTbFvrCSQ4LaLmcNtcFOzVUvCL24nYtN
+             INFO: The password for user logstash is bmtERx0schYGoANyGiWnyed6044CYGQv
+             INFO: The password for user readall is j9JOe7nEhKZhjyfUWVXhI2FNaM5A7eT6
+             INFO: The password for user snapshotrestore is tYyAqG9U72RURf0svrvJ8rtiVEzqjdmg
+             INFO: The password for user wazuh_admin is NHJMpiJkeBgjwNSJnoPV1KD9XMD7a98N
+             INFO: The password for user wazuh_user is N364F1kSkgKfUkVPzRxnCKwszaDVLqu0
+             WARNING: Passwords changed. Remember to update the password in the Wazuh dashboard and Filebeat nodes if necessary, and restart the services.
 
-#. On your `Wazuh dashboard` server, update the `kibanaserver` password in the Wazuh dashboard keystore. Replace ``<kibanaserver-password>`` with the random password generated in the previous step and run the following command:   
+       #. On your `Wazuh servers`, update the `admin` password in the Filebeat keystore. Replace ``<admin-password>`` with the random password generated in the previous step and run the following command:  
+      
+          .. code-block:: console
 
-      .. code-block:: console
+             # echo <admin-password> | filebeat keystore add password --stdin --force
 
-        # echo <kibanaserver-password> | /usr/share/wazuh-dashboard/bin/opensearch-dashboards-keystore --allow-root add -f --stdin opensearch.password         
+       #. Restart Filebeat.
 
-#. Restart the Wazuh dashboard. 
+          .. include:: /_templates/common/restart_filebeat.rst
 
-   .. include:: /_templates/common/restart_dashboard.rst
+       #. On your `Wazuh dashboard` server, update the `kibanaserver` password in the Wazuh dashboard keystore. Replace ``<kibanaserver-password>`` with the random password generated in the previous step and run the following command:   
 
+          .. code-block:: console
+
+             # echo <kibanaserver-password> | /usr/share/wazuh-dashboard/bin/opensearch-dashboards-keystore --allow-root add -f --stdin opensearch.password         
+
+       #. Restart the Wazuh dashboard. 
+
+          .. include:: /_templates/common/restart_dashboard.rst
 
 
 Next steps

--- a/source/installation-guide/wazuh-dashboard/step-by-step.rst
+++ b/source/installation-guide/wazuh-dashboard/step-by-step.rst
@@ -134,7 +134,7 @@ Change the default Wazuh API credentials
 
 Change the default password of the admin users: `wazuh` and `wazuh-wui`. Note that the commands below use localhost, set your Wazuh manager IP address if necessary. 
 
-#. Get an authorization TOKEN. 
+#. Get an authorization token. 
 
    .. code-block:: console
 


### PR DESCRIPTION
## Description

This PR adds instructions to secure Wazuh in the step-by-step installation guide. These instructions include changing the default Wazuh API credentials as well as the Wazuh indexer passwords. This PR closes #5247.  

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

## Note to the reviewer

This PR includes changes to the `redirect.js` script that need to be included in all production branches.
