### PR TITLE
[4.3] Restored the link to edit on GitHub

### DIFF
--- a/source/_themes/wazuh_doc_theme_v3/template-parts/edit-repo.html
+++ b/source/_themes/wazuh_doc_theme_v3/template-parts/edit-repo.html
@@ -25,7 +25,7 @@
 {% endif %}
 
 {% block breadcrumbs_aside %}
-{% if include_edit_repo == True %}
+{% if theme_include_edit_repo == True %}
 {% if display_github or display_bitbucket or display_gitlab  %}
   <span class="edit-repo d-none d-xl-inline-block">
     {% if hasdoc(pagename) %}


### PR DESCRIPTION

## Description

Restored the link to edit on GitHub that was missing after the latest update of the theme.

## Checks
- [x] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
