### PR TITLE
Add information about new Cluster sync status feature

### DIFF
--- a/source/development/wazuh-cluster.rst
+++ b/source/development/wazuh-cluster.rst
@@ -313,6 +313,8 @@ This communication protocol is used by the API to forward requests to other clus
 +-------------------+-------------+-----------------------+-------------------------------------------------------------------------------------------------+
 | ``get_health``    | Both        | Arguments<Dict>       | Request sent from ``cluster_control -i``.                                                       |
 +-------------------+-------------+-----------------------+-------------------------------------------------------------------------------------------------+
+| ``get_hash``      | Both        | None                  | Receive a request to obtain custom ruleset files and their hashes.                              |
++-------------------+-------------+-----------------------+-------------------------------------------------------------------------------------------------+
 | ``send_file``     | Both        | Filepath<str>,        | Request used to test send file protocol.                                                        |
 |                   |             | Node name<str>        | Node name parameter is ignored in worker nodes (it's always sent to the master node).           |
 +-------------------+-------------+-----------------------+-------------------------------------------------------------------------------------------------+

--- a/source/user-manual/api/rbac/reference.rst
+++ b/source/user-manual/api/rbac/reference.rst
@@ -371,6 +371,7 @@ cluster:read
 - :api-ref:`GET /cluster/{node_id}/status <operation/api.controllers.cluster_controller.get_status_node>` (`node:id`_)
 - :api-ref:`PUT /agents/node/{node_id}/restart <operation/api.controllers.agent_controller.restart_agents_by_node>` (`node:id`_)
 - :api-ref:`PUT /cluster/restart <operation/api.controllers.cluster_controller.put_restart>` (`node:id`_)
+- :api-ref:`GET /cluster/ruleset/synchronization <operation/api.controllers.cluster_controller.get_nodes_ruleset_sync_status>` (`node:id`_)
 
 cluster:restart
 ~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
| Related issue |
|--|
| Closes #5513 |

## Description

This PR adds information about the new Cluster sync status feature that has been added at https://github.com/wazuh/wazuh/issues/14533.


## Checks
- [ ] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
