### PR TITLE
suricata repo outdated

### DIFF
--- a/source/learning-wazuh/suricata.rst
+++ b/source/learning-wazuh/suricata.rst
@@ -25,7 +25,8 @@ Set up Suricata on your Linux agent
    
        # cd /root
        # yum -y install epel-release wget jq
-       # curl -O https://copr.fedorainfracloud.org/coprs/jasonish/suricata-6.0/repo/epel-7/jasonish-suricata-6.0-epel-7.repo
+       # yum-config-manager --add-repo https://copr.fedorainfracloud.org/coprs/g/oisf/suricata-latest/repo/epel-7/group_oisf-suricata-latest-epel-7.repo
+       # yum-config-manager --enable /etc/yum.repos.d/group_oisf-suricata-latest-epel-7.repo
        # yum -y install suricata
        # wget https://rules.emergingthreats.net/open/suricata-6.0.3/emerging.rules.tar.gz
        # tar zxvf emerging.rules.tar.gz


### PR DESCRIPTION


<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice

We love our community contributions. First, we work with the numbered branches. The `master` branch is only updated when a new Wazuh release is done. We recommend making PRs from the actual branch. For instance, if Wazuh 3.11.4 is the latest release, the branch to be used is 3.11.

Anyway, if you contribute from the master branch, we will `cherry-pick` your commits to the numerated branch for you. 

Thanks!
-->

## Description

I have tested this guide from a Oracle Linux 7 system. I was able to install Suricata but on a outdated version (4.1.10) that has a known CVE vulnerability (CVE-2021-37592). 
The Suricata repo provided on this guide doesn't exist anymore. Thus, I propose to change to the latest repo (https://copr.fedorainfracloud.org/coprs/g/oisf/suricata-6.0/repo/epel-7/group_oisf-suricata-6.0-epel-7.repo).

Also, some references from the Suricata documentation might be useful for additional configurations like changing the monitoring interface (by default, Suricata monitors eth0).
https://suricata.readthedocs.io/en/suricata-6.0.0/configuration/suricata-yaml.html
<!--
Add a clear description of how the problem has been solved. 
If your PR closes an issue, please use the "closes" keyword indicating the issue. 
-->

## Checks
- [ ] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

## Note to the reviewer

This PR includes changes to the `redirect.js` script that need to be included in all production branches.
