### PR TITLE
Upgrade Solaris packages references to current 3.13 release version

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -471,7 +471,7 @@ custom_replacements = {
     "|WAZUH_LATEST_PUPPET|" : "3.13.6",
     "|WAZUH_LATEST_OVA|" : "3.13.6",
     "|WAZUH_LATEST_HPUX|": "3.13.6",
-    "|WAZUH_LATEST_SPARC|": "3.13.5",
+    "|WAZUH_LATEST_SPARC|": "3.13.6",
     "|WAZUH_LATEST_DOCKER|" : "3.13.6",
     "|ELASTICSEARCH_LATEST|" : "7.9.2",
     "|ELASTICSEARCH_ODFE|" : "7.8.0",


### PR DESCRIPTION
## Description
This PR updates  Solaris packages references to 3.13.6 version

## Checks
- [X] Compiles without warnings.
- [X] Uses present tense, active voice, and semi-formal registry.
- [X] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [X] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
