### PR TITLE
Update deprecated apt-key add command for Wazuh key

### DIFF
--- a/source/_templates/installations/basic/elastic/deb/add_repository.rst
+++ b/source/_templates/installations/basic/elastic/deb/add_repository.rst
@@ -4,13 +4,13 @@
 
     .. code-block:: console
 
-      # curl -s https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add -
+      # curl -s https://artifacts.elastic.co/GPG-KEY-elasticsearch | gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/elasticsearch.gpg --import && chmod 644 /usr/share/keyrings/elasticsearch.gpg
 
 #. Add the repository:
 
     .. code-block:: console
 
-      # echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee /etc/apt/sources.list.d/elastic-7.x.list
+      # echo "deb [signed-by=/usr/share/keyrings/elasticsearch.gpg] https://artifacts.elastic.co/packages/7.x/apt stable main" | tee /etc/apt/sources.list.d/elastic-7.x.list
 
 #. Update the package information:
 

--- a/source/_templates/installations/basic/wazuh/deb/add_repository.rst
+++ b/source/_templates/installations/basic/wazuh/deb/add_repository.rst
@@ -11,13 +11,13 @@
 
     .. code-block:: console
 
-      # curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | apt-key add -
+      # curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/wazuh.gpg --import && chmod 644 /usr/share/keyrings/wazuh.gpg
 
 #. Add the repository:
 
     .. code-block:: console
 
-      # echo "deb https://packages.wazuh.com/4.x/apt/ stable main" | tee -a /etc/apt/sources.list.d/wazuh.list
+      # echo "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages.wazuh.com/4.x/apt/ stable main" | tee -a /etc/apt/sources.list.d/wazuh.list
 
 #. Update the package information:
 

--- a/source/_templates/installations/basic/wazuh/deb/add_repository_aio.rst
+++ b/source/_templates/installations/basic/wazuh/deb/add_repository_aio.rst
@@ -4,13 +4,13 @@
 
     .. code-block:: console
 
-      # curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | apt-key add -
+      # curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/wazuh.gpg --import && chmod 644 /usr/share/keyrings/wazuh.gpg
 
 #. Add the repository:
 
     .. code-block:: console
 
-      # echo "deb https://packages.wazuh.com/4.x/apt/ stable main" | tee -a /etc/apt/sources.list.d/wazuh.list
+      # echo "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages.wazuh.com/4.x/apt/ stable main" | tee -a /etc/apt/sources.list.d/wazuh.list
 
 #. Update the package information:
 

--- a/source/_templates/installations/common/deb/add-repository.rst
+++ b/source/_templates/installations/common/deb/add-repository.rst
@@ -10,13 +10,13 @@
 
     .. code-block:: console
 
-      # curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | apt-key add -
+      # curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/wazuh.gpg --import && chmod 644 /usr/share/keyrings/wazuh.gpg
 
 #. Add the repository.
 
     .. code-block:: console
 
-       # echo "deb https://packages.wazuh.com/4.x/apt/ stable main" | tee -a /etc/apt/sources.list.d/wazuh.list
+       # echo "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages.wazuh.com/4.x/apt/ stable main" | tee -a /etc/apt/sources.list.d/wazuh.list
 
 #. Update the packages information.
 

--- a/source/_templates/installations/dashboard/apt/add_repository.rst
+++ b/source/_templates/installations/dashboard/apt/add_repository.rst
@@ -4,13 +4,13 @@
 
     .. code-block:: console
 
-      # curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | apt-key add -
+      # curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/wazuh.gpg --import && chmod 644 /usr/share/keyrings/wazuh.gpg
 
 #. Add the repository.
 
     .. code-block:: console
 
-      # echo "deb https://packages.wazuh.com/4.x/apt/ stable main" | tee -a /etc/apt/sources.list.d/wazuh.list
+      # echo "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages.wazuh.com/4.x/apt/ stable main" | tee -a /etc/apt/sources.list.d/wazuh.list
 
 #. Update the package information.
 

--- a/source/_templates/installations/elastic/common/signing_key_filebeat.rst
+++ b/source/_templates/installations/elastic/common/signing_key_filebeat.rst
@@ -7,8 +7,8 @@
 
     .. code-block:: console
 
-        # wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add -
-        # echo "deb https://artifacts.elastic.co/packages/oss-7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list
+        # wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/elasticsearch.gpg --import && chmod 644 /usr/share/keyrings/elasticsearch.gpg
+        # echo "deb [signed-by=/usr/share/keyrings/elasticsearch.gpg] https://artifacts.elastic.co/packages/oss-7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list
         # apt-get update 
 
 

--- a/source/_templates/installations/wazuh/common/add_repository.rst
+++ b/source/_templates/installations/wazuh/common/add_repository.rst
@@ -30,13 +30,13 @@
 
          .. code-block:: console
 
-            # curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | apt-key add -
+            # curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/wazuh.gpg --import && chmod 644 /usr/share/keyrings/wazuh.gpg
 
       #. Add the repository:
 
          .. code-block:: console
 
-            # echo "deb https://packages.wazuh.com/4.x/apt/ stable main" | tee -a /etc/apt/sources.list.d/wazuh.list
+            # echo "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages.wazuh.com/4.x/apt/ stable main" | tee -a /etc/apt/sources.list.d/wazuh.list
 
       #. Update the package information:
 

--- a/source/_templates/installations/wazuh/deb/add_repository.rst
+++ b/source/_templates/installations/wazuh/deb/add_repository.rst
@@ -4,18 +4,29 @@
 
     .. code-block:: console
 
-      # curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | apt-key add -
+      # curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/wazuh.gpg --import && chmod 644 /usr/share/keyrings/wazuh.gpg
 
 #. Add the repository:
 
     .. code-block:: console
 
-      # echo "deb https://packages.wazuh.com/4.x/apt/ stable main" | tee -a /etc/apt/sources.list.d/wazuh.list
+      # echo "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages.wazuh.com/4.x/apt/ stable main" | tee -a /etc/apt/sources.list.d/wazuh.list
 
 #. Update the package information:
 
     .. code-block:: console
 
+      # apt-get update
+
+.. note::
+
+   For Debian 7, 8, and Ubuntu 14 systems run the following commands instead.
+
+   .. code-block:: console
+
+      # apt-get install gnupg apt-transport-https
+      # curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | apt-key add -
+      # echo "deb https://packages.wazuh.com/4.x/apt/ stable main" | tee -a /etc/apt/sources.list.d/wazuh.list
       # apt-get update
 
 .. End of include file

--- a/source/_templates/installations/wazuh/deb/add_repository.rst
+++ b/source/_templates/installations/wazuh/deb/add_repository.rst
@@ -20,13 +20,12 @@
 
 .. note::
 
-   For Debian 7, 8, and Ubuntu 14 systems run the following commands instead.
+   For Debian 7, 8, and Ubuntu 14 systems import the GCP key and add the Wazuh repository (steps 1 and 2) using the following commands.
 
    .. code-block:: console
 
       # apt-get install gnupg apt-transport-https
       # curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | apt-key add -
       # echo "deb https://packages.wazuh.com/4.x/apt/ stable main" | tee -a /etc/apt/sources.list.d/wazuh.list
-      # apt-get update
 
 .. End of include file

--- a/source/_templates/installations/wazuh/deb/add_repository_aio.rst
+++ b/source/_templates/installations/wazuh/deb/add_repository_aio.rst
@@ -10,13 +10,13 @@
 
     .. code-block:: console
 
-      # curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | apt-key add -
+      # curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/wazuh.gpg --import && chmod 644 /usr/share/keyrings/wazuh.gpg
 
 #. Add the repository:
 
     .. code-block:: console
 
-      # echo "deb https://packages.wazuh.com/4.x/apt/ stable main" | tee -a /etc/apt/sources.list.d/wazuh.list
+      # echo "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages.wazuh.com/4.x/apt/ stable main" | tee -a /etc/apt/sources.list.d/wazuh.list
 
 #. Update the package information:
 

--- a/source/_templates/installations/wazuh/deb/add_repository_elastic_cluster.rst
+++ b/source/_templates/installations/wazuh/deb/add_repository_elastic_cluster.rst
@@ -10,13 +10,13 @@
 
     .. code-block:: console
 
-      # curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | apt-key add -
+      # curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/wazuh.gpg --import && chmod 644 /usr/share/keyrings/wazuh.gpg
 
 #. Add the repository.
 
     .. code-block:: console
 
-      # echo "deb https://packages.wazuh.com/4.x/apt/ stable main" | tee -a /etc/apt/sources.list.d/wazuh.list
+      # echo "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages.wazuh.com/4.x/apt/ stable main" | tee -a /etc/apt/sources.list.d/wazuh.list
 
 #. Update the package information.
 

--- a/source/_templates/installations/wazuh/deb/add_repository_kibana.rst
+++ b/source/_templates/installations/wazuh/deb/add_repository_kibana.rst
@@ -10,13 +10,13 @@
 
     .. code-block:: console
 
-      # curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | apt-key add -
+      # curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/wazuh.gpg --import && chmod 644 /usr/share/keyrings/wazuh.gpg
 
 #. Add the repository.
 
     .. code-block:: console
 
-      # echo "deb https://packages.wazuh.com/4.x/apt/ stable main" | tee -a /etc/apt/sources.list.d/wazuh.list
+      # echo "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages.wazuh.com/4.x/apt/ stable main" | tee -a /etc/apt/sources.list.d/wazuh.list
 
 #. Update the package information.
 

--- a/source/_templates/installations/wazuh/deb/add_repository_wazuh_server.rst
+++ b/source/_templates/installations/wazuh/deb/add_repository_wazuh_server.rst
@@ -10,13 +10,13 @@
 
     .. code-block:: console
 
-      # curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | apt-key add -
+      # curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/wazuh.gpg --import && chmod 644 /usr/share/keyrings/wazuh.gpg
 
 #. Add the repository.
 
     .. code-block:: console
 
-      # echo "deb https://packages.wazuh.com/4.x/apt/ stable main" | tee -a /etc/apt/sources.list.d/wazuh.list
+      # echo "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages.wazuh.com/4.x/apt/ stable main" | tee -a /etc/apt/sources.list.d/wazuh.list
 
 #. Update the package information.
 

--- a/source/deployment-options/offline-installation.rst
+++ b/source/deployment-options/offline-installation.rst
@@ -203,7 +203,7 @@ Installing the Wazuh manager
 
             .. code-block:: console
         
-                # apt-key add ./wazuh-offline/wazuh-files/GPG-KEY-WAZUH
+                # gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/wazuh.gpg --import ./wazuh-offline/wazuh-files/GPG-KEY-WAZUH && chmod 644 /usr/share/keyrings/wazuh.gpg
                 # dpkg -i ./wazuh-offline/wazuh-packages/wazuh-manager*.deb
 
 #.  Enable and start the Wazuh manager service.

--- a/source/upgrade-guide/legacy/upgrading-elastic-stack/from-6.8-to-7.x.rst
+++ b/source/upgrade-guide/legacy/upgrading-elastic-stack/from-6.8-to-7.x.rst
@@ -44,8 +44,8 @@ Preparing the Elastic Stack
 
         .. code-block:: console
 
-          # curl -s https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add -
-          # echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee /etc/apt/sources.list.d/elastic-7.x.list
+          # curl -s https://artifacts.elastic.co/GPG-KEY-elasticsearch | gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/elasticsearch.gpg --import && chmod 644 /usr/share/keyrings/elasticsearch.gpg
+          # echo "deb [signed-by=/usr/share/keyrings/elasticsearch.gpg] https://artifacts.elastic.co/packages/7.x/apt stable main" | tee /etc/apt/sources.list.d/elastic-7.x.list
 
       .. group-tab:: ZYpp
 

--- a/source/upgrade-guide/wazuh-agent/linux.rst
+++ b/source/upgrade-guide/wazuh-agent/linux.rst
@@ -64,13 +64,13 @@ Select your package manager and follow the instructions to upgrade the Wazuh age
 
        .. code-block:: console
 
-         # curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | apt-key add -
+         # curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/wazuh.gpg --import && chmod 644 /usr/share/keyrings/wazuh.gpg
 
     #. Add the Wazuh repository.
 
        .. code-block:: console
 
-         # echo "deb https://packages.wazuh.com/4.x/apt/ stable main" | tee -a /etc/apt/sources.list.d/wazuh.list
+         # echo "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages.wazuh.com/4.x/apt/ stable main" | tee -a /etc/apt/sources.list.d/wazuh.list
 
 
     #. Upgrade the Wazuh agent to the latest version.
@@ -84,6 +84,20 @@ Select your package manager and follow the instructions to upgrade the Wazuh age
     #. It is recommended to disable the Wazuh repository in order to avoid undesired upgrades and compatibility issues as the Wazuh agent should always be in the same or an older version than the Wazuh manager. Skip this step if the package is set to a ``hold`` state.
 
         .. code-block:: console
+
+          # sed -i "s/^deb/#deb/" /etc/apt/sources.list.d/wazuh.list
+          # apt-get update
+
+    .. note::
+
+       For Debian 7, 8, and Ubuntu 14 systems run the following commands instead.
+
+       .. code-block:: console
+
+          # apt-get install gnupg apt-transport-https
+          # curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | apt-key add -
+          # echo "deb https://packages.wazuh.com/4.x/apt/ stable main" | tee -a /etc/apt/sources.list.d/wazuh.list
+          # apt-get update
 
           # sed -i "s/^deb/#deb/" /etc/apt/sources.list.d/wazuh.list
           # apt-get update

--- a/source/upgrade-guide/wazuh-agent/linux.rst
+++ b/source/upgrade-guide/wazuh-agent/linux.rst
@@ -90,17 +90,13 @@ Select your package manager and follow the instructions to upgrade the Wazuh age
 
     .. note::
 
-       For Debian 7, 8, and Ubuntu 14 systems run the following commands instead.
+       For Debian 7, 8, and Ubuntu 14 systems import the GCP key and add the Wazuh repository (steps 1 and 2) using the following commands.
 
        .. code-block:: console
 
           # apt-get install gnupg apt-transport-https
           # curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | apt-key add -
           # echo "deb https://packages.wazuh.com/4.x/apt/ stable main" | tee -a /etc/apt/sources.list.d/wazuh.list
-          # apt-get update
-
-          # sed -i "s/^deb/#deb/" /etc/apt/sources.list.d/wazuh.list
-          # apt-get update
 
 
   .. group-tab:: ZYpp


### PR DESCRIPTION
## Description

This PR changes `apt-key add` references with the updated command as found here:

- https://github.com/wazuh/wazuh-packages/issues/1623#issuecomment-1239113879.

It closes #5297

## Checks
- [X] It compiles without warnings.
- [X] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [X] Used uppercase only on nouns. 
- [X] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).