### PR TITLE
Fix Wazuh folder in 'from sources'

### DIFF
--- a/source/deployment-options/wazuh-from-sources/wazuh-agent/index.rst
+++ b/source/deployment-options/wazuh-from-sources/wazuh-agent/index.rst
@@ -114,14 +114,14 @@ The Wazuh agent is a single and lightweight monitoring software. It is a multi-p
 
             .. code-block:: console
 
-                # cd wazuh-*
+                # cd wazuh-|WAZUH_LATEST_FROM_SOURCES|
                 # ./install.sh
 
             If you have previously compiled for another platform, you must clean the build using the Makefile in ``src``:
 
             .. code-block:: console
 
-                # cd wazuh-*
+                # cd wazuh-|WAZUH_LATEST_FROM_SOURCES|
                 # make -C src clean
                 # make -C src clean-deps
 
@@ -240,8 +240,8 @@ The Wazuh agent is a single and lightweight monitoring software. It is a multi-p
 
             .. code-block:: doscon
 
-                cd wazuh-*\src\win32
-                .\wazuh-installer-build-msi.bat
+                > cd wazuh-|WAZUH_LATEST_FROM_SOURCES|\src\win32
+                > .\wazuh-installer-build-msi.bat
 
             If you do not want to sign the installer, you will have to comment or delete the signtool line in the previous script.
 
@@ -305,7 +305,7 @@ The Wazuh agent is a single and lightweight monitoring software. It is a multi-p
 
             .. code-block:: console
 
-                # cd wazuh-*
+                # cd wazuh-|WAZUH_LATEST_FROM_SOURCES|
                 # USER_DIR="/Library/Ossec" ./install.sh
 
             .. note::
@@ -316,7 +316,7 @@ The Wazuh agent is a single and lightweight monitoring software. It is a multi-p
 
             .. code-block:: console
 
-                # cd wazuh-*
+                # cd wazuh-|WAZUH_LATEST_FROM_SOURCES|
                 # make -C src clean
                 # make -C src clean-deps
 
@@ -433,7 +433,7 @@ The Wazuh agent is a single and lightweight monitoring software. It is a multi-p
 
             .. code-block:: console
 
-                # cd wazuh-*
+                # cd wazuh-|WAZUH_LATEST_FROM_SOURCES|
                 # cd src
                 # gmake clean-deps
                 # gmake clean
@@ -577,7 +577,7 @@ The Wazuh agent is a single and lightweight monitoring software. It is a multi-p
 
             .. code-block:: console
 
-                # cd wazuh-*
+                # cd wazuh-|WAZUH_LATEST_FROM_SOURCES|
                 # /usr/local/bin/gmake -C src deps RESOURCES_URL=http://packages.wazuh.com/deps/14 TARGET=agent
                 # /usr/local/bin/gmake -C src TARGET=agent USE_SELINUX=no
 

--- a/source/deployment-options/wazuh-from-sources/wazuh-server/index.rst
+++ b/source/deployment-options/wazuh-from-sources/wazuh-server/index.rst
@@ -133,14 +133,14 @@ Installing Wazuh manager
 
     .. code-block:: console
 
-        # cd wazuh-*
+        # cd wazuh-|WAZUH_LATEST_FROM_SOURCES|
         # ./install.sh
 
     If you have previously compiled for another platform, you must clean the build using the Makefile  in ``src``:
 
     .. code-block:: console
 
-        # cd wazuh-*
+        # cd wazuh-|WAZUH_LATEST_FROM_SOURCES|
         # make -C src clean
         # make -C src clean-deps
 

--- a/source/user-manual/manager/manual-database-output.rst
+++ b/source/user-manual/manager/manual-database-output.rst
@@ -58,7 +58,7 @@ Execute the following command before **step 3** from the installation guide:
 
 .. code-block:: console
 
-  # cd wazuh-*/src
+  # cd wazuh-|WAZUH_LATEST|/src
   # make deps && make TARGET=server DATABASE=<mysql/pgsql>
 
 To indicate what kind of database users will use, users need the ``DATABASE`` flag. The allowed values are *mysql* or *pgsql*.

--- a/source/user-manual/manager/manual-database-output.rst
+++ b/source/user-manual/manager/manual-database-output.rst
@@ -58,7 +58,7 @@ Execute the following command before **step 3** from the installation guide:
 
 .. code-block:: console
 
-  # cd wazuh-|WAZUH_LATEST|/src
+  # cd wazuh-|WAZUH_LATEST_FROM_SOURCES|/src
   # make deps && make TARGET=server DATABASE=<mysql/pgsql>
 
 To indicate what kind of database users will use, users need the ``DATABASE`` flag. The allowed values are *mysql* or *pgsql*.


### PR DESCRIPTION
## Description

This PR replaces text showing directories with `-*` with the current Wazuh version. It closes #5334 

## Checks
- [ ] It compiles without warnings.
- [X] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [X] Used uppercase only on nouns. 
- [X] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).