### PR TITLE
Improve the "Securing your Wazuh installation" section in the step-by-step installation guide

### DIFF
--- a/source/installation-guide/wazuh-dashboard/step-by-step.rst
+++ b/source/installation-guide/wazuh-dashboard/step-by-step.rst
@@ -217,11 +217,11 @@ Select your deployment type and follow the instructions to change the default pa
            
             hosts:
               - default:
-                 url: https://localhost
-                 port: 55000
-                 username: wazuh-wui
-                 password: <wazuh-wui-password>
-                 run_as: false
+                  url: https://localhost
+                  port: 55000
+                  username: wazuh-wui
+                  password: <wazuh-wui-password>
+                  run_as: false
 
       #. Restart the Wazuh dashboard to apply the changes.
 

--- a/source/installation-guide/wazuh-dashboard/step-by-step.rst
+++ b/source/installation-guide/wazuh-dashboard/step-by-step.rst
@@ -161,7 +161,7 @@ Select your deployment type and follow the instructions to change the default pa
     
    .. group-tab:: Distributed deployment
 
-      #. On `any Wazuh indexer node`, use the Wazuh passwords tool to change all the Wazuh indexer user passwords. 
+      #. On `any Wazuh indexer node`, use the Wazuh passwords tool to change the passwords of the Wazuh indexer users. 
 
          .. code-block:: console
   
@@ -179,7 +179,7 @@ Select your deployment type and follow the instructions to change the default pa
             INFO: The password for user snapshotrestore is Mb2EHw8SIc1d.oz.nM?dHiPBGk7s?UZB
             WARNING: Wazuh indexer passwords changed. Remember to update the password in the Wazuh dashboard and Filebeat nodes if necessary, and restart the services.
 
-      #. On your `Wazuh server master node`, download the Wazuh passwords tool and use it to change the Wazuh API users passwords.
+      #. On your `Wazuh server master node`, download the Wazuh passwords tool and use it to change the passwords of the Wazuh API users.
 
          .. code-block:: console
   
@@ -198,13 +198,13 @@ Select your deployment type and follow the instructions to change the default pa
 
             # echo <admin-password> | filebeat keystore add password --stdin --force
 
-      #. Restart Filebeat on `all your Wazuh server nodes`.
+      #. Restart Filebeat to apply the change.
 
          .. include:: /_templates/common/restart_filebeat.rst
 
          .. note:: Repeat steps 3 and 4 on `every Wazuh server node`.
        
-      #. On your `Wazuh dashboard server`, run the following command to update the `kibanaserver` password in the Wazuh dashboard keystore. Replace ``<kibanaserver-password>`` with the random password generated in the first step.
+      #. On your `Wazuh dashboard node`, run the following command to update the `kibanaserver` password in the Wazuh dashboard keystore. Replace ``<kibanaserver-password>`` with the random password generated in the first step.
 
          .. code-block:: console
 
@@ -216,14 +216,14 @@ Select your deployment type and follow the instructions to change the default pa
             :emphasize-lines: 6
            
             hosts:
-            - default:
-               url: https://localhost
-               port: 55000
-               username: wazuh-wui
-               password: <wazuh-wui-password>
-               run_as: false
+              - default:
+                 url: https://localhost
+                 port: 55000
+                 username: wazuh-wui
+                 password: <wazuh-wui-password>
+                 run_as: false
 
-      #. Restart the Wazuh dashboard.
+      #. Restart the Wazuh dashboard to apply the changes.
 
          .. include:: /_templates/common/restart_dashboard.rst
 

--- a/source/installation-guide/wazuh-dashboard/step-by-step.rst
+++ b/source/installation-guide/wazuh-dashboard/step-by-step.rst
@@ -138,94 +138,94 @@ Select your deployment type and follow the instructions to change the default pa
 
    .. group-tab:: All-in-one deployment
 
-       #. Use the Wazuh passwords tool to change all the internal users passwords. 
+      #. Use the Wazuh passwords tool to change all the internal users passwords.
       
-          .. code-block:: console
+         .. code-block:: console
          
             # /usr/share/wazuh-indexer/plugins/opensearch-security/tools/wazuh-passwords-tool.sh --change-all --admin-user wazuh --admin-password wazuh
          
-          .. code-block:: console
-             :class: output
+         .. code-block:: console
+            :class: output
        
-             INFO: The password for user admin is yWOzmNA.?Aoc+rQfDBcF71KZp?1xd7IO
-             INFO: The password for user kibanaserver is nUa+66zY.eDF*2rRl5GKdgLxvgYQA+wo
-             INFO: The password for user kibanaro is 0jHq.4i*VAgclnqFiXvZ5gtQq1D5LCcL
-             INFO: The password for user logstash is hWW6U45rPoCT?oR.r.Baw2qaWz2iH8Ml
-             INFO: The password for user readall is PNt5K+FpKDMO2TlxJ6Opb2D0mYl*I7FQ
-             INFO: The password for user snapshotrestore is +GGz2noZZr2qVUK7xbtqjUup049tvLq.
-             WARNING: Wazuh indexer passwords changed. Remember to update the password in the Wazuh dashboard and Filebeat nodes if necessary, and restart the services.
-             INFO: The password for Wazuh API user wazuh is JYWz5Zdb3Yq+uOzOPyUU4oat0n60VmWI
-             INFO: The password for Wazuh API user wazuh-wui is +fLddaCiZePxh24*?jC0nyNmgMGCKE+2
-             INFO: Updated wazuh-wui user password in wazuh dashboard. Remember to restart the service.
+            INFO: The password for user admin is yWOzmNA.?Aoc+rQfDBcF71KZp?1xd7IO
+            INFO: The password for user kibanaserver is nUa+66zY.eDF*2rRl5GKdgLxvgYQA+wo
+            INFO: The password for user kibanaro is 0jHq.4i*VAgclnqFiXvZ5gtQq1D5LCcL
+            INFO: The password for user logstash is hWW6U45rPoCT?oR.r.Baw2qaWz2iH8Ml
+            INFO: The password for user readall is PNt5K+FpKDMO2TlxJ6Opb2D0mYl*I7FQ
+            INFO: The password for user snapshotrestore is +GGz2noZZr2qVUK7xbtqjUup049tvLq.
+            WARNING: Wazuh indexer passwords changed. Remember to update the password in the Wazuh dashboard and Filebeat nodes if necessary, and restart the services.
+            INFO: The password for Wazuh API user wazuh is JYWz5Zdb3Yq+uOzOPyUU4oat0n60VmWI
+            INFO: The password for Wazuh API user wazuh-wui is +fLddaCiZePxh24*?jC0nyNmgMGCKE+2
+            INFO: Updated wazuh-wui user password in wazuh dashboard. Remember to restart the service.
        
     
    .. group-tab:: Distributed deployment
 
-       #. On `any Wazuh indexer` node, use the Wazuh passwords tool to change all the Wazuh indexer user passwords. 
+      #. On `any Wazuh indexer node`, use the Wazuh passwords tool to change all the Wazuh indexer user passwords. 
 
-          .. code-block:: console
+         .. code-block:: console
   
-             # /usr/share/wazuh-indexer/plugins/opensearch-security/tools/wazuh-passwords-tool.sh --change-all
+            # /usr/share/wazuh-indexer/plugins/opensearch-security/tools/wazuh-passwords-tool.sh --change-all
   
-          .. code-block:: console
-             :class: output
+         .. code-block:: console
+            :class: output
 
-             INFO: Wazuh API admin credentials not provided, Wazuh API passwords not changed.
-             INFO: The password for user admin is wcAny.XUwOVWHFy.+7tW9l8gUW1L8N3j
-             INFO: The password for user kibanaserver is qy6fBrNOI4fD9yR9.Oj03?pihN6Ejfpp
-             INFO: The password for user kibanaro is Nj*sSXSxwntrx3O7m8ehrgdHkxCc0dna
-             INFO: The password for user logstash is nQg1Qw0nIQFZXUJc8r8+zHVrkelch33h
-             INFO: The password for user readall is s0iWAei?RXObSDdibBfzSgXdhZCD9kH4
-             INFO: The password for user snapshotrestore is Mb2EHw8SIc1d.oz.nM?dHiPBGk7s?UZB
-             WARNING: Wazuh indexer passwords changed. Remember to update the password in the Wazuh dashboard and Filebeat nodes if necessary, and restart the services.
+            INFO: Wazuh API admin credentials not provided, Wazuh API passwords not changed.
+            INFO: The password for user admin is wcAny.XUwOVWHFy.+7tW9l8gUW1L8N3j
+            INFO: The password for user kibanaserver is qy6fBrNOI4fD9yR9.Oj03?pihN6Ejfpp
+            INFO: The password for user kibanaro is Nj*sSXSxwntrx3O7m8ehrgdHkxCc0dna
+            INFO: The password for user logstash is nQg1Qw0nIQFZXUJc8r8+zHVrkelch33h
+            INFO: The password for user readall is s0iWAei?RXObSDdibBfzSgXdhZCD9kH4
+            INFO: The password for user snapshotrestore is Mb2EHw8SIc1d.oz.nM?dHiPBGk7s?UZB
+            WARNING: Wazuh indexer passwords changed. Remember to update the password in the Wazuh dashboard and Filebeat nodes if necessary, and restart the services.
 
-       #. On your `Wazuh master` node, download the Wazuh passwords tool and use it to change the Wazuh API user passwords.
+      #. On your `Wazuh server master node`, download the Wazuh passwords tool and use it to change the Wazuh API users passwords.
 
-          .. code-block:: console
+         .. code-block:: console
   
-             # curl -so wazuh-passwords-tool.sh https://packages.wazuh.com/4.3/wazuh-passwords-tool.sh
-             # bash wazuh-passwords-tool.sh --change-all --admin-user wazuh --admin-password wazuh 
+            # curl -sO https://packages.wazuh.com/|WAZUH_CURRENT_MINOR|/wazuh-passwords-tool.sh
+            # bash wazuh-passwords-tool.sh --change-all --admin-user wazuh --admin-password wazuh
   
-          .. code-block:: console
-             :class: output
+         .. code-block:: console
+            :class: output
 
-             INFO: The password for Wazuh API user wazuh is ivLOfmj7.jL6*7Ev?UJoFjrkGy9t6Je.
-             INFO: The password for Wazuh API user wazuh-wui is fL+f?sFRPEv5pYRE559rqy9b6G4Z5pVi                    
+            INFO: The password for Wazuh API user wazuh is ivLOfmj7.jL6*7Ev?UJoFjrkGy9t6Je.
+            INFO: The password for Wazuh API user wazuh-wui is fL+f?sFRPEv5pYRE559rqy9b6G4Z5pVi
 
-       #. On your `Wazuh servers`, update the `admin` password in the Filebeat keystore. Replace ``<admin-password>`` with the random password generated in the first step and run the following command:  
+      #. On `all your Wazuh server nodes`, run the following command to update the `admin` password in the Filebeat keystore. Replace ``<admin-password>`` with the random password generated in the first step.
       
-          .. code-block:: console
+         .. code-block:: console
 
-             # echo <admin-password> | filebeat keystore add password --stdin --force
+            # echo <admin-password> | filebeat keystore add password --stdin --force
 
-       #. Restart Filebeat.
+      #. Restart Filebeat on `all your Wazuh server nodes`.
 
-          .. include:: /_templates/common/restart_filebeat.rst
+         .. include:: /_templates/common/restart_filebeat.rst
 
-          .. note:: Update the `admin` password and restart Filebeat on every Wazuh server node.   
+         .. note:: Repeat steps 3 and 4 on `every Wazuh server node`.
        
-       #. On your `Wazuh dashboard` server, update the `kibanaserver` password in the Wazuh dashboard keystore. Replace ``<kibanaserver-password>`` with the random password generated in the first step and run the following command:   
+      #. On your `Wazuh dashboard server`, run the following command to update the `kibanaserver` password in the Wazuh dashboard keystore. Replace ``<kibanaserver-password>`` with the random password generated in the first step.
 
-          .. code-block:: console
+         .. code-block:: console
 
-             # echo <kibanaserver-password> | /usr/share/wazuh-dashboard/bin/opensearch-dashboards-keystore --allow-root add -f --stdin opensearch.password         
+            # echo <kibanaserver-password> | /usr/share/wazuh-dashboard/bin/opensearch-dashboards-keystore --allow-root add -f --stdin opensearch.password
 
-       #. Update the ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` configuration file with the new `wazuh-wui` password generated in the second step.  
+      #. Update the ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` configuration file with the new `wazuh-wui` password generated in the second step.
 
-          .. code-block:: yaml
+         .. code-block:: yaml
             :emphasize-lines: 6
            
-             hosts:
-               - default:
-                 url: https://localhost
-                 port: 55000
-                 username: wazuh-wui
-                 password: <wazuh-wui-password>
-                 run_as: false 
+            hosts:
+            - default:
+               url: https://localhost
+               port: 55000
+               username: wazuh-wui
+               password: <wazuh-wui-password>
+               run_as: false
 
-       #. Restart the Wazuh dashboard. 
+      #. Restart the Wazuh dashboard.
 
-          .. include:: /_templates/common/restart_dashboard.rst
+         .. include:: /_templates/common/restart_dashboard.rst
 
 
 Next steps

--- a/source/installation-guide/wazuh-dashboard/step-by-step.rst
+++ b/source/installation-guide/wazuh-dashboard/step-by-step.rst
@@ -131,73 +131,7 @@ Securing your Wazuh installation
 
 You have now installed and configured all the Wazuh central components. We recommend changing the default credentials to protect your infrastructure from possible attacks. 
 
-Follow the instructions below to change the passwords for both the Wazuh API and the Wazuh indexer users.  
-
-Change the default Wazuh API credentials
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Change the default password of the admin users: `wazuh` and `wazuh-wui`. Note that the commands below use localhost, set your Wazuh manager IP address if necessary. 
-
-#. Get an authorization token. 
-
-   .. code-block:: console
-
-      # TOKEN=$(curl -u wazuh-wui:wazuh-wui -k -X GET "https://localhost:55000/security/user/authenticate?raw=true")
-
-#. Change the `wazuh` user credentials (ID 1). Select a password between 8 and 64 characters long, it should contain at least one uppercase and one lowercase letter, a number, and a symbol. See :api-ref:`PUT /security/users/{user_id} <operation/api.controllers.security_controller.update_user>` to learn more. 
-
-   .. code-block:: console
-
-      curl -k -X PUT "https://localhost:55000/security/users/1" -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -d' 
-      {
-        "password": "SuperS3cretPassword!"
-      }'
-
-   .. code-block:: console
-      :class: output
-
-      {"data": {"affected_items": [{"id": 1, "username": "wazuh", "allow_run_as": true, "roles": [1]}], "total_affected_items": 1, "total_failed_items": 0, "failed_items": []}, "message": "User was successfully updated", "error": 0}  
-    
-        
-#. Change the `wazuh-wui` user credentials (ID 2). 
-
-   .. code-block:: console
-
-      curl -k -X PUT "https://localhost:55000/security/users/2" -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -d' 
-      {
-        "password": "SuperS3cretPassword!"
-      }'
-
-   .. code-block:: console
-     :class: output   
-
-      {"data": {"affected_items": [{"id": 2, "username": "wazuh-wui", "allow_run_as": true, "roles": [1]}], "total_affected_items": 1, "total_failed_items": 0, "failed_items": []}, "message": "User was successfully updated", "error": 0}
-
-   See the :doc:`Securing the Wazuh API </user-manual/api/securing-api>` section for additional security configurations. 
-
-#. In your `Wazuh dashboard` server, update ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` with your new password.  
-
-   .. code-block:: yaml
-     :emphasize-lines: 6
-    
-      hosts:
-        - default:
-          url: https://localhost
-          port: 55000
-          username: wazuh-wui
-          password: SuperS3cretPassword!
-          run_as: false 
-
-#. Restart the Wazuh dashboard.
-
-   .. include:: /_templates/common/restart_dashboard.rst
-
-
-
-Change the default Wazuh indexer credentials
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Select your deployment type and follow the instructions to change the default Wazuh indexer passwords. 
+Select your deployment type and follow the instructions to change the default passwords for both the Wazuh API and the Wazuh indexer users.
 
 
 .. tabs::
@@ -208,42 +142,55 @@ Select your deployment type and follow the instructions to change the default Wa
       
           .. code-block:: console
          
-            # /usr/share/wazuh-indexer/plugins/opensearch-security/tools/wazuh-passwords-tool.sh --change-all
+            # /usr/share/wazuh-indexer/plugins/opensearch-security/tools/wazuh-passwords-tool.sh --change-all --admin-user wazuh --admin-password wazuh
          
           .. code-block:: console
-            :class: output
+             :class: output
        
-            INFO: The password for user admin is o5XWBs044S5PJ1edYgw4R4MOM7r00Hjm
-            INFO: The password for user kibanaserver is mqhbijWWw8vVyuOBDtFQvqoLYwMdrcXP
-            INFO: The password for user kibanaro is jTbFvrCSQ4LaLmcNtcFOzVUvCL24nYtN
-            INFO: The password for user logstash is bmtERx0schYGoANyGiWnyed6044CYGQv
-            INFO: The password for user readall is j9JOe7nEhKZhjyfUWVXhI2FNaM5A7eT6
-            INFO: The password for user snapshotrestore is tYyAqG9U72RURf0svrvJ8rtiVEzqjdmg
-            INFO: The password for user wazuh_admin is NHJMpiJkeBgjwNSJnoPV1KD9XMD7a98N
-            INFO: The password for user wazuh_user is N364F1kSkgKfUkVPzRxnCKwszaDVLqu0
-            WARNING: Passwords changed. Remember to update the password in the Wazuh dashboard and Filebeat nodes if necessary, and restart the services.
+             INFO: The password for user admin is yWOzmNA.?Aoc+rQfDBcF71KZp?1xd7IO
+             INFO: The password for user kibanaserver is nUa+66zY.eDF*2rRl5GKdgLxvgYQA+wo
+             INFO: The password for user kibanaro is 0jHq.4i*VAgclnqFiXvZ5gtQq1D5LCcL
+             INFO: The password for user logstash is hWW6U45rPoCT?oR.r.Baw2qaWz2iH8Ml
+             INFO: The password for user readall is PNt5K+FpKDMO2TlxJ6Opb2D0mYl*I7FQ
+             INFO: The password for user snapshotrestore is +GGz2noZZr2qVUK7xbtqjUup049tvLq.
+             WARNING: Wazuh indexer passwords changed. Remember to update the password in the Wazuh dashboard and Filebeat nodes if necessary, and restart the services.
+             INFO: The password for Wazuh API user wazuh is JYWz5Zdb3Yq+uOzOPyUU4oat0n60VmWI
+             INFO: The password for Wazuh API user wazuh-wui is +fLddaCiZePxh24*?jC0nyNmgMGCKE+2
+             INFO: Updated wazuh-wui user password in wazuh dashboard. Remember to restart the service.
        
     
    .. group-tab:: Distributed deployment
 
-       #. Use the Wazuh password tool on `any Wazuh indexer node` to change all the internal users passwords. 
+       #. On `any Wazuh indexer node`,  use the Wazuh password tool to change all the internal users passwords. 
 
           .. code-block:: console
   
              # /usr/share/wazuh-indexer/plugins/opensearch-security/tools/wazuh-passwords-tool.sh --change-all
   
           .. code-block:: console
-            :class: output
+             :class: output
 
-             INFO: The password for user admin is o5XWBs044S5PJ1edYgw4R4MOM7r00Hjm
-             INFO: The password for user kibanaserver is mqhbijWWw8vVyuOBDtFQvqoLYwMdrcXP
-             INFO: The password for user kibanaro is jTbFvrCSQ4LaLmcNtcFOzVUvCL24nYtN
-             INFO: The password for user logstash is bmtERx0schYGoANyGiWnyed6044CYGQv
-             INFO: The password for user readall is j9JOe7nEhKZhjyfUWVXhI2FNaM5A7eT6
-             INFO: The password for user snapshotrestore is tYyAqG9U72RURf0svrvJ8rtiVEzqjdmg
-             INFO: The password for user wazuh_admin is NHJMpiJkeBgjwNSJnoPV1KD9XMD7a98N
-             INFO: The password for user wazuh_user is N364F1kSkgKfUkVPzRxnCKwszaDVLqu0
-             WARNING: Passwords changed. Remember to update the password in the Wazuh dashboard and Filebeat nodes if necessary, and restart the services.
+             INFO: Wazuh API admin credentials not provided, Wazuh API passwords not changed.
+             INFO: The password for user admin is wcAny.XUwOVWHFy.+7tW9l8gUW1L8N3j
+             INFO: The password for user kibanaserver is qy6fBrNOI4fD9yR9.Oj03?pihN6Ejfpp
+             INFO: The password for user kibanaro is Nj*sSXSxwntrx3O7m8ehrgdHkxCc0dna
+             INFO: The password for user logstash is nQg1Qw0nIQFZXUJc8r8+zHVrkelch33h
+             INFO: The password for user readall is s0iWAei?RXObSDdibBfzSgXdhZCD9kH4
+             INFO: The password for user snapshotrestore is Mb2EHw8SIc1d.oz.nM?dHiPBGk7s?UZB
+             WARNING: Wazuh indexer passwords changed. Remember to update the password in the Wazuh dashboard and Filebeat nodes if necessary, and restart the services.
+
+       #. On your `Wazuh master` node,  download the Wazuh password tool and use it to change the default users passwords.
+
+          .. code-block:: console
+  
+             # curl -so wazuh-passwords-tool.sh https://packages.wazuh.com/4.3/wazuh-passwords-tool.sh
+             # bash wazuh-passwords-tool.sh --change-all --admin-user wazuh --admin-password wazuh 
+  
+          .. code-block:: console
+             :class: output
+
+             INFO: The password for Wazuh API user wazuh is ivLOfmj7.jL6*7Ev?UJoFjrkGy9t6Je.
+             INFO: The password for Wazuh API user wazuh-wui is fL+f?sFRPEv5pYRE559rqy9b6G4Z5pVi                    
 
        #. On your `Wazuh servers`, update the `admin` password in the Filebeat keystore. Replace ``<admin-password>`` with the random password generated in the previous step and run the following command:  
       
@@ -255,6 +202,19 @@ Select your deployment type and follow the instructions to change the default Wa
 
           .. include:: /_templates/common/restart_filebeat.rst
 
+       #. On your `Wazuh dashboard` server, update ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` with your new password.  
+
+          .. code-block:: yaml
+            :emphasize-lines: 6
+           
+             hosts:
+               - default:
+                 url: https://localhost
+                 port: 55000
+                 username: wazuh-wui
+                 password: SuperS3cretPassword!
+                 run_as: false 
+       
        #. On your `Wazuh dashboard` server, update the `kibanaserver` password in the Wazuh dashboard keystore. Replace ``<kibanaserver-password>`` with the random password generated in the previous step and run the following command:   
 
           .. code-block:: console

--- a/source/installation-guide/wazuh-dashboard/step-by-step.rst
+++ b/source/installation-guide/wazuh-dashboard/step-by-step.rst
@@ -138,7 +138,7 @@ Select your deployment type and follow the instructions to change the default pa
 
    .. group-tab:: All-in-one deployment
 
-       #. Use the Wazuh password tool to change all the internal users passwords. 
+       #. Use the Wazuh passwords tool to change all the internal users passwords. 
       
           .. code-block:: console
          
@@ -161,7 +161,7 @@ Select your deployment type and follow the instructions to change the default pa
     
    .. group-tab:: Distributed deployment
 
-       #. On `any Wazuh indexer node`,  use the Wazuh password tool to change all the internal users passwords. 
+       #. On `any Wazuh indexer` node, use the Wazuh passwords tool to change all the Wazuh indexer user passwords. 
 
           .. code-block:: console
   
@@ -179,7 +179,7 @@ Select your deployment type and follow the instructions to change the default pa
              INFO: The password for user snapshotrestore is Mb2EHw8SIc1d.oz.nM?dHiPBGk7s?UZB
              WARNING: Wazuh indexer passwords changed. Remember to update the password in the Wazuh dashboard and Filebeat nodes if necessary, and restart the services.
 
-       #. On your `Wazuh master` node,  download the Wazuh password tool and use it to change the default users passwords.
+       #. On your `Wazuh master` node, download the Wazuh passwords tool and use it to change the Wazuh API user passwords.
 
           .. code-block:: console
   
@@ -192,7 +192,7 @@ Select your deployment type and follow the instructions to change the default pa
              INFO: The password for Wazuh API user wazuh is ivLOfmj7.jL6*7Ev?UJoFjrkGy9t6Je.
              INFO: The password for Wazuh API user wazuh-wui is fL+f?sFRPEv5pYRE559rqy9b6G4Z5pVi                    
 
-       #. On your `Wazuh servers`, update the `admin` password in the Filebeat keystore. Replace ``<admin-password>`` with the random password generated in the previous step and run the following command:  
+       #. On your `Wazuh servers`, update the `admin` password in the Filebeat keystore. Replace ``<admin-password>`` with the random password generated in the first step and run the following command:  
       
           .. code-block:: console
 
@@ -202,7 +202,15 @@ Select your deployment type and follow the instructions to change the default pa
 
           .. include:: /_templates/common/restart_filebeat.rst
 
-       #. On your `Wazuh dashboard` server, update ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` with your new password.  
+          .. note:: Update the `admin` password and restart Filebeat on every Wazuh server node.   
+       
+       #. On your `Wazuh dashboard` server, update the `kibanaserver` password in the Wazuh dashboard keystore. Replace ``<kibanaserver-password>`` with the random password generated in the first step and run the following command:   
+
+          .. code-block:: console
+
+             # echo <kibanaserver-password> | /usr/share/wazuh-dashboard/bin/opensearch-dashboards-keystore --allow-root add -f --stdin opensearch.password         
+
+       #. Update the ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` configuration file with the new `wazuh-wui` password generated in the second step.  
 
           .. code-block:: yaml
             :emphasize-lines: 6
@@ -212,14 +220,8 @@ Select your deployment type and follow the instructions to change the default pa
                  url: https://localhost
                  port: 55000
                  username: wazuh-wui
-                 password: SuperS3cretPassword!
+                 password: <wazuh-wui-password>
                  run_as: false 
-       
-       #. On your `Wazuh dashboard` server, update the `kibanaserver` password in the Wazuh dashboard keystore. Replace ``<kibanaserver-password>`` with the random password generated in the previous step and run the following command:   
-
-          .. code-block:: console
-
-             # echo <kibanaserver-password> | /usr/share/wazuh-dashboard/bin/opensearch-dashboards-keystore --allow-root add -f --stdin opensearch.password         
 
        #. Restart the Wazuh dashboard. 
 


### PR DESCRIPTION
## Description

This PR takes into account the [recent changes](https://github.com/wazuh/wazuh-packages/pull/1548) introduced in the Wazuh passwords tool and simplifies the instructions to secure the Wazuh installation. 

Instructions are simplified by using the passwords tool to change the Wazuh manager API passwords. This improvement is especially noticeable in all-in-one deployments, where a single command is now sufficient to change all the passwords. 
For distributed deployments, there are still manual steps that could be simplified by applying the changes and improvements suggested in https://github.com/wazuh/wazuh-packages/issues/1854.  

## Checks
- [x] It compiles without warnings.
- [x] Use present tense, active voice, and semi-formal registry. Write short sentences, simple sentences.
- [x] Use **bold** for user interface elements, _italics_ for key terms or emphasis, and `Code` font for Bash commands, file names, REST paths, and code.
- [x] Add meta descriptions to new pages.
- [x] Indent using three spaces.
- [x] The `redirect.js` script is updated (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
