### PR TITLE
Add permissions required for AWS ECR image scanning

### DIFF
--- a/source/amazon/services/supported-services/ecr-image-scanning.rst
+++ b/source/amazon/services/supported-services/ecr-image-scanning.rst
@@ -29,6 +29,77 @@ AWS configuration
 
 AWS provides a `template <https://github.com/aws-samples/ecr-image-scan-findings-logger/blob/main/Template-ECR-SFL.yml>`_ for creating a stack in CloudFormation that loads the image scan findings from Amazon ECR in CloudWatch using an AWS Lambda function.
 
+Policy configuration
+^^^^^^^^^^^^^^^^^^^^
+.. include:: /_templates/cloud/amazon/create_policy.rst
+
+.. note::
+      The permissions inside the ``RoleCreator`` section of the policy are necessary in order to create/delete the stack and can and should be deactivated once the creation process is finished.
+
+.. note::
+      The permissions part of the ``ImagePush`` section are required by Amazon ECR to `push images <https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-push.html#image-push-iam>`_ and are scoped down to a specific repository. The steps to push Docker images is also described in the `Amazon ECR - Pushing a Docker image <https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html>`_ documentation.
+
+
+.. code-block:: json
+
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "RoleCreator",
+        "Effect": "Allow",
+        "Action": [
+          "iam:CreateRole",
+          "iam:PutRolePolicy",
+          "iam:AttachRolePolicy",
+          "iam:DeleteRolePolicy",
+          "iam:DeleteRole",
+          "iam:GetRole",
+          "iam:GetRolePolicy"
+        ],
+        "Resource": "*"
+      },
+      {
+        "Sid": "CloudFormationActions",
+        "Effect": "Allow",
+        "Action": [
+            "cloudformation:CreateStack",
+            "cloudformation:ValidateTemplate",
+            "cloudformation:CreateUploadBucket",
+            "cloudformation:GetTemplateSummary",
+            "cloudformation:DescribeStackEvents",
+            "cloudformation:DescribeStackResources",
+            "cloudformation:ListStacks",
+            "cloudformation:DeleteStack",
+            "s3:PutObject",
+            "s3:ListBucket",
+            "s3:GetObject",
+            "s3:CreateBucket"
+        ],
+        "Resource": "*"   
+      },
+      {
+        "Sid": "ImagePush",
+        "Effect": "Allow",
+        "Action": [
+            "ecr:CompleteLayerUpload",
+            "ecr:UploadLayerPart",
+            "ecr:InitiateLayerUpload",
+            "ecr:BatchCheckLayerAvailability",
+            "ecr:PutImage"
+        ],
+        "Resource": "arn:aws:ecr:region:111122223333:repository/repository-name"
+      },
+      {
+        "Sid": "ECRAuthToken",
+        "Effect": "Allow",
+        "Action": "ecr:GetAuthorizationToken",
+        "Resource": "*"
+      }
+    ]
+  }
+
+
 How to create the CloudFormation Stack
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/source/amazon/services/supported-services/ecr-image-scanning.rst
+++ b/source/amazon/services/supported-services/ecr-image-scanning.rst
@@ -33,19 +33,15 @@ Policy configuration
 ^^^^^^^^^^^^^^^^^^^^
 .. include:: /_templates/cloud/amazon/create_policy.rst
 
-.. note::
-      The permissions inside the ``RoleCreator`` section of the policy are necessary in order to create/delete the stack and can and should be deactivated once the creation process is finished.
+IAM permissions
+~~~~~~~~~~~~~~~
 
-.. note::
-      The permissions part of the ``ImagePush`` section are required by Amazon ECR to `push images <https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-push.html#image-push-iam>`_ and are scoped down to a specific repository. The steps to push Docker images is also described in the `Amazon ECR - Pushing a Docker image <https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html>`_ documentation.
-
+.. warning::
+      The permissions inside the ``RoleCreator`` section of the policy are necessary in order to create/delete the stack and can and should be deactivated once the creation process is finished due to overly permissive actions.
 
 .. code-block:: json
-
+  
   {
-    "Version": "2012-10-17",
-    "Statement": [
-      {
         "Sid": "RoleCreator",
         "Effect": "Allow",
         "Action": [
@@ -58,8 +54,14 @@ Policy configuration
           "iam:GetRolePolicy"
         ],
         "Resource": "*"
-      },
-      {
+      }
+
+CloudFormation Stack permissions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: json
+
+  {
         "Sid": "CloudFormationActions",
         "Effect": "Allow",
         "Action": [
@@ -77,8 +79,17 @@ Policy configuration
             "s3:CreateBucket"
         ],
         "Resource": "*"   
-      },
-      {
+      }
+
+Image Pushing permissions
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. note::
+      The permissions part of the ``ImagePush`` section are required by Amazon ECR to `push images <https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-push.html#image-push-iam>`_ and are scoped down to a specific repository. The steps to push Docker images is also described in the `Amazon ECR - Pushing a Docker image <https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html>`_ documentation.
+
+.. code-block:: json
+
+  {
         "Sid": "ImagePush",
         "Effect": "Allow",
         "Action": [
@@ -89,14 +100,23 @@ Policy configuration
             "ecr:PutImage"
         ],
         "Resource": "arn:aws:ecr:region:111122223333:repository/repository-name"
-      },
-      {
-        "Sid": "ECRAuthToken",
-        "Effect": "Allow",
-        "Action": "ecr:GetAuthorizationToken",
-        "Resource": "*"
       }
-    ]
+
+
+Registry permissions
+~~~~~~~~~~~~~~~~~~~~
+
+.. note::
+      The permissions part of the ``ECRAuthToken`` section are required by `Amazon ECR <https://docs.aws.amazon.com/AmazonECR/latest/userguide/set-repository-policy.html>`_ for users to have permission to make calls to the ``ecr:GetAuthorizationToken`` API through an IAM policy before they can authenticate to a registry and push or pull any images from any Amazon ECR repository. 
+
+
+.. code-block:: json
+
+  {
+    "Sid": "ECRAuthToken",
+    "Effect": "Allow",
+    "Action": "ecr:GetAuthorizationToken",
+    "Resource": "*"
   }
 
 

--- a/source/amazon/services/supported-services/ecr-image-scanning.rst
+++ b/source/amazon/services/supported-services/ecr-image-scanning.rst
@@ -39,7 +39,7 @@ IAM
 """
 
 .. warning::
-      The permissions inside the ``RoleCreator`` section are necessary in order to create/delete the stack based on the named template and can and should be deactivated once the creation process is finished due to overly permissive actions.
+      The permissions inside the ``RoleCreator`` and ``PassRole`` sections are necessary in order to create/delete the stack based on the named template and must be bound to the described specific resources due to overly permissive actions.
 
 .. code-block:: json
   
@@ -57,6 +57,12 @@ IAM
          "iam:PassRole"
       ],
       "Resource": "arn:aws:iam::user-id:role/*"
+   },
+   {
+      "Sid": "PassRole",
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": "arn:aws:iam::user-id:role/*-LambdaExecutionRole*"
    }
 
 Amazon Lambda and Amazon EventBridge

--- a/source/amazon/services/supported-services/ecr-image-scanning.rst
+++ b/source/amazon/services/supported-services/ecr-image-scanning.rst
@@ -27,17 +27,14 @@ The following sections cover how to configure AWS to store the scan findings in 
 AWS configuration
 -----------------
 
-AWS provides a `template <https://github.com/aws-samples/ecr-image-scan-findings-logger/blob/main/Template-ECR-SFL.yml>`_ for creating a stack in CloudFormation. The template has an AWS Lambda function. It logs the image scan findings from Amazon ECR in CloudWatch.
+AWS provides a `template <https://github.com/aws-samples/ecr-image-scan-findings-logger/blob/main/Template-ECR-SFL.yml>`__ that logs to CloudWatch the findings of Amazon ECR scans of images. The template uses an AWS Lambda function to accomplish this.
 
-Create the stack and upload images to Amazon ECR to use this template. You need to create a custom policy to grant the necessary permissions.
+Uploading the template and creating a stack, uploading the images to Amazon ECR, scanning the images, and using the logger all require specific permissions. Because of this, you need to create a custom policy granting these permissions.
 
 .. include:: /_templates/cloud/amazon/create_policy.rst
 
-Template specific permissions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-IAM 
-~~~
+IAM permissions
+^^^^^^^^^^^^^^^
 
 You need the permissions listed below inside the sections for  ``RoleCreator`` and ``PassRole`` to create and delete the stack based on the template.
 
@@ -69,8 +66,80 @@ You need the permissions listed below inside the sections for  ``RoleCreator`` a
       "Resource": "arn:aws:iam::<account-ID>:role/*-LambdaExecutionRole*"
    }
 
-Amazon Lambda and Amazon EventBridge
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+CloudFormation stack permissions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You need the following permissions to create and delete any template-based CloudFormation stack.
+
+.. code-block:: json
+
+   {
+      "Sid": "CloudFormationStackCreation",
+      "Effect": "Allow",
+      "Action": [
+         "cloudformation:CreateStack",
+         "cloudformation:ValidateTemplate",
+         "cloudformation:CreateUploadBucket",
+         "cloudformation:GetTemplateSummary",
+         "cloudformation:DescribeStackEvents",
+         "cloudformation:DescribeStackResources",
+         "cloudformation:ListStacks",
+         "cloudformation:DeleteStack",
+         "s3:PutObject",
+         "s3:ListBucket",
+         "s3:GetObject",
+         "s3:CreateBucket"
+      ],
+      "Resource": "*"   
+   }
+
+ECR registry and repository permissions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This `Amazon ECR <https://docs.aws.amazon.com/AmazonECR/latest/userguide/set-repository-policy.html>`__ permission allows calls to the API through an IAM policy.
+
+.. note::
+
+   Before authenticating to a registry and pushing or pulling any images from any Amazon ECR repository, you need  ``ecr:GetAuthorizationToken``. 
+
+.. code-block:: json
+
+   { 
+      "Sid": "ECRUtilities",
+      "Effect": "Allow",
+      "Action": [
+         "ecr:GetAuthorizationToken",  
+         "ecr:DescribeRepositories"    
+      ],
+      "Resource": "*"
+   }
+
+Image pushing and scanning permissions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You need the following Amazon ECR permissions to `push images <https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-push.html#image-push-iam>`__. They are scoped down to a specific repository. The steps to push Docker images are described in the `Amazon ECR - Pushing a Docker image <https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html>`_ documentation.
+
+.. code-block:: json
+
+   {
+      "Sid": "ScanPushImage",
+      "Effect": "Allow",
+      "Action": [
+         "ecr:CompleteLayerUpload",
+         "ecr:UploadLayerPart",
+         "ecr:InitiateLayerUpload",
+         "ecr:BatchCheckLayerAvailability",
+         "ecr:PutImage",
+         "ecr:ListImages",
+         "ecr:DescribeImages",
+         "ecr:DescribeImageScanFindings",
+         "ecr:StartImageScan"
+      ],
+      "Resource": "arn:aws:ecr:<region>:<account-ID>:repository/<repository-name>"
+   }
+
+Amazon Lambda and Amazon EventBridge permissions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You need the following permissions to create and delete the resources handled by the Scan Findings Logger template.
   
@@ -100,82 +169,6 @@ You need the following permissions to create and delete the resources handled by
       ],
       "Resource": "arn:aws:events:<region>:<account-ID>:*"
     }
-
-
-
-CloudFormation Stack
-^^^^^^^^^^^^^^^^^^^^
-
-You need the following permissions to create and delete any template-based CloudFormation stack.
-
-.. code-block:: json
-
-   {
-      "Sid": "CloudFormationStackCreation",
-      "Effect": "Allow",
-      "Action": [
-         "cloudformation:CreateStack",
-         "cloudformation:ValidateTemplate",
-         "cloudformation:CreateUploadBucket",
-         "cloudformation:GetTemplateSummary",
-         "cloudformation:DescribeStackEvents",
-         "cloudformation:DescribeStackResources",
-         "cloudformation:ListStacks",
-         "cloudformation:DeleteStack",
-         "s3:PutObject",
-         "s3:ListBucket",
-         "s3:GetObject",
-         "s3:CreateBucket"
-      ],
-      "Resource": "*"   
-   }
-
-Amazon ECR usage permissions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Image Pushing and Scanning
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-You need the following Amazon ECR permissions to `push images <https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-push.html#image-push-iam>`__. They are scoped down to a specific repository. The steps to push Docker images are described in the `Amazon ECR - Pushing a Docker image <https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html>`_ documentation.
-
-.. code-block:: json
-
-   {
-      "Sid": "ScanPushImage",
-      "Effect": "Allow",
-      "Action": [
-         "ecr:CompleteLayerUpload",
-         "ecr:UploadLayerPart",
-         "ecr:InitiateLayerUpload",
-         "ecr:BatchCheckLayerAvailability",
-         "ecr:PutImage",
-         "ecr:ListImages",
-         "ecr:DescribeImages",
-         "ecr:DescribeImageScanFindings",
-         "ecr:StartImageScan"
-      ],
-      "Resource": "arn:aws:ecr:<region>:<account-ID>:repository/<repository-name>"
-   }
-
-ECR Registry and Repository
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. note::
-
-   Before authenticating to a registry and pushing or pulling any images from any Amazon ECR repository, you need  ``ecr:GetAuthorizationToken``. This `Amazon ECR <https://docs.aws.amazon.com/AmazonECR/latest/userguide/set-repository-policy.html>`__ permission allows calls to the API through an IAM policy.
-
-.. code-block:: json
-
-   { 
-      "Sid": "ECRUtilities",
-      "Effect": "Allow",
-      "Action": [
-         "ecr:GetAuthorizationToken",  
-         "ecr:DescribeRepositories"    
-      ],
-      "Resource": "*"
-   }
-
 
 How to create the CloudFormation Stack
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/amazon/services/supported-services/ecr-image-scanning.rst
+++ b/source/amazon/services/supported-services/ecr-image-scanning.rst
@@ -39,68 +39,64 @@ IAM
 """
 
 .. warning::
-      The permissions inside the ``IAMRole`` section and the ``PassRole`` section are necessary in order to create/delete the stack based on the named template and can and should be deactivated once the creation process is finished due to overly permissive actions.
+      The permissions inside the ``RoleCreator`` section are necessary in order to create/delete the stack based on the named template and can and should be deactivated once the creation process is finished due to overly permissive actions.
 
 .. code-block:: json
   
   {
-        "Sid": "RoleCreator",
-        "Effect": "Allow",
-        "Action": [
-          "iam:CreateRole",
-          "iam:PutRolePolicy",
-          "iam:AttachRolePolicy",
-          "iam:DeleteRolePolicy",
-          "iam:DeleteRole",
-          "iam:GetRole",
-          "iam:GetRolePolicy"
-        ],
-        "Resource": "*",
-        "Condition": {
-          "StringEquals": {"iam:PassedToService": "replicator.lambda.amazonaws.com"}
-        }
-      },
-      {
-        "Sid": "PassRole",
-        "Effect": "Allow",
-        "Action": "iam:PassRole",
-        "Resource": "*",
-        "Condition": {
-          "StringEquals": {"iam:PassedToService": "replicator.lambda.amazonaws.com"}
-        }
+          "Sid": "RoleCreator",
+          "Effect": "Allow",
+          "Action": [
+              "iam:CreateRole",
+              "iam:PutRolePolicy",
+              "iam:AttachRolePolicy",
+              "iam:DeleteRolePolicy",
+              "iam:DeleteRole",
+              "iam:GetRole",
+              "iam:GetRolePolicy",
+              "iam:PassRole"
+          ],
+          "Resource": "arn:aws:iam::user-id:role/*"
       }
 
 Amazon Lambda and Amazon EventBridge
 """"""""""""""""""""""""""""""""""""
 
-The following permissions are required to create/delete the resources handled by the Scan Findings Logger template
+The following permissions are required to create/delete the resources handled by the Scan Findings Logger template.
   
 .. code-block:: json
 
   {
-    "Sid": "TemplateRequired",
-    "Effect": "Allow",
-    "Action": [
-      "lambda:RemovePermission",
-      "lambda:DeleteFunction",
-      "lambda:GetFunction",
-      "lambda:CreateFunction",
-      "lambda:AddPermission",
-      "events:RemoveTargets",
-      "events:DeleteRule",
-      "events:PutRule",
-      "events:DescribeRule",
-      "events:PutTargets"
-    ],
-    "Resource": "*"
-  }
+          "Sid": "TemplateRequired0",
+          "Effect": "Allow",
+          "Action": [
+              "lambda:RemovePermission",
+              "lambda:DeleteFunction",
+              "lambda:GetFunction",
+              "lambda:CreateFunction",
+              "lambda:AddPermission"
+          ],
+          "Resource": "arn:aws:lambda:region:user-id:*"
+      },
+      {
+          "Sid": "TemplateRequired1",
+          "Effect": "Allow",
+          "Action": [
+              "events:RemoveTargets",
+              "events:DeleteRule",
+              "events:PutRule",
+              "events:DescribeRule",
+              "events:PutTargets"
+          ],
+          "Resource": "arn:aws:events:region:user-id:*"
+      }
 
 
 
 CloudFormation Stack
 ~~~~~~~~~~~~~~~~~~~~
 
-The following permissions are required to create/delete any template based CloudFormation stack
+The following permissions are required to create/delete any template based CloudFormation stack.
 
 .. code-block:: json
 
@@ -129,7 +125,7 @@ Amazon ECR usage permissions
 Image Pushing and Scanning
 """"""""""""""""""""""""""
 
-  The following permissions are required by Amazon ECR to `push images <https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-push.html#image-push-iam>`_ and are scoped down to a specific repository. The steps to push Docker images is also described in the `Amazon ECR - Pushing a Docker image <https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html>`_ documentation.
+The following permissions are required by Amazon ECR to `push images <https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-push.html#image-push-iam>`_ and are scoped down to a specific repository. The steps to push Docker images is also described in the `Amazon ECR - Pushing a Docker image <https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html>`_ documentation.
 
 .. code-block:: json
 
@@ -154,7 +150,7 @@ ECR Registry and Repository
 """""""""""""""""""""""""""
 
 .. note::
-      The permission "ecr:GetAuthorizationToken" is required by `Amazon ECR <https://docs.aws.amazon.com/AmazonECR/latest/userguide/set-repository-policy.html>`_ for users to have permission to make calls to the ``ecr:GetAuthorizationToken`` API through an IAM policy before they can authenticate to a registry and push or pull any images from any Amazon ECR repository.
+      The permission ``ecr:GetAuthorizationToken`` is required by `Amazon ECR <https://docs.aws.amazon.com/AmazonECR/latest/userguide/set-repository-policy.html>`_ for users to have permission to make calls to the API through an IAM policy before they can authenticate to a registry and push or pull any images from any Amazon ECR repository.
 
 
 .. code-block:: json

--- a/source/amazon/services/supported-services/ecr-image-scanning.rst
+++ b/source/amazon/services/supported-services/ecr-image-scanning.rst
@@ -27,17 +27,23 @@ The following sections cover how to configure AWS to store the scan findings in 
 AWS configuration
 -----------------
 
-AWS provides a `template <https://github.com/aws-samples/ecr-image-scan-findings-logger/blob/main/Template-ECR-SFL.yml>`_ for creating a stack in CloudFormation that loads the image scan findings from Amazon ECR in CloudWatch using an AWS Lambda function. To be able to use this template, create the stack and upload images to Amazon ECR, it is necessary to create a custom policy granting the necessary permissions. 
+AWS provides a `template <https://github.com/aws-samples/ecr-image-scan-findings-logger/blob/main/Template-ECR-SFL.yml>`_ for creating a stack in CloudFormation. The template has an AWS Lambda function. It logs the image scan findings from Amazon ECR in CloudWatch.
+
+Create the stack and upload images to Amazon ECR to use this template. You need to create a custom policy to grant the necessary permissions.
 
 .. include:: /_templates/cloud/amazon/create_policy.rst
 
 Template specific permissions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 IAM 
 ~~~
 
+You need the permissions listed below inside the sections for  ``RoleCreator`` and ``PassRole`` to create and delete the stack based on the template.
+
 .. warning::
-      The permissions inside the ``RoleCreator`` and ``PassRole`` sections are necessary in order to create and delete the stack based on the named template and must be bound to the described specific resources due to overly permissive actions.
+
+   These permissions must be bound to the specific resources due to overly permissive actions.
 
 .. code-block:: json
   
@@ -66,7 +72,7 @@ IAM
 Amazon Lambda and Amazon EventBridge
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following permissions are required to create and delete the resources handled by the Scan Findings Logger template.
+You need the following permissions to create and delete the resources handled by the Scan Findings Logger template.
   
 .. code-block:: json
 
@@ -100,7 +106,7 @@ The following permissions are required to create and delete the resources handle
 CloudFormation Stack
 ^^^^^^^^^^^^^^^^^^^^
 
-The following permissions are required to create and delete any template based CloudFormation stack.
+You need the following permissions to create and delete any template-based CloudFormation stack.
 
 .. code-block:: json
 
@@ -126,10 +132,11 @@ The following permissions are required to create and delete any template based C
 
 Amazon ECR usage permissions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 Image Pushing and Scanning
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following permissions are required by Amazon ECR to `push images <https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-push.html#image-push-iam>`_ and are scoped down to a specific repository. The steps to push Docker images is also described in the `Amazon ECR - Pushing a Docker image <https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html>`_ documentation.
+You need the following Amazon ECR permissions to `push images <https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-push.html#image-push-iam>`__. They are scoped down to a specific repository. The steps to push Docker images are described in the `Amazon ECR - Pushing a Docker image <https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html>`_ documentation.
 
 .. code-block:: json
 
@@ -154,8 +161,8 @@ ECR Registry and Repository
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. note::
-      The permission ``ecr:GetAuthorizationToken`` is required by `Amazon ECR <https://docs.aws.amazon.com/AmazonECR/latest/userguide/set-repository-policy.html>`_ for users to have permission to make calls to the API through an IAM policy before they can authenticate to a registry and push or pull any images from any Amazon ECR repository.
 
+   Before authenticating to a registry and pushing or pulling any images from any Amazon ECR repository, you need  ``ecr:GetAuthorizationToken``. This `Amazon ECR <https://docs.aws.amazon.com/AmazonECR/latest/userguide/set-repository-policy.html>`__ permission allows calls to the API through an IAM policy.
 
 .. code-block:: json
 

--- a/source/amazon/services/supported-services/ecr-image-scanning.rst
+++ b/source/amazon/services/supported-services/ecr-image-scanning.rst
@@ -43,21 +43,21 @@ IAM
 
 .. code-block:: json
   
-  {
-          "Sid": "RoleCreator",
-          "Effect": "Allow",
-          "Action": [
-              "iam:CreateRole",
-              "iam:PutRolePolicy",
-              "iam:AttachRolePolicy",
-              "iam:DeleteRolePolicy",
-              "iam:DeleteRole",
-              "iam:GetRole",
-              "iam:GetRolePolicy",
-              "iam:PassRole"
-          ],
-          "Resource": "arn:aws:iam::user-id:role/*"
-      }
+   {
+      "Sid": "RoleCreator",
+      "Effect": "Allow",
+      "Action": [
+         "iam:CreateRole",
+         "iam:PutRolePolicy",
+         "iam:AttachRolePolicy",
+         "iam:DeleteRolePolicy",
+         "iam:DeleteRole",
+         "iam:GetRole",
+         "iam:GetRolePolicy",
+         "iam:PassRole"
+      ],
+      "Resource": "arn:aws:iam::user-id:role/*"
+   }
 
 Amazon Lambda and Amazon EventBridge
 """"""""""""""""""""""""""""""""""""
@@ -66,30 +66,30 @@ The following permissions are required to create/delete the resources handled by
   
 .. code-block:: json
 
-  {
-          "Sid": "TemplateRequired0",
-          "Effect": "Allow",
-          "Action": [
-              "lambda:RemovePermission",
-              "lambda:DeleteFunction",
-              "lambda:GetFunction",
-              "lambda:CreateFunction",
-              "lambda:AddPermission"
-          ],
-          "Resource": "arn:aws:lambda:region:user-id:*"
-      },
-      {
-          "Sid": "TemplateRequired1",
-          "Effect": "Allow",
-          "Action": [
-              "events:RemoveTargets",
-              "events:DeleteRule",
-              "events:PutRule",
-              "events:DescribeRule",
-              "events:PutTargets"
-          ],
-          "Resource": "arn:aws:events:region:user-id:*"
-      }
+   {
+      "Sid": "TemplateRequired0",
+      "Effect": "Allow",
+      "Action": [
+         "lambda:RemovePermission",
+         "lambda:DeleteFunction",
+         "lambda:GetFunction",
+         "lambda:CreateFunction",
+         "lambda:AddPermission"
+      ],
+      "Resource": "arn:aws:lambda:region:user-id:*"
+   },
+   {
+      "Sid": "TemplateRequired1",
+      "Effect": "Allow",
+      "Action": [
+         "events:RemoveTargets",
+         "events:DeleteRule",
+         "events:PutRule",
+         "events:DescribeRule",
+         "events:PutTargets"
+      ],
+      "Resource": "arn:aws:events:region:user-id:*"
+    }
 
 
 
@@ -100,25 +100,25 @@ The following permissions are required to create/delete any template based Cloud
 
 .. code-block:: json
 
-  {
-    "Sid": "CloudFormationStackCreation",
-    "Effect": "Allow",
-    "Action": [
-      "cloudformation:CreateStack",
-      "cloudformation:ValidateTemplate",
-      "cloudformation:CreateUploadBucket",
-      "cloudformation:GetTemplateSummary",
-      "cloudformation:DescribeStackEvents",
-      "cloudformation:DescribeStackResources",
-      "cloudformation:ListStacks",
-      "cloudformation:DeleteStack",
-      "s3:PutObject",
-      "s3:ListBucket",
-      "s3:GetObject",
-      "s3:CreateBucket"
-    ],
-    "Resource": "*"   
-  }
+   {
+      "Sid": "CloudFormationStackCreation",
+      "Effect": "Allow",
+      "Action": [
+         "cloudformation:CreateStack",
+         "cloudformation:ValidateTemplate",
+         "cloudformation:CreateUploadBucket",
+         "cloudformation:GetTemplateSummary",
+         "cloudformation:DescribeStackEvents",
+         "cloudformation:DescribeStackResources",
+         "cloudformation:ListStacks",
+         "cloudformation:DeleteStack",
+         "s3:PutObject",
+         "s3:ListBucket",
+         "s3:GetObject",
+         "s3:CreateBucket"
+      ],
+      "Resource": "*"   
+   }
 
 Amazon ECR usage permissions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -129,22 +129,22 @@ The following permissions are required by Amazon ECR to `push images <https://do
 
 .. code-block:: json
 
-    {
+   {
       "Sid": "ScanPushImage",
       "Effect": "Allow",
       "Action": [
-        "ecr:CompleteLayerUpload",
-        "ecr:UploadLayerPart",
-        "ecr:InitiateLayerUpload",
-        "ecr:BatchCheckLayerAvailability",
-        "ecr:PutImage",
-        "ecr:ListImages",
-        "ecr:DescribeImages",
-        "ecr:DescribeImageScanFindings",
-        "ecr:StartImageScan"
+         "ecr:CompleteLayerUpload",
+         "ecr:UploadLayerPart",
+         "ecr:InitiateLayerUpload",
+         "ecr:BatchCheckLayerAvailability",
+         "ecr:PutImage",
+         "ecr:ListImages",
+         "ecr:DescribeImages",
+         "ecr:DescribeImageScanFindings",
+         "ecr:StartImageScan"
       ],
       "Resource": "arn:aws:ecr:region:user-id:repository/repository-name"
-    }
+   }
 
 ECR Registry and Repository
 """""""""""""""""""""""""""
@@ -155,15 +155,15 @@ ECR Registry and Repository
 
 .. code-block:: json
 
-    { 
+   { 
       "Sid": "ECRUtilities",
       "Effect": "Allow",
       "Action": [
-        "ecr:GetAuthorizationToken",  
-        "ecr:DescribeRepositories"    
+         "ecr:GetAuthorizationToken",  
+         "ecr:DescribeRepositories"    
       ],
       "Resource": "*"
-    }
+   }
 
 
 How to create the CloudFormation Stack

--- a/source/amazon/services/supported-services/ecr-image-scanning.rst
+++ b/source/amazon/services/supported-services/ecr-image-scanning.rst
@@ -27,19 +27,17 @@ The following sections cover how to configure AWS to store the scan findings in 
 AWS configuration
 -----------------
 
-AWS provides a `template <https://github.com/aws-samples/ecr-image-scan-findings-logger/blob/main/Template-ECR-SFL.yml>`_ for creating a stack in CloudFormation that loads the image scan findings from Amazon ECR in CloudWatch using an AWS Lambda function.
+AWS provides a `template <https://github.com/aws-samples/ecr-image-scan-findings-logger/blob/main/Template-ECR-SFL.yml>`_ for creating a stack in CloudFormation that loads the image scan findings from Amazon ECR in CloudWatch using an AWS Lambda function. To be able to use this template, create the stack and upload images to Amazon ECR, it is necessary to create a custom policy granting the necessary permissions. 
 
-Policy configuration
-^^^^^^^^^^^^^^^^^^^^
 .. include:: /_templates/cloud/amazon/create_policy.rst
 
 Template specific permissions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 IAM 
-"""
+~~~
 
 .. warning::
-      The permissions inside the ``RoleCreator`` and ``PassRole`` sections are necessary in order to create/delete the stack based on the named template and must be bound to the described specific resources due to overly permissive actions.
+      The permissions inside the ``RoleCreator`` and ``PassRole`` sections are necessary in order to create and delete the stack based on the named template and must be bound to the described specific resources due to overly permissive actions.
 
 .. code-block:: json
   
@@ -56,19 +54,19 @@ IAM
          "iam:GetRolePolicy",
          "iam:PassRole"
       ],
-      "Resource": "arn:aws:iam::user-id:role/*"
+      "Resource": "arn:aws:iam::<account-ID>:role/*"
    },
    {
       "Sid": "PassRole",
       "Effect": "Allow",
       "Action": "iam:PassRole",
-      "Resource": "arn:aws:iam::user-id:role/*-LambdaExecutionRole*"
+      "Resource": "arn:aws:iam::<account-ID>:role/*-LambdaExecutionRole*"
    }
 
 Amazon Lambda and Amazon EventBridge
-""""""""""""""""""""""""""""""""""""
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following permissions are required to create/delete the resources handled by the Scan Findings Logger template.
+The following permissions are required to create and delete the resources handled by the Scan Findings Logger template.
   
 .. code-block:: json
 
@@ -82,7 +80,7 @@ The following permissions are required to create/delete the resources handled by
          "lambda:CreateFunction",
          "lambda:AddPermission"
       ],
-      "Resource": "arn:aws:lambda:region:user-id:*"
+      "Resource": "arn:aws:lambda:<region>:<account-ID>:*"
    },
    {
       "Sid": "TemplateRequired1",
@@ -94,15 +92,15 @@ The following permissions are required to create/delete the resources handled by
          "events:DescribeRule",
          "events:PutTargets"
       ],
-      "Resource": "arn:aws:events:region:user-id:*"
+      "Resource": "arn:aws:events:<region>:<account-ID>:*"
     }
 
 
 
 CloudFormation Stack
-~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^
 
-The following permissions are required to create/delete any template based CloudFormation stack.
+The following permissions are required to create and delete any template based CloudFormation stack.
 
 .. code-block:: json
 
@@ -127,9 +125,9 @@ The following permissions are required to create/delete any template based Cloud
    }
 
 Amazon ECR usage permissions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Image Pushing and Scanning
-""""""""""""""""""""""""""
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following permissions are required by Amazon ECR to `push images <https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-push.html#image-push-iam>`_ and are scoped down to a specific repository. The steps to push Docker images is also described in the `Amazon ECR - Pushing a Docker image <https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html>`_ documentation.
 
@@ -149,11 +147,11 @@ The following permissions are required by Amazon ECR to `push images <https://do
          "ecr:DescribeImageScanFindings",
          "ecr:StartImageScan"
       ],
-      "Resource": "arn:aws:ecr:region:user-id:repository/repository-name"
+      "Resource": "arn:aws:ecr:<region>:<account-ID>:repository/<repository-name>"
    }
 
 ECR Registry and Repository
-"""""""""""""""""""""""""""
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. note::
       The permission ``ecr:GetAuthorizationToken`` is required by `Amazon ECR <https://docs.aws.amazon.com/AmazonECR/latest/userguide/set-repository-policy.html>`_ for users to have permission to make calls to the API through an IAM policy before they can authenticate to a registry and push or pull any images from any Amazon ECR repository.


### PR DESCRIPTION
| Related issue |
|----|
| Closes #5005 |

## Description

This PR closes the issue #5005. It adds the required permissions to complete the [Amazon ECR image scanning guide](https://documentation.wazuh.com/current/amazon/services/supported-services/ecr-image-scanning.html) divided in sections and with the appropriate notes and warnings.

## Checks
- [x] It compiles without warnings.
- [x] Use present tense, active voice, and semi-formal registry. Write short sentences, simple sentences.
- [x] Use **bold** for user interface elements, _italics_ for key terms or emphasis, and `Code` font for Bash commands, file names, REST paths, and code.
- [x] Add meta descriptions to new pages.
- [x] Indent using three spaces.
- [x] The `redirect.js` script is updated (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
