### PR TITLE
Add the Wazuh dashboard browser requirements

### DIFF
--- a/source/installation-guide/wazuh-dashboard/index.rst
+++ b/source/installation-guide/wazuh-dashboard/index.rst
@@ -108,7 +108,7 @@ Wazuh dashboard supports the following web browsers:
 - Firefox 93 or later
 - Safari 13.7 or later
 
-Other Chromium-based browsers might work, as well. Internet Explorer 11 is not supported.
+Other Chromium-based browsers might also work. Internet Explorer 11 is not supported.
 
 
 .. toctree::

--- a/source/installation-guide/wazuh-dashboard/index.rst
+++ b/source/installation-guide/wazuh-dashboard/index.rst
@@ -99,7 +99,16 @@ The Wazuh dashboard can be installed on a dedicated node or along with the Wazuh
   | Wazuh dashboard         |     4    |     2        |     8        |       4        |
   +-------------------------+----------+--------------+--------------+----------------+
 
+Browser compatibility
+^^^^^^^^^^^^^^^^^^^^^
 
+Wazuh dashboard supports the following web browsers:
+
+- Chrome 95 or later
+- Firefox 93 or later
+- Safari 13.7 or later
+
+Other Chromium-based browsers might work, as well. Internet Explorer 11 is not supported.
 
 
 .. toctree::

--- a/source/quickstart.rst
+++ b/source/quickstart.rst
@@ -66,7 +66,7 @@ Wazuh dashboard supports the following web browsers:
 - Firefox 93 or later
 - Safari 13.7 or later
 
-Other Chromium-based browsers might work, as well. Internet Explorer 11 is not supported.
+Other Chromium-based browsers might also work. Internet Explorer 11 is not supported.
 
 Installing Wazuh
 ----------------

--- a/source/quickstart.rst
+++ b/source/quickstart.rst
@@ -56,6 +56,18 @@ Wazuh central components can be installed on a 64-bit Linux operating system. Wa
     * - Red Hat Enterprise Linux 7, 8, 9
       - Ubuntu 16.04, 18.04, 20.04, 22.04
 
+
+Browser compatibility
+^^^^^^^^^^^^^^^^^^^^^
+
+Wazuh dashboard supports the following web browsers:
+
+- Chrome 95 or later
+- Firefox 93 or later
+- Safari 13.7 or later
+
+Other Chromium-based browsers might work, as well. Internet Explorer 11 is not supported.
+
 Installing Wazuh
 ----------------
 


### PR DESCRIPTION
## Description

This PR adds the Wazuh dashboard browser compatibility information in the **Quickstart** section as well as in the **Installation guide** > **Wazuh dashboard** index. This PR closes #5595. 

![image](https://user-images.githubusercontent.com/61882981/197168757-56dbded6-ab79-416e-8a00-9f0605d67d2d.png)

![image](https://user-images.githubusercontent.com/61882981/197168537-12e2d0e9-406c-4487-bacd-0844b34e5357.png)


## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
