### PR TITLE
Add Release notes 3.13.5 to 4.1

### DIFF
--- a/source/_static/js/redirects.js
+++ b/source/_static/js/redirects.js
@@ -2170,6 +2170,8 @@ redirections.push(
 );
 
 newUrls['3.13'] = [
+  '/release-notes/release-3-13-5.html', 
+  '/release-notes/release-3-13-4.html',  
   '/release-notes/release_3_13_3.html',
   '/release-notes/release_3_13_2.html',
   '/getting-started/use_cases/index.html',

--- a/source/release-notes/index.rst
+++ b/source/release-notes/index.rst
@@ -25,6 +25,7 @@ This section summarizes the most important features of each Wazuh release.
         release_4_0_2
         release_4_0_1
         release_4_0_0
+        release-3-13-5
         release-3-13-4
         release_3_13_3
         release_3_13_2

--- a/source/release-notes/release-3-13-5.rst
+++ b/source/release-notes/release-3-13-5.rst
@@ -5,8 +5,8 @@
 
 .. _release_3_13_5:
 
-3.13.5 Release notes - 20 July 2022
-===================================
+3.13.5 Release notes
+====================
 
 This section lists the changes in version 3.13.5. More details about these changes are provided in each component changelog:
 
@@ -14,18 +14,15 @@ This section lists the changes in version 3.13.5. More details about these chang
 - `wazuh/wazuh-kibana-app <https://github.com/wazuh/wazuh-kibana-app/blob/v3.13.5-7.9.2/CHANGELOG.md>`_
 - `wazuh/wazuh-splunk <https://github.com/wazuh/wazuh-splunk/blob/v3.13.5-8.0.4/CHANGELOG.md>`_
 
-
 Wazuh core
 ----------
 
 - Support for Wazuh v3.13.5.
 
-
 Wazuh Kibana app
 ----------------
 
-- Support for Wazuh v3.13.5.
-
+- `#4336 <https://github.com/wazuh/wazuh-kibana-app/pull/4336>`_  Sanitize the report's inputs and usernames.
 
 Wazuh Splunk
 ------------

--- a/source/release-notes/release-3-13-5.rst
+++ b/source/release-notes/release-3-13-5.rst
@@ -1,0 +1,33 @@
+.. Copyright (C) 2022 Wazuh, Inc.
+
+.. meta::
+  :description: Wazuh 3.13.5 has been released. Check out our release notes to discover the changes and additions of this release.
+
+.. _release_3_13_5:
+
+3.13.5 Release notes - 20 July 2022
+===================================
+
+This section lists the changes in version 3.13.5. More details about these changes are provided in each component changelog:
+
+- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/v3.13.5/CHANGELOG.md>`_
+- `wazuh/wazuh-kibana-app <https://github.com/wazuh/wazuh-kibana-app/blob/v3.13.5-7.9.2/CHANGELOG.md>`_
+- `wazuh/wazuh-splunk <https://github.com/wazuh/wazuh-splunk/blob/v3.13.5-8.0.4/CHANGELOG.md>`_
+
+
+Wazuh core
+----------
+
+- Support for Wazuh v3.13.5.
+
+
+Wazuh Kibana app
+----------------
+
+- Support for Wazuh v3.13.5.
+
+
+Wazuh Splunk
+------------
+
+- Support for Wazuh v3.13.5.

--- a/source/release-notes/release-3-13-5.rst
+++ b/source/release-notes/release-3-13-5.rst
@@ -10,7 +10,6 @@
 
 This section lists the changes in version 3.13.5. More details about these changes are provided in each component changelog:
 
-- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/v3.13.5/CHANGELOG.md>`_
 - `wazuh/wazuh-kibana-app <https://github.com/wazuh/wazuh-kibana-app/blob/v3.13.5-7.9.2/CHANGELOG.md>`_
 - `wazuh/wazuh-splunk <https://github.com/wazuh/wazuh-splunk/blob/v3.13.5-8.0.4/CHANGELOG.md>`_
 

--- a/source/release-notes/release-3-13-5.rst
+++ b/source/release-notes/release-3-13-5.rst
@@ -14,11 +14,6 @@ This section lists the changes in version 3.13.5. More details about these chang
 - `wazuh/wazuh-kibana-app <https://github.com/wazuh/wazuh-kibana-app/blob/v3.13.5-7.9.2/CHANGELOG.md>`_
 - `wazuh/wazuh-splunk <https://github.com/wazuh/wazuh-splunk/blob/v3.13.5-8.0.4/CHANGELOG.md>`_
 
-Wazuh core
-----------
-
-- Support for Wazuh v3.13.5.
-
 Wazuh Kibana app
 ----------------
 


### PR DESCRIPTION
## Description

This PR aims to add Release notes 3.13.5 to 4.1.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

## Note to the reviewer

This PR includes changes to the `redirect.js` script that need to be included in all production branches.
