### PR TITLE
Agent enrollment using password authentication - Fix indentation and highlighting

### DIFF
--- a/source/user-manual/agent-enrollment/security-options/using-password-authentication.rst
+++ b/source/user-manual/agent-enrollment/security-options/using-password-authentication.rst
@@ -39,7 +39,9 @@ Before an agent can be enrolled to the Wazuh manager using the password authenti
 
 #. Create a password to be used for agent enrollment. This can be achieved in two ways:
 
-   #. **Recommended** - By creating the file ``/var/ossec/etc/authd.pass`` on the manager and including your own password there. We recommend this method for creating the agent enrollment password. This can be done by running the line below in the terminal and subsequently restarting the Wazuh manager.
+   #. **Recommended** - By creating the file ``/var/ossec/etc/authd.pass`` on the manager and including your own password there. 
+
+      We recommend this method for creating the agent enrollment password. This can be done by running the line below in the terminal and subsequently restarting the Wazuh manager.
 
       .. code-block:: console
 
@@ -65,16 +67,14 @@ Before an agent can be enrolled to the Wazuh manager using the password authenti
 
       After this, restart the Wazuh service for the changes to take effect.
 
-         .. code-block:: console
-
-            # systemctl restart wazuh-manager
+         .. include:: /_templates/common/restart_manager.rst
 
 
-   #. By allowing the enrollment service to set a random password. Having added the ``<use_password>yes</use_password>`` configuration to the Wazuh manager, proceed to restart the manager.
+   #. By allowing the enrollment service to set a random password. 
+   
+      Having added the ``<use_password>yes</use_password>`` configuration to the Wazuh manager, proceed to restart the manager.
 
-      .. code-block:: console
-
-         # systemctl restart wazuh-manager
+      .. include:: /_templates/common/restart_manager.rst
       
       This will cause the enrollment service to generate a random password. This password can then be found in ``/var/ossec/logs/ossec.log``. Run the following command to get the agent enrollment password.
 

--- a/source/user-manual/agent-enrollment/security-options/using-password-authentication.rst
+++ b/source/user-manual/agent-enrollment/security-options/using-password-authentication.rst
@@ -41,52 +41,42 @@ Before an agent can be enrolled to the Wazuh manager using the password authenti
 
    #. **Recommended** - By creating the file ``/var/ossec/etc/authd.pass`` on the manager and including your own password there. 
 
-      We recommend this method for creating the agent enrollment password. This can be done by running the line below in the terminal and subsequently restarting the Wazuh manager.
+      #. Replace ``<custom_password>`` with your chosen agent enrollment password and run the following command: 
 
-      .. code-block:: console
+         .. code-block:: console
 
-         # echo "<custom_password>" > /var/ossec/etc/authd.pass
+            # echo "<custom_password>" > /var/ossec/etc/authd.pass
 
-      Note that you have to replace ``<custom_password>`` with your own agent enrollment password.
 
-      File permissions for the authd.pass file should be set to 644 and the owner should be root. The permissions and ownership can be configured by running the commands below:
+      #. Change the ``authd.pass`` file permissions and ownership: 
 
          .. code-block:: console
 
             # chmod 644 /var/ossec/etc/authd.pass
             # chown root:wazuh /var/ossec/etc/authd.pass
 
-
-      The output below shows the recommended file owner and permissions.
-
-         .. code-block:: xml
-           :class: output
-
-            -rw-r--r-- 1 root wazuh 9 Jan 11 12:50 /var/ossec/etc/authd.pass
-
-
-      After this, restart the Wazuh service for the changes to take effect.
+      #. Restart the Wazuh service for the changes to take effect.
 
          .. include:: /_templates/common/restart_manager.rst
 
 
    #. By allowing the enrollment service to set a random password. 
    
-      Having added the ``<use_password>yes</use_password>`` configuration to the Wazuh manager, proceed to restart the manager.
+      #. Restart the manager so the enrollment service will generate a random password. This password will be stored in ``/var/ossec/logs/ossec.log``. 
 
-      .. include:: /_templates/common/restart_manager.rst
+         .. include:: /_templates/common/restart_manager.rst
       
-      This will cause the enrollment service to generate a random password. This password can then be found in ``/var/ossec/logs/ossec.log``. Run the following command to get the agent enrollment password.
+      #. Run the following command to get the agent enrollment password: 
 
-      .. code-block:: console
+         .. code-block:: console
 
-         # grep "Random password" /var/ossec/logs/ossec.log
+            # grep "Random password" /var/ossec/logs/ossec.log
 
   
-      .. code-block:: xml
-        :class: output   
+         .. code-block:: xml
+            :class: output   
 
-         2022/01/11 12:41:35 wazuh-authd: INFO: Accepting connections on port 1515. Random password chosen for agent authentication: 6258b4eb21550e4f182a08c10d94585e
+            2022/01/11 12:41:35 wazuh-authd: INFO: Accepting connections on port 1515. Random password chosen for agent authentication: 6258b4eb21550e4f182a08c10d94585e
 
 
 .. note::
@@ -123,14 +113,14 @@ The following steps serve as a guide on how to enroll a Linux/Unix endpoint with
       The output below shows the recommended file owner and permissions.
 
       .. code-block:: xml
-        :class: output 
+         :class: output 
 
          -rw-r--r-- 1 root wazuh 18 Jan 11 13:03 /var/ossec/etc/authd.pass
 
 #. Add the Wazuh manager IP address or DNS name in the ``<client><server><address>`` section of the agent configuration file ``/var/ossec/etc/ossec.conf``.
 
    .. code-block:: xml
-     :emphasize-lines: 3
+      :emphasize-lines: 3
 
       <client>
          <server>
@@ -197,7 +187,7 @@ The Wazuh agent installation directory depends on the architecture of the host.
 #. Add the Wazuh manager IP address or DNS name in the ``<client><server><address>`` section of ``C:\Program Files (x86)\ossec-agent\ossec.conf``:
 
    .. code-block:: xml
-     :emphasize-lines: 3
+      :emphasize-lines: 3
 
       <client>
          <server>
@@ -259,14 +249,14 @@ The following steps serve as a guide on how to enroll a macOS endpoint with pass
       The output below shows the recommended file owner and permissions:
 
       .. code-block:: xml
-        :class: output 
+         :class: output 
 
          -rw-r--r-- 1 root wazuh 18 Jan 11 13:03 /Library/Ossec/etc/authd.pass
 
 #. Add the Wazuh manager IP address or DNS name in the ``<client><server><address>`` section of ``/Library/Ossec/etc/ossec.conf``:
 
    .. code-block:: xml
-     :emphasize-lines: 3      
+      :emphasize-lines: 3      
 
       <client>
         <server>

--- a/source/user-manual/agent-enrollment/security-options/using-password-authentication.rst
+++ b/source/user-manual/agent-enrollment/security-options/using-password-authentication.rst
@@ -37,15 +37,15 @@ Before an agent can be enrolled to the Wazuh manager using the password authenti
        </auth>
  
 
-#. Create a password to be used for agent enrollment. This can be achieved in two ways:
+#. Set a password to be used with agent enrollment. This can be achieved in two ways:
 
-   #. **Recommended** - By creating the file ``/var/ossec/etc/authd.pass`` on the manager and including your own password there. 
+   #. **Recommended** - Setting your own password. This is done by creating the file ``/var/ossec/etc/authd.pass`` on the manager with your password.
 
-      #. Replace ``<custom_password>`` with your chosen agent enrollment password and run the following command: 
+      #. Replace ``<CUSTOM_PASSWORD>`` with your chosen agent enrollment password and run the following command: 
 
          .. code-block:: console
 
-            # echo "<custom_password>" > /var/ossec/etc/authd.pass
+            # echo "<CUSTOM_PASSWORD>" > /var/ossec/etc/authd.pass
 
 
       #. Change the ``authd.pass`` file permissions and ownership.
@@ -60,9 +60,9 @@ Before an agent can be enrolled to the Wazuh manager using the password authenti
          .. include:: /_templates/common/restart_manager.rst
 
 
-   #. By allowing the enrollment service to set a random password. Note that a new random password will be generated each time the service is restarted. 
+   #. Allowing the enrollment service to set a random password. A new random password is generated each time the Wazuh manager service is restarted. 
    
-      #. Restart the manager so the enrollment service will generate a random password. This password will be stored in ``/var/ossec/logs/ossec.log``. 
+      #. Restart the manager so the enrollment service generates a random password. This password is stored in ``/var/ossec/logs/ossec.log``. 
 
          .. include:: /_templates/common/restart_manager.rst
       
@@ -98,10 +98,10 @@ The following steps serve as a guide on how to enroll a Linux/Unix endpoint with
 
    .. code-block:: console
 
-      # echo "<custom_password>" > /var/ossec/etc/authd.pass
+      # echo "<CUSTOM_PASSWORD>" > /var/ossec/etc/authd.pass
 
 
-   #. You have to replace ``<custom_password>`` with the agents enrollment password created on the manager.
+   #. You have to replace ``<CUSTOM_PASSWORD>`` with the agents enrollment password created on the manager.
    #. File permissions for the ``authd.pass`` file should be set to 644 and the owner should be ``root``. The permissions and ownership can be configured by running the commands below:
 
       .. code-block:: console
@@ -180,9 +180,9 @@ The Wazuh agent installation directory depends on the architecture of the host.
 
    .. code-block:: console
       
-      # echo “<custom_password>” > "C:\Program Files (x86)\ossec-agent\authd.pass"
+      # echo “<CUSTOM_PASSWORD>” > "C:\Program Files (x86)\ossec-agent\authd.pass"
 
-   Note that you have to replace ``<custom_password>`` with the agents enrollment password created on the manager.
+   Note that you have to replace ``<CUSTOM_PASSWORD>`` with the agents enrollment password created on the manager.
 
 #. Add the Wazuh manager IP address or DNS name in the ``<client><server><address>`` section of ``C:\Program Files (x86)\ossec-agent\ossec.conf``:
 
@@ -236,9 +236,9 @@ The following steps serve as a guide on how to enroll a macOS endpoint with pass
 
    .. code-block:: console
 
-      # echo "<custom_password>" > /Library/Ossec/etc/authd.pass
+      # echo "<CUSTOM_PASSWORD>" > /Library/Ossec/etc/authd.pass
 
-   #. You have to replace ``<custom_password>`` with the agents enrollment password created on the manager.
+   #. You have to replace ``<CUSTOM_PASSWORD>`` with the agents enrollment password created on the manager.
    #. File permissions for the ``authd.pass`` file should be set to 644 and the owner should be root. The permissions and ownership can be configured by running the commands below:
 
       .. code-block:: console 

--- a/source/user-manual/agent-enrollment/security-options/using-password-authentication.rst
+++ b/source/user-manual/agent-enrollment/security-options/using-password-authentication.rst
@@ -127,7 +127,7 @@ The following steps serve as a guide on how to enroll a Linux/Unix endpoint with
 
          -rw-r--r-- 1 root wazuh 18 Jan 11 13:03 /var/ossec/etc/authd.pass
 
-#. Add the Wazuh manager IP address or DNS name in the ``<client><server><address>`` section of the manager configuration file ``/var/ossec/etc/ossec.conf``.
+#. Add the Wazuh manager IP address or DNS name in the ``<client><server><address>`` section of the agent configuration file ``/var/ossec/etc/ossec.conf``.
 
    .. code-block:: xml
      :emphasize-lines: 3

--- a/source/user-manual/agent-enrollment/security-options/using-password-authentication.rst
+++ b/source/user-manual/agent-enrollment/security-options/using-password-authentication.rst
@@ -39,15 +39,15 @@ Before an agent can be enrolled to the Wazuh manager using the password authenti
 
 #. Create a password to be used for agent enrollment. This can be achieved in two ways:
 
-   - **Recommended** - By creating the file ``/var/ossec/etc/authd.pass`` on the manager and including your own password there. We recommend this method for creating the agent enrollment password. This can be done by running the line below in the terminal and subsequently restarting the Wazuh manager.
+   #. **Recommended** - By creating the file ``/var/ossec/etc/authd.pass`` on the manager and including your own password there. We recommend this method for creating the agent enrollment password. This can be done by running the line below in the terminal and subsequently restarting the Wazuh manager.
 
-     .. code-block:: console
+      .. code-block:: console
 
-        # echo "<custom_password>" > /var/ossec/etc/authd.pass
+         # echo "<custom_password>" > /var/ossec/etc/authd.pass
 
-   Note that you have to replace ``<custom_password>`` with your own agent enrollment password.
+      Note that you have to replace ``<custom_password>`` with your own agent enrollment password.
 
-   File permissions for the authd.pass file should be set to 644 and the owner should be root. The permissions and ownership can be configured by running the commands below:
+      File permissions for the authd.pass file should be set to 644 and the owner should be root. The permissions and ownership can be configured by running the commands below:
 
          .. code-block:: console
 
@@ -55,38 +55,38 @@ Before an agent can be enrolled to the Wazuh manager using the password authenti
             # chown root:wazuh /var/ossec/etc/authd.pass
 
 
-   The output below shows the recommended file owner and permissions.
+      The output below shows the recommended file owner and permissions.
 
-        .. code-block:: xml
-         :class: output
+         .. code-block:: xml
+           :class: output
 
-           -rw-r--r-- 1 root wazuh 9 Jan 11 12:50 /var/ossec/etc/authd.pass
-
-
-   After this, restart the Wazuh service for the changes to take effect.
-
-   .. code-block:: console
-
-       # systemctl restart wazuh-manager
+            -rw-r--r-- 1 root wazuh 9 Jan 11 12:50 /var/ossec/etc/authd.pass
 
 
-   - By allowing the enrollment service to set a random password. Having added the ``<use_password>yes</use_password>`` configuration to the Wazuh manager, proceed to restart the manager.
+      After this, restart the Wazuh service for the changes to take effect.
 
-   .. code-block:: console
+         .. code-block:: console
 
-       # systemctl restart wazuh-manager
+            # systemctl restart wazuh-manager
+
+
+   #. By allowing the enrollment service to set a random password. Having added the ``<use_password>yes</use_password>`` configuration to the Wazuh manager, proceed to restart the manager.
+
+      .. code-block:: console
+
+         # systemctl restart wazuh-manager
       
-   This will cause the enrollment service to generate a random password. This password can then be found in /var/ossec/logs/ossec.log. Run the following command to get the agent enrollment password.
+      This will cause the enrollment service to generate a random password. This password can then be found in ``/var/ossec/logs/ossec.log``. Run the following command to get the agent enrollment password.
 
-   .. code-block:: console
+      .. code-block:: console
 
-       # grep "Random password" /var/ossec/logs/ossec.log
+         # grep "Random password" /var/ossec/logs/ossec.log
 
   
-   .. code-block:: xml
-    :class: output   
+      .. code-block:: xml
+        :class: output   
 
-      2022/01/11 12:41:35 wazuh-authd: INFO: Accepting connections on port 1515. Random password chosen for agent authentication: 6258b4eb21550e4f182a08c10d94585e
+         2022/01/11 12:41:35 wazuh-authd: INFO: Accepting connections on port 1515. Random password chosen for agent authentication: 6258b4eb21550e4f182a08c10d94585e
 
 
 .. note::
@@ -106,42 +106,41 @@ The following steps serve as a guide on how to enroll a Linux/Unix endpoint with
 #. Launch the terminal as a root user.
 #. Create the file ``/var/ossec/etc/authd.pass`` with the enrollment password in it.
 
-       .. code-block:: console
+   .. code-block:: console
 
-          # echo "<custom_password>" > /var/ossec/etc/authd.pass
-
-
-    #. You have to replace ``<custom_password>`` with the agents enrollment password created on the manager.
-    #. File permissions for the ``authd.pass`` file should be set to 644 and the owner should be root. The permissions and ownership can be configured by running the commands below:
-
-       .. code-block:: console
-
-          # chmod 644 /var/ossec/etc/authd.pass
-          # chown root:wazuh /var/ossec/etc/authd.pass
+      # echo "<custom_password>" > /var/ossec/etc/authd.pass
 
 
-    The output below shows the recommended file owner and permissions.
+   #. You have to replace ``<custom_password>`` with the agents enrollment password created on the manager.
+   #. File permissions for the ``authd.pass`` file should be set to 644 and the owner should be ``root``. The permissions and ownership can be configured by running the commands below:
 
-       .. code-block:: xml
+      .. code-block:: console
+
+         # chmod 644 /var/ossec/etc/authd.pass
+         # chown root:wazuh /var/ossec/etc/authd.pass
+
+
+      The output below shows the recommended file owner and permissions.
+
+      .. code-block:: xml
         :class: output 
 
-          -rw-r--r-- 1 root wazuh 18 Jan 11 13:03 /var/ossec/etc/authd.pass
+         -rw-r--r-- 1 root wazuh 18 Jan 11 13:03 /var/ossec/etc/authd.pass
 
 #. Add the Wazuh manager IP address or DNS name in the ``<client><server><address>`` section of the manager configuration file ``/var/ossec/etc/ossec.conf``.
 
    .. code-block:: xml
-       :emphasize-lines: 3
+     :emphasize-lines: 3
 
-         <client>
-            <server>
-               <address>MANAGER_IP</address>
-            ...
-            </server>
-         </client>
+      <client>
+         <server>
+            <address>MANAGER_IP</address>
+         ...
+         </server>
+      </client>
 
 
    This will allow the agent to send logs to the manager specified.
-
 
 
 #. Restart the agent to make the changes effective.
@@ -191,22 +190,21 @@ The Wazuh agent installation directory depends on the architecture of the host.
 
    .. code-block:: console
       
-        # echo “<custom_password>” > "C:\Program Files (x86)\ossec-agent\authd.pass"
+      # echo “<custom_password>” > "C:\Program Files (x86)\ossec-agent\authd.pass"
 
    Note that you have to replace ``<custom_password>`` with the agents enrollment password created on the manager.
-
 
 #. Add the Wazuh manager IP address or DNS name in the ``<client><server><address>`` section of ``C:\Program Files (x86)\ossec-agent\ossec.conf``:
 
    .. code-block:: xml
-       :emphasize-lines: 3
+     :emphasize-lines: 3
 
-         <client>
-            <server>
-                <address>MANAGER_IP</address>
-               ...
-            </server>
-         </client>
+      <client>
+         <server>
+             <address>MANAGER_IP</address>
+            ...
+         </server>
+      </client>
 
 
 
@@ -246,36 +244,36 @@ The following steps serve as a guide on how to enroll a macOS endpoint with pass
 
 #. Create a file called ``/Library/Ossec/etc/authd.pass`` and save the password to it.
 
-       .. code-block:: console
+   .. code-block:: console
 
-          # echo "<custom_password>" > /Library/Ossec/etc/authd.pass
+      # echo "<custom_password>" > /Library/Ossec/etc/authd.pass
 
-    #. You have to replace ``<custom_password>`` with the agents enrollment password created on the manager.
-    #. File permissions for the ``authd.pass`` file should be set to 644 and the owner should be root. The permissions and ownership can be configured by running the commands below:
+   #. You have to replace ``<custom_password>`` with the agents enrollment password created on the manager.
+   #. File permissions for the ``authd.pass`` file should be set to 644 and the owner should be root. The permissions and ownership can be configured by running the commands below:
 
-       .. code-block:: console 
+      .. code-block:: console 
 
-          # chmod 644 /Library/Ossec/etc/authd.pass
-          # chown root:wazuh /Library/Ossec/etc/authd.pass
+         # chmod 644 /Library/Ossec/etc/authd.pass
+         # chown root:wazuh /Library/Ossec/etc/authd.pass
 
-    The output below shows the recommended file owner and permissions:
+      The output below shows the recommended file owner and permissions:
 
-       .. code-block:: xml
-           :class: output 
+      .. code-block:: xml
+        :class: output 
 
-            -rw-r--r-- 1 root wazuh 18 Jan 11 13:03 /Library/Ossec/etc/authd.pass
+         -rw-r--r-- 1 root wazuh 18 Jan 11 13:03 /Library/Ossec/etc/authd.pass
 
 #. Add the Wazuh manager IP address or DNS name in the ``<client><server><address>`` section of ``/Library/Ossec/etc/ossec.conf``:
 
    .. code-block:: xml
-       :emphasize-lines: 3      
+     :emphasize-lines: 3      
 
-       <client>
-         <server>
-            <address>MANAGER_IP</address>
-            ...
-         </server>
-       </client>
+      <client>
+        <server>
+           <address>MANAGER_IP</address>
+           ...
+        </server>
+      </client>
 
    This will allow the agent to send logs to the specified manager.
 

--- a/source/user-manual/agent-enrollment/security-options/using-password-authentication.rst
+++ b/source/user-manual/agent-enrollment/security-options/using-password-authentication.rst
@@ -48,7 +48,7 @@ Before an agent can be enrolled to the Wazuh manager using the password authenti
             # echo "<custom_password>" > /var/ossec/etc/authd.pass
 
 
-      #. Change the ``authd.pass`` file permissions and ownership: 
+      #. Change the ``authd.pass`` file permissions and ownership.
 
          .. code-block:: console
 
@@ -60,7 +60,7 @@ Before an agent can be enrolled to the Wazuh manager using the password authenti
          .. include:: /_templates/common/restart_manager.rst
 
 
-   #. By allowing the enrollment service to set a random password. 
+   #. By allowing the enrollment service to set a random password. Note that a new random password will be generated each time the service is restarted. 
    
       #. Restart the manager so the enrollment service will generate a random password. This password will be stored in ``/var/ossec/logs/ossec.log``. 
 


### PR DESCRIPTION
## Description

This PR fixes the indentation and highlighting. 

By fixing indentation and adding nested lists, it makes clear that there are two available options for creating the registration password. This closes #5264. 

![image](https://user-images.githubusercontent.com/61882981/170707984-a067ab38-9579-4c1c-9065-c17f5d09844c.png)


This PR also fixes nested lists. See images below. 

Before:

![image](https://user-images.githubusercontent.com/61882981/170220576-7f917477-b5cd-44ee-82c9-06134822f1ae.png)


After: 

![image](https://user-images.githubusercontent.com/61882981/170220280-d210fb61-f25f-4220-a3e3-85971f389ffb.png)


## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

## Note to the reviewer

This PR includes changes to the `redirect.js` script that need to be included in all production branches.
