### PR TITLE
Clarify the `-a` option description of the `agent_upgrade` binary

### DIFF
--- a/source/user-manual/reference/tools/agent-upgrade.rst
+++ b/source/user-manual/reference/tools/agent-upgrade.rst
@@ -11,26 +11,27 @@ The agent_upgrade program allows you to list outdated agents and upgrade them.
 
 .. note:: Since v4.1.0, the upgrade procedure is performed by the :ref:`Agent upgrade module<agent-upgrade-module>` and the agent_upgrade script can be executed on any node.
 
-+--------------------------------------------+---------------------------------------------------------+
-| ``-h, --help``                             | Display the help message.                               |
-+--------------------------------------------+---------------------------------------------------------+
-| ``-l, --list_outdated``                    | Generates a list with all outdated agents.              |
-+--------------------------------------------+---------------------------------------------------------+
-| ``-a AGENT_IDs, --agents AGENT_IDs``       | Agent IDs to upgrade.                                   |
-+--------------------------------------------+---------------------------------------------------------+
-| ``-F, --force``                            | Allows reinstall same version and downgrade version.    |
-+--------------------------------------------+---------------------------------------------------------+
-| ``-s, --silent``                           | Do not show output.                                     |
-+--------------------------------------------+---------------------------------------------------------+
-| ``-v VERSION, --version VERSION``          | Version to install.                                     |
-+--------------------------------------------+---------------------------------------------------------+
-| ``-r REPOSITORY, --repository REPOSITORY`` | Specify a repository URL.                               |
-+--------------------------------------------+---------------------------------------------------------+
-| ``-f FILE, --file FILE``                   | Custom WPK filename.                                    |
-+--------------------------------------------+---------------------------------------------------------+
-| ``-x EXECUTE, --execute EXECUTE``          | Executable filename in the WPK custom file.             |
-|                                            | By default it will try to launch upgrade.sh.            |
-+--------------------------------------------+---------------------------------------------------------+
++--------------------------------------------+--------------------------------------------------------------------------------+
+| ``-h, --help``                             | Display the help message.                                                      |
++--------------------------------------------+--------------------------------------------------------------------------------+
+| ``-l, --list_outdated``                    | Generates a list with all outdated agents.                                     |
++--------------------------------------------+--------------------------------------------------------------------------------+
+| ``-a AGENT_IDs, --agents AGENT_IDs``       | Agent IDs to upgrade. When upgrading multiple agents, separate IDs with spaces |
++--------------------------------------------+--------------------------------------------------------------------------------+
+| ``-F, --force``                            | Allows reinstall same version and downgrade version.                           |
++--------------------------------------------+--------------------------------------------------------------------------------+
+| ``-s, --silent``                           | Do not show output.                                                            |
++--------------------------------------------+--------------------------------------------------------------------------------+
+| ``-v VERSION, --version VERSION``          | Version to upgrade. [Default: latest Wazuh version]                            |
++--------------------------------------------+--------------------------------------------------------------------------------+
+| ``-r REPOSITORY, --repository REPOSITORY`` | Specify a repository URL. [Default: packages.wazuh.com/4.x/wpk/]               |
++--------------------------------------------+--------------------------------------------------------------------------------+
+| ``-f FILE, --file FILE``                   | Custom WPK filename.                                                           |
++--------------------------------------------+--------------------------------------------------------------------------------+
+| ``-x EXECUTE, --execute EXECUTE``          | Executable filename in the WPK custom file. [Default ``upgrade.sh``]           |
++--------------------------------------------+--------------------------------------------------------------------------------+
+| ``--http``                                 | Uses http protocol instead of https.                                           |
++--------------------------------------------+--------------------------------------------------------------------------------+
 
 .. note:: By default, the timeout will be the maximum allowed by the agent with the ``execd.max_restart_lock`` option in :doc:`internal_options.conf<../internal-options>`.
 

--- a/source/user-manual/reference/tools/agent-upgrade.rst
+++ b/source/user-manual/reference/tools/agent-upgrade.rst
@@ -69,6 +69,22 @@ Examples
         Agent 002 upgraded: Wazuh v3.13.2 -> |WAZUH_LATEST|
 
 
+* Upgrade multiple agents:
+
+.. code-block:: console
+
+    # /var/ossec/bin/agent_upgrade -a 001 002
+
+.. code-block:: none
+   :class: output
+
+   Upgrading...
+
+   Upgraded agents:
+       Agent 001 upgraded: Wazuh v4.2.0 -> |WAZUH_LATEST|
+       Agent 002 upgraded: Wazuh v4.0.0 -> |WAZUH_LATEST|
+
+
 * Downgrade agent using a custom repository:
 
 .. code-block:: console


### PR DESCRIPTION
## Description

This PR adds an example of how to upgrade multiple agents using the agent_upgrade binary and updates the arguments information. This PR closes #5302. 

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

## Note to the reviewer

This PR includes changes to the `redirect.js` script that need to be included in all production branches.
