### PR TITLE
Improve the syscollector alerts guide note

### DIFF
--- a/source/user-manual/capabilities/syscollector.rst
+++ b/source/user-manual/capabilities/syscollector.rst
@@ -401,7 +401,10 @@ Using Syscollector information to trigger alerts
 
 .. warning::
    
-   This functionality is not currently supported. It will be available starting with version 4.4.
+   This capability is not available in Wazuh 4.2 and Wazuh 4.3 versions. It will be available starting with version 4.4.
+
+   In Wazuh 4.2 changes were made to the syscollector that greatly improves the flow of information between agent and manager for information synchronization.
+   Once this stage is finished, the tasks to enable the alerts will start, since the information received is sufficient to activate them.
 
 Since Wazuh 3.9 version, ``Syscollector`` module information can be used to trigger alerts and show that information in the alerts' description.
 


### PR DESCRIPTION
## Description
This PR closes #5675. It adds more information in the syscollector alerts guide note.

## Checks
- [x] Compiles without warnings.
- [x] Uses three spaces indentation.

## Evidence
```
(wazuh_venv) (base) dmangold@dmangold:~/Wazuh/dev/wazuh-documentation$ make -j8 html
sphinx-build -b html -d build/doctrees   source build/html
Running Sphinx v3.2.0
loading translations [en-US]... not available for built-in messages
loading pickled environment... done
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 632 source files that are out of date
updating environment: 0 added, 1 changed, 0 removed
reading sources... [100%] user-manual/capabilities/syscollector                                                                                                                                                                                 
Copying static files for wazuh-doc-images...[100%] img/loading.gif                                                                                                                                                                              
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] user-manual/wazuh-dashboard/troubleshooting                                                                                                                                                                            
generating indices... done
writing additional pages...  not_found moved-content searchdone
copying images... [100%] user-manual/wazuh-dashboard/../../images/kibana-app/features/settings/about.png                                                                                                                                        
copying static files... ... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded.

The HTML pages are in build/html.
Copying tabs assets

Build finished. The HTML pages are in build/html.
```

![image](https://user-images.githubusercontent.com/106940255/198996832-9d8bc945-cc81-4d4c-8307-ebb4a79c0a31.png)

