### PR TITLE
Rephrase for clarity about single-node clusters

### DIFF
--- a/source/installation-guide/wazuh-indexer/installation-assistant.rst
+++ b/source/installation-guide/wazuh-indexer/installation-assistant.rst
@@ -96,7 +96,7 @@ Install and configure the Wazuh indexer nodes.
         # bash wazuh-install.sh --wazuh-indexer node-1 
 
 
-Repeat this process on each Wazuh indexer node and proceed with initializing the single-node or multi-node cluster.
+Repeat this stage of the installation process for every Wazuh indexer node in your cluster. Then proceed with initializing your single-node or multi-node cluster in the next stage.
 
 
 3. Cluster initialization 
@@ -105,7 +105,7 @@ Repeat this process on each Wazuh indexer node and proceed with initializing the
 
 The final stage of the process for installing the Wazuh indexer single-node or multi-node cluster consists in running the security admin script. 
 
-#. Run the Wazuh installation assistant with option ``--start-cluster`` on `any` Wazuh indexer node to load the new certificates information and start the single-node or multi-node cluster. 
+#. Run the Wazuh installation assistant with option ``--start-cluster`` on `any` Wazuh indexer node to load the new certificates information and start the cluster. 
 
    .. code-block:: console
  

--- a/source/installation-guide/wazuh-indexer/installation-assistant.rst
+++ b/source/installation-guide/wazuh-indexer/installation-assistant.rst
@@ -9,8 +9,8 @@ Installing the Wazuh indexer using the assistant
 Install and configure the Wazuh indexer as a single-node or multi-node cluster with the aid of the Wazuh installation assistant. The Wazuh indexer is a highly scalable full-text search engine and offers advanced security, alerting, index management, deep performance analysis, and several other features.
 
 
-Wazuh indexer installation
---------------------------
+Wazuh indexer cluster installation
+----------------------------------
 
 The installation process is divided into three stages. 
 
@@ -18,7 +18,7 @@ The installation process is divided into three stages.
 
 #. Wazuh indexer nodes installation
 
-#. Initialization
+#. Cluster initialization
 
 .. note:: Root user privileges are required to run the commands described below.
 
@@ -99,11 +99,11 @@ Install and configure the Wazuh indexer nodes.
 Repeat this process on each Wazuh indexer node and proceed with initializing the single-node or multi-node cluster.
 
 
-3. Initialization 
-------------------
+3. Cluster initialization 
+-------------------------
 
 
-The final stage of the process for installing the Wazuh indexer consists in running the security admin script. 
+The final stage of the process for installing the Wazuh indexer single-node or multi-node cluster consists in running the security admin script. 
 
 #. Run the Wazuh installation assistant with option ``--start-cluster`` on `any` Wazuh indexer node to load the new certificates information and start the single-node or multi-node cluster. 
 

--- a/source/installation-guide/wazuh-indexer/installation-assistant.rst
+++ b/source/installation-guide/wazuh-indexer/installation-assistant.rst
@@ -9,8 +9,8 @@ Installing the Wazuh indexer using the assistant
 Install and configure the Wazuh indexer as a single-node or multi-node cluster with the aid of the Wazuh installation assistant. The Wazuh indexer is a highly scalable full-text search engine and offers advanced security, alerting, index management, deep performance analysis, and several other features.
 
 
-Wazuh indexer cluster installation
-----------------------------------
+Wazuh indexer installation
+--------------------------
 
 The installation process is divided into three stages. 
 
@@ -18,7 +18,7 @@ The installation process is divided into three stages.
 
 #. Wazuh indexer nodes installation
 
-#. Cluster initialization
+#. Initialization
 
 .. note:: Root user privileges are required to run the commands described below.
 
@@ -96,16 +96,16 @@ Install and configure the Wazuh indexer nodes.
         # bash wazuh-install.sh --wazuh-indexer node-1 
 
 
-Repeat this process on each Wazuh indexer node and proceed with initializing the cluster.             
+Repeat this process on each Wazuh indexer node and proceed with initializing the single-node or multi-node cluster.
 
 
-3. Cluster initialization 
--------------------------
+3. Initialization 
+------------------
 
 
-The final stage of the process for installing the Wazuh indexer cluster consists in running the security admin script. 
+The final stage of the process for installing the Wazuh indexer consists in running the security admin script. 
 
-#. Run the Wazuh installation assistant with option ``--start-cluster`` on `any` Wazuh indexer node to load the new certificates information and start the cluster. 
+#. Run the Wazuh installation assistant with option ``--start-cluster`` on `any` Wazuh indexer node to load the new certificates information and start the single-node or multi-node cluster. 
 
    .. code-block:: console
  

--- a/source/installation-guide/wazuh-indexer/step-by-step.rst
+++ b/source/installation-guide/wazuh-indexer/step-by-step.rst
@@ -14,7 +14,7 @@ The installation process is divided into three stages.
 
 #. Nodes installation
 
-#. Initialization
+#. Cluster initialization
 
 
 .. note:: Root user privileges are required to run the commands described below.
@@ -89,11 +89,11 @@ Starting the service
 
       .. include:: /_templates/installations/indexer/common/enable_indexer.rst
     
-Repeat this stage of the installation process for every Wazuh indexer node in your multi-node cluster. Then proceed to the initialization stage.
+Repeat this stage of the installation process for every Wazuh indexer node in your cluster. Then proceed to the single-node or multi-node cluster initialization stage.
 
 
-3. Initialization
-------------------
+3. Cluster initialization
+-------------------------
 .. raw:: html
 
     <div class="accordion-section open">
@@ -107,8 +107,8 @@ Repeat this stage of the installation process for every Wazuh indexer node in yo
 
    .. note:: You only have to initialize the cluster `once`, there is no need to run this command on every node. 
       
-Testing the installation
-^^^^^^^^^^^^^^^^^^^^^^^^^
+Testing the cluster installation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
   #. Replace ``<WAZUH_INDEXER_IP>`` and run the following commands to confirm that the installation is successful.
 

--- a/source/installation-guide/wazuh-indexer/step-by-step.rst
+++ b/source/installation-guide/wazuh-indexer/step-by-step.rst
@@ -89,7 +89,7 @@ Starting the service
 
       .. include:: /_templates/installations/indexer/common/enable_indexer.rst
     
-Repeat this stage of the installation process for every Wazuh indexer node in your cluster. Then proceed to the single-node or multi-node cluster initialization stage.
+Repeat this stage of the installation process for every Wazuh indexer node in your cluster. Then proceed with initializing your single-node or multi-node cluster in the next stage.
 
 
 3. Cluster initialization

--- a/source/installation-guide/wazuh-indexer/step-by-step.rst
+++ b/source/installation-guide/wazuh-indexer/step-by-step.rst
@@ -14,7 +14,7 @@ The installation process is divided into three stages.
 
 #. Nodes installation
 
-#. Cluster initialization
+#. Initialization
 
 
 .. note:: Root user privileges are required to run the commands described below.
@@ -89,17 +89,17 @@ Starting the service
 
       .. include:: /_templates/installations/indexer/common/enable_indexer.rst
     
-Repeat this stage of the installation process for every Wazuh indexer node in your multi-node cluster. Then proceed to the cluster initialization stage.
+Repeat this stage of the installation process for every Wazuh indexer node in your multi-node cluster. Then proceed to the initialization stage.
 
 
-3. Cluster initialization
--------------------------
+3. Initialization
+------------------
 .. raw:: html
 
     <div class="accordion-section open">
 
 
-#. Run the Wazuh indexer ``indexer-security-init.sh`` script on `any` Wazuh indexer node to load the new certificates information and start the cluster. 
+#. Run the Wazuh indexer ``indexer-security-init.sh`` script on `any` Wazuh indexer node to load the new certificates information and start the single-node or multi-node cluster. 
     
    .. code-block:: console
 
@@ -107,8 +107,8 @@ Repeat this stage of the installation process for every Wazuh indexer node in yo
 
    .. note:: You only have to initialize the cluster `once`, there is no need to run this command on every node. 
       
-Testing the cluster installation
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Testing the installation
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
   #. Replace ``<WAZUH_INDEXER_IP>`` and run the following commands to confirm that the installation is successful.
 
@@ -137,7 +137,7 @@ Testing the cluster installation
           }
           
 
-  #. Replace ``<WAZUH_INDEXER_IP>`` and run the following command to check if the cluster is working correctly. 
+  #. Replace ``<WAZUH_INDEXER_IP>`` and run the following command to check if the single-node or multi-node cluster is working correctly. 
   
       .. code-block:: console
 


### PR DESCRIPTION
## Description
This PR changes wording about cluster initialization when installing the Wazuh indexer. The initialization step is mandatory even for single-node configurations and should be clear enough.

## Checks
- [X] It compiles without warnings.
- [X] Spelling and grammar. 
- [ ] Used impersonal speech. 
- [X] Used uppercase only on nouns. 
- [X] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
