### PR TITLE
Add Reparse section to GCP and Azure and modify the AWS one

### DIFF
--- a/source/amazon/services/prerequisites/considerations.rst
+++ b/source/amazon/services/prerequisites/considerations.rst
@@ -33,10 +33,7 @@ On the other hand, the ``CloudWatch Logs`` module can process logs older than th
 
 
 Reparse
-~~~~~~~
-
-.. note::
-  Option not available for CloudWatch Logs.
+-------
 
 .. warning::
   Using the ``reparse`` option will fetch and process every log from the starting date until the present. This process may generate duplicate alerts.

--- a/source/amazon/services/prerequisites/considerations.rst
+++ b/source/amazon/services/prerequisites/considerations.rst
@@ -44,8 +44,7 @@ Below there is an example of a manual execution of the module using the ``--repa
 
 .. code-block:: console
 
-  # cd /var/ossec/wodles/aws
-  # ./aws-s3 -b 'wazuh-example-bucket' --reparse --only_logs_after '2021-Jun-10' --debug 2
+  # /var/ossec/wodles/aws/aws-s3 -b 'wazuh-example-bucket' --reparse --only_logs_after '2021-Jun-10' --debug 2
 
 The ``--debug 2`` parameter was used to get a verbose output since by default the script won't print anything on the terminal, and it could seem like it's not working when it could be handling a great amount of data instead.
 

--- a/source/amazon/services/prerequisites/considerations.rst
+++ b/source/amazon/services/prerequisites/considerations.rst
@@ -36,17 +36,20 @@ Reparse
 -------
 
 .. warning::
-  Using the ``reparse`` option will fetch and process every log from the starting date until the present. This process may generate duplicate alerts.
+  
+   Using the ``reparse`` option will fetch and process all the logs from the starting date until the present. This process may generate duplicate alerts.
 
-To process older logs, it's necessary to manually execute the module using the ``--reparse`` or ``-o`` option. Executing the module with this option will use the ``only_logs_after`` value provided to fetch and process every log from that date until the present. If no ``only_logs_after`` value was provided, it will use the date of the first file processed.
+To fetch and process older logs, you need to manually run the module using the ``--reparse`` option.
 
-Below there is an example of a manual execution of the module using the ``--reparse`` option on a manager, being ``/var/ossec`` the Wazuh installation path:
+The ``only_logs_after`` value sets the time for the starting point. If you don't provide an ``only_logs_after`` value, the module uses the date of the first file processed.
+
+Find an example of running the module on a manager using the ``--reparse`` option. ``/var/ossec`` is the Wazuh installation path.
 
 .. code-block:: console
 
   # /var/ossec/wodles/aws/aws-s3 -b 'wazuh-example-bucket' --reparse --only_logs_after '2021-Jun-10' --debug 2
 
-The ``--debug 2`` parameter was used to get a verbose output since by default the script won't print anything on the terminal, and it could seem like it's not working when it could be handling a great amount of data instead.
+The ``--debug 2`` parameter gets a verbose output. This is useful to show the script is working, specially when handling a large amount of data.
 
 Configuring multiple services
 -----------------------------

--- a/source/azure/activity-services/prerequisites/considerations.rst
+++ b/source/azure/activity-services/prerequisites/considerations.rst
@@ -5,6 +5,24 @@
 Considerations for configuration
 ================================
 
+Reparse
+-------
+
+.. warning::
+  Using the ``reparse`` option will fetch and process every log from the starting date until the present. This process may generate duplicate alerts.
+
+To process older logs, it's necessary to manually execute the module using the ``--reparse`` option. Executing the module with this option will use the ``la_time_offset`` value provided to fetch and process every log starting from the described offset. If no ``la_time_offset`` value was provided, it will use the date of the first file processed.
+
+Below there is an example of a manual execution of the module using the ``--reparse`` option on a manager, being ``/var/ossec`` the Wazuh installation path:
+
+.. code-block:: console
+
+  # cd /var/ossec/wodles/azure
+  # ./azure-logs --log_analytics --la_auth_path credentials_example --la_tenant_domain 'wazuh.example.domain' --la_tag azure-activity --la_query "AzureActivity" --workspace example-workspace --la_time_offset 50d --debug 2 --reparse
+
+The ``--debug 2`` parameter was used to get a verbose output since by default the script won't print anything on the terminal, and it could seem like it's not working when it could be handling a great amount of data instead.
+
+
 Configuring multiple services
 -----------------------------
 

--- a/source/azure/activity-services/prerequisites/considerations.rst
+++ b/source/azure/activity-services/prerequisites/considerations.rst
@@ -10,7 +10,7 @@ Reparse
 
 .. warning::
 
-   Using the ``reparse`` option may fetch and process all the logs from the starting date until the present. This process may generate duplicate alerts.
+   Using the ``reparse`` option will fetch and process all the logs from the starting date until the present. This process may generate duplicate alerts.
 
 To fetch and process older logs, you need to manually run the module using the ``--reparse`` option.
 

--- a/source/azure/activity-services/prerequisites/considerations.rst
+++ b/source/azure/activity-services/prerequisites/considerations.rst
@@ -9,17 +9,20 @@ Reparse
 -------
 
 .. warning::
-  Using the ``reparse`` option will fetch and process every log from the starting date until the present. This process may generate duplicate alerts.
 
-To process older logs, it's necessary to manually execute the module using the ``--reparse`` option. Executing the module with this option will use the ``la_time_offset`` value provided to fetch and process every log starting from the described offset. If no ``la_time_offset`` value was provided, it will use the date of the first file processed.
+   Using the ``reparse`` option may fetch and process all the logs from the starting date until the present. This process may generate duplicate alerts.
 
-Below there is an example of a manual execution of the module using the ``--reparse`` option on a manager, being ``/var/ossec`` the Wazuh installation path:
+To fetch and process older logs, you need to manually run the module using the ``--reparse`` option.
+
+The ``la_time_offset`` value sets the time as an offset for the starting point. If you don't provide an ``la_time_offset`` value, the module goes back to the date of the first file processed.
+
+Find an example of running the module on a manager using the ``--reparse`` option. ``/var/ossec`` is the Wazuh installation path.
 
 .. code-block:: console
 
   # /var/ossec/wodles/azure/azure-logs --log_analytics --la_auth_path credentials_example --la_tenant_domain 'wazuh.example.domain' --la_tag azure-activity --la_query "AzureActivity" --workspace example-workspace --la_time_offset 50d --debug 2 --reparse
 
-The ``--debug 2`` parameter was used to get a verbose output since by default the script won't print anything on the terminal, and it could seem like it's not working when it could be handling a great amount of data instead.
+The ``--debug 2`` parameter gets a verbose output. This is useful to show the script is working, specially when handling a large amount of data.
 
 
 Configuring multiple services

--- a/source/azure/activity-services/prerequisites/considerations.rst
+++ b/source/azure/activity-services/prerequisites/considerations.rst
@@ -17,8 +17,7 @@ Below there is an example of a manual execution of the module using the ``--repa
 
 .. code-block:: console
 
-  # cd /var/ossec/wodles/azure
-  # ./azure-logs --log_analytics --la_auth_path credentials_example --la_tenant_domain 'wazuh.example.domain' --la_tag azure-activity --la_query "AzureActivity" --workspace example-workspace --la_time_offset 50d --debug 2 --reparse
+  # /var/ossec/wodles/azure/azure-logs --log_analytics --la_auth_path credentials_example --la_tenant_domain 'wazuh.example.domain' --la_tag azure-activity --la_query "AzureActivity" --workspace example-workspace --la_time_offset 50d --debug 2 --reparse
 
 The ``--debug 2`` parameter was used to get a verbose output since by default the script won't print anything on the terminal, and it could seem like it's not working when it could be handling a great amount of data instead.
 

--- a/source/gcp/prerequisites/considerations.rst
+++ b/source/gcp/prerequisites/considerations.rst
@@ -32,6 +32,24 @@ Logging level
 To switch between different logging levels for debugging and troubleshooting purposes, the Google Cloud integration uses the :ref:`wazuh_modules.debug <wazuh_modules_options>` level to set its verbosity level.
 
 
+Reparse
+-------
+
+.. warning::
+  Using the ``reparse`` option will fetch and process every log from the starting date until the present. This process may generate duplicate alerts.
+
+To process older logs, it's necessary to manually execute the module using the ``--reparse`` option. Executing the module with this option will use the ``only_logs_after`` value provided to fetch and process every log from that date until the present. If no ``only_logs_after`` value was provided, it will use the date of the first file processed.
+
+Below there is an example of a manual execution of the module using the ``--reparse`` option on a manager, being ``/var/ossec`` the Wazuh installation path:
+
+.. code-block:: console
+
+  # cd /var/ossec/wodles/gcloud
+  # ./gcloud --integration_type access_logs -b 'wazuh-example-bucket' -c credentials.json --reparse --only_logs_after '2021-Jun-10' --debug 2
+
+The ``--debug 2`` parameter was used to get a verbose output since by default the script won't print anything on the terminal, and it could seem like it's not working when it could be handling a great amount of data instead.
+
+
 Configuring multiple Google Cloud Storage bucket
 ------------------------------------------------
 

--- a/source/gcp/prerequisites/considerations.rst
+++ b/source/gcp/prerequisites/considerations.rst
@@ -36,17 +36,20 @@ Reparse
 -------
 
 .. warning::
-  Using the ``reparse`` option will fetch and process every log from the starting date until the present. This process may generate duplicate alerts.
 
-To process older logs, it's necessary to manually execute the module using the ``--reparse`` option. Executing the module with this option will use the ``only_logs_after`` value provided to fetch and process every log from that date until the present. If no ``only_logs_after`` value was provided, it will use the date of the first file processed.
+   Using the ``reparse`` option may fetch and process all the logs from the starting date until the present. This process may generate duplicate alerts.
 
-Below there is an example of a manual execution of the module using the ``--reparse`` option on a manager, being ``/var/ossec`` the Wazuh installation path:
+To fetch and process older logs, you need to manually run the module using the ``--reparse`` option.
+
+The ``only_logs_after`` value sets the time for the starting point. If you don't provide an ``only_logs_after`` value, the module uses the date of the first file processed.
+
+Find an example of running the module on a manager using the ``--reparse`` option. ``/var/ossec`` is the Wazuh installation path.
 
 .. code-block:: console
 
   # /var/ossec/wodles/gcloud/gcloud --integration_type access_logs -b 'wazuh-example-bucket' -c credentials.json --reparse --only_logs_after '2021-Jun-10' --debug 2
 
-The ``--debug 2`` parameter was used to get a verbose output since by default the script won't print anything on the terminal, and it could seem like it's not working when it could be handling a great amount of data instead.
+The ``--debug 2`` parameter gets a verbose output. This is useful to show the script is working, specially when handling a large amount of data.
 
 
 Configuring multiple Google Cloud Storage bucket

--- a/source/gcp/prerequisites/considerations.rst
+++ b/source/gcp/prerequisites/considerations.rst
@@ -37,7 +37,7 @@ Reparse
 
 .. warning::
 
-   Using the ``reparse`` option may fetch and process all the logs from the starting date until the present. This process may generate duplicate alerts.
+   Using the ``reparse`` option will fetch and process all the logs from the starting date until the present. This process may generate duplicate alerts.
 
 To fetch and process older logs, you need to manually run the module using the ``--reparse`` option.
 

--- a/source/gcp/prerequisites/considerations.rst
+++ b/source/gcp/prerequisites/considerations.rst
@@ -44,8 +44,7 @@ Below there is an example of a manual execution of the module using the ``--repa
 
 .. code-block:: console
 
-  # cd /var/ossec/wodles/gcloud
-  # ./gcloud --integration_type access_logs -b 'wazuh-example-bucket' -c credentials.json --reparse --only_logs_after '2021-Jun-10' --debug 2
+  # /var/ossec/wodles/gcloud/gcloud --integration_type access_logs -b 'wazuh-example-bucket' -c credentials.json --reparse --only_logs_after '2021-Jun-10' --debug 2
 
 The ``--debug 2`` parameter was used to get a verbose output since by default the script won't print anything on the terminal, and it could seem like it's not working when it could be handling a great amount of data instead.
 


### PR DESCRIPTION
| Related issue |
|----|
| Closes #4902 |


## Description

This PR closes the issue #4902. It adds the `Reparse` section in the `Considerations for configuration` page of the Azure and GCP modules. It also modifies the `Reparse` section in the AWS module documentation, removing the previous note about the `--reparse` option not being available for CloudWatch Logs.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
