### PR TITLE
Update "Keep watch for malicious command execution" - Learning Wazuh 

### DIFF
--- a/source/learning-wazuh/audit-commands.rst
+++ b/source/learning-wazuh/audit-commands.rst
@@ -139,12 +139,12 @@ Look over the relevant Wazuh rule
 
     .. code-block:: xml
 
-      <rule id="80789" level="3">
-        <if_sid>80700</if_sid>
-        <list field="audit.key" lookup="match_key_value" check_value="execute">etc/lists/audit-keys</list>
-        <description>Audit: Watch - Execute access: $(audit.file.name).</description>
-        <group>audit_watch_execute,gdpr_IV_30.1.g,</group>
-      </rule>  
+       <rule id="80792" level="3">
+         <if_sid>80700</if_sid>
+         <list field="audit.key" lookup="match_key_value" check_value="command">etc/lists/audit-keys</list>
+         <description>Audit: Command: $(audit.exe).</description>
+         <group>audit_command,gdpr_IV_30.1.g,</group>
+       </rule>
           
     Parent rule 80700 catches all auditd events, while this rule focuses on auditd command events.  Notice how the ``<list>`` line in this rule takes the decoded ``audit.key`` value which all our auditd rules set to "audit-wazuh-c" presently, and looks this up in a CDB list called ``audit-keys`` to see if the ``audit.key`` value is listed with a value of "command".
 


### PR DESCRIPTION
## Description

This PR fixes an error in which rule 80789 was shown instead of rule [80792](https://github.com/wazuh/wazuh/blob/4.3/ruleset/rules/0365-auditd_rules.xml#L331). This PR closes #5496.  

![image](https://user-images.githubusercontent.com/61882981/184096329-8fd7b0e5-d573-41ab-9559-5bdfd7871f08.png)


## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

