### PR TITLE
Restrict default authd.pass permissions

### DIFF
--- a/source/user-manual/agent-enrollment/security-options/using-password-authentication.rst
+++ b/source/user-manual/agent-enrollment/security-options/using-password-authentication.rst
@@ -52,7 +52,7 @@ Before an agent can be enrolled to the Wazuh manager using the password authenti
 
          .. code-block:: console
 
-            # chmod 644 /var/ossec/etc/authd.pass
+            # chmod 640 /var/ossec/etc/authd.pass
             # chown root:wazuh /var/ossec/etc/authd.pass
 
       #. Restart the Wazuh service for the changes to take effect.
@@ -102,11 +102,11 @@ The following steps serve as a guide on how to enroll a Linux/Unix endpoint with
 
 
    #. You have to replace ``<CUSTOM_PASSWORD>`` with the agents enrollment password created on the manager.
-   #. File permissions for the ``authd.pass`` file should be set to 644 and the owner should be ``root``. The permissions and ownership can be configured by running the commands below:
+   #. File permissions for the ``authd.pass`` file should be set to 640 and the owner should be ``root``. The permissions and ownership can be configured by running the commands below:
 
       .. code-block:: console
 
-         # chmod 644 /var/ossec/etc/authd.pass
+         # chmod 640 /var/ossec/etc/authd.pass
          # chown root:wazuh /var/ossec/etc/authd.pass
 
 
@@ -239,11 +239,11 @@ The following steps serve as a guide on how to enroll a macOS endpoint with pass
       # echo "<CUSTOM_PASSWORD>" > /Library/Ossec/etc/authd.pass
 
    #. You have to replace ``<CUSTOM_PASSWORD>`` with the agents enrollment password created on the manager.
-   #. File permissions for the ``authd.pass`` file should be set to 644 and the owner should be root. The permissions and ownership can be configured by running the commands below:
+   #. File permissions for the ``authd.pass`` file should be set to 640 and the owner should be root. The permissions and ownership can be configured by running the commands below:
 
       .. code-block:: console 
 
-         # chmod 644 /Library/Ossec/etc/authd.pass
+         # chmod 640 /Library/Ossec/etc/authd.pass
          # chown root:wazuh /Library/Ossec/etc/authd.pass
 
       The output below shows the recommended file owner and permissions:


### PR DESCRIPTION
This changes the default recommendations from 644 (world readable) to 640, which can only be read by root and the wazuh group. 

Sensitive files should not be readable by any user.

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->
