### PR TITLE
 Fix typo in the aws-s3 wodle configuration documentation

### DIFF
--- a/source/user-manual/reference/ossec-conf/wodle-s3.rst
+++ b/source/user-manual/reference/ossec-conf/wodle-s3.rst
@@ -65,7 +65,7 @@ Disables the AWS-S3 wodle.
 skip_on_error
 ^^^^^^^^^^^^^
 
-When unable to process and parse a CloudTrail log, skip the log and continue processing
+When unable to process and parse a log, skip the log and continue processing.
 
 +--------------------+---------+
 | **Default value**  | yes     |


### PR DESCRIPTION
## Description

This PR fixes a typo in the aws-s3 wodle configuration documentation and closes [#4014](https://github.com/wazuh/wazuh-documentation/issues/4014).

The `skip_on_error` description referred to a specific service, _CloudTrail_, when in fact it is a general option. Removing the reference to _CloudTrail_ fixes the description.

## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
