### PR TITLE
Fix SCA configuration typo

### DIFF
--- a/source/user-manual/reference/ossec-conf/sca.rst
+++ b/source/user-manual/reference/ossec-conf/sca.rst
@@ -227,7 +227,7 @@ Configuration example
 
         <policies>
           <policy>etc/shared/cis_debian10.yml</policy>
-          <policy enabled="no">ruleset/sca/cis_debian9.yml/policy>
+          <policy enabled="no">ruleset/sca/cis_debian9.yml</policy>
           <policy>/my/custom/policy/path/my_policy.yaml</policy>
         </policies>
       </sca>


### PR DESCRIPTION
## Description
This simple PR closes #5643 where the sample SCA configuration had a malformed XML tag
## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
