### PR TITLE
Update URL for Arch Linux feed

### DIFF
--- a/source/user-manual/capabilities/vulnerability-detection/offline-update.rst
+++ b/source/user-manual/capabilities/vulnerability-detection/offline-update.rst
@@ -254,7 +254,7 @@ To perform an offline update of the Arch feed, download the corresponding ``JSON
 +------------+--------------------------------------------------------------------------------------------+
 | OS         | Files                                                                                      |
 +============+============================================================================================+
-| Rolling    | `all.json <https://security.archlinux.org/all.json>`_                                      |
+| Rolling    | `all.json <https://security.archlinux.org/issues/all.json>`_                               |
 +------------+--------------------------------------------------------------------------------------------+
 
 To fetch the vulnerability feed from an alternative repository, configure your manager in a similar way as shown in this example:
@@ -263,7 +263,7 @@ To fetch the vulnerability feed from an alternative repository, configure your m
 
     <provider name="arch">
         <enabled>yes</enabled>
-        <url>http://local_repo/security.archlinux.org/all.json</url>
+        <url>http://local_repo/security.archlinux.org/issues/all.json</url>
         <update_interval>1h</update_interval>
     </provider>
 


### PR DESCRIPTION
## Description

As reported at https://github.com/wazuh/wazuh/issues/15180, the URL of the Arch Linux vulnerability feed has been updated from `https://security.archlinux.org/all.json` to `https://security.archlinux.org/issues/all.json`.

This pull request updates the URL in the documentation.

## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
