### PR TITLE
Update authentication method deprecation message

### DIFF
--- a/source/amazon/services/prerequisites/credentials.rst
+++ b/source/amazon/services/prerequisites/credentials.rst
@@ -183,8 +183,7 @@ If you're using a single AWS account for all your buckets this could be the most
 Insert the credentials into the configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. warning::
-   This authentication method is not recommended for production environments and will be deprecated in future releases.
+.. deprecated:: 4.4.0
 
 Another available option to set up credentials is writing them right into the Wazuh configuration file (``/var/ossec/etc/ossec.conf``), inside of the ``<bucket>`` block on the module configuration.
 

--- a/source/azure/activity-services/prerequisites/credentials.rst
+++ b/source/azure/activity-services/prerequisites/credentials.rst
@@ -117,8 +117,7 @@ Check the :doc:`azure-logs wodle </user-manual/reference/ossec-conf/wodle-azure-
 Inserting the credentials into the configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. warning::
-   This authentication method is not recommended for production environments and will be deprecated in future releases.
+.. deprecated:: 4.4.0
 
 Another authentication option is to set up credentials by storing them directly into the Wazuh configuration file ``/var/ossec/etc/ossec.conf``, inside of the ``<graph>``, ``<log_analytics>`` and ``<storage>`` blocks on the module configuration.
 


### PR DESCRIPTION


## Description

This PR updates the AWS and Azure credentials pages to indicate in which release was the plain authentication method deprecated.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->