### PR TITLE
Add the release date to the 3.x and 2.x release notes 

### DIFF
--- a/source/release-notes/index-2x.rst
+++ b/source/release-notes/index-2x.rst
@@ -7,9 +7,18 @@
 
 This section summarizes the most important features of each Wazuh 2.x release.
 
-.. topic:: Contents
 
-    .. toctree::
-        :maxdepth: 2
-        
-        release-2-1
+=============================================   ====================
+Wazuh version                                   Release date
+=============================================   ====================
+:doc:`2.1.0 </release-notes/release-2-1>`       17 August 2017
+=============================================   ====================
+
+
+.. rst-class:: d-none
+
+   .. toctree::
+
+       2.1.0 Release notes <release-2-1>
+
+

--- a/source/release-notes/index-3x.rst
+++ b/source/release-notes/index-3x.rst
@@ -7,50 +7,97 @@
 
 This section summarizes the most important features of each Wazuh 3.x release.
 
-.. topic:: Contents
+=============================================  ====================
+Wazuh version                                  Release date
+=============================================  ====================
+:doc:`3.13.4 </release-notes/release-3-13-4>`  30 May 2022
+:doc:`3.13.3 </release-notes/release-3-13-3>`  28 April 2021  
+:doc:`3.13.2 </release-notes/release-3-13-2>`  22 September 2020
+:doc:`3.13.1 </release-notes/release-3-13-1>`  15 July 2020
+:doc:`3.13.0 </release-notes/release-3-13-0>`  22 June 2020
+:doc:`3.12.3 </release-notes/release-3-12-3>`  30 April 2020
+:doc:`3.12.2 </release-notes/release-3-12-2>`  9 April 2020
+:doc:`3.12.1 </release-notes/release-3-12-1>`  8 April 2020
+:doc:`3.12.0 </release-notes/release-3-12-0>`  24 March 2020
+:doc:`3.11.4 </release-notes/release-3-11-4>`  25 February 2020  
+:doc:`3.11.3 </release-notes/release-3-11-3>`  28 January 2020
+:doc:`3.11.2 </release-notes/release-3-11-2>`  22 January 2020
+:doc:`3.11.1 </release-notes/release-3-11-1>`  10 January 2020
+:doc:`3.11.0 </release-notes/release-3-11-0>`  23 December 2019
+:doc:`3.10.2 </release-notes/release-3-10-2>`  23 September 2019
+:doc:`3.10.1 </release-notes/release-3-10-1>`  19 September 2019
+:doc:`3.10.0 </release-notes/release-3-10-0>`  18 September 2019
+:doc:`3.9.5 </release-notes/release-3-9-5>`    8 August 2019
+:doc:`3.9.4 </release-notes/release-3-9-4>`    7 August 2019 
+:doc:`3.9.3 </release-notes/release-3-9-3>`    9 July 2019
+:doc:`3.9.2 </release-notes/release-3-9-2>`    10 June 2019
+:doc:`3.9.1 </release-notes/release-3-9-1>`    21 May 2019
+:doc:`3.9.0 </release-notes/release-3-9-0>`    2 May 2019
+:doc:`3.8.2 </release-notes/release-3-8-2>`    31 January 2019
+:doc:`3.8.1 </release-notes/release-3-8-1>`    24 January 2019
+:doc:`3.8.0 </release-notes/release-3-8-0>`    18 January 2019
+:doc:`3.7.2 </release-notes/release-3-7-2>`    17 December 2018
+:doc:`3.7.1 </release-notes/release-3-7-1>`    5 December 2018
+:doc:`3.7.0 </release-notes/release-3-7-0>`    10 November 2018
+:doc:`3.6.1 </release-notes/release-3-6-1>`    7 September 2018
+:doc:`3.6.0 </release-notes/release-3-6-0>`    29 August 2018
+:doc:`3.5.0 </release-notes/release-3-5-0>`    10 August 2018
+:doc:`3.4.0 </release-notes/release-3-4-0>`    24 July 2018
+:doc:`3.3.1 </release-notes/release-3-3-1>`    18 June 2018
+:doc:`3.3.0 </release-notes/release-3-3-0>`    8 June 2018
+:doc:`3.2.4 </release-notes/release-3-2-4>`    1 June 2018  
+:doc:`3.2.3 </release-notes/release-3-2-3>`    28 May 2018
+:doc:`3.2.2 </release-notes/release-3-2-2>`    7 May 2018
+:doc:`3.2.1 </release-notes/release-3-2-1>`    2 March 2018
+:doc:`3.2.0 </release-notes/release-3-2-0>`    8 February 2018
+:doc:`3.1.0 </release-notes/release-3-1-0>`    22 December 2017
+:doc:`3.0.0 </release-notes/release-3-0-0>`    3 December 2017
+=============================================  ====================
 
-    .. toctree::
-        :maxdepth: 2
 
-        release-3-13-4
-        release-3-13-3
-        release-3-13-2
-        release-3-13-1
-        release-3-13-0
-        release-3-12-3
-        release-3-12-2
-        release-3-12-1
-        release-3-12-0
-        release-3-11-4
-        release-3-11-3
-        release-3-11-2
-        release-3-11-1
-        release-3-11-0
-        release-3-10-2
-        release-3-10-1
-        release-3-10-0
-        release-3-9-5
-        release-3-9-4
-        release-3-9-3
-        release-3-9-2
-        release-3-9-1
-        release-3-9-0
-        release-3-8-2
-        release-3-8-1
-        release-3-8-0
-        release-3-7-2
-        release-3-7-1
-        release-3-7-0
-        release-3-6-1
-        release-3-6-0
-        release-3-5-0
-        release-3-4-0
-        release-3-3-1
-        release-3-3-0
-        release-3-2-4
-        release-3-2-3
-        release-3-2-2
-        release-3-2-1
-        release-3-2-0
-        release-3-1-0
-        release-3-0-0
+.. rst-class:: d-none
+
+   .. toctree::
+
+       3.13.4 Release notes <release-3-13-4>
+       3.13.3 Release notes <release-3-13-3>
+       3.13.2 Release notes <release-3-13-2>
+       3.13.1 Release notes <release-3-13-1>
+       3.13.0 Release notes <release-3-13-0>
+       3.12.3 Release notes <release-3-12-3>
+       3.12.2 Release notes <release-3-12-2>
+       3.12.1 Release notes <release-3-12-1>
+       3.12.0 Release notes <release-3-12-0>
+       3.11.4 Release notes <release-3-11-4>
+       3.11.3 Release notes <release-3-11-3>
+       3.11.2 Release notes <release-3-11-2>
+       3.11.1 Release notes <release-3-11-1>
+       3.11.0 Release notes <release-3-11-0>
+       3.10.2 Release notes <release-3-10-2>
+       3.10.1 Release notes <release-3-10-1>
+       3.10.0 Release notes <release-3-10-0>
+       3.9.5 Release notes <release-3-9-5>
+       3.9.4 Release notes <release-3-9-4>
+       3.9.3 Release notes <release-3-9-3>
+       3.9.2 Release notes <release-3-9-2>       
+       3.9.1 Release notes <release-3-9-1>
+       3.9.0 Release notes <release-3-9-0>
+       3.8.2 Release notes <release-3-8-2>       
+       3.8.1 Release notes <release-3-8-1>
+       3.8.0 Release notes <release-3-8-0>
+       3.7.2 Release notes <release-3-7-2>
+       3.7.1 Release notes <release-3-7-1>
+       3.7.0 Release notes <release-3-7-0>
+       3.6.1 Release notes <release-3-6-1>
+       3.6.0 Release notes <release-3-6-0>
+       3.5.0 Release notes <release-3-5-0>
+       3.4.0 Release notes <release-3-4-0>
+       3.3.1 Release notes <release-3-3-1>
+       3.3.0 Release notes <release-3-3-0>
+       3.2.4 Release notes <release-3-2-4>
+       3.2.3 Release notes <release-3-2-3>
+       3.2.2 Release notes <release-3-2-2>
+       3.2.1 Release notes <release-3-2-1>
+       3.2.0 Release notes <release-3-2-0>
+       3.1.0 Release notes <release-3-1-0>
+       3.0.0 Release notes <release-3-0-0>

--- a/source/release-notes/release-2-1.rst
+++ b/source/release-notes/release-2-1.rst
@@ -4,8 +4,8 @@
   :description: Wazuh 2.1 has been released. Check out our release notes to discover the changes and additions of this release.
 .. _release_2_1:
 
-2.1 Release notes
-===================
+2.1 Release notes - 17 August 2017
+==================================
 
 This section shows the most relevant new features of Wazuh v2.1. You will find more detailed information in our `changelog <https://github.com/wazuh/wazuh/blob/v2.1.0/CHANGELOG.md>`_ file.
 

--- a/source/release-notes/release-3-0-0.rst
+++ b/source/release-notes/release-3-0-0.rst
@@ -4,8 +4,8 @@
   :description: Wazuh 3.0.0 has been released. Check out our release notes to discover the changes and additions of this release.
 .. _release_3_0_0:
 
-3.0.0 Release notes
-===================
+3.0.0 Release notes - 3 December 2017
+=====================================
 
 This section shows the most relevant new features of Wazuh v3.0.0. You will find more detailed information in our `changelog <https://github.com/wazuh/wazuh/blob/v3.0.0/CHANGELOG.md>`_ file.
 

--- a/source/release-notes/release-3-1-0.rst
+++ b/source/release-notes/release-3-1-0.rst
@@ -4,8 +4,8 @@
   :description: Wazuh 3.1.0 has been released. Check out our release notes to discover the changes and additions of this release.
 .. _release_3_1_0:
 
-3.1.0 Release notes
-===================
+3.1.0 Release notes - 22 December 2017
+======================================
 
 This section shows the most relevant new features of Wazuh v3.1.0. You will find more detailed information in our `changelog <https://github.com/wazuh/wazuh/blob/v3.1.0/CHANGELOG.md>`_ file.
 

--- a/source/release-notes/release-3-10-0.rst
+++ b/source/release-notes/release-3-10-0.rst
@@ -5,8 +5,8 @@
 
 .. _release_3_10_0:
 
-3.10.0 Release notes
-====================
+3.10.0 Release notes - 18 September 2019
+========================================
 
 This section shows the most relevant improvements and fixes in version 3.10.0. More details about these changes are provided in each component changelog:
 

--- a/source/release-notes/release-3-10-1.rst
+++ b/source/release-notes/release-3-10-1.rst
@@ -5,8 +5,8 @@
 
 .. _release_3_10_1:
 
-3.10.1 Release notes
-====================
+3.10.1 Release notes - 19 September 2019
+========================================
 
 This section lists the changes in version 3.10.1. More details about these changes are provided in each component changelog:
 

--- a/source/release-notes/release-3-10-2.rst
+++ b/source/release-notes/release-3-10-2.rst
@@ -5,8 +5,8 @@
 
 .. _release_3_10_2:
 
-3.10.2 Release notes
-====================
+3.10.2 Release notes - 23 September 2019
+========================================
 
 This section lists the changes in version 3.10.2. More details about these changes are provided in each component changelog:
 

--- a/source/release-notes/release-3-11-0.rst
+++ b/source/release-notes/release-3-11-0.rst
@@ -5,8 +5,8 @@
 
 .. _release_3_11_0:
 
-3.11.0 Release notes
-====================
+3.11.0 Release notes - 23 December 2019
+=======================================
 
 This section shows the most relevant improvements and fixes in version 3.11.0. More details about these changes are provided in each component changelog:
 

--- a/source/release-notes/release-3-11-1.rst
+++ b/source/release-notes/release-3-11-1.rst
@@ -5,8 +5,8 @@
 
 .. _release_3_11_1:
 
-3.11.1 Release notes
-====================
+3.11.1 Release notes - 10 January 2020
+======================================
 
 This section lists the changes in version 3.11.1. More details about these changes are provided in each component changelog:
 

--- a/source/release-notes/release-3-11-2.rst
+++ b/source/release-notes/release-3-11-2.rst
@@ -5,8 +5,8 @@
 
 .. _release_3_11_2:
 
-3.11.2 Release notes
-====================
+3.11.2 Release notes - 22 January 2020
+======================================
 
 This section lists the changes in version 3.11.2. More details about these changes are provided in each component changelog:
 

--- a/source/release-notes/release-3-11-3.rst
+++ b/source/release-notes/release-3-11-3.rst
@@ -5,8 +5,8 @@
 
 .. _release_3_11_3:
 
-3.11.3 Release notes
-====================
+3.11.3 Release notes - 28 January 2020
+======================================
 
 This section lists the changes in version 3.11.3. More details about these changes are provided in each component changelog:
 

--- a/source/release-notes/release-3-11-4.rst
+++ b/source/release-notes/release-3-11-4.rst
@@ -5,8 +5,8 @@
 
 .. _release_3_11_4:
 
-3.11.4 Release notes
-====================
+3.11.4 Release notes - 25 February 2020
+=======================================
 
 This section lists the changes in version 3.11.4. More details about these changes are provided in each component changelog:
 

--- a/source/release-notes/release-3-12-0.rst
+++ b/source/release-notes/release-3-12-0.rst
@@ -5,8 +5,8 @@
 
 .. _release_3_12_0:
 
-3.12.0 Release notes
-====================
+3.12.0 Release notes - 24 March 2020
+====================================
 
 This section lists the changes in version 3.12.0. More details about these changes are provided in each component changelog:
 

--- a/source/release-notes/release-3-12-1.rst
+++ b/source/release-notes/release-3-12-1.rst
@@ -5,8 +5,8 @@
 
 .. _release_3_12_1:
 
-3.12.1 Release notes
-====================
+3.12.1 Release notes - 8 April 2020
+===================================
 
 This section lists the changes in version 3.12.1. More details about these changes are provided in each component changelog:
 

--- a/source/release-notes/release-3-12-2.rst
+++ b/source/release-notes/release-3-12-2.rst
@@ -5,8 +5,8 @@
 
 .. _release_3_12_2:
 
-3.12.2 Release notes
-====================
+3.12.2 Release notes - 9 April 2020
+===================================
 
 This section lists the changes in version 3.12.2. More details about these changes are provided in each component changelog:
 

--- a/source/release-notes/release-3-12-3.rst
+++ b/source/release-notes/release-3-12-3.rst
@@ -5,8 +5,8 @@
 
 .. _release_3_12_3:
 
-3.12.3 Release notes
-====================
+3.12.3 Release notes - 30 April 2020
+====================================
 
 This section lists the changes in version 3.12.3. More details about these changes are provided in each component changelog:
 

--- a/source/release-notes/release-3-13-0.rst
+++ b/source/release-notes/release-3-13-0.rst
@@ -5,8 +5,8 @@
 
 .. _release_3_13_0:
 
-3.13.0 Release notes
-====================
+3.13.0 Release notes - 22 June 2020
+===================================
 
 This section lists the changes in version 3.13.0. More details about these changes are provided in each component changelog:
 

--- a/source/release-notes/release-3-13-1.rst
+++ b/source/release-notes/release-3-13-1.rst
@@ -5,8 +5,8 @@
 
 .. _release_3_13_1:
 
-3.13.1 Release notes
-====================
+3.13.1 Release notes - 15 July 2020
+===================================
 
 This section lists the changes in version 3.13.1. More details about these changes are provided in each component changelog:
 

--- a/source/release-notes/release-3-13-2.rst
+++ b/source/release-notes/release-3-13-2.rst
@@ -5,8 +5,8 @@
 
 .. _release_3_13_2:
 
-3.13.2 Release notes
-====================
+3.13.2 Release notes - 22 September 2020
+========================================
 
 This section lists the changes in version 3.13.2. More details about these changes are provided in each component changelog:
 

--- a/source/release-notes/release-3-13-3.rst
+++ b/source/release-notes/release-3-13-3.rst
@@ -5,8 +5,8 @@
 
 .. _release_3_13_3:
 
-3.13.3 Release notes
-====================
+3.13.3 Release notes - 28 April 2021
+====================================
 
 This section lists the changes in version 3.13.3. More details about these changes are provided in each component changelog:
 

--- a/source/release-notes/release-3-13-4.rst
+++ b/source/release-notes/release-3-13-4.rst
@@ -5,8 +5,8 @@
 
 .. _release_3_13_4:
 
-3.13.4 Release notes
-====================
+3.13.4 Release notes - 30 May 2022
+==================================
 
 This section lists the changes in version 3.13.4. More details about these changes are provided in each component changelog:
 

--- a/source/release-notes/release-3-2-0.rst
+++ b/source/release-notes/release-3-2-0.rst
@@ -4,8 +4,8 @@
   :description: Wazuh 3.2.0 has been released. Check out our release notes to discover the changes and additions of this release.
 .. _release_3_2_0:
 
-3.2.0 Release notes
-===================
+3.2.0 Release notes - 8 February 2018
+=====================================
 
 This section shows the most relevant new features of Wazuh v3.2.0. You will find more detailed information in our `changelog <https://github.com/wazuh/wazuh/blob/v3.2.0/CHANGELOG.md>`_ file.
 

--- a/source/release-notes/release-3-2-1.rst
+++ b/source/release-notes/release-3-2-1.rst
@@ -4,8 +4,8 @@
   :description: Wazuh 3.2.1 has been released. Check out our release notes to discover the changes and additions of this release.
 .. _release_3_2_1:
 
-3.2.1 Release notes
-===================
+3.2.1 Release notes - 2 March 2018
+==================================
 
 This release is a bug fix release. This section shows the most relevant improvements and fixes of Wazuh v3.2.1. You will find more detailed information in the `changelog <https://github.com/wazuh/wazuh/blob/v3.2.1/CHANGELOG.md#v321>`_ file.
 

--- a/source/release-notes/release-3-2-2.rst
+++ b/source/release-notes/release-3-2-2.rst
@@ -4,8 +4,8 @@
   :description: Wazuh 3.2.2 has been released. Check out our release notes to discover the changes and additions of this release.
 .. _release_3_2_2:
 
-3.2.2 Release notes
-===================
+3.2.2 Release notes - 7 May 2018
+================================
 
 From the Wazuh team, we continue working hard improving the existing features as well as fixing bugs. This section shows the most relevant improvements and fixes in version 3.2.2. Find more details in each component changelog.
 

--- a/source/release-notes/release-3-2-3.rst
+++ b/source/release-notes/release-3-2-3.rst
@@ -4,8 +4,8 @@
   :description: Wazuh 3.2.3 has been released. Check out our release notes to discover the changes and additions of this release.
 .. _release_3_2_3:
 
-3.2.3 Release notes
-===================
+3.2.3 Release notes - 28 May 2018
+=================================
 
 This section shows the most relevant improvements and fixes in version 3.2.3. More details about these changes are provided in each component changelog.
 

--- a/source/release-notes/release-3-2-4.rst
+++ b/source/release-notes/release-3-2-4.rst
@@ -4,8 +4,8 @@
   :description: Wazuh 3.2.4 has been released. Check out our release notes to discover the changes and additions of this release.
 .. _release_3_2_4:
 
-3.2.4 Release notes
-===================
+3.2.4 Release notes - 1 June 2018
+=================================
 
 This section shows the most relevant improvements and fixes in version 3.2.4. More details about these changes are provided in each component changelog.
 

--- a/source/release-notes/release-3-3-0.rst
+++ b/source/release-notes/release-3-3-0.rst
@@ -4,8 +4,8 @@
   :description: Wazuh 3.3.0 has been released. Check out our release notes to discover the changes and additions of this release.
 .. _release_3_3_0:
 
-3.3.0 Release notes
-===================
+3.3.0 Release notes - 8 June 2018
+=================================
 
 This section shows the most relevant improvements and fixes in version 3.3.0. More details about these changes are provided in each component changelog.
 

--- a/source/release-notes/release-3-3-1.rst
+++ b/source/release-notes/release-3-3-1.rst
@@ -4,8 +4,8 @@
   :description: Wazuh 3.3.1 has been released. Check out our release notes to discover the changes and additions of this release.
 .. _release_3_3_1:
 
-3.3.1 Release notes
-===================
+3.3.1 Release notes - 18 June 2018
+==================================
 
 This section shows the most relevant improvements and fixes in version 3.3.1. More details about these changes are provided in each component changelog.
 

--- a/source/release-notes/release-3-4-0.rst
+++ b/source/release-notes/release-3-4-0.rst
@@ -4,8 +4,8 @@
   :description: Wazuh 3.4.0 has been released. Check out our release notes to discover the changes and additions of this release.
 .. _release_3_4_0:
 
-3.4.0 Release notes
-===================
+3.4.0 Release notes - 24 July 2018
+==================================
 
 This section shows the most relevant improvements and fixes in version 3.4.0. More details about these changes are provided in each component changelog.
 

--- a/source/release-notes/release-3-5-0.rst
+++ b/source/release-notes/release-3-5-0.rst
@@ -4,8 +4,8 @@
   :description: Wazuh 3.5.0 has been released. Check out our release notes to discover the changes and additions of this release.
 .. _release_3_5_0:
 
-3.5.0 Release notes
-===================
+3.5.0 Release notes - 10 August 2018
+====================================
 
 This section shows the most relevant improvements and fixes in version 3.5.0. More details about these changes are provided in each component changelog.
 

--- a/source/release-notes/release-3-6-0.rst
+++ b/source/release-notes/release-3-6-0.rst
@@ -4,8 +4,8 @@
   :description: Wazuh 3.6.0 has been released. Check out our release notes to discover the changes and additions of this release.
 .. _release_3_6_0:
 
-3.6.0 Release notes
-===================
+3.6.0 Release notes - 29 August 2018
+====================================
 
 This section shows the most relevant improvements and fixes in version 3.6.0. More details about these changes are provided in each component changelog.
 

--- a/source/release-notes/release-3-6-1.rst
+++ b/source/release-notes/release-3-6-1.rst
@@ -4,8 +4,8 @@
   :description: Wazuh 3.6.1 has been released. Check out our release notes to discover the changes and additions of this release.
 .. _release_3_6_1:
 
-3.6.1 Release notes
-===================
+3.6.1 Release notes - 7 September 2018
+======================================
 
 This section shows the most relevant improvements and fixes in version 3.6.1. More details about these changes are provided in each component changelog.
 

--- a/source/release-notes/release-3-7-0.rst
+++ b/source/release-notes/release-3-7-0.rst
@@ -4,8 +4,8 @@
   :description: Wazuh 3.7.0 has been released. Check out our release notes to discover the changes and additions of this release.
 .. _release_3_7_0:
 
-3.7.0 Release notes
-===================
+3.7.0 Release notes - 10 November 2018
+======================================
 
 This section shows the most relevant improvements and fixes in version 3.7.0. More details about these changes are provided in each component changelog:
 

--- a/source/release-notes/release-3-7-1.rst
+++ b/source/release-notes/release-3-7-1.rst
@@ -4,8 +4,8 @@
   :description: Wazuh 3.7.1 has been released. Check out our release notes to discover the changes and additions of this release.
 .. _release_3_7_1:
 
-3.7.1 Release notes
-===================
+3.7.1 Release notes - 5 December 2018
+=====================================
 
 This section shows the most relevant improvements and fixes in version 3.7.1. More details about these changes are provided in each component changelog:
 

--- a/source/release-notes/release-3-7-2.rst
+++ b/source/release-notes/release-3-7-2.rst
@@ -5,8 +5,8 @@
 
 .. _release_3_7_2:
 
-3.7.2 Release notes
-===================
+3.7.2 Release notes - 17 December 2018
+======================================
 
 This section shows the most relevant fixes in version 3.7.2. More details about these changes are provided in the component changelog:
 

--- a/source/release-notes/release-3-8-0.rst
+++ b/source/release-notes/release-3-8-0.rst
@@ -5,8 +5,8 @@
 
 .. _release_3_8_0:
 
-3.8.0 Release notes
-===================
+3.8.0 Release notes - 18 January 2019
+=====================================
 
 This section shows the most relevant improvements and fixes in version 3.8.0. More details about these changes are provided in each component changelog:
 

--- a/source/release-notes/release-3-8-1.rst
+++ b/source/release-notes/release-3-8-1.rst
@@ -5,8 +5,8 @@
 
 .. _release_3_8_1:
 
-3.8.1 Release notes
-===================
+3.8.1 Release notes - 24 January 2019
+=====================================
 
 This section shows the most relevant improvements and fixes in version 3.8.1. More details about these changes are provided in each component changelog:
 

--- a/source/release-notes/release-3-8-2.rst
+++ b/source/release-notes/release-3-8-2.rst
@@ -5,8 +5,8 @@
 
 .. _release_3_8_2:
 
-3.8.2 Release notes
-===================
+3.8.2 Release notes - 31 January 2019
+=====================================
 
 This section shows the most relevant fixes in version 3.8.2. A complete list of changes is provided in the `change log <https://github.com/wazuh/wazuh/blob/v3.8.2/CHANGELOG.md>`_.
 

--- a/source/release-notes/release-3-9-0.rst
+++ b/source/release-notes/release-3-9-0.rst
@@ -5,8 +5,8 @@
 
 .. _release_3_9_0:
 
-3.9.0 Release notes
-===================
+3.9.0 Release notes - 2 May 2019
+================================
 
 This section shows the most relevant improvements and fixes in version 3.9.0. More details about these changes are provided in each component changelog:
 

--- a/source/release-notes/release-3-9-1.rst
+++ b/source/release-notes/release-3-9-1.rst
@@ -5,8 +5,8 @@
 
 .. _release_3_9_1:
 
-3.9.1 Release notes
-===================
+3.9.1 Release notes - 21 May 2019
+=================================
 
 This section shows the most relevant improvements and fixes in version 3.9.1. More details about these changes are provided in each component changelog:
 

--- a/source/release-notes/release-3-9-2.rst
+++ b/source/release-notes/release-3-9-2.rst
@@ -5,8 +5,8 @@
 
 .. _release_3_9_2:
 
-3.9.2 Release notes
-===================
+3.9.2 Release notes - 10 June 2019
+==================================
 
 This section shows the most relevant improvements and fixes in version 3.9.2. More details about these changes are provided in each component changelog:
 

--- a/source/release-notes/release-3-9-3.rst
+++ b/source/release-notes/release-3-9-3.rst
@@ -5,8 +5,8 @@
 
 .. _release_3_9_3:
 
-3.9.3 Release notes
-===================
+3.9.3 Release notes - 9 July 2019
+=================================
 
 This section shows the most relevant improvements and fixes in version 3.9.3. More details about these changes are provided in each component changelog:
 

--- a/source/release-notes/release-3-9-4.rst
+++ b/source/release-notes/release-3-9-4.rst
@@ -5,8 +5,8 @@
 
 .. _release_3_9_4:
 
-3.9.4 Release notes
-===================
+3.9.4 Release notes - 7 August 2019
+===================================
 
 This section shows the most relevant improvements and fixes in version 3.9.4. More details about these changes are provided in each component changelog:
 

--- a/source/release-notes/release-3-9-5.rst
+++ b/source/release-notes/release-3-9-5.rst
@@ -5,8 +5,8 @@
 
 .. _release_3_9_5:
 
-3.9.5 Release notes
-===================
+3.9.5 Release notes - 8 August 2019
+===================================
 
 This section shows the most relevant improvements and fixes in version 3.9.5. More details about these changes are provided in each component changelog:
 


### PR DESCRIPTION
## Description

This PR adds the release date to the 3.x and 2.x release notes. It also adds a table containing the version and release date. 

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).


