### PR TITLE
Fix typo of missing t in syscollector wodle hotfixes note

### DIFF
--- a/source/user-manual/reference/ossec-conf/wodle-syscollector.rst
+++ b/source/user-manual/reference/ossec-conf/wodle-syscollector.rst
@@ -177,7 +177,7 @@ Enables the hotfixes scan. It reports the Windows updates installed.
 +--------------------+---------+
 
 .. note::
-  This option is enabled by default but no included in the initial configuration.
+  This option is enabled by default but not included in the initial configuration.
 
 
 synchronization


### PR DESCRIPTION
## Description
This PR fixes #2353  which was originally reported and fixed for 3.12 but not correctly propagated for more recent versions. 

By enacting the change to the current branch (4.3) this typo should be fixed in the current and future versions.

## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
