### PR TITLE
Add clarification of setting deprecated alert_new_files

### DIFF
--- a/source/user-manual/reference/ossec-conf/syscheck.rst
+++ b/source/user-manual/reference/ossec-conf/syscheck.rst
@@ -1,7 +1,7 @@
 .. Copyright (C) 2022 Wazuh, Inc.
 
 .. meta::
-  :description: The ossec.conf file is the main configuration file on the Wazuh manager and it also plays an important role on the agents. Learn more about it here. 
+  :description: The ossec.conf file is the main configuration file on the Wazuh manager and it also plays an important role on the agents. Learn more about it here.
 
 
 .. _reference_ossec_syscheck:
@@ -62,10 +62,10 @@ Example:
 .. code-block:: xml
 
  <alert_new_files>yes</alert_new_files>
- 
+
 .. note::
 
-	This setting only applies in managers.
+	This setting is applied in the manager configuration, but it only takes effect on agents with versions lower than 3.12.
 
 .. _reference_ossec_syscheck_allow_remote_prefilter_cmd:
 


### PR DESCRIPTION
## Description

Closes: https://github.com/wazuh/wazuh-documentation/issues/5232

This setting has been deprecated since version 4.0, with the update of the decoder used for alerts. We want to add an explanatory note and mark it as deprecated for agents version 3.12 or lower.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
