### PR TITLE
Add "Securing your Wazuh installation" instructions - Offline installation guide

### DIFF
--- a/source/_templates/installations/filebeat/opensearch/configure_filebeat.rst
+++ b/source/_templates/installations/filebeat/opensearch/configure_filebeat.rst
@@ -1,6 +1,6 @@
 .. Copyright (C) 2015, Wazuh, Inc.
 
-#. ``hosts``: The list of Wazuh indexer nodes to connect to, you can use either IP addresses or hostnames. By default, the host is set to localhost ``hosts: ["127.0.0.1:9200"]``. Replace your Wazuh indexer address accordingly. 
+#. ``hosts``: The list of Wazuh indexer nodes to connect to, you can use either IP addresses or hostnames. By default, the host is set to localhost ``hosts: ["127.0.0.1:9200"]``. Replace it with your Wazuh indexer address accordingly. 
   
     In case of having more than one Wazuh indexer node, you can separate the addresses using commas. For example, ``hosts: ["10.0.0.1:9200", "10.0.0.2:9200", "10.0.0.3:9200"]`` 
 

--- a/source/deployment-options/offline-installation.rst
+++ b/source/deployment-options/offline-installation.rst
@@ -259,34 +259,22 @@ Filebeat must be installed and configured on the same server as the Wazuh manage
           ...
         }      
 
-#.  Edit Filebeat configuration file ``/etc/filebeat/filebeat.yml``:
+#. Edit the ``/etc/filebeat/filebeat.yml`` configuration file and replace the following value:
 
-    -   All-in-one deployment
+   .. include:: /_templates/installations/filebeat/opensearch/configure_filebeat.rst
 
-        Change the value of ``username`` and ``password`` to the configured credentials. The default username and password is ``admin``.
-        
-        .. code-block:: yaml
-        
-            # Wazuh - Filebeat configuration file
-            output.elasticsearch:
-            hosts: ["127.0.0.1:9200"]
-            username: admin
-            password: admin
-            
-    -   Distributed deployment
-    
-        Change the value of ``hosts`` to the IP address of the Wazuh indexer node. In case of having more than one Wazuh indexer node, you can separate the addresses using commas. For example, ``hosts: ["10.0.0.1:9200", "10.0.0.2:9200", "10.0.0.3:9200"]``. Ensure to replace the ``<indexer-node-*-ip>`` with the addresses or hostnames of the Wazuh indexer nodes specified in ``config.yml``.
+#. Create a Filebeat keystore to securely store authentication credentials.
 
-        Also change the value of ``username`` and ``password`` to the configured credentials. The default username and password is ``admin``.
-        
-        .. code-block:: yaml
-           :emphasize-lines: 3
-        
-            # Wazuh - Filebeat configuration file
-            output.elasticsearch:
-            hosts: ["<indexer-node-1-ip>:9200", "<indexer-node-2-ip>:9200", "<indexer-node-3-ip>:9200"]
-            username: admin
-            password: admin
+   .. code-block:: console
+     
+      # filebeat keystore create
+
+#. Add the username and password ``admin``:``admin`` to the secrets keystore.
+      
+   .. code-block:: console
+
+      # echo admin | filebeat keystore add username --stdin --force
+      # echo admin | filebeat keystore add password --stdin --force              
 
 #.  Install the Wazuh module for Filebeat.
 

--- a/source/deployment-options/offline-installation.rst
+++ b/source/deployment-options/offline-installation.rst
@@ -430,7 +430,7 @@ Installing the Wazuh dashboard
 
 #. Edit the ``/etc/wazuh-dashboard/opensearch_dashboards.yml`` file and replace the following values:
 
-   #. ``server.host``: This setting specifies the host of the back end server. To allow remote users to connect, set the value to the IP address or DNS name of the Kibana server.  The value ``0.0.0.0`` will accept all the available IP addresses of the host.
+   #. ``server.host``: This setting specifies the host of the back end server. To allow remote users to connect, set the value to the IP address or DNS name of the Wazuh dashboard.  The value ``0.0.0.0`` will accept all the available IP addresses of the host.
 
    #. ``opensearch.hosts``: The URLs of the Wazuh indexer instances to use for all your queries. The Wazuh dashboard can be configured to connect to multiple Wazuh indexer nodes in the same cluster. The addresses of the nodes can be separated by commas. For example,  ``["https://10.0.0.2:9200", "https://10.0.0.3:9200","https://10.0.0.4:9200"]``
 

--- a/source/deployment-options/offline-installation.rst
+++ b/source/deployment-options/offline-installation.rst
@@ -282,7 +282,7 @@ Filebeat must be installed and configured on the same server as the Wazuh manage
     
         # tar -xzf ./wazuh-offline/wazuh-files/wazuh-filebeat-0.2.tar.gz -C /usr/share/filebeat/module
 
-#.  Replace ``<server-node-name>`` with your Wazuh server node certificate name, the same used in ``config.yml`` when creating the certificates. Then, move the certificates to their corresponding location.
+#.  Replace ``<server-node-name>`` with your Wazuh server node certificate name, the same used in ``config.yml`` when creating the certificates. For example, ``wazuh-1``. Then, move the certificates to their corresponding location.
 
      .. code-block:: console
         
@@ -412,7 +412,7 @@ Installing the Wazuh dashboard
        
                 # dpkg -i ./wazuh-offline/wazuh-packages/wazuh-dashboard*.deb
 
-#.  Replace ``<dashboard-node-name>`` with your Wazuh dashboard node name, the same used in ``config.yml`` to create the certificates, and move the certificates to their corresponding location.
+#.  Replace ``<dashboard-node-name>`` with your Wazuh dashboard node name, the same used in ``config.yml`` to create the certificates. For example, ``dashboard``. Then, move the certificates to their corresponding location.
 
     .. code-block:: console
 

--- a/source/deployment-options/offline-installation.rst
+++ b/source/deployment-options/offline-installation.rst
@@ -449,14 +449,15 @@ Installing the Wazuh dashboard
 #. **Only for distributed deployments**:  Edit the file ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` and replace the ``url`` value with the IP address or hostname of the Wazuh server master node.
           
             .. code-block:: yaml
+               :emphasize-lines: 3
             
-              hosts:
-                - default:
-                  url: https://localhost
-                  port: 55000
-                  username: wazuh-wui
-                  password: wazuh-wui
-                  run_as: false
+               hosts:
+                 - default:
+                     url: https://localhost
+                     port: 55000
+                     username: wazuh-wui
+                     password: wazuh-wui
+                     run_as: false
 
 #.  Run the following command to verify the Wazuh dashboard service is active.
 

--- a/source/deployment-options/offline-installation.rst
+++ b/source/deployment-options/offline-installation.rst
@@ -102,7 +102,7 @@ Installing the Wazuh indexer
       # chmod 400 /etc/wazuh-indexer/certs/*
       # chown -R wazuh-indexer:wazuh-indexer /etc/wazuh-indexer/certs
 
-   Here you move the node certificate and key files, such as `node-1.pem` and `node-1-key.pem`, to their corresponding `certs` folder. They're specific to the node and are not required on the other nodes. However, note that the `root-ca.pem` certificate isn't moved but copied to the `certs` folder. This way, you can continue deploying it to other nodes and component folders in the next steps.
+   Here you move the node certificate and key files, such as `node-1.pem` and `node-1-key.pem`, to their corresponding `certs` folder. They're specific to the node and are not required on the other nodes. However, note that the `root-ca.pem` certificate isn't moved but copied to the `certs` folder. This way, you can continue deploying it to other component folders in the next steps.
 
 #. Edit ``/etc/wazuh-indexer/opensearch.yml`` and replace the following values: 
 
@@ -145,15 +145,15 @@ Installing the Wazuh indexer
 
     .. include:: /_templates/installations/indexer/common/enable_indexer.rst
 
-#. For multi-node clusters, repeat the previous steps on every Wazuh indexer node. Then proceed to the cluster initialization stage.
+#. For multi-node clusters, repeat the previous steps on every Wazuh indexer node. 
 
-#.  When all Wazuh indexer nodes are running, run the Wazuh indexer ``indexer-security-init.sh`` script on any Wazuh indexer node to load the new certificates information and start the cluster:
+#. When all Wazuh indexer nodes are running, run the Wazuh indexer ``indexer-security-init.sh`` script on `any Wazuh indexer node` to load the new certificates information and start the cluster. 
 
     .. code-block:: console
 
         # /usr/share/wazuh-indexer/bin/indexer-security-init.sh
   
-#.  Run the following command to check that the installation is successful.
+#.  Run the following command to check that the installation is successful. Note that this command uses localhost, set your Wazuh indexer address if necessary. 
 
     .. code-block:: console
 
@@ -329,7 +329,7 @@ Filebeat must be installed and configured on the same server as the Wazuh manage
           talk to server... OK
           version: 7.10.2
 
-    To check the number of shards that have been configured, you can run the following command.
+    To check the number of shards that have been configured, you can run the following command. Note that this command uses localhost, set your Wazuh indexer address if necessary. 
     
     .. code-block:: console
 


### PR DESCRIPTION

## Description

This PR adds the "Securing your Wazuh installation" instructions in the Offline installation guide and closes #5578. These instructions include how to change the default Wazuh API and Wazuh indexer passwords. 

This PR also includes the instructions to create and configure the Filebeat keystore, as well as others improvements such as fixing indentation, adding highlighting and clarifications. 

## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
