### PR TITLE
[4.3] Changed the link to join us on Slack

### DIFF
--- a/source/_themes/wazuh_doc_theme_v3/template-parts/footer.html
+++ b/source/_themes/wazuh_doc_theme_v3/template-parts/footer.html
@@ -88,7 +88,7 @@
       <li class="rrss nav-item d-inline-block"><a class="nav-link" title="Wazuh on LinkedIn" aria-label="Wazuh on LinkedIn" target="_blank" href="https://www.linkedin.com/company/wazuh" rel="noreferrer noopener"><i class="fab fa-linkedin-in"></i></a></li>
       <li class="rrss nav-item d-inline-block"><a class="nav-link" title="Wazuh on Reddit" aria-label="Wazuh on Reddit" target="_blank" href="https://www.reddit.com/r/Wazuh/" rel="noreferrer noopener"><i class="fab fa-reddit-alien"></i></a></li>
       <li class="rrss nav-item d-inline-block"><a class="nav-link" title="Wazuh on Github" aria-label="Wazuh on Github" target="_blank" href="https://github.com/wazuh" rel="noreferrer noopener"><i class="fab fa-github"></i></a></li>
-      <li class="rrss nav-item d-inline-block"><a class="nav-link" title="Join us on Slack" aria-label="Join us on Slack" target="_blank" href="https://join.slack.com/t/wazuh/shared_invite/{{ theme_wazuh_community }}" rel="noreferrer noopener"><i class="fab fa-slack"></i></a></li>
+      <li class="rrss nav-item d-inline-block"><a class="nav-link" title="Join us on Slack" aria-label="Join us on Slack" target="_blank" href="https://wazuh.com/community/join-us-on-slack/" rel="noreferrer noopener"><i class="fab fa-slack"></i></a></li>
       <li class="rrss nav-item d-inline-block"><a class="nav-link" title="Subscribe to our mailing list" aria-label="Subscribe to our mailing list" target="_blank" href="mailto:wazuh+subscribe@googlegroups.com" rel="noreferrer noopener"><i class="fas fa-user-friends"></i></a></li>
     </ul>
     {% endif %}


### PR DESCRIPTION

## Description

This PR replaces the link to Slack with a link to our page [Join us on Slack](https://wazuh.com/community/join-us-on-slack/) which can be quickly updated with the latest auto-invitation link.

## Checks
- [x] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
