### PR TITLE
Change prompt symbol and 'this is to' sentences

### DIFF
--- a/source/_templates/installations/indexer/common/deploy_certificates.rst
+++ b/source/_templates/installations/indexer/common/deploy_certificates.rst
@@ -1,7 +1,7 @@
 .. Copyright (C) 2015, Wazuh, Inc.
 
 
-#. Run the following commands replacing ``<indexer-node-name>`` with the name of the Wazuh indexer node you are configuring as defined in ``config.yml``. For example ``node-1``. This is to deploy  the SSL certificates to encrypt communications between the Wazuh central components.
+#. Run the following commands replacing ``<indexer-node-name>`` with the name of the Wazuh indexer node you are configuring as defined in ``config.yml``. For example ``node-1``. This deploys the SSL certificates to encrypt communications between the Wazuh central components.
 
    .. code-block:: console
 

--- a/source/_templates/installations/indexer/common/generate_certificates.rst
+++ b/source/_templates/installations/indexer/common/generate_certificates.rst
@@ -1,6 +1,6 @@
 .. Copyright (C) 2015, Wazuh, Inc.
 
-#. Download the ``wazuh-certs-tool.sh`` script and the ``config.yml`` configuration file. This is to create the certificates that will encrypt communications between the Wazuh central components.
+#. Download the ``wazuh-certs-tool.sh`` script and the ``config.yml`` configuration file. This creates the certificates that encrypt communications between the Wazuh central components.
 
    .. code-block:: console
 

--- a/source/deployment-options/offline-installation.rst
+++ b/source/deployment-options/offline-installation.rst
@@ -98,7 +98,7 @@ Installing the Wazuh indexer
         
                 # dpkg -i ./wazuh-offline/wazuh-packages/wazuh-indexer*.deb
 
-#.  Run the following commands replacing ``<indexer-node-name>`` with the name of the Wazuh indexer node you are configuring as defined in ``config.yml``. For example, ``node-1``. This is to deploy the SSL certificates to encrypt communications between the Wazuh central components.
+#.  Run the following commands replacing ``<indexer-node-name>`` with the name of the Wazuh indexer node you are configuring as defined in ``config.yml``. For example, ``node-1``. This deploys the SSL certificates to encrypt communications between the Wazuh central components.
 
     .. code-block:: console
 

--- a/source/proof-of-concept-guide/detect-malware-yara-integration.rst
+++ b/source/proof-of-concept-guide/detect-malware-yara-integration.rst
@@ -16,7 +16,7 @@ Configuration
 
 Configure your environment as follows to test the PoC.
 
-#. Add the following rules to the ``/var/ossec/etc/rules/local_rules.xml`` file at the Wazuh manager. This is to alert about files added or modified in ``/tmp/yara/malware/`` directory at the Ubuntu 20 endpoint and to alert about malware being found there.
+#. Add the following rules to the ``/var/ossec/etc/rules/local_rules.xml`` file at the Wazuh manager. This alerts about files added or modified in ``/tmp/yara/malware/`` directory at the Ubuntu 20 endpoint and to alert about malware being found there.
 
     .. code-block:: XML
 
@@ -46,7 +46,7 @@ Configure your environment as follows to test the PoC.
         </group>
 
 
-#. Add the following decoders to ``/var/ossec/etc/decoders/local_decoder.xml`` at the Wazuh manager. This is to extract the information from Yara scan results.
+#. Add the following decoders to ``/var/ossec/etc/decoders/local_decoder.xml`` at the Wazuh manager. This extracts the information from Yara scan results.
 
     .. code-block:: XML
 

--- a/source/proof-of-concept-guide/detect-malware-yara-integration.rst
+++ b/source/proof-of-concept-guide/detect-malware-yara-integration.rst
@@ -16,7 +16,7 @@ Configuration
 
 Configure your environment as follows to test the PoC.
 
-#. Add the following rules to the ``/var/ossec/etc/rules/local_rules.xml`` file at the Wazuh manager. This alerts about files added or modified in ``/tmp/yara/malware/`` directory at the Ubuntu 20 endpoint and to alert about malware being found there.
+#. Add the following rules to the ``/var/ossec/etc/rules/local_rules.xml`` file at the Wazuh manager. These rules alert about files added or modified in ``/tmp/yara/malware/`` directory at the Ubuntu 20 endpoint and about malware being found there.
 
     .. code-block:: XML
 
@@ -46,7 +46,7 @@ Configure your environment as follows to test the PoC.
         </group>
 
 
-#. Add the following decoders to ``/var/ossec/etc/decoders/local_decoder.xml`` at the Wazuh manager. This extracts the information from Yara scan results.
+#. Add the following decoders to ``/var/ossec/etc/decoders/local_decoder.xml`` at the Wazuh manager. This extracts the information from the Yara scan results.
 
     .. code-block:: XML
 

--- a/source/proof-of-concept-guide/detect-remove-malware-virustotal.rst
+++ b/source/proof-of-concept-guide/detect-remove-malware-virustotal.rst
@@ -111,7 +111,7 @@ Configure your environment as follows to test the PoC.
 
 #. Run ``apt install jq -y`` if jq is missing. This allows the ``remove-threat.sh`` script to process the JSON input.
 
-#. Append the following blocks to ``/var/ossec/etc/ossec.conf`` at the Wazuh manager. This is to enable an active response and call ``remove-threat.sh`` when VirusTotal query results for threats are positive matches.
+#. Append the following blocks to ``/var/ossec/etc/ossec.conf`` at the Wazuh manager. This enables an active response and call ``remove-threat.sh`` when VirusTotal query results for threats are positive matches.
 
     .. code-block:: XML
 

--- a/source/proof-of-concept-guide/detect-unauthorized-processes-netcat.rst
+++ b/source/proof-of-concept-guide/detect-unauthorized-processes-netcat.rst
@@ -16,7 +16,7 @@ Configuration
 
 Configure your environment as follows to test the PoC.
 
-#. Add the following configuration block under the ``<localfile>`` section of the ``/var/ossec/etc/ossec.conf`` file at the monitored Ubuntu 20 endpoint. This is to periodically get a list of running processes.
+#. Add the following configuration block under the ``<localfile>`` section of the ``/var/ossec/etc/ossec.conf`` file at the monitored Ubuntu 20 endpoint. This periodically gets a list of running processes.
 
     .. code-block:: XML
 

--- a/source/quickstart.rst
+++ b/source/quickstart.rst
@@ -91,7 +91,7 @@ You can find the passwords for all the Wazuh indexer and Wazuh API users in the 
 
    .. code-block:: console
    
-      # tar -O -xvf wazuh-install-files.tar wazuh-install-files/wazuh-passwords.txt
+      $ tar -O -xvf wazuh-install-files.tar wazuh-install-files/wazuh-passwords.txt
 
 If you want to uninstall the Wazuh central components, run the Wazuh installation assistant using the option ``-u`` or ``–-uninstall``.
 

--- a/source/quickstart.rst
+++ b/source/quickstart.rst
@@ -91,7 +91,7 @@ You can find the passwords for all the Wazuh indexer and Wazuh API users in the 
 
    .. code-block:: console
    
-      $ tar -O -xvf wazuh-install-files.tar wazuh-install-files/wazuh-passwords.txt
+      $ sudo tar -O -xvf wazuh-install-files.tar wazuh-install-files/wazuh-passwords.txt
 
 If you want to uninstall the Wazuh central components, run the Wazuh installation assistant using the option ``-u`` or ``–-uninstall``.
 


### PR DESCRIPTION
## Description

This PR makes the following minor changes:

- Changes the prompt symbol on the show passwords command.
- Changes some sentences.

## Checks
- [X] It compiles without warnings.
- [X] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [X] Used uppercase only on nouns. 
- [X] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

