### PR TITLE
Add the release date to the 4.x release notes

### DIFF
--- a/source/release-notes/index-4x.rst
+++ b/source/release-notes/index-4x.rst
@@ -20,7 +20,7 @@ Wazuh version                                  Release date
 :doc:`4.2.5 </release-notes/release-4-2-5>`    15 November 2021
 :doc:`4.2.4 </release-notes/release-4-2-4>`    20 October 2021
 :doc:`4.2.3 </release-notes/release-4-2-3>`    6 October 2021
-:doc:`4.2.2 </release-notes/release-4-2-2>`    28 September 2022
+:doc:`4.2.2 </release-notes/release-4-2-2>`    28 September 2021
 :doc:`4.2.1 </release-notes/release-4-2-1>`    3 September 2021
 :doc:`4.2.0 </release-notes/release-4-2-0>`    25 August 2021
 :doc:`4.1.5 </release-notes/release-4-1-5>`    22 April 2021

--- a/source/release-notes/index-4x.rst
+++ b/source/release-notes/index-4x.rst
@@ -7,32 +7,60 @@
 
 This section summarizes the most important features of each Wazuh 4.x release.
 
-.. topic:: Contents
+============================================   ====================
+Wazuh version                                  Release date
+============================================   ====================
+:doc:`4.3.4 </release-notes/release-4-3-4>`    8 June 2022
+:doc:`4.3.3 </release-notes/release-4-3-3>`    1 June 2022
+:doc:`4.3.2 </release-notes/release-4-3-2>`    30 May 2022
+:doc:`4.3.1 </release-notes/release-4-3-1>`    18 May 2022
+:doc:`4.3.0 </release-notes/release-4-3-0>`    5 May 2022
+:doc:`4.2.7 </release-notes/release-4-2-7>`    30 May 2022
+:doc:`4.2.6 </release-notes/release-4-2-6>`    28 March 2022
+:doc:`4.2.5 </release-notes/release-4-2-5>`    15 November 2021
+:doc:`4.2.4 </release-notes/release-4-2-4>`    20 October 2021
+:doc:`4.2.3 </release-notes/release-4-2-3>`    6 October 2021
+:doc:`4.2.2 </release-notes/release-4-2-2>`    28 September 2022
+:doc:`4.2.1 </release-notes/release-4-2-1>`    3 September 2021
+:doc:`4.2.0 </release-notes/release-4-2-0>`    25 August 2021
+:doc:`4.1.5 </release-notes/release-4-1-5>`    22 April 2021
+:doc:`4.1.4 </release-notes/release-4-1-4>`    25 March 2021
+:doc:`4.1.3 </release-notes/release-4-1-3>`    23 March 2021
+:doc:`4.1.2 </release-notes/release-4-1-2>`    8 March 2021
+:doc:`4.1.1 </release-notes/release-4-1-1>`    25 February 2021 
+:doc:`4.1.0 </release-notes/release-4-1-0>`    15 February 2021 
+:doc:`4.0.4 </release-notes/release-4-0-4>`    14 January 2021
+:doc:`4.0.3 </release-notes/release-4-0-3>`    30 November 2020
+:doc:`4.0.2 </release-notes/release-4-0-2>`    24 November 2020
+:doc:`4.0.1 </release-notes/release-4-0-1>`    11 November 2020
+:doc:`4.0.0 </release-notes/release-4-0-0>`    23 October 2020
+============================================   ====================
 
-    .. toctree::
-        :maxdepth: 2
+.. rst-class:: d-none
 
-        release-4-3-4
-        release-4-3-3
-        release-4-3-2        
-        release-4-3-1
-        release-4-3-0
-        release-4-2-7        
-        release-4-2-6
-        release-4-2-5
-        release-4-2-4
-        release-4-2-3
-        release-4-2-2
-        release-4-2-1
-        release-4-2-0
-        release-4-1-5
-        release-4-1-4
-        release-4-1-3
-        release-4-1-2
-        release-4-1-1
-        release-4-1-0
-        release-4-0-4
-        release-4-0-3 
-        release-4-0-2
-        release-4-0-1
-        release-4-0-0
+   .. toctree::
+   
+       4.3.4 Release notes <release-4-3-4>
+       4.3.3 Release notes <release-4-3-3>
+       4.3.2 Release notes <release-4-3-2>        
+       4.3.1 Release notes <release-4-3-1>
+       4.3.0 Release notes <release-4-3-0>
+       4.2.7 Release notes <release-4-2-7>        
+       4.2.6 Release notes <release-4-2-6>
+       4.2.5 Release notes <release-4-2-5>
+       4.2.4 Release notes <release-4-2-4>
+       4.2.3 Release notes <release-4-2-3>
+       4.2.2 Release notes <release-4-2-2>
+       4.2.1 Release notes <release-4-2-1>
+       4.2.0 Release notes <release-4-2-0>
+       4.1.5 Release notes <release-4-1-5>
+       4.1.4 Release notes <release-4-1-4>
+       4.1.3 Release notes <release-4-1-3>
+       4.1.2 Release notes <release-4-1-2>
+       4.1.1 Release notes <release-4-1-1>
+       4.1.0 Release notes <release-4-1-0>
+       4.0.4 Release notes <release-4-0-4>
+       4.0.3 Release notes <release-4-0-3>
+       4.0.2 Release notes <release-4-0-2>
+       4.0.1 Release notes <release-4-0-1>
+       4.0.0 Release notes <release-4-0-0>

--- a/source/release-notes/release-4-0-0.rst
+++ b/source/release-notes/release-4-0-0.rst
@@ -5,8 +5,8 @@
 
 .. _release_4_0_0:
 
-4.0.0 Release notes
-===================
+4.0.0 Release notes - 23 October 2020
+=====================================
 
 This section lists the changes in version 4.0.0. More details about these changes are provided in the changelog of each component:
 

--- a/source/release-notes/release-4-0-1.rst
+++ b/source/release-notes/release-4-0-1.rst
@@ -5,8 +5,8 @@
 
 .. _release_4_0_1:
 
-4.0.1 Release notes
-===================
+4.0.1 Release notes - 11 November 2020
+======================================
 
 This section lists the changes in version 4.0.1. More details about these changes are provided in the changelog of each component:
 

--- a/source/release-notes/release-4-0-2.rst
+++ b/source/release-notes/release-4-0-2.rst
@@ -5,8 +5,8 @@
 
 .. _release_4_0_2:
 
-4.0.2 Release notes
-===================
+4.0.2 Release notes - 24 November 2020
+======================================
 
 This section lists the changes in version 4.0.2. More details about these changes are provided in the changelog of each component:
 

--- a/source/release-notes/release-4-0-3.rst
+++ b/source/release-notes/release-4-0-3.rst
@@ -5,8 +5,8 @@
 
 .. _release_4_0_3:
 
-4.0.3 Release notes
-===================
+4.0.3 Release notes - 30 November 2020
+======================================
 
 This section lists the changes in version 4.0.3. More details about these changes are provided in the changelog of each component:
 

--- a/source/release-notes/release-4-0-4.rst
+++ b/source/release-notes/release-4-0-4.rst
@@ -5,8 +5,8 @@
 
 .. _release_4_0_4:
 
-4.0.4 Release notes
-===================
+4.0.4 Release notes - 14 January 2021
+=====================================
 
 This section lists the changes in version 4.0.4. More details about these changes are provided in the changelog of each component:
 

--- a/source/release-notes/release-4-1-0.rst
+++ b/source/release-notes/release-4-1-0.rst
@@ -5,8 +5,8 @@
 
 .. _release_4_1_0:
 
-4.1.0 Release notes
-===================
+4.1.0 Release notes - 15 February 2021
+======================================
 
 This section lists the changes in version 4.1.0. More details about these changes are provided in the changelog of each component:
 

--- a/source/release-notes/release-4-1-1.rst
+++ b/source/release-notes/release-4-1-1.rst
@@ -5,8 +5,8 @@
 
 .. _release_4_1_1:
 
-4.1.1 Release notes
-===================
+4.1.1 Release notes - 25 February 2021
+======================================
 
 This section lists the changes in version 4.1.1. More details about these changes are provided in the changelog of each component:
 

--- a/source/release-notes/release-4-1-2.rst
+++ b/source/release-notes/release-4-1-2.rst
@@ -5,8 +5,8 @@
 
 .. _release_4_1_2:
 
-4.1.2 Release notes
-===================
+4.1.2 Release notes - 8 March 2021
+==================================
 
 This section lists the changes in version 4.1.2. More details about these changes are provided in the changelog of each component:
 

--- a/source/release-notes/release-4-1-3.rst
+++ b/source/release-notes/release-4-1-3.rst
@@ -5,8 +5,8 @@
 
 .. _release_4_1_3:
 
-4.1.3 Release notes
-===================
+4.1.3 Release notes - 23 March 2021
+===================================
 
 This section lists the changes in version 4.1.3. More details about these changes are provided in the changelog of each component:
 

--- a/source/release-notes/release-4-1-4.rst
+++ b/source/release-notes/release-4-1-4.rst
@@ -4,8 +4,8 @@
   :description: Wazuh 4.1.4 has been released. Check out our release notes to discover the changes and additions of this release.
 .. _release_4_1_4:
 
-4.1.4 Release notes
-===================
+4.1.4 Release notes - 25 March 2021
+===================================
 
 This section lists the changes in version 4.1.4. More details about these changes are provided in the changelog of each component:
 

--- a/source/release-notes/release-4-1-5.rst
+++ b/source/release-notes/release-4-1-5.rst
@@ -4,8 +4,8 @@
   :description: Wazuh 4.1.5 has been released. Check out our release notes to discover the changes and additions of this release.
 .. _release_4_1_5:
 
-4.1.5 Release notes
-===================
+4.1.5 Release notes - 22 April 2021
+===================================
 
 This section lists the changes in version 4.1.5. More details about these changes are provided in the changelog of each component:
 

--- a/source/release-notes/release-4-2-0.rst
+++ b/source/release-notes/release-4-2-0.rst
@@ -5,8 +5,8 @@
 
 .. _release_4_2_0:
 
-4.2.0 Release notes
-===================
+4.2.0 Release notes - 25 August 2021
+====================================
 
 This section lists the changes in version 4.2.0. Every update of the Wazuh solution is cumulative and includes all enhancements and fixes from previous releases.
 

--- a/source/release-notes/release-4-2-1.rst
+++ b/source/release-notes/release-4-2-1.rst
@@ -5,8 +5,8 @@
 
 .. _release_4_2_1:
 
-4.2.1 Release notes
-===================
+4.2.1 Release notes - 3 September 2021
+======================================
 
 This section lists the changes in version 4.2.1. Every update of the Wazuh solution is cumulative and includes all enhancements and fixes from previous releases.
 

--- a/source/release-notes/release-4-2-2.rst
+++ b/source/release-notes/release-4-2-2.rst
@@ -3,8 +3,8 @@
 
 .. _release_4_2_2:
 
-4.2.2 Release notes
-===================
+4.2.2 Release notes - 28 September 2022
+=======================================
 
 This section lists the changes in version 4.2.2. Every update of the Wazuh solution is cumulative and includes all enhancements and fixes from previous releases.
 

--- a/source/release-notes/release-4-2-2.rst
+++ b/source/release-notes/release-4-2-2.rst
@@ -3,7 +3,7 @@
 
 .. _release_4_2_2:
 
-4.2.2 Release notes - 28 September 2022
+4.2.2 Release notes - 28 September 2021
 =======================================
 
 This section lists the changes in version 4.2.2. Every update of the Wazuh solution is cumulative and includes all enhancements and fixes from previous releases.

--- a/source/release-notes/release-4-2-3.rst
+++ b/source/release-notes/release-4-2-3.rst
@@ -3,8 +3,8 @@
 
 .. _release_4_2_3:
 
-4.2.3 Release notes
-===================
+4.2.3 Release notes - 6 October 2021
+====================================
 
 This section lists the changes in version 4.2.3. Every update of the Wazuh solution is cumulative and includes all enhancements and fixes from previous releases.
 

--- a/source/release-notes/release-4-2-4.rst
+++ b/source/release-notes/release-4-2-4.rst
@@ -3,8 +3,8 @@
 
 .. _release_4_2_4:
 
-4.2.4 Release notes
-===================
+4.2.4 Release notes - 20 October 2021
+=====================================
 
 This section lists the changes in version 4.2.4. Every update of the Wazuh solution is cumulative and includes all enhancements and fixes from previous releases.
 

--- a/source/release-notes/release-4-2-5.rst
+++ b/source/release-notes/release-4-2-5.rst
@@ -3,8 +3,8 @@
 
 .. _release_4_2_5:
 
-4.2.5 Release notes
-===================
+4.2.5 Release notes - 15 November 2021
+======================================
 
 This section lists the changes in version 4.2.5. Every update of the Wazuh solution is cumulative and includes all enhancements and fixes from previous releases.
 

--- a/source/release-notes/release-4-2-6.rst
+++ b/source/release-notes/release-4-2-6.rst
@@ -3,8 +3,8 @@
 
 .. _release_4_2_6:
 
-4.2.6 Release notes
-===================
+4.2.6 Release notes - 28 March 2022
+===================================
 
 This section lists the changes in version 4.2.6. Every update of the Wazuh solution is cumulative and includes all enhancements and fixes from previous releases.
 

--- a/source/release-notes/release-4-2-7.rst
+++ b/source/release-notes/release-4-2-7.rst
@@ -3,8 +3,8 @@
 
 .. _release_4_2_7:
 
-4.2.7 Release notes
-===================
+4.2.7 Release notes - 30 May 2022 
+=================================
 
 This section lists the changes in version 4.2.7. Every update of the Wazuh solution is cumulative and includes all enhancements and fixes from previous releases.
 

--- a/source/release-notes/release-4-3-0.rst
+++ b/source/release-notes/release-4-3-0.rst
@@ -5,8 +5,8 @@
 
 .. _release_4_3_0:
 
-4.3.0 Release notes
-===================
+4.3.0 Release notes - 5 May 2022
+================================
 
 This section lists the changes in version 4.3.0. Every update of the Wazuh solution is cumulative and includes all enhancements and fixes from previous releases.
 

--- a/source/release-notes/release-4-3-1.rst
+++ b/source/release-notes/release-4-3-1.rst
@@ -5,8 +5,8 @@
 
 .. _release_4_3_1:
 
-4.3.1 Release notes
-===================
+4.3.1 Release notes - 18 May 2022
+=================================
 
 This section lists the changes in version 4.3.1. Every update of the Wazuh solution is cumulative and includes all enhancements and fixes from previous releases.
 

--- a/source/release-notes/release-4-3-2.rst
+++ b/source/release-notes/release-4-3-2.rst
@@ -5,8 +5,8 @@
 
 .. _release_4_3_2:
 
-4.3.2 Release notes
-===================
+4.3.2 Release notes - 30 May 2022
+=================================
 
 This section lists the changes in version 4.3.2. Every update of the Wazuh solution is cumulative and includes all enhancements and fixes from previous releases.
 

--- a/source/release-notes/release-4-3-3.rst
+++ b/source/release-notes/release-4-3-3.rst
@@ -5,8 +5,8 @@
 
 .. _release_4_3_3:
 
-4.3.3 Release notes
-===================
+4.3.3 Release notes - 1 June 2022
+=================================
 
 This section lists the changes in version 4.3.3. Every update of the Wazuh solution is cumulative and includes all enhancements and fixes from previous releases.
 

--- a/source/release-notes/release-4-3-4.rst
+++ b/source/release-notes/release-4-3-4.rst
@@ -4,10 +4,8 @@
   :description: Wazuh 4.3.4 has been released. Check out our release notes to discover the changes and additions of this release.
 
 
-4.3.4 Release notes
-===================
-
-June 8th 2022
+4.3.4 Release notes - 8 June 2022
+=================================
 
 This section lists the changes in version 4.3.4. Every update of the Wazuh solution is cumulative and includes all enhancements and fixes from previous releases.
 


### PR DESCRIPTION

## Description

This PR adds the release date to the Wazuh 4.x release notes. It also adds a table containing the version and release date. 

![image](https://user-images.githubusercontent.com/61882981/172831069-846e3510-7b71-46f6-824f-4438938d17ab.png)

![image](https://user-images.githubusercontent.com/61882981/172830744-9f806cf6-70aa-4427-b0c9-557e1ab59347.png)

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).


