### PR TITLE
[4.3] Updated requirements.txt with the minimum required version of Pygments

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ sphinx_tabs==1.2.1
 docutils==0.16
 jsmin==3.0.1
 Jinja2<3.1
+Pygments>2.7.2


### PR DESCRIPTION

## Description

This PR updates `requirements.txt` with the minimum version of Pygments that allows for partial JSON in code blocks (versions previous to 2.7.3 throw a warning during compilation and omit these code blocks in the final HTML file).

## Checks
- [x] It compiles without warnings.
- [ ] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [ ] Used uppercase only on nouns. 
- [ ] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
