### PR TITLE
Add clarification about the new wazuh system user and group

### DIFF
--- a/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-elastic-stack.rst
+++ b/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-elastic-stack.rst
@@ -48,7 +48,7 @@ Upgrading the Wazuh manager
 
 When upgrading a multi-node Wazuh manager cluster, run the upgrade in every node to make all the Wazuh manager nodes join the cluster. Start with the master node to reduce server downtime.
 
-.. note:: In upgrades from Wazuh 4.2.x or lower, the ``ossec`` system user and group are replaced by the ``wazuh`` system user and group. Before upgrading, make sure that there are not conflicts with this new user and group.
+.. note:: Upgrading from Wazuh 4.2.x or lower creates the ``wazuh`` operating system user and group to replace ``ossec``. To avoid upgrade conflicts, make sure that the ``wazuh`` user and group are not present in your operating system. 
 
 #. Upgrade the Wazuh manager to the latest version.
 

--- a/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-elastic-stack.rst
+++ b/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-elastic-stack.rst
@@ -46,13 +46,12 @@ Preparing the upgrade
 Upgrading the Wazuh manager
 ---------------------------
 
+When upgrading a multi-node Wazuh manager cluster, run the upgrade in every node to make all the Wazuh manager nodes join the cluster. Start with the master node to reduce server downtime.
+
+.. note:: In upgrades from Wazuh 4.2.x or lower, the ``ossec`` system user and group are replaced by the ``wazuh`` system user and group. Before upgrading, make sure that there are not conflicts with this new user and group.
+
 #. Upgrade the Wazuh manager to the latest version.
 
-   -  When upgrading a multi-node Wazuh manager cluster, run the upgrade in every node to make all the Wazuh manager nodes join the cluster. Start with the master node to reduce server downtime.
-
-   .. note::
-
-      If the ``/var/ossec/etc/ossec.conf`` configuration file was modified, it will not be replaced by the upgrade. You will therefore have to add the settings of the new capabilities manually. More information can be found in :doc:`/user-manual/index`.
 
    .. tabs::
 
@@ -67,6 +66,10 @@ Upgrading the Wazuh manager
          .. code-block:: console
 
             # apt-get install wazuh-manager
+
+    .. note::
+
+      If the ``/var/ossec/etc/ossec.conf`` configuration file was modified, it will not be replaced by the upgrade. You will therefore have to add the settings of the new capabilities manually. More information can be found in :doc:`/user-manual/index`.      
 
 #. Repeat the previous steps for every Wazuh manager node.
 

--- a/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-open-distro.rst
+++ b/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-open-distro.rst
@@ -42,13 +42,13 @@ Preparing the upgrade
 Upgrading the Wazuh manager
 ---------------------------
 
+When upgrading a multi-node Wazuh manager cluster, run the upgrade in every node to make all the Wazuh manager nodes join the cluster. Start with the master node to reduce server downtime.
+
+.. note:: In upgrades from Wazuh 4.2.x or lower, the ``ossec`` system user and group are replaced by the ``wazuh`` system user and group. Before upgrading, make sure that there are not conflicts with this new user and group. 
+
 #. Upgrade the Wazuh manager to the latest version.
 
-   -  When upgrading a multi-node Wazuh manager cluster, run the upgrade in every node to make all the Wazuh manager nodes join the cluster. Start with the master node to reduce server downtime.
-
-   .. note::
-
-      If the ``/var/ossec/etc/ossec.conf`` configuration file was modified, it will not be replaced by the upgrade. You will therefore have to add the settings of the new capabilities manually. More information can be found in :doc:`/user-manual/index`.
+  
 
    .. tabs::
 
@@ -63,6 +63,10 @@ Upgrading the Wazuh manager
          .. code-block:: console
 
             # apt-get install wazuh-manager
+
+    .. note::
+
+      If the ``/var/ossec/etc/ossec.conf`` configuration file was modified, it will not be replaced by the upgrade. You will therefore have to add the settings of the new capabilities manually. More information can be found in :doc:`/user-manual/index`.        
 
 #. Repeat the previous steps for every Wazuh manager node.
 

--- a/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-open-distro.rst
+++ b/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-open-distro.rst
@@ -44,7 +44,7 @@ Upgrading the Wazuh manager
 
 When upgrading a multi-node Wazuh manager cluster, run the upgrade in every node to make all the Wazuh manager nodes join the cluster. Start with the master node to reduce server downtime.
 
-.. note:: In upgrades from Wazuh 4.2.x or lower, the ``ossec`` system user and group are replaced by the ``wazuh`` system user and group. Before upgrading, make sure that there are not conflicts with this new user and group. 
+.. note:: Upgrading from Wazuh 4.2.x or lower creates the ``wazuh`` operating system user and group to replace ``ossec``. To avoid upgrade conflicts, make sure that the ``wazuh`` user and group are not present in your operating system.  
 
 #. Upgrade the Wazuh manager to the latest version.
 

--- a/source/upgrade-guide/upgrading-central-components.rst
+++ b/source/upgrade-guide/upgrading-central-components.rst
@@ -149,7 +149,7 @@ Upgrading the Wazuh server
 
 When upgrading a multi-node Wazuh manager cluster, run the upgrade in every node to make all the Wazuh manager nodes join the cluster. Start with the master node to reduce server downtime.
 
-   .. note:: In upgrades from Wazuh 4.2.x or lower, the ``ossec`` system user and group are replaced by the ``wazuh`` system user and group. Before upgrading, make sure that there are not conflicts with this new user and group. 
+   .. note:: Upgrading from Wazuh 4.2.x or lower creates the ``wazuh`` operating system user and group to replace ``ossec``. To avoid upgrade conflicts, make sure that the ``wazuh`` user and group are not present in your operating system.  
 
 #. Upgrade the Wazuh manager to the latest version.
 

--- a/source/upgrade-guide/upgrading-central-components.rst
+++ b/source/upgrade-guide/upgrading-central-components.rst
@@ -149,11 +149,9 @@ Upgrading the Wazuh server
 
 When upgrading a multi-node Wazuh manager cluster, run the upgrade in every node to make all the Wazuh manager nodes join the cluster. Start with the master node to reduce server downtime.
 
+   .. note:: In upgrades from Wazuh 4.2.x or lower, the ``ossec`` system user and group are replaced by the ``wazuh`` system user and group. Before upgrading, make sure that there are not conflicts with this new user and group. 
+
 #. Upgrade the Wazuh manager to the latest version.
-
-   .. note::
-
-      If the ``/var/ossec/etc/ossec.conf`` configuration file was modified, it will not be replaced by the upgrade. You will therefore have to add the settings of the new capabilities manually. More information can be found in :doc:`/user-manual/index`.
 
    .. tabs::
 
@@ -168,6 +166,10 @@ When upgrading a multi-node Wazuh manager cluster, run the upgrade in every node
          .. code-block:: console
 
             # apt-get install wazuh-manager
+
+   .. note::
+
+      If the ``/var/ossec/etc/ossec.conf`` configuration file was modified, it will not be replaced by the upgrade. You will therefore have to add the settings of the new capabilities manually. More information can be found in :doc:`/user-manual/index`.
 
 
 #. Download the Wazuh module for Filebeat:


### PR DESCRIPTION
## Description

This PR add a clarification stating that in upgrades from Wazuh 4.2.x or lower, the ``ossec`` system user and group are replaced by the ``wazuh`` system user and group. It's recommended to make sure that there are no conflicts with this new user and group before upgrading. This PR closes #5276. 

A previous note was moved to avoid having two notes in a row. 

![image](https://user-images.githubusercontent.com/61882981/171639741-9ab4545f-ab3e-42c9-94d1-e258edbfc480.png)

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

## Note to the reviewer

This PR includes changes to the `redirect.js` script that need to be included in all production branches.
