### PR TITLE
Clarification about the `same_source_ip` label

### DIFF
--- a/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
@@ -234,8 +234,12 @@ Example:
       <same_source_ip />
       <description>sendmail: Sender domain has bogus MX record. </description>
       <description>It should not be sending e-mail.</description>
-      <group>multiple_spam,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SI.4,</group>
-    </rule>
+      <mitre>
+        <id>T1114</id>
+        <id>T1499</id>
+      </mitre>
+      <group>multiple_spam,pci_dss_11.4,gdpr_IV_35.7.d,nist_800_53_SI.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+    </rule>    
 
 The rule is created with ID: ``3151`` and it will trigger a level 10 alert if the rule ``3102`` has matched 8 times in the last 120 seconds.
 

--- a/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
@@ -1426,6 +1426,9 @@ This option is used in conjunction with ``frequency`` and ``timeframe``.
 | **Example of use** | <same_srcip /> |
 +--------------------+----------------+
 
+Deprecated label ``same_source_ip`` works like an alias for ``same_scrip``. 
+
+
 different_srcip
 ^^^^^^^^^^^^^^^
 

--- a/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
@@ -1344,10 +1344,14 @@ Example:
 
       <rule id="30316" level="10" frequency="10" timeframe="120">
         <if_matched_sid>30315</if_matched_sid>
-        <same_srcip />
+        <same_source_ip />
         <description>Apache: Multiple Invalid URI requests from same source.</description>
-        <group>invalid_request,pci_dss_10.2.4,pci_dss_11.4,gdpr_IV_35.7.d,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,</group>
+        <mitre>
+          <id>T1499</id>
+        </mitre>
+        <group>gdpr_IV_35.7.d,hipaa_164.312.b,invalid_request,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,pci_dss_10.2.4,pci_dss_11.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
       </rule>
+
 
 The rule is triggered when rule 30315 has been triggered 10 times in 120 seconds and if the requests were made by the same ``srcip``.
 

--- a/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
@@ -1341,21 +1341,19 @@ This option is used in conjunction with ``frequency`` and ``timeframe``.
 .. note::
   Rules at level 0 are discarded immediately and will not be used with the if_matched_rules. The level must be at least 1, but the <no_log> option can be added to the rule to make sure it does not get logged.
 
-
 Example:
 
-  .. code-block:: xml
+.. code-block:: xml
 
-      <rule id="30316" level="10" frequency="10" timeframe="120">
-        <if_matched_sid>30315</if_matched_sid>
-        <same_source_ip />
-        <description>Apache: Multiple Invalid URI requests from same source.</description>
-        <mitre>
-          <id>T1499</id>
-        </mitre>
-        <group>gdpr_IV_35.7.d,hipaa_164.312.b,invalid_request,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,pci_dss_10.2.4,pci_dss_11.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
-      </rule>
-
+   <rule id="30316" level="10" frequency="10" timeframe="120">
+     <if_matched_sid>30315</if_matched_sid>
+     <same_source_ip />
+     <description>Apache: Multiple Invalid URI requests from same source.</description>
+     <mitre>
+       <id>T1499</id>
+     </mitre>
+     <group>gdpr_IV_35.7.d,hipaa_164.312.b,invalid_request,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_SI.4,pci_dss_10.2.4,pci_dss_11.4,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
+   </rule>
 
 The rule is triggered when rule 30315 has been triggered 10 times in 120 seconds and if the requests were made by the same ``srcip``.
 
@@ -1426,8 +1424,7 @@ This option is used in conjunction with ``frequency`` and ``timeframe``.
 | **Example of use** | <same_srcip /> |
 +--------------------+----------------+
 
-Deprecated label ``same_source_ip`` works like an alias for ``same_scrip``. 
-
+Deprecated label ``same_source_ip`` works like an alias for ``same_srcip``. 
 
 different_srcip
 ^^^^^^^^^^^^^^^
@@ -1438,6 +1435,8 @@ This option is used in conjunction with ``frequency`` and ``timeframe``.
 +--------------------+----------------------+
 | **Example of use** | <different_srcip />  |
 +--------------------+----------------------+
+
+Deprecated label ``not_same_source_ip`` works like an alias for ``different_srcip``. 
 
 same_dstip
 ^^^^^^^^^^


### PR DESCRIPTION
## Description

Deprecated label `same_source_ip` is still present in the current ruleset. This PR adds the clarification that this label works like an alias for `same_scrip`.  

![image](https://user-images.githubusercontent.com/61882981/170016913-efcb84c9-eea5-44be-bc80-4c30f17c1173.png)


It also updates rules [3151](https://github.com/wazuh/wazuh/blob/v4.3.1/ruleset/rules/0025-sendmail_rules.xml#L100) and [30316](https://github.com/wazuh/wazuh/blob/v4.3.1/ruleset/rules/0250-apache_rules.xml#L266). This PR closes #5142. 

![image](https://user-images.githubusercontent.com/61882981/170018398-7fb717d3-6c59-489b-b867-83e1fb83b119.png)

![image](https://user-images.githubusercontent.com/61882981/170018275-7304a875-b4c6-451d-a0e4-bf8b126c35d8.png)

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

## Note to the reviewer

This PR includes changes to the `redirect.js` script that need to be included in all production branches.
