### PR TITLE
Add Release note 3.13.6 to 4.2

### DIFF
--- a/source/_static/js/redirects.js
+++ b/source/_static/js/redirects.js
@@ -2170,6 +2170,7 @@ redirections.push(
 );
 
 newUrls['3.13'] = [
+  '/release-notes/release-3-13-6.html',
   '/release-notes/release-3-13-5.html', 
   '/release-notes/release-3-13-4.html',  
   '/release-notes/release_3_13_3.html',

--- a/source/release-notes/index.rst
+++ b/source/release-notes/index.rst
@@ -33,6 +33,7 @@ This section summarizes the most important features of each Wazuh release.
         release-4-0-2
         release-4-0-1
         release-4-0-0
+        release-3-13-6
         release-3-13-5
         release-3-13-4
         release-3-13-3

--- a/source/release-notes/release-3-13-6.rst
+++ b/source/release-notes/release-3-13-6.rst
@@ -1,0 +1,25 @@
+.. Copyright (C) 2022 Wazuh, Inc.
+
+.. meta::
+  :description: Wazuh 3.13.6 has been released. Check out our release notes to discover the changes and additions of this release.
+
+.. _release_3_13_6:
+
+3.13.6 Release notes
+====================
+
+This section lists the changes in version 3.13.6. More details about these changes are provided in each component changelog:
+
+- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/v3.13.6/CHANGELOG.md>`_
+- `wazuh/wazuh-kibana-app <https://github.com/wazuh/wazuh-kibana-app/blob/v3.13.6-7.9.2/CHANGELOG.md>`_
+- `wazuh/wazuh-splunk <https://github.com/wazuh/wazuh-splunk/blob/v3.13.6-8.0.4/CHANGELOG.md>`_
+
+Wazuh core
+----------
+
+- `#14823 <https://github.com/wazuh/wazuh/pull/14823>`_  A path traversal flaw in Active Response affecting agents from v3.6.1 is fixed.
+
+Wazuh Splunk
+------------
+
+- Support for Wazuh v3.13.6.


### PR DESCRIPTION
## Description

This PR aims to add Release notes 3.13.6 to 4.2.

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 
- [x] Updated the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).

<!--
Leave the following note if you made any changes to the redirect.js script. Remove it otherwise.
-->

## Note to the reviewer

This PR includes changes to the `redirect.js` script that need to be included in all production branches.
