### PR TITLE
Remote syslog section suggestions to be clearer

### DIFF
--- a/source/user-manual/capabilities/log-data-collection/how-it-works.rst
+++ b/source/user-manual/capabilities/log-data-collection/how-it-works.rst
@@ -90,39 +90,44 @@ Remote syslog
 
 In order to integrate network devices such as routers, firewalls, etc, the log analysis component can be configured to receive log events through syslog. To do that, we have two methods available:
 
-One option is for Wazuh to receive syslog logs by a custom port:
+#. The first method consists of Wazuh receiving syslog logs by a custom port:
 
-  .. code-block:: xml
+    .. code-block:: xml
 
-    <ossec_config>
-      <remote>
-        <connection>syslog</connection>
-        <port>513</port>
-        <protocol>tcp</protocol>
-        <allowed-ips>192.168.2.0/24</allowed-ips>
-      </remote>
-    </ossec_config>
+      <ossec_config>
+        <remote>
+          <connection>syslog</connection>
+          <port>513</port>
+          <protocol>tcp</protocol>
+          <allowed-ips>192.168.2.0/24</allowed-ips>
+        </remote>
+      </ossec_config>
 
-- ``<connection>syslog</connection>`` indicates that the manager will accept incoming syslog messages from across the network.
-- ``<port>513</port>`` defines the port that Wazuh will listen to retrieve the logs. The port must be free.
-- ``<protocol>tcp</protocol>`` defines the protocol to listen the port. It can be UDP or TCP.
-- ``<allowed-ips>192.168.2.0/24</allowed-ips>`` defines the network or IP address from which syslog messages will be accepted.
+    - ``<connection>syslog</connection>`` indicates that the manager will accept incoming syslog messages from across the network.
+    - ``<port>513</port>`` defines the port that Wazuh will listen to retrieve the logs. The port must be free.
+    - ``<protocol>tcp</protocol>`` defines the protocol to listen the port. It can be UDP or TCP.
+    - ``<allowed-ips>192.168.2.0/24</allowed-ips>`` defines the network or IP address from which syslog messages will be accepted.
 
-The other option stores the logs in a plaintext file and monitors that file with Wazuh. If a ``/etc/rsyslog.conf`` configuration file is being used and we have defined where to store the syslog logs we can monitor them in Wazuh ``ossec.conf`` using a ``<localfile>`` block with ``syslog`` as the log format.
+    .. note::
 
-.. code-block:: xml
+      The ``allowed-ips`` label is mandatory, without it the configuration will not take effect. 
 
-  <localfile>
-    <log_format>syslog</log_format>
-    <location>/custom/file/path</location>
-  </localfile>
 
-- ``<log_format>syslog</log_format>`` indicates the source log format, in this case, syslog format.
-- ``<location>/custom/file/path</location>`` indicates where we have stored the syslog logs.
+#. The second method consists of storing the logs in a plaintext file and monitoring that file with Wazuh. If a ``/etc/rsyslog.conf`` configuration file is being used and we have defined where to store the syslog logs we can monitor them in Wazuh ``ossec.conf`` using a ``<localfile>`` block with ``syslog`` as the log format.
 
-.. note::
+    .. code-block:: xml
 
-  For more information about the ``localfile`` label, see the :ref:`Local configuration's localfile <reference_ossec_localfile>`.
+      <localfile>
+        <log_format>syslog</log_format>
+        <location>/custom/file/path</location>
+      </localfile>
+
+    - ``<log_format>syslog</log_format>`` indicates the source log format, in this case, syslog format.
+    - ``<location>/custom/file/path</location>`` indicates where we have stored the syslog logs.
+
+    .. note::
+
+      For more information about the ``localfile`` label, see the :ref:`Local configuration's localfile <reference_ossec_localfile>`.
 
 Analysis
 --------
@@ -130,7 +135,7 @@ Analysis
 Pre-decoding
 ^^^^^^^^^^^^
 
-In the pre-decoding phase of analysis, static information from well-known fields all that is extracted from the log header.
+In the pre-decoding phase of analysis, static information from well-known fields is extracted from the log header.
 
 .. code-block:: none
   :class: output

--- a/source/user-manual/capabilities/log-data-collection/how-it-works.rst
+++ b/source/user-manual/capabilities/log-data-collection/how-it-works.rst
@@ -90,11 +90,11 @@ Remote syslog
 
 In order to integrate network devices such as routers, firewalls, etc, the log analysis component can be configured to receive log events through syslog. To do that, we have two methods available:
 
-- Receiving Syslog logs
-- Storing logs
+- Receiving Syslog logs in a custom port
+- Storing logs in a plaintext file
 
-Receiving Syslog logs
-~~~~~~~~~~~~~~~~~~~~~
+Receiving Syslog logs in a custom port
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In this method Wazuh receives syslog logs in a custom port:
 
@@ -118,8 +118,8 @@ In this method Wazuh receives syslog logs in a custom port:
 
       The ``allowed-ips`` label is mandatory, without it the configuration will not take effect. 
 
-Storing logs
-~~~~~~~~~~~~
+Storing logs in a plaintext file
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This method consists of storing the logs in a plaintext file and monitoring that file with Wazuh. If a ``/etc/rsyslog.conf`` configuration file is being used and we have defined where to store the syslog logs we can monitor them in Wazuh ``ossec.conf`` using a ``<localfile>`` block with ``syslog`` as the log format.
 

--- a/source/user-manual/capabilities/log-data-collection/how-it-works.rst
+++ b/source/user-manual/capabilities/log-data-collection/how-it-works.rst
@@ -88,15 +88,15 @@ Wazuh can monitor logs from the macOS Unified Logging System.
 Remote syslog
 ^^^^^^^^^^^^^
 
-In order to integrate network devices such as routers, firewalls, etc, the log analysis component can be configured to receive log events through syslog. To do that, we have two methods available:
+To integrate network devices such as routers and firewalls, among others, the log analysis component can be configured to receive log events through syslog. To do that, we have two methods available:
 
-- Receiving logs in a custom port
-- Storing logs in a plaintext file
+- Receiving syslog logs in a custom port
+- Storing syslog logs in a plaintext file and monitoring it with Wazuh
 
-Receiving logs in a custom port
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Receiving syslog logs in a custom port
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In this method Wazuh receives syslog logs in a custom port:
+Configure Wazuh as follows to receive logs in a given port: 
 
     .. code-block:: xml
 
@@ -118,10 +118,10 @@ In this method Wazuh receives syslog logs in a custom port:
 
       The ``allowed-ips`` label is mandatory, without it the configuration will not take effect. 
 
-Storing logs in a plaintext file
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Storing syslog logs in a plaintext file and monitoring it with Wazuh
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This method consists of storing the logs in a plaintext file and monitoring that file with Wazuh. If a ``/etc/rsyslog.conf`` configuration file is being used and we have defined where to store the syslog logs we can monitor them in Wazuh ``ossec.conf`` using a ``<localfile>`` block with ``syslog`` as the log format.
+This method consists of storing the logs in a plaintext file and monitoring that file. If a ``/etc/rsyslog.conf`` configuration file is being used and we have defined where to store the syslog logs, we can monitor them with Wazuh by configuring a ``<localfile>`` block with ``syslog`` as the log format.
 
     .. code-block:: xml
 
@@ -135,7 +135,7 @@ This method consists of storing the logs in a plaintext file and monitoring that
 
     .. note::
 
-      For more information about the ``localfile`` label, see the :ref:`Local configuration's localfile <reference_ossec_localfile>`.
+      For more information about the ``localfile`` label, see the :ref:`Local configuration localfile <reference_ossec_localfile>`.
 
 Analysis
 --------

--- a/source/user-manual/capabilities/log-data-collection/how-it-works.rst
+++ b/source/user-manual/capabilities/log-data-collection/how-it-works.rst
@@ -90,7 +90,13 @@ Remote syslog
 
 In order to integrate network devices such as routers, firewalls, etc, the log analysis component can be configured to receive log events through syslog. To do that, we have two methods available:
 
-#. The first method consists of Wazuh receiving syslog logs by a custom port:
+- Receiving Syslog logs
+- Storing logs
+
+Receiving Syslog logs
+~~~~~~~~~~~~~~~~~~~~~
+
+In this method Wazuh receives syslog logs in a custom port:
 
     .. code-block:: xml
 
@@ -112,8 +118,10 @@ In order to integrate network devices such as routers, firewalls, etc, the log a
 
       The ``allowed-ips`` label is mandatory, without it the configuration will not take effect. 
 
+Storing logs
+~~~~~~~~~~~~
 
-#. The second method consists of storing the logs in a plaintext file and monitoring that file with Wazuh. If a ``/etc/rsyslog.conf`` configuration file is being used and we have defined where to store the syslog logs we can monitor them in Wazuh ``ossec.conf`` using a ``<localfile>`` block with ``syslog`` as the log format.
+This method consists of storing the logs in a plaintext file and monitoring that file with Wazuh. If a ``/etc/rsyslog.conf`` configuration file is being used and we have defined where to store the syslog logs we can monitor them in Wazuh ``ossec.conf`` using a ``<localfile>`` block with ``syslog`` as the log format.
 
     .. code-block:: xml
 

--- a/source/user-manual/capabilities/log-data-collection/how-it-works.rst
+++ b/source/user-manual/capabilities/log-data-collection/how-it-works.rst
@@ -90,11 +90,11 @@ Remote syslog
 
 In order to integrate network devices such as routers, firewalls, etc, the log analysis component can be configured to receive log events through syslog. To do that, we have two methods available:
 
-- Receiving Syslog logs in a custom port
+- Receiving logs in a custom port
 - Storing logs in a plaintext file
 
-Receiving Syslog logs in a custom port
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Receiving logs in a custom port
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In this method Wazuh receives syslog logs in a custom port:
 


### PR DESCRIPTION
## Description
- This issue aims to make clearer the section: https://documentation.wazuh.com/current/user-manual/capabilities/log-data-collection/how-it-works.html#remote-syslog where the users configure Wazuh to receive logs via Syslog.

- Closes issue #5583

## Checks
- [x] It compiles without warnings.
- [x] Use present tense, active voice, and semi-formal registry. Write short sentences, simple sentences.
- [x] Use **bold** for user interface elements, _italics_ for key terms or emphasis, and `Code` font for Bash commands, file names, REST paths, and code.
- [x] Add meta descriptions to new pages.
- [x] Indent using three spaces.
- [ ] The `redirect.js` script is updated (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
