### PR TITLE
Fix `certs.yml` path in Docker deployments

### DIFF
--- a/source/deployment-options/docker/wazuh-container.rst
+++ b/source/deployment-options/docker/wazuh-container.rst
@@ -69,7 +69,7 @@ Single-node Deployment
                environment:
                  - HTTP_PROXY=YOUR_PROXY_ADDRESS_OR_DNS
         
-        Modify the file ``config/wazuh_indexer_ssl_certs/certs.yml`` and execute the following command to obtain the desired certificates:
+        Modify the file ``config/certs.yml`` and execute the following command to obtain the desired certificates:
       
          .. code-block:: console
          
@@ -174,7 +174,7 @@ Multi-node deployment
              environment:
                - HTTP_PROXY=YOUR_PROXY_ADDRESS_OR_DNS
       
-      Modify the file ``config/wazuh_indexer_ssl_certs/certs.yml`` and execute the following command to obtain the desired certificates:
+      Modify the file ``config/certs.yml`` and execute the following command to obtain the desired certificates:
         
          .. code-block:: console
 


### PR DESCRIPTION
## Description

This PR fixes the `certs.yml` path in Docker deployments and closes #5306.   

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).


