### PR TITLE
Add release note 3.13.4 to 4.0

### DIFF
--- a/source/release-notes/index.rst
+++ b/source/release-notes/index.rst
@@ -20,6 +20,7 @@ This section summarizes the most important features of each Wazuh release.
         release_4_0_2
         release_4_0_1
         release_4_0_0
+        release_3-13-4
         release_3_13_3
         release_3_13_2
         release_3_13_1

--- a/source/release-notes/index.rst
+++ b/source/release-notes/index.rst
@@ -20,7 +20,7 @@ This section summarizes the most important features of each Wazuh release.
         release_4_0_2
         release_4_0_1
         release_4_0_0
-        release_3-13-4
+        release-3-13-4
         release_3_13_3
         release_3_13_2
         release_3_13_1

--- a/source/release-notes/release-3-13-4.rst
+++ b/source/release-notes/release-3-13-4.rst
@@ -1,0 +1,29 @@
+.. Copyright (C) 2022 Wazuh, Inc.
+
+.. _release_3_13_4:
+
+3.13.4 Release notes
+====================
+
+This section lists the changes in version 3.13.4. More details about these changes are provided in each component changelog:
+
+- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/3.14/CHANGELOG.md>`_
+- `wazuh/wazuh-kibana-app <https://github.com/wazuh/wazuh-kibana-app/blob/v3.13.4-7.9.2/CHANGELOG.md>`_
+- `wazuh/wazuh-splunk <https://github.com/wazuh/wazuh-splunk/blob/v3.13.4-8.0.4/CHANGELOG.md>`_
+
+Wazuh core
+----------
+
+- A crash in Vulnerability Detector when scanning agents running on Windows is now fixed (backport from 4.3.2).
+
+
+Wazuh Kibana app
+----------------
+
+- Support for Wazuh v3.13.4.
+
+
+Wazuh Splunk
+------------
+
+- Support for Wazuh v3.13.4.

--- a/source/release-notes/release-3-13-4.rst
+++ b/source/release-notes/release-3-13-4.rst
@@ -1,5 +1,8 @@
 .. Copyright (C) 2022 Wazuh, Inc.
 
+.. meta::
+  :description: Wazuh 3.13.4 has been released. Check out our release notes to discover the changes and additions of this release.
+
 .. _release_3_13_4:
 
 3.13.4 Release notes

--- a/source/release-notes/release-3-13-4.rst
+++ b/source/release-notes/release-3-13-4.rst
@@ -7,7 +7,7 @@
 
 This section lists the changes in version 3.13.4. More details about these changes are provided in each component changelog:
 
-- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/3.14/CHANGELOG.md>`_
+- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/3.13.4/CHANGELOG.md>`_
 - `wazuh/wazuh-kibana-app <https://github.com/wazuh/wazuh-kibana-app/blob/v3.13.4-7.9.2/CHANGELOG.md>`_
 - `wazuh/wazuh-splunk <https://github.com/wazuh/wazuh-splunk/blob/v3.13.4-8.0.4/CHANGELOG.md>`_
 


### PR DESCRIPTION
This PR adds the Wazuh 3.13.4 Release note to 4.0:

## Tasks:
- [x] Work on the branch `add-release-note-3.13.4-to-4.0`
- [x] Make the tasks listed in the Issue #5283

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

Regards,
Damian Furfuro