### PR TITLE
Fix Vulnerability Detector offline update regex

### DIFF
--- a/source/user-manual/capabilities/vulnerability-detection/offline-update.rst
+++ b/source/user-manual/capabilities/vulnerability-detection/offline-update.rst
@@ -118,7 +118,7 @@ To perform an offline update, you must download the corresponding file:
 | ALL        | `Debian Security Tracker JSON <https://security-tracker.debian.org/tracker/data/json>`_    |
 +------------+--------------------------------------------------------------------------------------------+
 
-In order to use a local feed file, just use the ``path`` option:
+In order to use a local feed file, just use the ``path`` option which must be indicated by a POSIX regular expression:
 
 .. code-block:: xml
 
@@ -218,7 +218,7 @@ It is possible that the script will output error messages like the following:
 
 This indicates that the Red Hat servers may be temporarily unavailable to you. The script will continue trying to finish the download until it acquires the full feed.
 
-Finally, you will have the feed divided into a succession of numbered files whose names follow the format ``redhat-feed<number>.json``. To update locally, the path to those files must be indicated by a regular expression such as the following:
+Finally, you will have the feed divided into a succession of numbered files whose names follow the format ``redhat-feed<number>.json``. To update locally, the path to those files must be indicated by a POSIX regular expression such as the following:
 
 .. code-block:: xml
 
@@ -259,13 +259,13 @@ To fetch the vulnerability feed from an alternative repository, configure your m
         <update_interval>1h</update_interval>
     </provider>
 
-Alternatively, the feeds can be loaded from a local path. To achieve it, configure the ``path`` attribute in a similar way as shown in this example:
+Alternatively, the feeds can be loaded from a local path and must be indicated by a POSIX regular expression as shown in this example:
 
 .. code-block:: xml
 
     <provider name="arch">
         <enabled>yes</enabled>
-        <path>/local_path/archlinux_all\.json$</path>
+        <path>/local_path/all\.json$</path>
         <update_interval>1h</update_interval>
     </provider>
 
@@ -335,7 +335,7 @@ It is possible that the script will output error messages like the following:
 
 This indicates that the National Vulnerability Database servers may be temporarily unavailable to you. The script will continue trying to finish the download until it acquires the full feed.
 
-Finally, you will have the feed divided into a succession of numbered files whose name follows format ``nvd-feed<number>.json.gz``. To update locally, the path to those files must be indicated by a regular expression as such:
+Finally, you will have the feed divided into a succession of numbered files whose name follows the format ``nvd-feed<year>.json.gz``. To update locally, the path to those files must be indicated by a POSIX regular expression as such:
 
 .. code-block:: xml
 
@@ -371,7 +371,7 @@ The Microsoft Software Update feed update is now handled by the Wazuh manager in
         <update_interval>1h</update_interval>
     </provider>
 
-Or in a local path:
+To update locally, the path to those files must be indicated by a POSIX regular expression as such:
 
 .. code-block:: xml
 

--- a/source/user-manual/capabilities/vulnerability-detection/offline-update.rst
+++ b/source/user-manual/capabilities/vulnerability-detection/offline-update.rst
@@ -124,7 +124,7 @@ In order to use a local feed file, just use the ``path`` option:
 
     <provider name="debian">
         <enabled>yes</enabled>
-        <path>/local_path/security_tracker_local.json</path>
+        <path>/local_path/security_tracker_local\.json$</path>
         <update_interval>1h</update_interval>
     </provider>
 
@@ -224,7 +224,7 @@ Finally, you will have the feed divided into a succession of numbered files whos
 
     <provider name="redhat">
         <enabled>yes</enabled>
-        <path>/local_path/rh-feed/redhat-feed.*json$</path>
+        <path>/local_path/rh-feed/redhat-feed[[:digit:]]+\.json$</path>
         <update_interval>1h</update_interval>
     </provider>
 
@@ -265,7 +265,7 @@ Alternatively, the feeds can be loaded from a local path. To achieve it, configu
 
     <provider name="arch">
         <enabled>yes</enabled>
-        <path>/local_path/archlinux_all.json$</path>
+        <path>/local_path/archlinux_all\.json$</path>
         <update_interval>1h</update_interval>
     </provider>
 
@@ -341,7 +341,7 @@ Finally, you will have the feed divided into a succession of numbered files whos
 
     <provider name="nvd">
         <enabled>yes</enabled>
-        <path>/local_path/nvd-feed.*json$</path>
+        <path>/local_path/nvd-feed[[:digit:]]\{4\}\.json\.gz$</path>
         <update_interval>1h</update_interval>
     </provider>
 
@@ -377,6 +377,6 @@ Or in a local path:
 
     <provider name="msu">
         <enabled>yes</enabled>
-        <path>/local_path/msu-updates.json.gz</path>
+        <path>/local_path/msu-updates\.json\.gz$</path>
         <update_interval>1h</update_interval>
     </provider>

--- a/source/user-manual/capabilities/vulnerability-detection/offline-update.rst
+++ b/source/user-manual/capabilities/vulnerability-detection/offline-update.rst
@@ -335,7 +335,7 @@ It is possible that the script will output error messages like the following:
 
 This indicates that the National Vulnerability Database servers may be temporarily unavailable to you. The script will continue trying to finish the download until it acquires the full feed.
 
-Finally, you will have the feed divided into a succession of numbered files whose name follows format ``nvd-feed<number>.json.gz``. Those files are compressed and should be extracted. To update locally, the path to those files must be indicated by a regular expression as such:
+Finally, you will have the feed divided into a succession of numbered files whose name follows format ``nvd-feed<number>.json.gz``. To update locally, the path to those files must be indicated by a regular expression as such:
 
 .. code-block:: xml
 


### PR DESCRIPTION
| Related issue|
|---|
| #5347 |

## Description

This PR aims to fix some regex related to [Vulnerability Detector Offline Update](https://documentation.wazuh.com/4.3/user-manual/capabilities/vulnerability-detection/offline-update.html). Those regex where treated as patterns rather that POSIX regex (and also might be inaccurate).

Applied changes:
- Dots that aims to match literal dots were escaped (prepending `\`)
- Missing end of regex (`$`) were added
- Regex with years were changed to specifically match YYYYY
- Regex with counter were were changed to specifically match one or more digits

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] ~Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).~
