### PR TITLE
Add Sydney Region on Wazuh Cloud Services Glossary

### DIFF
--- a/source/cloud-service/glossary.rst
+++ b/source/cloud-service/glossary.rst
@@ -83,6 +83,8 @@ Available regions:
 
 * Singapore: ``ap-southeast-1``
 
+* Sydney: ``ap-southeast-2``
+
 .. _cloud_glossary_wazuh_cloud_api:
 
 Wazuh Cloud API

--- a/source/cloud-service/your-environment/technical-faq.rst
+++ b/source/cloud-service/your-environment/technical-faq.rst
@@ -126,4 +126,6 @@ Available regions:
 
 * Singapore: ``ap-southeast-1``
 
+* Sydney: ``ap-southeast-2``
+
 When selecting a region to host your environment, if you are not sure which one is the best option for you, select one that is the closest to your location since this typically reduces latency for indexing and search requests.


### PR DESCRIPTION
# Related

|Related issue|
|--|
|Closes #5359  |

## Description
It is necessary to include the Sydney region since there is support for this region in Wazuh Cloud services.


## Before
![](https://user-images.githubusercontent.com/14912971/174473967-f060ac11-d131-4b4b-9bd6-262f7674a3f2.png)


## After

![](https://user-images.githubusercontent.com/14912971/174474622-ff9c2369-6870-45c4-aacc-e17e99f35a36.png)



## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).


## Note to the reviewer

This PR DOES NOT includes changes to the `redirect.js` script