### PR TITLE
Change command apt with apt-get

### DIFF
--- a/source/_templates/installations/before_installation_all_in_one.rst
+++ b/source/_templates/installations/before_installation_all_in_one.rst
@@ -20,7 +20,7 @@
 
                     .. code-block:: console
 
-                        # apt install curl apt-transport-https unzip wget libcap2-bin software-properties-common lsb-release gnupg
+                        # apt-get install curl apt-transport-https unzip wget libcap2-bin software-properties-common lsb-release gnupg
 
 
                 Add the repository for Java Development Kit (JDK):
@@ -42,7 +42,7 @@
 
                     .. code-block:: console
 
-                        # apt update
+                        # apt-get update
 
                 Install all the required utilities:
 

--- a/source/_templates/installations/before_installation_all_in_one.rst
+++ b/source/_templates/installations/before_installation_all_in_one.rst
@@ -48,7 +48,7 @@
 
                 .. code-block:: console
 
-                    # export JAVA_HOME=/usr/ && apt install openjdk-11-jdk    
+                    # export JAVA_HOME=/usr/ && apt-get install openjdk-11-jdk    
 
                 In case JDK 11 is not available for the operating system being used, install the package ``adoptopenjdk-11-hotspot`` using `Adopt Open JDK <https://adoptopenjdk.net/installation.html#x64_linux-jdk>`_.
 

--- a/source/_templates/installations/common/apt/install-dependencies.rst
+++ b/source/_templates/installations/common/apt/install-dependencies.rst
@@ -4,6 +4,6 @@
 
     .. code-block:: console
 
-      # apt install curl apt-transport-https libcap2-bin
+      # apt-get install curl apt-transport-https libcap2-bin
 
 .. End of include file

--- a/source/_templates/installations/common/deb/add-repository.rst
+++ b/source/_templates/installations/common/deb/add-repository.rst
@@ -4,7 +4,7 @@
 
     .. code-block:: console
 
-      # apt install gnupg apt-transport-https
+      # apt-get install gnupg apt-transport-https
 
 #. Install the GPG key.
 

--- a/source/_templates/installations/dashboard/apt/install_dashboard.rst
+++ b/source/_templates/installations/dashboard/apt/install_dashboard.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # apt -y install wazuh-dashboard
+  # apt-get -y install wazuh-dashboard
 
 .. End of include file

--- a/source/_templates/installations/dashboard/install-dependencies.rst
+++ b/source/_templates/installations/dashboard/install-dependencies.rst
@@ -14,6 +14,6 @@
 
                   .. code-block:: console
 
-                      # apt install debhelper tar curl libcap2-bin #debhelper version 9 or later
+                      # apt-get install debhelper tar curl libcap2-bin #debhelper version 9 or later
 
 .. End of include file

--- a/source/_templates/installations/elastic/common/before_installation.rst
+++ b/source/_templates/installations/elastic/common/before_installation.rst
@@ -46,7 +46,7 @@
 
                     .. code-block:: console
 
-                        # export JAVA_HOME=/usr/ && apt install openjdk-11-jdk      
+                        # export JAVA_HOME=/usr/ && apt-get install openjdk-11-jdk      
 
                 In case JDK 11 is not available for the operating system being used, install the package ``adoptopenjdk-11-hotspot`` using `Adopt Open JDK <https://adoptopenjdk.net/installation.html#x64_linux-jdk>`_.
 

--- a/source/_templates/installations/elastic/common/before_installation.rst
+++ b/source/_templates/installations/elastic/common/before_installation.rst
@@ -19,7 +19,7 @@
 
                     .. code-block:: console
 
-                        # apt install curl apt-transport-https unzip wget software-properties-common
+                        # apt-get install curl apt-transport-https unzip wget software-properties-common
 
                 #. Add the repository for Java Development Kit (JDK):
 
@@ -40,7 +40,7 @@
 
                     .. code-block:: console
 
-                        # apt update
+                        # apt-get update
 
                 #. Install all the required utilities:
 

--- a/source/_templates/installations/elastic/common/before_installation_kibana.rst
+++ b/source/_templates/installations/elastic/common/before_installation_kibana.rst
@@ -16,7 +16,7 @@
 
                 .. code-block:: console
 
-                    # apt install curl apt-transport-https libcap2-bin
+                    # apt-get install curl apt-transport-https libcap2-bin
 
         .. group-tab:: ZYpp
 

--- a/source/_templates/installations/elastic/common/before_installation_kibana_filebeat.rst
+++ b/source/_templates/installations/elastic/common/before_installation_kibana_filebeat.rst
@@ -18,7 +18,7 @@
 
                 .. code-block:: console
 
-                    # apt install curl apt-transport-https lsb-release gnupg
+                    # apt-get install curl apt-transport-https lsb-release gnupg
 
 
                

--- a/source/_templates/installations/elastic/common/install_elastic.rst
+++ b/source/_templates/installations/elastic/common/install_elastic.rst
@@ -14,7 +14,7 @@
 
             .. code-block:: console
 
-                # apt install elasticsearch-oss opendistroforelasticsearch
+                # apt-get install elasticsearch-oss opendistroforelasticsearch
 
 
 

--- a/source/_templates/installations/elastic/common/install_wget_unzip.rst
+++ b/source/_templates/installations/elastic/common/install_wget_unzip.rst
@@ -6,7 +6,7 @@
         
         .. code-block:: console
 
-            # apt install unzip wget
+            # apt-get install unzip wget
 
     .. group-tab:: Yum
         

--- a/source/_templates/installations/filebeat/common/apt/install_filebeat.rst
+++ b/source/_templates/installations/filebeat/common/apt/install_filebeat.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-    # apt -y install filebeat
+    # apt-get -y install filebeat
 
 .. End of include file

--- a/source/_templates/installations/indexer/common/install-dependencies.rst
+++ b/source/_templates/installations/indexer/common/install-dependencies.rst
@@ -14,6 +14,6 @@
 
                   .. code-block:: console
 
-                      # apt install debconf adduser procps
+                      # apt-get install debconf adduser procps
 
 .. End of include file

--- a/source/_templates/installations/indexer/common/install-indexer.rst
+++ b/source/_templates/installations/indexer/common/install-indexer.rst
@@ -16,6 +16,6 @@
 
                 .. code-block:: console
 
-                    # apt -y install wazuh-indexer
+                    # apt-get -y install wazuh-indexer
 
 .. End of include file

--- a/source/_templates/installations/wazuh/common/install_wazuh_manager.rst
+++ b/source/_templates/installations/wazuh/common/install_wazuh_manager.rst
@@ -12,7 +12,7 @@
 
       .. code-block:: console
 
-         # apt -y install wazuh-manager
+         # apt-get -y install wazuh-manager
 
       
 .. End of include file

--- a/source/_templates/installations/wazuh/deb/add_repository_aio.rst
+++ b/source/_templates/installations/wazuh/deb/add_repository_aio.rst
@@ -4,7 +4,7 @@
 
     .. code-block:: console
 
-      # apt install curl apt-transport-https unzip wget libcap2-bin software-properties-common lsb-release gnupg
+      # apt-get install curl apt-transport-https unzip wget libcap2-bin software-properties-common lsb-release gnupg
 
 #. Install the GPG key:
 

--- a/source/_templates/installations/wazuh/deb/add_repository_elastic_cluster.rst
+++ b/source/_templates/installations/wazuh/deb/add_repository_elastic_cluster.rst
@@ -4,7 +4,7 @@
 
     .. code-block:: console
 
-      # apt install curl apt-transport-https unzip wget software-properties-common
+      # apt-get install curl apt-transport-https unzip wget software-properties-common
 
 #. Install the GPG key.
 

--- a/source/_templates/installations/wazuh/deb/add_repository_kibana.rst
+++ b/source/_templates/installations/wazuh/deb/add_repository_kibana.rst
@@ -4,7 +4,7 @@
 
     .. code-block:: console
 
-      # apt install curl apt-transport-https libcap2-bin
+      # apt-get install curl apt-transport-https libcap2-bin
 
 #. Install the GPG key.
 

--- a/source/_templates/installations/wazuh/deb/add_repository_wazuh_server.rst
+++ b/source/_templates/installations/wazuh/deb/add_repository_wazuh_server.rst
@@ -4,7 +4,7 @@
 
     .. code-block:: console
 
-      # apt install curl apt-transport-https lsb-release gnupg
+      # apt-get install curl apt-transport-https lsb-release gnupg
 
 #. Install the GPG key.
 

--- a/source/_templates/installations/wazuh/deb/install_wazuh_manager.rst
+++ b/source/_templates/installations/wazuh/deb/install_wazuh_manager.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # apt -y install wazuh-manager
+  # apt-get -y install wazuh-manager
 
 .. End of include file

--- a/source/deployment-options/deploying-with-puppet/setup-puppet/install-puppet-agent.rst
+++ b/source/deployment-options/deploying-with-puppet/setup-puppet/install-puppet-agent.rst
@@ -65,7 +65,7 @@ Install the appropriate Puppet apt repository, and then the “puppet-agent” p
 
     # wget https://apt.puppet.com/puppet7-release-focal.deb
     # dpkg -i puppet7-release-focal.deb
-    # apt update
+    # apt-get update
     # apt-get install -y puppet-agent
 
 

--- a/source/deployment-options/deploying-with-puppet/setup-puppet/install-puppet-master.rst
+++ b/source/deployment-options/deploying-with-puppet/setup-puppet/install-puppet-master.rst
@@ -63,7 +63,7 @@ Install the appropriate Puppet apt repository, and then the “puppetserver” p
 
     # wget https://apt.puppet.com/puppet7-release-focal.deb
     # dpkg -i puppet7-release-focal.deb
-    # apt update
+    # apt-get update
     # apt-get install -y puppetserver
 
 

--- a/source/deployment-options/splunk/splunk-minimal-distributed.rst
+++ b/source/deployment-options/splunk/splunk-minimal-distributed.rst
@@ -45,7 +45,7 @@ Before installing the Splunk indexer, some extra packages must be installed on t
       
       .. code-block:: console
       
-         # apt install curl apt-transport-https lsb-release gnupg
+         # apt-get install curl apt-transport-https lsb-release gnupg
    
 
 .. warning::

--- a/source/migration-guide/wazuh-indexer.rst
+++ b/source/migration-guide/wazuh-indexer.rst
@@ -100,7 +100,7 @@ Follow this guide to migrate from Open Distro for Elasticsearch 1.13 to the Wazu
 
           .. code-block:: console
 
-            # apt -y install wazuh-indexer
+            # apt-get -y install wazuh-indexer
 
 
 #. Create the ``/etc/wazuh-indexer/certs`` directory, copy your old certificates to the new location and change ownership and permissions. Note that the ``admin.pem`` and ``admin-key.pem`` certificates do not exist on every Elasticsearch node.

--- a/source/proof-of-concept-guide/detect-brute-force-attack.rst
+++ b/source/proof-of-concept-guide/detect-brute-force-attack.rst
@@ -33,7 +33,7 @@ Configure your environment as follows to test the PoC.
 
         .. code-block:: XML
 
-            # apt install -y hydra
+            # apt-get install -y hydra
 
 
 Steps to generate the alerts

--- a/source/proof-of-concept-guide/detect-malware-yara-integration.rst
+++ b/source/proof-of-concept-guide/detect-malware-yara-integration.rst
@@ -88,8 +88,8 @@ Configure your environment as follows to test the PoC.
 
     .. code-block:: console
 
-        # apt update
-        # apt install -y make gcc autoconf libtool libssl-dev pkg-config
+        # apt-get update
+        # apt-get install -y make gcc autoconf libtool libssl-dev pkg-config
         # curl -LO https://github.com/VirusTotal/yara/archive/v4.0.2.tar.gz
         # tar -xvzf v4.0.2.tar.gz -C /usr/local/bin/ && rm -f v4.0.2.tar.gz
         # cd /usr/local/bin/yara-4.0.2

--- a/source/proof-of-concept-guide/detect-malware-yara-integration.rst
+++ b/source/proof-of-concept-guide/detect-malware-yara-integration.rst
@@ -192,7 +192,7 @@ Configure your environment as follows to test the PoC.
         # chown root:wazuh /var/ossec/active-response/bin/yara.sh
         # chmod 750 /var/ossec/active-response/bin/yara.sh
 
-#. Run ``apt install -y jq`` if jq is missing. This allows the ``yara.sh`` script to process the JSON input.
+#. Run ``apt-get install -y jq`` if jq is missing. This allows the ``yara.sh`` script to process the JSON input.
 
 #. Change the file integrity monitoring settings in the ``/var/ossec/etc/ossec.conf`` file at the monitored Ubuntu 20 endpoint to monitor the ``/tmp/yara/malware`` directory in real time.
 

--- a/source/proof-of-concept-guide/detect-remove-malware-virustotal.rst
+++ b/source/proof-of-concept-guide/detect-remove-malware-virustotal.rst
@@ -109,7 +109,7 @@ Configure your environment as follows to test the PoC.
         # chmod 750 /var/ossec/active-response/bin/remove-threat.sh
         # chown root:wazuh /var/ossec/active-response/bin/remove-threat.sh
 
-#. Run ``apt install jq -y`` if jq is missing. This allows the ``remove-threat.sh`` script to process the JSON input.
+#. Run ``apt-get install jq -y`` if jq is missing. This allows the ``remove-threat.sh`` script to process the JSON input.
 
 #. Append the following blocks to ``/var/ossec/etc/ossec.conf`` at the Wazuh manager. This is to enable an active response and call ``remove-threat.sh`` when VirusTotal query results for threats are positive matches.
 

--- a/source/proof-of-concept-guide/detect-unauthorized-processes-netcat.rst
+++ b/source/proof-of-concept-guide/detect-unauthorized-processes-netcat.rst
@@ -39,7 +39,7 @@ Configure your environment as follows to test the PoC.
 
     .. code-block:: console
 
-        # apt install ncat nmap -y
+        # apt-get install ncat nmap -y
 
 #. Add following rules to ``/var/ossec/etc/rules/local_rules.xml`` at the Wazuh manager.
 

--- a/source/proof-of-concept-guide/integrate-osquery.rst
+++ b/source/proof-of-concept-guide/integrate-osquery.rst
@@ -21,7 +21,7 @@ Configure your environment as follows to test the PoC.
     .. code-block:: console
 
         # wget https://pkg.osquery.io/deb/osquery_4.5.1_1.linux.amd64.deb
-        # apt install ./osquery_4.5.1_1.linux.amd64.deb -y
+        # apt-get install ./osquery_4.5.1_1.linux.amd64.deb -y
 
 #. Add this content block to the Osquery configuration file ``/etc/osquery/osquery.conf``
 

--- a/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-open-distro.rst
+++ b/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-open-distro.rst
@@ -210,13 +210,13 @@ The IP address ``127.0.0.1`` is used in the commands below. If Elasticsearch is 
 
           .. code-block:: console
 
-            # apt install elasticsearch-oss=|ELASTICSEARCH_LATEST|
+            # apt-get install elasticsearch-oss=|ELASTICSEARCH_LATEST|
 
           Upgrade Open Distro for Elasticsearch:
 
           .. code-block:: console
 
-            # apt install opendistroforelasticsearch=|OPEN_DISTRO_LATEST|-1
+            # apt-get install opendistroforelasticsearch=|OPEN_DISTRO_LATEST|-1
 
 
         .. group-tab:: ZYpp

--- a/source/user-manual/capabilities/auditing-whodata/who-linux.rst
+++ b/source/user-manual/capabilities/auditing-whodata/who-linux.rst
@@ -29,7 +29,7 @@ For Debian based systems, use the following:
 
 .. code-block:: console
 
-    # apt install auditd
+    # apt-get install auditd
 
 Next step is to configure syscheck to enable who-data monitoring in the selected folder in our ``ossec.conf`` file:
 

--- a/source/user-manual/uninstall/central-components.rst
+++ b/source/user-manual/uninstall/central-components.rst
@@ -42,7 +42,7 @@ Uninstall the Wazuh dashboard
 
         .. code:: console
 
-          # apt remove --purge wazuh-dashboard -y
+          # apt-get remove --purge wazuh-dashboard -y
 
 .. _uninstall_server:
 
@@ -64,7 +64,7 @@ Uninstall the Wazuh server
 
         .. code-block:: console
         
-          # apt remove --purge wazuh-manager -y
+          # apt-get remove --purge wazuh-manager -y
 
 #. Disable the Wazuh manager service.
 
@@ -87,7 +87,7 @@ Uninstall the Wazuh server
 
         .. code:: console
       
-          # apt remove --purge filebeat -y
+          # apt-get remove --purge filebeat -y
 
 
 .. _uninstall_indexer:
@@ -112,4 +112,4 @@ Uninstall the Wazuh indexer
 
         .. code:: console
 
-          # apt remove --purge wazuh-indexer -y
+          # apt-get remove --purge wazuh-indexer -y


### PR DESCRIPTION
## Description
This PR aims to change command `apt` with `apt-get` to support older systems. 
This PR closes the issues https://github.com/wazuh/wazuh-documentation/issues/5381 and https://github.com/wazuh/wazuh-documentation/issues/5454

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
