### PR TITLE
Add a note about the ODFE performance analyzer plugin and the migration to the Wazuh indexer 

### DIFF
--- a/source/migration-guide/wazuh-indexer.rst
+++ b/source/migration-guide/wazuh-indexer.rst
@@ -128,6 +128,10 @@ Follow this guide to migrate from Open Distro for Elasticsearch 1.13 to the Wazu
       # chown wazuh-indexer:wazuh-indexer -R /var/log/wazuh-indexer/
       # chown wazuh-indexer:wazuh-indexer -R /var/lib/wazuh-indexer/
 
+   .. note::
+
+      If you have the Open Distro for Elasticsearch performance analyzer plugin installed, change the ownership of the ``/dev/shm/performanceanalyzer/`` directory by running the following command: ``chown wazuh-indexer:wazuh-indexer -R /dev/shm/performanceanalyzer/``.
+
 #. Port your settings from ``/etc/elasticsearch/elasticsearch.yml`` to ``/etc/wazuh-indexer/opensearch.yml``. Most settings use the same names.
 
    Take into account the following considerations: 


### PR DESCRIPTION
## Description

This PR adds a note stating that, if the user has the performance analyzer plugin installed, it's necessary to change the ownership of the `/dev/shm/performanceanalyzer/` directory to `wazuh-indexer` during the migration process. This PR closes #5375.

![image](https://user-images.githubusercontent.com/61882981/186893689-0b96606b-ed3d-4c0b-a335-039a8b06b3cd.png)

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

## Note to the reviewer

This PR includes changes to the `redirect.js` script that need to be included in all production branches.
