### PR TITLE
Update offline guide with verification steps of downloaded packages

### DIFF
--- a/source/deployment-options/offline-installation.rst
+++ b/source/deployment-options/offline-installation.rst
@@ -59,16 +59,18 @@ Download the packages and configuration files
 Install Wazuh components from local files
 -----------------------------------------
 
-In the working directory where you placed ``wazuh-offline.tar.gz`` and ``./wazuh-certificates/``, execute the following command to decompress the installation files:
+#. In the working directory where you placed ``wazuh-offline.tar.gz`` and ``./wazuh-certificates/``, execute the following command to decompress the installation files:
 
-.. code-block:: console
+   .. code-block:: console
 
-    # tar xf wazuh-offline.tar.gz
+      # tar xf wazuh-offline.tar.gz
+
+   Check the SHA512 of the decompressed package files in ``wazuh-offline/wazuh-packages/``. You can find the SHA512 checksums in :doc:`/installation-guide/packages-list`.
 
 Installing the Wazuh indexer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-#.  Run the following command to install the Wazuh indexer.
+#.  Run the following commands to install the Wazuh indexer.
 
     .. tabs::
 
@@ -76,7 +78,8 @@ Installing the Wazuh indexer
 
             .. code-block:: console
         
-                # rpm -ivh ./wazuh-offline/wazuh-packages/wazuh-indexer*.rpm
+               # rpm --import https://packages.wazuh.com/key/GPG-KEY-WAZUH
+               # rpm -ivh ./wazuh-offline/wazuh-packages/wazuh-indexer*.rpm
 
         .. group-tab:: DEB
 
@@ -203,7 +206,6 @@ Installing the Wazuh manager
 
             .. code-block:: console
         
-                # gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/wazuh.gpg --import ./wazuh-offline/wazuh-files/GPG-KEY-WAZUH && chmod 644 /usr/share/keyrings/wazuh.gpg
                 # dpkg -i ./wazuh-offline/wazuh-packages/wazuh-manager*.deb
 
 #.  Enable and start the Wazuh manager service.
@@ -396,7 +398,7 @@ Testing Wazuh server cluster
 Installing the Wazuh dashboard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-#.  Run the following command to install the Wazuh dashboard.
+#.  Run the following commands to install the Wazuh dashboard.
 
     .. tabs::
 
@@ -404,6 +406,7 @@ Installing the Wazuh dashboard
 
             .. code-block:: console
        
+                # rpm --import ./wazuh-offline/wazuh-files/GPG-KEY-WAZUH
                 # rpm -ivh ./wazuh-offline/wazuh-packages/wazuh-dashboard*.rpm
 
         .. group-tab:: DEB

--- a/source/deployment-options/offline-installation.rst
+++ b/source/deployment-options/offline-installation.rst
@@ -65,7 +65,7 @@ Install Wazuh components from local files
 
       # tar xf wazuh-offline.tar.gz
 
-   You can check the SHA512 of the decompressed package files in ``wazuh-offline/wazuh-packages/``. Find the SHA512 checksums in :doc:`/installation-guide/packages-list`.
+   You can check the SHA512 of the decompressed package files in ``wazuh-offline/wazuh-packages/``. Find the SHA512 checksums in the :doc:`/installation-guide/packages-list`.
 
 Installing the Wazuh indexer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/deployment-options/offline-installation.rst
+++ b/source/deployment-options/offline-installation.rst
@@ -65,7 +65,7 @@ Install Wazuh components from local files
 
       # tar xf wazuh-offline.tar.gz
 
-   Check the SHA512 of the decompressed package files in ``wazuh-offline/wazuh-packages/``. You can find the SHA512 checksums in :doc:`/installation-guide/packages-list`.
+   You can check the SHA512 of the decompressed package files in ``wazuh-offline/wazuh-packages/``. Find the SHA512 checksums in :doc:`/installation-guide/packages-list`.
 
 Installing the Wazuh indexer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -78,7 +78,7 @@ Installing the Wazuh indexer
 
             .. code-block:: console
         
-               # rpm --import https://packages.wazuh.com/key/GPG-KEY-WAZUH
+               # rpm --import ./wazuh-offline/wazuh-files/GPG-KEY-WAZUH
                # rpm -ivh ./wazuh-offline/wazuh-packages/wazuh-indexer*.rpm
 
         .. group-tab:: DEB


### PR DESCRIPTION
## Description
This PR modifies the steps in the offline guide to:
- Import the Wazuh rpm packages key.
- Removes unnecesary step for debian distributions.
- Recommends sha512 verification.

## Checks
- [X] Compiles without warnings.
- [X] Uses present tense, active voice, and semi-formal registry.
- [X] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [X] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
