### PR TITLE
Add sub-section for disconnected agents removal

### DIFF
--- a/source/user-manual/agents/remove-agents/restful-api-remove.rst
+++ b/source/user-manual/agents/remove-agents/restful-api-remove.rst
@@ -8,9 +8,9 @@
 Remove agents using the Wazuh API
 ----------------------------------
 
-The request :api-ref:`DELETE /agents <operation/api.controllers.agent_controller.delete_agents>` removes the specified agents.
+This section includes examples of how to use the :api-ref:`DELETE /agents <operation/api.controllers.agent_controller.delete_agents>` request to either delete a list of agents or agents that have been disconnected for a given period of time. 
 
-The examples in this section :ref:`use a token <api_log_in>` for authentication to the Wazuh API. Run the following command to get your token for the API calls below.
+The examples use :ref:`an authentication token <api_log_in>`. To get your token, replace ``<user>:<password>`` with your Wazuh API credentials and run the following command:
 
 .. code-block:: console
 
@@ -48,7 +48,7 @@ You can remove specific agents using a list. Use the parameter ``agents_list`` t
 Removing disconnected agents
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-You can remove agents which never connected or which have been disconnected for a long time. Use the parameter ``older_than`` to set a period of time of no known activity. Use ``status`` to select the `Never connected` and `Disconnected` agents. For example, to remove agents inactive for more than 21 days, run a query like the following one.
+You can remove agents which never connected or which have been disconnected for a given period of time. Use the parameter ``older_than`` to set a period of no known activity. Use ``status`` to select the `Never connected` and `Disconnected` agents. For example, to remove agents inactive for more than 21 days, run a query like the following one.
 
 .. code-block:: console
 

--- a/source/user-manual/agents/remove-agents/restful-api-remove.rst
+++ b/source/user-manual/agents/remove-agents/restful-api-remove.rst
@@ -10,6 +10,11 @@ Remove agents using the Wazuh API
 
 The request :api-ref:`DELETE /agents <operation/api.controllers.agent_controller.delete_agents>` removes the specified agents.
 
+Removing agents in a list
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can remove specific agents using a list. Use the parameter ``agents_list`` to set a list of agent IDs separated by commas. For example, to remove agents ID ``005``, ``006``, and ``007``, run a query like the following one.
+
 .. code-block:: console
 
     # curl -k -X DELETE "https://localhost:55000/agents?pretty=true&older_than=0s&agents_list=005,006,007&status=all" -H  "Authorization: Bearer $TOKEN"
@@ -31,3 +36,30 @@ The request :api-ref:`DELETE /agents <operation/api.controllers.agent_controller
         "message": "All selected agents were deleted",
         "error": 0,
     }
+
+.. _remove_disconnected_agents:
+
+Removing agents not connecting
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can remove agents which never connected or which have been disconnected for a long time. Use the parameter ``older_than`` to set a period of time of no known activity. Use ``status`` to select the `Never connected` and `Disconnected` agents. For example, to remove agents inactive for more than 21 days, run a query like the following one.
+
+.. code-block:: console
+
+    # curl -k -X DELETE "https://localhost:55000/agents?pretty=true&older_than=21d&agents_list=all&status=never_connected,disconnected," -H  "Authorization: Bearer $TOKEN"
+
+.. code-block:: json
+   :class: output
+
+   {
+      "data": {
+         "affected_items": [
+            "003"
+         ],
+         "total_affected_items": 1,
+         "total_failed_items": 0,
+         "failed_items": []
+      },
+      "message": "All selected agents were deleted",
+      "error": 0
+   }

--- a/source/user-manual/agents/remove-agents/restful-api-remove.rst
+++ b/source/user-manual/agents/remove-agents/restful-api-remove.rst
@@ -10,6 +10,12 @@ Remove agents using the Wazuh API
 
 The request :api-ref:`DELETE /agents <operation/api.controllers.agent_controller.delete_agents>` removes the specified agents.
 
+The examples in this section :ref:`use a token <api_log_in>` for authentication to the Wazuh API. Run the following command to get your token for the API calls below.
+
+.. code-block:: console
+
+   # TOKEN=$(curl -u <user>:<password> -k -X GET "https://localhost:55000/security/user/authenticate?raw=true")
+
 Removing agents in a list
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -39,14 +45,14 @@ You can remove specific agents using a list. Use the parameter ``agents_list`` t
 
 .. _remove_disconnected_agents:
 
-Removing agents not connecting
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Removing disconnected agents
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can remove agents which never connected or which have been disconnected for a long time. Use the parameter ``older_than`` to set a period of time of no known activity. Use ``status`` to select the `Never connected` and `Disconnected` agents. For example, to remove agents inactive for more than 21 days, run a query like the following one.
 
 .. code-block:: console
 
-    # curl -k -X DELETE "https://localhost:55000/agents?pretty=true&older_than=21d&agents_list=all&status=never_connected,disconnected," -H  "Authorization: Bearer $TOKEN"
+    # curl -k -X DELETE "https://localhost:55000/agents?pretty=true&older_than=21d&agents_list=all&status=never_connected,disconnected" -H  "Authorization: Bearer $TOKEN"
 
 .. code-block:: json
    :class: output


### PR DESCRIPTION
## Description
This PR adds a sub-section within the _Removing agents > Remove agents using the Wazuh API_ User manual section to remove agents that have been disconnected for long. It's related with the blog post [How to purge non-active agents](https://wazuh.com/blog/how-to-purge-non-active-agents/).

## Checks
- [X] Compiles without warnings.
- [X] Uses present tense, active voice, and semi-formal registry.
- [X] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [X] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).