### PR TITLE
Office365 interval option note and error handling warning

### DIFF
--- a/source/user-manual/reference/ossec-conf/office365-module.rst
+++ b/source/user-manual/reference/ossec-conf/office365-module.rst
@@ -91,6 +91,10 @@ interval
 
 Interval between Wazuh wodle executions.
 
+.. note::
+
+    When Wazuh starts, it waits for the configured time interval before running the first scan, unless the module has already been running before and the ``only_future_events`` option is set to no.
+
 +--------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 | **Default value**  | 10m                                                                                                                                     |
 +--------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
@@ -117,6 +121,10 @@ This block configures the credential for the **authentication** with the Office3
 - `api_auth\\client_id`_
 - `api_auth\\client_secret_path`_
 - `api_auth\\client_secret`_
+
+.. warning::
+
+    In case of invalid configuration, after the third scan attempt, a warning message is generated in the log file and an alert is triggered.
 
 +----------------------------------------+----------------------------------------------+
 | Options                                | Allowed values                               |


### PR DESCRIPTION
|Related PR|
|---|
|https://github.com/wazuh/wazuh/pull/13958|

## Description

The goal of this change is enrich the information about how Office365 integration works.
Two new messages are added, A note in interval option section and a Warning in authentication option section.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).