### PR TITLE
Add warning note to solve homebrew installation

### DIFF
--- a/source/deployment-options/wazuh-from-sources/wazuh-agent/index.rst
+++ b/source/deployment-options/wazuh-from-sources/wazuh-agent/index.rst
@@ -286,11 +286,27 @@ The Wazuh agent is a single and lightweight monitoring software. It is a multi-p
 
     .. group-tab:: macOS
 
-        #.  Install development tools and compilers. In macOS, this can be easily done by installing brew, a package manager for macOS:
+        #. Install brew, a package manager for macOS:
 
             .. code-block:: console
 
                 $ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+            .. warning::
+                In some macOS versions this first command may fail reporting that `homebrew/core` is shallow clone. If this happens, run the following commands to solve it.
+
+            .. code-block:: console
+
+                $ rm -rf "/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core"
+                $ brew tap homebrew/core
+
+            After that, run again the first one to properly install brew:
+
+            .. code-block:: console
+
+                $ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+        #. Install development tools and compilers through brew.
 
             .. code-block:: console
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

Closes #5377 

As described in the linked issue, in some macOS versions such as Catalina the installation process from sources fails in the first step.

This pull request adds a warning note to inform about the problem as well as a couple of extra steps to solve it.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

