### PR TITLE
Fix wrong paths in the osquery configuration example

### DIFF
--- a/source/proof-of-concept-guide/integrate-osquery.rst
+++ b/source/proof-of-concept-guide/integrate-osquery.rst
@@ -52,12 +52,12 @@ Configure your environment as follows to test the PoC.
         },
 
         "packs": {
-            "osquery-monitoring": "/usr/share/osquery/packs/osquery-monitoring.conf",
-            "incident-response": "/usr/share/osquery/packs/incident-response.conf",
-            "it-compliance": "/usr/share/osquery/packs/it-compliance.conf",
-            "vuln-management": "/usr/share/osquery/packs/vuln-management.conf",
-            "hardware-monitoring": "/usr/share/osquery/packs/hardware-monitoring.conf",
-            "ossec-rootkit": "/usr/share/osquery/packs/ossec-rootkit.conf"
+            "osquery-monitoring": "/opt/osquery/share/osquery/packs/osquery-monitoring.conf",
+            "incident-response": "/opt/osquery/share/osquery/packs/incident-response.conf",
+            "it-compliance": "/opt/osquery/share/osquery/packs/it-compliance.conf",
+            "vuln-management": "/opt/osquery/share/osquery/packs/vuln-management.conf",
+            "hardware-monitoring": "/opt/osquery/share/osquery/packs/hardware-monitoring.conf",
+            "ossec-rootkit": "/opt/osquery/share/osquery/packs/ossec-rootkit.conf"
             }
         }
 


### PR DESCRIPTION
## Description:

This PR aims to fix wrong paths in the osquery configuration example. 

## Tasks:
- [x] Work on the branch `4.3-fix-osquery-wrong-paths`
- [x] Make the tasks listed in Issue #5353.

## Checks:
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).