### PR TITLE
Unify instructions for restarting services

### DIFF
--- a/source/_templates/common/restart_dashboard.rst
+++ b/source/_templates/common/restart_dashboard.rst
@@ -2,16 +2,16 @@
 
 .. tabs::
 
- .. group-tab:: Systemd
+   .. group-tab:: Systemd
 
-  .. code-block:: console
+      .. code-block:: console
 
-   # systemctl restart wazuh-dashboard
+         # systemctl restart wazuh-dashboard
 
- .. group-tab:: SysV init
+   .. group-tab:: SysV init
 
-  .. code-block:: console
+      .. code-block:: console
 
-   # service wazuh-dashboard restart
+         # service wazuh-dashboard restart
 
 .. End of include file

--- a/source/_templates/common/restart_filebeat.rst
+++ b/source/_templates/common/restart_filebeat.rst
@@ -2,16 +2,16 @@
 
 .. tabs::
 
- .. group-tab:: Systemd
+   .. group-tab:: Systemd
 
-  .. code-block:: console
+      .. code-block:: console
 
-   # systemctl restart filebeat
+         # systemctl restart filebeat
 
- .. group-tab:: SysV init
+   .. group-tab:: SysV init
 
-  .. code-block:: console
+      .. code-block:: console
 
-   # service filebeat restart
+         # service filebeat restart
 
 .. End of include file

--- a/source/_templates/common/restart_manager.rst
+++ b/source/_templates/common/restart_manager.rst
@@ -2,16 +2,16 @@
 
 .. tabs::
 
- .. group-tab:: Systemd
+   .. group-tab:: Systemd
 
-  .. code-block:: console
+      .. code-block:: console         
 
-   # systemctl restart wazuh-manager
+         # systemctl restart wazuh-manager
 
- .. group-tab:: SysV init
+   .. group-tab:: SysV init
 
-  .. code-block:: console
+      .. code-block:: console
 
-   # service wazuh-manager restart
+         # service wazuh-manager restart
 
 .. End of include file

--- a/source/_templates/common/restart_nginx.rst
+++ b/source/_templates/common/restart_nginx.rst
@@ -1,0 +1,17 @@
+.. Copyright (C) 2015, Wazuh, Inc.
+
+.. tabs::
+
+ .. group-tab:: Systemd
+
+  .. code-block:: console
+
+   # systemctl restart nginx
+
+ .. group-tab:: SysV init
+
+  .. code-block:: console
+
+   # service nginx restart
+
+.. End of include file

--- a/source/_templates/common/restart_nginx.rst
+++ b/source/_templates/common/restart_nginx.rst
@@ -2,16 +2,16 @@
 
 .. tabs::
 
- .. group-tab:: Systemd
+   .. group-tab:: Systemd
 
-  .. code-block:: console
+      .. code-block:: console
 
-   # systemctl restart nginx
+         # systemctl restart nginx
 
- .. group-tab:: SysV init
+   .. group-tab:: SysV init
 
-  .. code-block:: console
+      .. code-block:: console
 
-   # service nginx restart
+         # service nginx restart
 
 .. End of include file

--- a/source/_templates/installations/basic/elastic/common/load_filebeat_template.rst
+++ b/source/_templates/installations/basic/elastic/common/load_filebeat_template.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # filebeat setup --index-management -E setup.template.json.enabled=false
+   # filebeat setup --index-management -E setup.template.json.enabled=false
 
 .. End of include file

--- a/source/_templates/installations/basic/elastic/common/restart_kibana.rst
+++ b/source/_templates/installations/basic/elastic/common/restart_kibana.rst
@@ -1,0 +1,17 @@
+.. Copyright (C) 2015, Wazuh, Inc.
+
+.. tabs::
+
+   .. group-tab:: Systemd
+
+      .. code-block:: console
+  
+         # systemctl restart kibana
+
+   .. group-tab:: SysV init
+
+      .. code-block:: console
+  
+         # service kibana restart
+
+.. End of include file

--- a/source/_templates/installations/basic/elastic/common/stop_elasticsearch.rst
+++ b/source/_templates/installations/basic/elastic/common/stop_elasticsearch.rst
@@ -2,16 +2,16 @@
 
 .. tabs::
 
-  .. group-tab:: Systemd
+   .. group-tab:: Systemd
 
-    .. code-block:: console
+      .. code-block:: console
 
-      # systemctl stop elasticsearch
+         # systemctl stop elasticsearch
 
-  .. group-tab:: SysV Init
+   .. group-tab:: SysV Init
 
-    .. code-block:: console
+      .. code-block:: console
 
-      # service elasticsearch stop
+         # service elasticsearch stop
 
 .. End of include file

--- a/source/_templates/installations/basic/elastic/common/stop_filebeat.rst
+++ b/source/_templates/installations/basic/elastic/common/stop_filebeat.rst
@@ -6,12 +6,12 @@
 
     .. code-block:: console
 
-      # systemctl stop elasticsearch
+      # systemctl stop filebeat      
 
   .. group-tab:: SysV Init
 
     .. code-block:: console
 
-      # service elasticsearch stop
+      # service filebeat stop
 
 .. End of include file

--- a/source/_templates/installations/basic/elastic/common/stop_filebeat.rst
+++ b/source/_templates/installations/basic/elastic/common/stop_filebeat.rst
@@ -2,16 +2,16 @@
 
 .. tabs::
 
-  .. group-tab:: Systemd
+   .. group-tab:: Systemd
 
-    .. code-block:: console
+      .. code-block:: console
 
-      # systemctl stop filebeat      
+         # systemctl stop filebeat      
 
-  .. group-tab:: SysV Init
+   .. group-tab:: SysV Init
 
-    .. code-block:: console
+      .. code-block:: console
 
-      # service filebeat stop
+         # service filebeat stop
 
 .. End of include file

--- a/source/_templates/installations/basic/elastic/common/stop_kibana_filebeat.rst
+++ b/source/_templates/installations/basic/elastic/common/stop_kibana_filebeat.rst
@@ -2,21 +2,18 @@
 
 .. tabs::
 
+   .. group-tab:: Systemd
 
-  .. tab:: Systemd
+      .. code-block:: console
 
+         # systemctl stop filebeat
+         # systemctl stop kibana
 
-    .. code-block:: console
+   .. group-tab:: SysV Init
 
-      # systemctl stop filebeat
-      # systemctl stop kibana
+      .. code-block:: console
 
-
-  .. tab:: SysV Init
-
-    .. code-block:: console
-
-      # service filebeat stop
-      # service kibana stop
+         # service filebeat stop
+         # service kibana stop
 
 .. End of include file

--- a/source/_templates/installations/wazuh/common/check_wazuh_manager.rst
+++ b/source/_templates/installations/wazuh/common/check_wazuh_manager.rst
@@ -2,14 +2,11 @@
 
 .. tabs::
 
-
   .. group-tab:: Systemd
-
 
     .. code-block:: console
 
       # systemctl status wazuh-manager
-
 
   .. group-tab:: SysV Init
 

--- a/source/_templates/installations/wazuh/common/install_wazuh_manager.rst
+++ b/source/_templates/installations/wazuh/common/install_wazuh_manager.rst
@@ -13,6 +13,5 @@
       .. code-block:: console
 
          # apt-get -y install wazuh-manager
-
       
 .. End of include file

--- a/source/amazon/services/supported-services/alb.rst
+++ b/source/amazon/services/supported-services/alb.rst
@@ -65,28 +65,10 @@ Wazuh configuration
 
     * If you're configuring a Wazuh manager:
 
-      a. For Systemd:
-
-      .. code-block:: console
-
-        # systemctl restart wazuh-manager
-
-      b. For SysV Init:
-
-      .. code-block:: console
-
-        # service wazuh-manager restart
+      .. include:: /_templates/common/restart_manager.rst
 
     * If you're configuring a Wazuh agent:
 
-      a. For Systemd:
+      .. include:: /_templates/common/restart_agent.rst
 
-      .. code-block:: console
-
-        # systemctl restart wazuh-agent
-
-      b. For SysV Init:
-
-      .. code-block:: console
-
-        # service wazuh-agent restart
+   

--- a/source/amazon/services/supported-services/cisco-umbrella.rst
+++ b/source/amazon/services/supported-services/cisco-umbrella.rst
@@ -53,28 +53,10 @@ Wazuh configuration
 
     * If you're configuring a Wazuh manager:
 
-      a. For Systemd:
-
-      .. code-block:: console
-
-        # systemctl restart wazuh-manager
-
-      b. For SysV Init:
-
-      .. code-block:: console
-
-        # service wazuh-manager restart
+      .. include:: /_templates/common/restart_manager.rst
 
     * If you're configuring a Wazuh agent:
+  
+      .. include:: /_templates/common/restart_agent.rst
 
-      a. For Systemd:
-
-      .. code-block:: console
-
-        # systemctl restart wazuh-agent
-
-      b. For SysV Init:
-
-      .. code-block:: console
-
-        # service wazuh-agent restart
+      

--- a/source/amazon/services/supported-services/clb.rst
+++ b/source/amazon/services/supported-services/clb.rst
@@ -65,28 +65,9 @@ Wazuh configuration
 
     * If you're configuring a Wazuh manager:
 
-      a. For Systemd:
-
-      .. code-block:: console
-
-        # systemctl restart wazuh-manager
-
-      b. For SysV Init:
-
-      .. code-block:: console
-
-        # service wazuh-manager restart
+      .. include:: /_templates/common/restart_manager.rst
 
     * If you're configuring a Wazuh agent:
 
-      a. For Systemd:
+      .. include:: /_templates/common/restart_agent.rst
 
-      .. code-block:: console
-
-        # systemctl restart wazuh-agent
-
-      b. For SysV Init:
-
-      .. code-block:: console
-
-        # service wazuh-agent restart

--- a/source/amazon/services/supported-services/cloudtrail.rst
+++ b/source/amazon/services/supported-services/cloudtrail.rst
@@ -67,31 +67,11 @@ Wazuh configuration
 
     * If you're configuring a Wazuh manager:
 
-      a. For Systemd:
-
-      .. code-block:: console
-
-        # systemctl restart wazuh-manager
-
-      b. For SysV Init:
-
-      .. code-block:: console
-
-        # service wazuh-manager restart
+      .. include:: /_templates/common/restart_manager.rst
 
     * If you're configuring a Wazuh agent:
 
-      a. For Systemd:
-
-      .. code-block:: console
-
-        # systemctl restart wazuh-agent
-
-      b. For SysV Init:
-
-      .. code-block:: console
-
-        # service wazuh-agent restart
+      .. include:: /_templates/common/restart_agent.rst
 
 CloudTrail use cases
 --------------------

--- a/source/amazon/services/supported-services/cloudwatchlogs.rst
+++ b/source/amazon/services/supported-services/cloudwatchlogs.rst
@@ -52,31 +52,11 @@ Wazuh configuration
 
     * If you are configuring a Wazuh manager:
 
-      a. For Systemd:
-
-      .. code-block:: console
-
-        # systemctl restart wazuh-manager
-
-      b. For SysV Init:
-
-      .. code-block:: console
-
-        # service wazuh-manager restart
+      .. include:: /_templates/common/restart_manager.rst
 
     * If you are configuring a Wazuh agent:
 
-      a. For Systemd:
-
-      .. code-block:: console
-
-        # systemctl restart wazuh-agent
-
-      b. For SysV Init:
-
-      .. code-block:: console
-
-        # service wazuh-agent restart
+      .. include:: /_templates/common/restart_agent.rst
 
 
 CloudWatch Logs use cases

--- a/source/amazon/services/supported-services/config.rst
+++ b/source/amazon/services/supported-services/config.rst
@@ -84,28 +84,9 @@ Wazuh configuration
 
     * If you're configuring a Wazuh manager:
 
-      a. For Systemd:
-
-      .. code-block:: console
-
-        # systemctl restart wazuh-manager
-
-      b. For SysV Init:
-
-      .. code-block:: console
-
-        # service wazuh-manager restart
+      .. include:: /_templates/common/restart_manager.rst
 
     * If you're configuring a Wazuh agent:
 
-      a. For Systemd:
+      .. include:: /_templates/common/restart_agent.rst
 
-      .. code-block:: console
-
-        # systemctl restart wazuh-agent
-
-      b. For SysV Init:
-
-      .. code-block:: console
-
-        # service wazuh-agent restart

--- a/source/amazon/services/supported-services/ecr-image-scanning.rst
+++ b/source/amazon/services/supported-services/ecr-image-scanning.rst
@@ -90,28 +90,9 @@ Wazuh configuration
 
     * If you are configuring a Wazuh manager:
 
-      a. For Systemd:
-
-      .. code-block:: console
-
-        # systemctl restart wazuh-manager
-
-      b. For SysV Init:
-
-      .. code-block:: console
-
-        # service wazuh-manager restart
+      .. include:: /_templates/common/restart_manager.rst
 
     * If you are configuring a Wazuh agent:
 
-      a. For Systemd:
+      .. include:: /_templates/common/restart_agent.rst
 
-      .. code-block:: console
-
-        # systemctl restart wazuh-agent
-
-      b. For SysV Init:
-
-      .. code-block:: console
-
-        # service wazuh-agent restart

--- a/source/amazon/services/supported-services/guardduty.rst
+++ b/source/amazon/services/supported-services/guardduty.rst
@@ -121,31 +121,12 @@ Wazuh configuration
 
     * If you're configuring a Wazuh manager:
 
-      a. For Systemd:
-
-      .. code-block:: console
-
-        # systemctl restart wazuh-manager
-
-      b. For SysV Init:
-
-      .. code-block:: console
-
-        # service wazuh-manager restart
+      .. include:: /_templates/common/restart_manager.rst
 
     * If you're configuring a Wazuh agent:
 
-      a. For Systemd:
-
-      .. code-block:: console
-
-        # systemctl restart wazuh-agent
-
-      b. For SysV Init:
-
-      .. code-block:: console
-
-        # service wazuh-agent restart
+      .. include:: /_templates/common/restart_agent.rst
+        
 
 GuarDuty use cases
 ------------------

--- a/source/amazon/services/supported-services/inspector.rst
+++ b/source/amazon/services/supported-services/inspector.rst
@@ -42,28 +42,9 @@ Wazuh configuration
 
     * If you're configuring a Wazuh manager:
 
-      a. For Systemd:
-
-      .. code-block:: console
-
-        # systemctl restart wazuh-manager
-
-      b. For SysV Init:
-
-      .. code-block:: console
-
-        # service wazuh-manager restart
+      .. include:: /_templates/common/restart_manager.rst
 
     * If you're configuring a Wazuh agent:
 
-      a. For Systemd:
+      .. include:: /_templates/common/restart_agent.rst
 
-      .. code-block:: console
-
-        # systemctl restart wazuh-agent
-
-      b. For SysV Init:
-
-      .. code-block:: console
-
-        # service wazuh-agent restart

--- a/source/amazon/services/supported-services/kms.rst
+++ b/source/amazon/services/supported-services/kms.rst
@@ -121,28 +121,9 @@ Wazuh configuration
 
     * If you're configuring a Wazuh manager:
 
-      a. For Systemd:
-
-      .. code-block:: console
-
-        # systemctl restart wazuh-manager
-
-      b. For SysV Init:
-
-      .. code-block:: console
-
-        # service wazuh-manager restart
+      .. include:: /_templates/common/restart_manager.rst
 
     * If you're configuring a Wazuh agent:
 
-      a. For Systemd:
+      .. include:: /_templates/common/restart_agent.rst
 
-      .. code-block:: console
-
-        # systemctl restart wazuh-agent
-
-      b. For SysV Init:
-
-      .. code-block:: console
-
-        # service wazuh-agent restart

--- a/source/amazon/services/supported-services/macie.rst
+++ b/source/amazon/services/supported-services/macie.rst
@@ -121,31 +121,12 @@ Wazuh configuration
 
     * If you're configuring a Wazuh manager:
 
-      a. For Systemd:
-
-      .. code-block:: console
-
-        # systemctl restart wazuh-manager
-
-      b. For SysV Init:
-
-      .. code-block:: console
-
-        # service wazuh-manager restart
+      .. include:: /_templates/common/restart_manager.rst
 
     * If you're configuring a Wazuh agent:
 
-      a. For Systemd:
+      .. include:: /_templates/common/restart_agent.rst
 
-      .. code-block:: console
-
-        # systemctl restart wazuh-agent
-
-      b. For SysV Init:
-
-      .. code-block:: console
-
-        # service wazuh-agent restart
 
 Use cases
 ---------

--- a/source/amazon/services/supported-services/nlb.rst
+++ b/source/amazon/services/supported-services/nlb.rst
@@ -65,28 +65,9 @@ Wazuh configuration
 
     * If you're configuring a Wazuh manager:
 
-      a. For Systemd:
-
-      .. code-block:: console
-
-        # systemctl restart wazuh-manager
-
-      b. For SysV Init:
-
-      .. code-block:: console
-
-        # service wazuh-manager restart
+      .. include:: /_templates/common/restart_manager.rst
 
     * If you're configuring a Wazuh agent:
 
-      a. For Systemd:
+      .. include:: /_templates/common/restart_agent.rst
 
-      .. code-block:: console
-
-        # systemctl restart wazuh-agent
-
-      b. For SysV Init:
-
-      .. code-block:: console
-
-        # service wazuh-agent restart

--- a/source/amazon/services/supported-services/server-access.rst
+++ b/source/amazon/services/supported-services/server-access.rst
@@ -77,28 +77,9 @@ Wazuh configuration
 
     * If you're configuring a Wazuh manager:
 
-      a. For Systemd:
-
-      .. code-block:: console
-
-        # systemctl restart wazuh-manager
-
-      b. For SysV Init:
-
-      .. code-block:: console
-
-        # service wazuh-manager restart
+      .. include:: /_templates/common/restart_manager.rst
 
     * If you're configuring a Wazuh agent:
 
-      a. For Systemd:
+      .. include:: /_templates/common/restart_agent.rst
 
-      .. code-block:: console
-
-        # systemctl restart wazuh-agent
-
-      b. For SysV Init:
-
-      .. code-block:: console
-
-        # service wazuh-agent restart

--- a/source/amazon/services/supported-services/trusted-advisor.rst
+++ b/source/amazon/services/supported-services/trusted-advisor.rst
@@ -121,28 +121,9 @@ Wazuh configuration
 
     * If you're configuring a Wazuh manager:
 
-      a. For Systemd:
-
-      .. code-block:: console
-
-        # systemctl restart wazuh-manager
-
-      b. For SysV Init:
-
-      .. code-block:: console
-
-        # service wazuh-manager restart
+      .. include:: /_templates/common/restart_manager.rst
 
     * If you're configuring a Wazuh agent:
 
-      a. For Systemd:
+      .. include:: /_templates/common/restart_agent.rst
 
-      .. code-block:: console
-
-        # systemctl restart wazuh-agent
-
-      b. For SysV Init:
-
-      .. code-block:: console
-
-        # service wazuh-agent restart

--- a/source/amazon/services/supported-services/vpc.rst
+++ b/source/amazon/services/supported-services/vpc.rst
@@ -60,31 +60,12 @@ Wazuh configuration
 
     * If you're configuring a Wazuh manager:
 
-      a. For Systemd:
-
-      .. code-block:: console
-
-        # systemctl restart wazuh-manager
-
-      b. For SysV Init:
-
-      .. code-block:: console
-
-        # service wazuh-manager restart
+      .. include:: /_templates/common/restart_manager.rst
 
     * If you're configuring a Wazuh agent:
 
-      a. For Systemd:
-
-      .. code-block:: console
-
-        # systemctl restart wazuh-agent
-
-      b. For SysV Init:
-
-      .. code-block:: console
-
-        # service wazuh-agent restart
+      .. include:: /_templates/common/restart_agent.rst
+        
 
 Use cases
 ---------

--- a/source/amazon/services/supported-services/waf.rst
+++ b/source/amazon/services/supported-services/waf.rst
@@ -122,31 +122,11 @@ Wazuh configuration
 
     * If you're configuring a Wazuh manager:
 
-      a. For Systemd:
-
-      .. code-block:: console
-
-        # systemctl restart wazuh-manager
-
-      b. For SysV Init:
-
-      .. code-block:: console
-
-        # service wazuh-manager restart
+      .. include:: /_templates/common/restart_manager.rst
 
     * If you're configuring a Wazuh agent:
 
-      a. For Systemd:
-
-      .. code-block:: console
-
-        # systemctl restart wazuh-agent
-
-      b. For SysV Init:
-
-      .. code-block:: console
-
-        # service wazuh-agent restart
+      .. include:: /_templates/common/restart_agent.rst
 
 
 HTTP Request headers

--- a/source/deployment-options/splunk/splunk-reverse-proxy.rst
+++ b/source/deployment-options/splunk/splunk-reverse-proxy.rst
@@ -158,17 +158,7 @@ Enable authentication by htpasswd
 
 #. Restart NGINX:
 
-   #. For Systemd:
-
-      .. code-block:: console
-
-         # systemctl restart nginx
-
-   #. For SysV Init:
-
-      .. code-block:: console
-
-         # service nginx restart
+   .. include:: /_templates/common/restart_nginx.rst
 
 Now, access the Splunk web interface via HTTPS. It will prompt you for the username and password that you created in the steps above.
 
@@ -242,17 +232,7 @@ Enable authentication by htpasswd
 
 #. Restart NGINX:
 
-   #. For Systemd:
-
-      .. code-block:: console
-
-         # systemctl restart nginx
-
-   #. For SysV Init:
-
-      .. code-block:: console
-
-         # service nginx restart
+   .. include:: /_templates/common/restart_nginx.rst
 
 Now, access the Splunk web interface via HTTPS. It will prompt you for the username and password that you created in the steps above.
 

--- a/source/deployment-options/splunk/splunk-wazuh.rst
+++ b/source/deployment-options/splunk/splunk-wazuh.rst
@@ -72,6 +72,8 @@ Choose the corresponding tab to configure the installation as a single-node or m
 
          .. include:: /_templates/installations/wazuh/common/check_wazuh_manager.rst
 
+            
+
    .. group-tab:: Multi-node cluster
 
       One Wazuh server has to be chosen as a master, the rest will be workers. So, the section ``Wazuh server master node`` will be added in the configuration file of the server chosen for the master role. For all the other servers, the section ``Wazuh server worker node`` should be applied.

--- a/source/deployment-options/splunk/splunk-wazuh.rst
+++ b/source/deployment-options/splunk/splunk-wazuh.rst
@@ -70,19 +70,7 @@ Choose the corresponding tab to configure the installation as a single-node or m
 
       #. Run the following command to check if the Wazuh manager is active: 
 
-         .. tabs::
-
-            .. group-tab:: Systemd
-
-               .. code-block:: console
-
-                  # systemctl status wazuh-manager
-
-            .. group-tab:: SysV Init
-
-               .. code-block:: console
-
-                  # service wazuh-manager status
+         .. include:: /_templates/installations/wazuh/common/check_wazuh_manager.rst
 
    .. group-tab:: Multi-node cluster
 

--- a/source/migration-guide/wazuh-indexer.rst
+++ b/source/migration-guide/wazuh-indexer.rst
@@ -26,43 +26,17 @@ Follow this guide to migrate from Open Distro for Elasticsearch 1.13 to the Wazu
 
 #. Stop indexing, and perform a flush: indexing/searching should be stopped and _flush can be used to permanently store information into the index which will prevent any data loss during the upgrade.
 
-
    .. code-block:: console
 
         curl -X POST "https://<elasticsearch_IP>:9200/_flush/synced" -u <username>:<password> -k
 
-
 #. Stop Filebeat.
 
-   .. tabs::
-   
-    .. group-tab:: Systemd
-   
-     .. code-block:: console
-   
-      # systemctl stop filebeat
-   
-    .. group-tab:: SysV init
-   
-     .. code-block:: console
-   
-      # service filebeat stop          
+      .. include:: /_templates/installations/basic/elastic/common/stop_filebeat.rst
 
 #. Shutdown Elasticsearch. For distributed deployments, you can shut down a single node at a time: first data nodes and later master nodes.
 
-   .. tabs::
-   
-    .. group-tab:: Systemd
-   
-     .. code-block:: console
-   
-      # systemctl stop elasticsearch
-   
-    .. group-tab:: SysV init
-   
-     .. code-block:: console
-   
-      # service elasticsearch stop 
+      .. include:: /_templates/installations/basic/elastic/common/stop_elasticsearch.rst
 
 #. Add the Wazuh repository. You can skip this step if the repository is already present and enabled on your server. 
 

--- a/source/migration-guide/wazuh-indexer.rst
+++ b/source/migration-guide/wazuh-indexer.rst
@@ -166,20 +166,7 @@ Follow this guide to migrate from Open Distro for Elasticsearch 1.13 to the Wazu
 
 #. Once all the nodes have been upgraded, restart Filebeat.   
 
-   .. tabs::
-   
-    .. group-tab:: Systemd
-   
-     .. code-block:: console
-   
-      # systemctl restart filebeat
-   
-    .. group-tab:: SysV init
-   
-     .. code-block:: console
-   
-      # service filebeat restart  
-
+   .. include:: /_templates/common/restart_filebeat.rst
 
 #. Run the following command to verify that the communication between Filebeat and the Wazuh indexer is working as expected. 
 

--- a/source/user-manual/api/configuration.rst
+++ b/source/user-manual/api/configuration.rst
@@ -75,17 +75,8 @@ Here are all the available settings for the ``api.yaml`` configuration file. For
 
 Make sure to restart the Wazuh API using the **wazuh-manager** service after editing the configuration file:
 
-  a. For Systemd:
+  .. include:: /_templates/common/restart_manager.rst
 
-  .. code-block:: console
-
-    # systemctl restart wazuh-manager
-
-  b. For SysV Init:
-
-  .. code-block:: console
-
-    # service wazuh-manager restart
 
 Security configuration
 ----------------------

--- a/source/user-manual/api/securing-api.rst
+++ b/source/user-manual/api/securing-api.rst
@@ -42,17 +42,7 @@ Recommended changes to secure the Wazuh API
 
     After setting these parameters, it will be necessary to restart the Wazuh API using the ``wazuh-manager`` service:
 
-      * For Systemd:
-
-        .. code-block:: console
-
-          # systemctl restart wazuh-manager
-
-      * For SysV Init:
-
-        .. code-block:: console
-
-          # service wazuh-manager restart
+      .. include:: /_templates/common/restart_manager.rst
 
 #. Change the default password of the admin users (**wazuh** and **wazuh-wui**): 
 
@@ -82,17 +72,7 @@ Recommended changes to secure the Wazuh API
 
     After configuring these parameters, it will be necessary to restart the Wazuh API using the ``wazuh-manager`` service.
 
-      * For Systemd:
-
-        .. code-block:: console
-
-          # systemctl restart wazuh-manager
-
-      * For SysV Init:
-
-        .. code-block:: console
-
-          # service wazuh-manager restart
+      .. include:: /_templates/common/restart_manager.rst
 
 #. Set maximum number of requests per minute:
 

--- a/source/user-manual/capabilities/system-calls-monitoring/audit-configuration.rst
+++ b/source/user-manual/capabilities/system-calls-monitoring/audit-configuration.rst
@@ -94,17 +94,7 @@ Restarting Wazuh
 
 Finally, we must restart the Wazuh agent in order to apply the changes:
 
-a. For Systemd:
-
-  .. code-block:: console
-
-    # systemctl restart wazuh-agent
-
-b. For SysV Init:
-
-  .. code-block:: console
-
-    # service wazuh-agent restart
+.. include:: /_templates/common/restart_agent.rst
 
 Now everything is ready to process audit events. You only need to create the proper audit rules (via *auditctl* or */etc/audit/audit.rules*). In the next section we will describe some good use cases.
 

--- a/source/user-manual/capabilities/virustotal-scan/integration.rst
+++ b/source/user-manual/capabilities/virustotal-scan/integration.rst
@@ -64,17 +64,7 @@ For this use case, we will show how to monitor the folder ``/media/user/software
 
 2. After applying the configuration, you must restart the Wazuh manager:
 
-    a. For Systemd:
-
-      .. code-block:: console
-
-        # systemctl restart wazuh-manager
-
-    b. For SysV Init:
-
-      .. code-block:: console
-
-        # service wazuh-manager restart
+    .. include:: /_templates/common/restart_manager.rst
 
 After restarting, FIM will apply the new configuration and the specified folder will be monitored in real-time. The alert below appears when a file is added to the monitored directory:
 

--- a/source/user-manual/configuring-cluster/advanced-settings.rst
+++ b/source/user-manual/configuring-cluster/advanced-settings.rst
@@ -37,18 +37,7 @@ Pointing agents to the cluster with a load balancer
 
     2. Restart the agents:
 
-      a. For Systemd:
-
-        .. code-block:: console
-
-          # systemctl restart wazuh-agent
-
-      b. For SysV Init:
-
-        .. code-block:: console
-
-          # service wazuh-agent restart
-
+      .. include:: /_templates/common/restart_agent.rst
 
     3. Include in the ``Load Balancer`` the IP address of every instance of the cluster we want to deliver events.
 

--- a/source/user-manual/elasticsearch/configure-indices.rst
+++ b/source/user-manual/elasticsearch/configure-indices.rst
@@ -107,19 +107,7 @@ Let's suppose that we want to add a new index pattern (``my-custom-alerts-*``) a
 
     Restart the Kibana service:
 
-    .. tabs::
-   
-      .. group-tab:: Systemd
-    
-        .. code-block:: console
-      
-            # systemctl restart kibana
-    
-      .. group-tab:: SysV init
-    
-        .. code-block:: console
-      
-          # service kibana restart
+    .. include:: /_templates/installations/basic/elastic/common/restart_kibana.rst
 
 #. Restart the Filebeat service:
 

--- a/source/user-manual/elasticsearch/configure-indices.rst
+++ b/source/user-manual/elasticsearch/configure-indices.rst
@@ -36,17 +36,19 @@ Let's suppose that we want to add a new index pattern (``my-custom-alerts-*``) a
 
 #. First of all, stop the Filebeat service:
 
-    a. For Systemd:
+    .. tabs::
 
-       .. code-block:: console
+      .. group-tab:: Systemd
 
-        # systemctl stop filebeat
+        .. code-block:: console
+      
+            # systemctl stop filebeat
+    
+      .. group-tab:: SysV init
 
-    b. For SysV Init:
-
-       .. code-block:: console
-
-        # service filebeat stop
+        .. code-block:: console
+      
+          # service filebeat stop
 
 #. Download the Wazuh template for Elasticsearch and save it into a file (for example, *template.json*):
 

--- a/source/user-manual/elasticsearch/configure-indices.rst
+++ b/source/user-manual/elasticsearch/configure-indices.rst
@@ -36,19 +36,7 @@ Let's suppose that we want to add a new index pattern (``my-custom-alerts-*``) a
 
 #. First of all, stop the Filebeat service:
 
-    .. tabs::
-
-      .. group-tab:: Systemd
-
-        .. code-block:: console
-      
-            # systemctl stop filebeat
-    
-      .. group-tab:: SysV init
-
-        .. code-block:: console
-      
-          # service filebeat stop
+    .. include:: /_templates/common/stop_filebeat.rst
 
 #. Download the Wazuh template for Elasticsearch and save it into a file (for example, *template.json*):
 

--- a/source/user-manual/elasticsearch/configure-indices.rst
+++ b/source/user-manual/elasticsearch/configure-indices.rst
@@ -36,11 +36,11 @@ Let's suppose that we want to add a new index pattern (``my-custom-alerts-*``) a
 
 #. First of all, stop the Filebeat service:
 
-    .. include:: /_templates/common/stop_filebeat.rst
+   .. include:: /_templates/installations/basic/elastic/common/stop_filebeat.rst
 
 #. Download the Wazuh template for Elasticsearch and save it into a file (for example, *template.json*):
 
-    .. code-block:: console
+   .. code-block:: console
 
       # curl -so template.json https://raw.githubusercontent.com/wazuh/wazuh/v|WAZUH_CURRENT|/extensions/elasticsearch/7.x/wazuh-template.json
 

--- a/source/user-manual/elasticsearch/configure-indices.rst
+++ b/source/user-manual/elasticsearch/configure-indices.rst
@@ -117,31 +117,23 @@ Let's suppose that we want to add a new index pattern (``my-custom-alerts-*``) a
 
     Restart the Kibana service:
 
-    a. For Systemd:
-
-       .. code-block:: console
-
-        # systemctl restart kibana
-
-    b. For SysV Init:
-
-       .. code-block:: console
-
-        # service kibana restart
+    .. tabs::
+   
+      .. group-tab:: Systemd
+    
+        .. code-block:: console
+      
+            # systemctl restart kibana
+    
+      .. group-tab:: SysV init
+    
+        .. code-block:: console
+      
+          # service kibana restart
 
 #. Restart the Filebeat service:
 
-    a. For Systemd:
-
-       .. code-block:: console
-
-        # systemctl restart filebeat
-
-    b. For SysV Init:
-
-       .. code-block:: console
-
-        # service filebeat restart
+    .. include:: /_templates/common/restart_filebeat.rst    
 
 If the pattern is not present in Kibana UI, you may create a new one using the same name used on the Elasticsearch template, and make sure to use ``timestamp`` as the Time Filter field name.
 

--- a/source/user-manual/elasticsearch/troubleshooting.rst
+++ b/source/user-manual/elasticsearch/troubleshooting.rst
@@ -88,24 +88,7 @@ Wazuh API seems to be down
 
 This issue means that your Wazuh API might be unavailable. Check the status of the Wazuh manager to check if the service is active: 
 
-.. tabs::
-
-
-  .. group-tab:: Systemd
-
-
-    .. code-block:: console
-
-      # systemctl status wazuh-manager
-
-
-
-  .. group-tab:: SysV init
-
-    .. code-block:: console
-
-      # service wazuh-manager status
-
+.. include:: /_templates/installations/wazuh/common/check_wazuh_manager.rst
 
 If the Wazuh API is running, try to fetch data using the CLI from the Kibana server:
 

--- a/source/user-manual/manager/alert-threshold.rst
+++ b/source/user-manual/manager/alert-threshold.rst
@@ -27,14 +27,5 @@ This will set the minimum severity level that will trigger alerts that will be s
 
 When any value is changed in the ``ossec.conf`` file, the service must be restarted before the changes will take effect.
 
-a. For Systemd:
+.. include:: /_templates/common/restart_manager.rst
 
-.. code-block:: console
-
-  # systemctl restart wazuh-manager
-
-b. For SysV Init:
-
-.. code-block:: console
-
-  # service wazuh-manager restart

--- a/source/user-manual/manager/manual-database-output.rst
+++ b/source/user-manual/manager/manual-database-output.rst
@@ -142,16 +142,6 @@ Last steps
 
 The setup process for the database output is finished. Now the only thing left is to restart the Wazuh manager:
 
-  a. For Systemd:
-
-  .. code-block:: console
-
-    # systemctl restart wazuh-manager
-
-  b. For SysV Init:
-
-  .. code-block:: console
-
-    # service wazuh-manager restart
+  .. include:: /_templates/common/restart_manager.rst
 
 Now the database will start being filled with data provided by the manager.

--- a/source/user-manual/manager/manual-email-report/index.rst
+++ b/source/user-manual/manager/manual-email-report/index.rst
@@ -67,18 +67,7 @@ This example will set the minimum level to 10. For more information, see the :re
 
 After the ``alert_level`` has been configured, Wazuh needs to be restarted for the change to take effect.
 
-a) For Systemd:
-
-.. code-block:: console
-
-  # systemctl restart wazuh-manager
-
-b) For SysV Init:
-
-.. code-block:: console
-
-  # service wazuh-manager restart
-
+.. include:: /_templates/common/restart_manager.rst
 
 .. warning::
  Wazuh doesn't handle SMTP authentication. If your email service uses this, you will need to :ref:`configure a server relay<smtp_authentication>`.

--- a/source/user-manual/manager/manual-integration.rst
+++ b/source/user-manual/manager/manual-integration.rst
@@ -31,17 +31,7 @@ The integrations are configured on the Wazuh manager ``ossec.conf`` file which i
 
 After enabling the daemon and configure the integrations, restart the Wazuh manager to apply the changes:
 
-a. For Systemd:
-
-.. code-block:: console
-
-  # systemctl restart wazuh-manager
-
-b. For SysV Init:
-
-.. code-block:: console
-
-  # service wazuh-manager restart
+.. include:: /_templates/common/restart_manager.rst
 
 The full configuration reference for the Integrator daemon can be found :ref:`here <reference_ossec_integration>`.
 

--- a/source/user-manual/manager/manual-syslog-output.rst
+++ b/source/user-manual/manager/manual-syslog-output.rst
@@ -32,14 +32,5 @@ The above configuration will send alerts to ``192.168.1.240`` and, if the alert 
 
 To apply the changes, restart Wazuh:
 
-  a. For Systemd:
+  .. include:: /_templates/common/restart_manager.rst
 
-  .. code-block:: console
-
-    # systemctl restart wazuh-manager
-
-  b. For SysV Init:
-
-  .. code-block:: console
-
-    # service wazuh-manager restart

--- a/source/user-manual/manager/remote-service.rst
+++ b/source/user-manual/manager/remote-service.rst
@@ -29,14 +29,5 @@ This will set the manager to listen on IP address ``10.0.0.10``.
 
 When you change any value in the ``ossec.conf`` file, you must restart the service before these changes will take effect.
 
-a. For Systemd:
+.. include:: /_templates/common/restart_manager.rst
 
-.. code-block:: console
-
-  # systemctl restart wazuh-manager
-
-b. For SysV Init:
-
-.. code-block:: console
-
-  # service wazuh-manager restart

--- a/source/user-manual/ruleset/cdb-list.rst
+++ b/source/user-manual/ruleset/cdb-list.rst
@@ -64,17 +64,7 @@ Each list must be defined in the ``ossec.conf`` file using the following syntax:
 
 Restart Wazuh to apply the changes:
 
-  a. For Systemd:
-
-  .. code-block:: console
-
-    # systemctl restart wazuh-manager
-
-  b. For SysV Init:
-
-  .. code-block:: console
-
-    # service wazuh-manager restart
+  .. include:: /_templates/common/restart_manager.rst
 
 Using the CDB list in the rules
 -------------------------------

--- a/source/user-manual/wazuh-dashboard/multi-tenancy.rst
+++ b/source/user-manual/wazuh-dashboard/multi-tenancy.rst
@@ -45,16 +45,4 @@ To enable multi-tenancy, follow the instructions below.
 
 #. Restart the Wazuh dashboard so changes can take effect. 
 
-   .. tabs::
-   
-    .. group-tab:: Systemd
-   
-     .. code-block:: console
-   
-      # systemctl restart wazuh-dashboard
-   
-    .. group-tab:: SysV init
-   
-     .. code-block:: console
-   
-      # service wazuh-dashboard restart
+   .. include:: /_templates/common/restart_dashboard.rst

--- a/source/user-manual/wazuh-dashboard/troubleshooting.rst
+++ b/source/user-manual/wazuh-dashboard/troubleshooting.rst
@@ -15,24 +15,7 @@ Wazuh API seems to be down
 
 This issue means that your Wazuh API might be unavailable. Check the status of the Wazuh manager to check if the service is active: 
 
-.. tabs::
-
-
-  .. group-tab:: Systemd
-
-
-    .. code-block:: console
-
-      # systemctl status wazuh-manager
-
-
-
-  .. group-tab:: SysV init
-
-    .. code-block:: console
-
-      # service wazuh-manager status
-
+.. include:: /_templates/installations/wazuh/common/check_wazuh_manager.rst
 
 If the Wazuh API is running, try to fetch data using the CLI from the Wazuh dashboard server:
 


### PR DESCRIPTION
## Description
- In many sections, we still find old instructions for restarting the Wazuh manager that does not include the tabs for _Systemd_ and _SysV Init_.  We should replace them with the new templates, to gain uniformity throughout the documentation and make them easier to maintain. We should also update the instructions to restart the Wazuh agents, and Filebeat, among others.
- This PR closes #5705.

## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
