### PR TITLE
[4.3] Updated the menu to link the page Platform instead of Product

### DIFF
--- a/source/_themes/wazuh_doc_theme_v3/template-parts/footer.html
+++ b/source/_themes/wazuh_doc_theme_v3/template-parts/footer.html
@@ -34,9 +34,9 @@
     </div>
     <div class="col-12 col-sm-6 col-lg-4">
       <div class="footer-section">
-        <div class="footer-title">Platform</div>
+        <div class="footer-title">EXPLORE</div>
         <ul>
-          <li><a href="{{ theme_wazuh_web_url + '/product/' }}" target="_blank" rel="noreferrer noopener">Product</a></li>
+          <li><a href="{{ theme_wazuh_web_url + '/platform/' }}" target="_blank" rel="noreferrer noopener">Platform</a></li>
           <li><a href="{{ theme_wazuh_web_url + '/cloud/' }}" target="_blank" rel="noreferrer noopener">Cloud</a></li>
         </ul>
       </div>

--- a/source/_themes/wazuh_doc_theme_v3/template-parts/header.html
+++ b/source/_themes/wazuh_doc_theme_v3/template-parts/header.html
@@ -23,7 +23,7 @@
     {% if theme_breadcrumb_root_title == 'Documentation' %}
       <ul class="navbar-nav ml-auto d-none d-xl-flex flex-row">
         <li class="nav-item">
-          <a class="nav-link" href="{{ theme_wazuh_web_url + '/product/' }}" target="_blank" rel="noreferrer noopener">Product</a>
+          <a class="nav-link" href="{{ theme_wazuh_web_url + '/platform/' }}" target="_blank" rel="noreferrer noopener">Platform</a>
         </li>
         <li class="nav-item">
           <a class="nav-link" href="{{ theme_wazuh_web_url + '/cloud/' }}" target="_blank" rel="noreferrer noopener">Cloud</a>


### PR DESCRIPTION

## Description

Since the page Product on our site has been changed to Platform and the change includes the modification of the URL, this PR updates the links in the header and the footer of our documentation in order to match these changes.

**Before:** 
![imagen](https://user-images.githubusercontent.com/13232723/176147219-51ebb8e0-6762-421d-9443-88fc8c07e8c0.png)
![imagen](https://user-images.githubusercontent.com/13232723/176147473-b3f42553-2c73-44e9-80ce-8205c52b503a.png)

**After:**
![imagen](https://user-images.githubusercontent.com/13232723/176147741-0600f830-2d86-4e25-b8a4-2629bb6d23d2.png)
![imagen](https://user-images.githubusercontent.com/13232723/176147764-8c5a9238-e9c6-427c-abe9-0dad505dd561.png)


## Checks
- [x] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
