### PR TITLE
Fix json decoder example

### DIFF
--- a/source/user-manual/ruleset/json-decoder.rst
+++ b/source/user-manual/ruleset/json-decoder.rst
@@ -223,7 +223,7 @@ We can set several children decoders from a parent specifying a plugin decoder a
     <decoder name="json_child">
         <parent>json_parent</parent>
         <regex>@(\S+)"</regex>
-        <order>email.domain</order>
+        <order>email_domain</order>
     </decoder>
 
 The output of the *wazuh-logtest* tool shows the decoded fields by the JSON decoder, as well as the matched field from the regex expression:
@@ -244,5 +244,6 @@ The output of the *wazuh-logtest* tool shows the decoded fields by the JSON deco
             name: 'json_parent'
             parent: 'json_parent'
             email: 'curry@gmail.com'
+            email_domain: 'gmail.com'
             name: 'Stephen'
             surname: 'Curry'


### PR DESCRIPTION
## Description

This PR changes the docoder to avoid the bug describe in https://github.com/wazuh/wazuh/issues/8430

changes this:
```xml
<decoder name="json_child">
    <parent>json_parent</parent>
    <regex>@(\S+)"</regex>
    <order>email.domain</order>
</decoder>
```
for this:
```xml
<decoder name="json_child">
    <parent>json_parent</parent>
    <regex>@(\S+)"</regex>
    <order>email_domain</order>
</decoder>
```


## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).


## Note to the reviewer

This PR includes changes to the `redirect.js` script that need to be included in all production branches.
