### PR TITLE
Fix WPK manual generation

### DIFF
--- a/source/user-manual/agents/remote-upgrading/create-custom-wpk/generate-wpk-package-manually.rst
+++ b/source/user-manual/agents/remote-upgrading/create-custom-wpk/generate-wpk-package-manually.rst
@@ -67,13 +67,15 @@ Delete the files that are no longer needed. This step can be skipped, but the si
 
 .. code-block:: console
 
+  $ rm -rf ./{api,framework}
   $ rm -rf doc wodles/oscap/content/* gen_ossec.sh add_localfiles.sh Jenkinsfile*
   $ rm -rf src/{addagent,analysisd,client-agent,config,error_messages,external/*,headers,logcollector,monitord,os_auth,os_crypto,os_csyslogd,os_dbdos_execd}
-  $ rm -rf src/{os_integrator,os_maild,os_netos_regex,os_xml,os_zlib,remoted,reportd,shared,syscheckd,tests,update,wazuh_db,wazuh_modules}
+  $ rm -rf src/{os_integrator,os_maild,os_netos_regex,os_xml,os_zlib,remoted,reportd,shared,syscheckd,tests,update,wazuh_db}
   $ rm -rf src/win32
   $ rm -rf src/*.a
   $ rm -rf etc/{decoders,lists,rules}
-  $ find etc/templates/* -maxdepth 0 -not -name "en" | xargs rm -rf
+  $ find etc/templates/config -not -name "sca.files" -delete 2>/dev/null
+  $ find etc/templates/* -maxdepth 0 -not -name "en" -not -name "config" | xargs rm -rf
 
 Install the root CA if you want to overwrite the root CA with the file you created previously:
 


### PR DESCRIPTION

## Description

The changes made in this PR, allow us to fix bugs related to the removal of the wazuh-modules folder in the manual WPK generation. In addition, we applied some more changes to remove unnecessary files and use the same steps as currently used in Jenkins.

With the changes to this PR, the following issues would be fixed:
- https://github.com/wazuh/wazuh/issues/15080
- https://github.com/wazuh/wazuh/issues/14986

The changes that have been made are as follows:
- Removal of unnecessary files (related to https://github.com/wazuh/wazuh-packages/pull/721):
```
$ rm -rf ./{api,framework}
```
- Avoid removal of wazuh-modules which causes errors due to missing compiled library (related to https://github.com/wazuh/wazuh-packages/pull/721):
```
$ rm -rf src/{os_integrator,os_maild,os_netos_regex,os_xml,os_zlib,remoted,reportd,shared,syscheckd,tests,update,wazuh_db}
```
- Preservation of SCA templates (related to https://github.com/wazuh/wazuh-packages/pull/249):
```
  $ find etc/templates/config -not -name "sca.files" -delete 2>/dev/null
  $ find etc/templates/* -maxdepth 0 -not -name "en" -not -name "config" | xargs rm -rf
```

## Checks
- [ ] Compiles without warnings.
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
