### PR TITLE
Review the section: User manual / Single sign-on

### DIFF
--- a/source/user-manual/wazuh-dashboard/single-sign-on/azure-active-directory.rst
+++ b/source/user-manual/wazuh-dashboard/single-sign-on/azure-active-directory.rst
@@ -161,39 +161,39 @@ Edit the Wazuh indexer security configuration files. It is recommended to back u
 
    - Include a ``saml_auth_domain`` configuration under the ``authc`` section similar to the following:
 
-      .. code-block:: console
-         :emphasize-lines: 7,10,22,23,25,26,27,28
+   .. code-block:: console
+      :emphasize-lines: 7,10,22,23,25,26,27,28
 
-            authc:
-         ...
-               basic_internal_auth_domain:
-               description: "Authenticate via HTTP Basic against internal users database"
-               http_enabled: true
-               transport_enabled: true
-               order: 0
-               http_authenticator:
-                  type: "basic"
-                  challenge: false
-               authentication_backend:
-                  type: "intern"
-               saml_auth_domain:
-               http_enabled: true
-               transport_enabled: false
-               order: 1
-               http_authenticator:
-                  type: saml
-                  challenge: true
-                  config:
-                     idp:
-                     metadata_url: https://login.microsoftonline.com/...
-                     entity_id: https://sts.windows.net/...
-                     sp:
-                     entity_id: wazuh-saml
-                     kibana_url: https://<WAZUH_DASHBOARD_URL>
-                     roles_key: Roles
-                     exchange_key: '...'
-               authentication_backend:
-                  type: noop
+          authc:
+      ...
+            basic_internal_auth_domain:
+              description: "Authenticate via HTTP Basic against internal users database"
+              http_enabled: true
+              transport_enabled: true
+              order: 0
+              http_authenticator:
+                type: "basic"
+                challenge: false
+              authentication_backend:
+                type: "intern"
+            saml_auth_domain:
+              http_enabled: true
+              transport_enabled: false
+              order: 1
+              http_authenticator:
+                type: saml
+                challenge: true
+                config:
+                  idp:
+                    metadata_url: https://login.microsoftonline.com/...
+                    entity_id: https://sts.windows.net/...
+                  sp:
+                    entity_id: wazuh-saml
+                  kibana_url: https://<WAZUH_DASHBOARD_ADDRESS>
+                  roles_key: Roles
+                  exchange_key: '...'
+              authentication_backend:
+                type: noop
 
 
    - The ``roles_key`` must be the same value that we used in the Azure AD configuration.

--- a/source/user-manual/wazuh-dashboard/single-sign-on/google.rst
+++ b/source/user-manual/wazuh-dashboard/single-sign-on/google.rst
@@ -124,36 +124,36 @@ Edit the Wazuh indexer security configuration files. It is recommended to back u
    .. code-block:: console
       :emphasize-lines: 7,10,22,23,25,26,27,28
 
-         authc:
+          authc:
       ...
             basic_internal_auth_domain:
-            description: "Authenticate via HTTP Basic against internal users database"
-            http_enabled: true
-            transport_enabled: true
-            order: 0
-            http_authenticator:
-               type: "basic"
-               challenge: false
-            authentication_backend:
-               type: "intern"
+              description: "Authenticate via HTTP Basic against internal users database"
+              http_enabled: true
+              transport_enabled: true
+              order: 0
+              http_authenticator:
+                type: "basic"
+                challenge: false
+              authentication_backend:
+                type: "intern"
             saml_auth_domain:
-            http_enabled: true
-            transport_enabled: false
-            order: 1
-            http_authenticator:
-               type: saml
-               challenge: true
-               config:
+              http_enabled: true
+              transport_enabled: false
+              order: 1
+              http_authenticator:
+                type: saml
+                challenge: true
+                config:
                   idp:
-                  metadata_file: “/usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/Google_Metadata.xml”
-                  entity_id: “https://accounts.google.com/o/saml2?idpid=C02…”
+                    metadata_file: “/usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/Google_Metadata.xml”
+                    entity_id: “https://accounts.google.com/o/saml2?idpid=C02…”
                   sp:
-                  entity_id: wazuh-saml
-                  kibana_url: https://<WAZUH_DASHBOARD_URL>
+                    entity_id: wazuh-saml
+                  kibana_url: https://<WAZUH_DASHBOARD_ADDRESS>
                   roles_key: Roles
                   exchange_key: 'X509Certificate'
-            authentication_backend:
-               type: noop
+              authentication_backend:
+                type: noop
 
    Ensure to change the following parameters to their corresponding value:
 

--- a/source/user-manual/wazuh-dashboard/single-sign-on/jumpcloud.rst
+++ b/source/user-manual/wazuh-dashboard/single-sign-on/jumpcloud.rst
@@ -120,37 +120,37 @@ Edit the Wazuh indexer security configuration files. It is recommended to back u
    .. code-block:: console
       :emphasize-lines: 7,10,22,23,25,26,27,28,29
 
-         authc:
+          authc:
       ...
             basic_internal_auth_domain:
-            description: "Authenticate via HTTP Basic against internal users database"
-            http_enabled: true
-            transport_enabled: true
-            order: 0
-            http_authenticator:
-               type: "basic"
-               challenge: false
-            authentication_backend:
-               type: "intern"
+              description: "Authenticate via HTTP Basic against internal users database"
+              http_enabled: true
+              transport_enabled: true
+              order: 0
+              http_authenticator:
+                type: "basic"
+                challenge: false
+              authentication_backend:
+                type: "intern"
             saml_auth_domain:
-            http_enabled: true
-            transport_enabled: true
-            order: 1
-            http_authenticator:
-               type: saml
-               challenge: true
-               config:
+              http_enabled: true
+              transport_enabled: true
+              order: 1
+              http_authenticator:
+                type: saml
+                challenge: true
+                config:
                   idp:
-                  metadata_file: “/usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/metadata_jumpcloud.xml”
-                  entity_id: wazuh
+                    metadata_file: “/usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/metadata_jumpcloud.xml”
+                    entity_id: wazuh
                   sp:
-                  entity_id: wazuh-saml
-                  forceAuthn: true
-                  kibana_url: https://<WAZUH_DASHBOARD_URL>
+                    entity_id: wazuh-saml
+                    forceAuthn: true
+                  kibana_url: https://<WAZUH_DASHBOARD_ADDRESS>
                   roles_key: Roles
                   exchange_key: '...'
-            authentication_backend:
-               type: noop
+              authentication_backend:
+                type: noop
 
    Ensure to change the following parameters to their corresponding value:
 

--- a/source/user-manual/wazuh-dashboard/single-sign-on/okta.rst
+++ b/source/user-manual/wazuh-dashboard/single-sign-on/okta.rst
@@ -160,26 +160,26 @@ Edit the Wazuh indexer security configuration files. It is recommended to back u
    .. code-block:: console
       :emphasize-lines: 7,10,22,23,25,26,27,2
 
-        authc:
+          authc:
       ...
-          basic_internal_auth_domain:
-            description: "Authenticate via HTTP Basic against internal users database"
-            http_enabled: true
-            transport_enabled: true
-            order: 0
-            http_authenticator:
-              type: "basic"
-              challenge: false
-            authentication_backend:
-              type: "intern"
-          saml_auth_domain:
-            http_enabled: true
-            transport_enabled: false
-            order: 1
-            http_authenticator:
-              type: saml
-              challenge: true
-              config:
+            basic_internal_auth_domain:
+              description: "Authenticate via HTTP Basic against internal users database"
+              http_enabled: true
+              transport_enabled: true
+              order: 0
+              http_authenticator:
+                type: "basic"
+                challenge: false
+              authentication_backend:
+                type: "intern"
+            saml_auth_domain:
+              http_enabled: true
+              transport_enabled: false
+              order: 1
+              http_authenticator:
+                type: saml
+                challenge: true
+                config:
                   idp:
                     metadata_url: ""
                     entity_id: ""
@@ -188,8 +188,8 @@ Edit the Wazuh indexer security configuration files. It is recommended to back u
                   kibana_url: https://<WAZUH_DASHBOARD_ADDRESS>
                   roles_key: Roles
                   exchange_key: ''
-            authentication_backend:
-              type: noop               
+              authentication_backend:
+                type: noop               
          
    Ensure to change the following parameters to their corresponding value:
 

--- a/source/user-manual/wazuh-dashboard/single-sign-on/okta.rst
+++ b/source/user-manual/wazuh-dashboard/single-sign-on/okta.rst
@@ -158,39 +158,39 @@ Edit the Wazuh indexer security configuration files. It is recommended to back u
    - Include a ``saml_auth_domain`` configuration under the ``authc`` section similar to the following:
 
    .. code-block:: console
-      :emphasize-lines: 7,10,22,23,25,26,27,2   
+      :emphasize-lines: 7,10,22,23,25,26,27,2
 
-            authc:
+        authc:
       ...
-            basic_internal_auth_domain:
+          basic_internal_auth_domain:
             description: "Authenticate via HTTP Basic against internal users database"
             http_enabled: true
             transport_enabled: true
             order: 0
             http_authenticator:
-               type: "basic"
-               challenge: false
+              type: "basic"
+              challenge: false
             authentication_backend:
-               type: "intern"
-         saml_auth_domain:
+              type: "intern"
+          saml_auth_domain:
             http_enabled: true
             transport_enabled: false
             order: 1
             http_authenticator:
-            type: saml
-            challenge: true
-            config:
-               idp:
-                  metadata_url: ""
-                  entity_id: ""
-               sp:
-                  entity_id: wazuh-saml
-               kibana_url: https://<WAZUH_DASHBOARD_URL>
-               roles_key: Roles
-               exchange_key: ''
+              type: saml
+              challenge: true
+              config:
+                  idp:
+                    metadata_url: ""
+                    entity_id: ""
+                  sp:
+                    entity_id: wazuh-saml
+                  kibana_url: https://<WAZUH_DASHBOARD_ADDRESS>
+                  roles_key: Roles
+                  exchange_key: ''
             authentication_backend:
-            type: noo   
-   
+              type: noop               
+         
    Ensure to change the following parameters to their corresponding value:
 
       - ``idp.metadata_url``  

--- a/source/user-manual/wazuh-dashboard/single-sign-on/onelogin.rst
+++ b/source/user-manual/wazuh-dashboard/single-sign-on/onelogin.rst
@@ -152,36 +152,36 @@ Edit the Wazuh indexer security configuration files. It is recommended to back u
    .. code-block:: console
       :emphasize-lines: 7,10,22,23,25,26,27,28
 
-         authc:
+          authc:
       ...
             basic_internal_auth_domain:
-            description: "Authenticate via HTTP Basic against internal users database"
-            http_enabled: true
-            transport_enabled: true
-            order: 0
-            http_authenticator:
-               type: "basic"
-               challenge: false
-            authentication_backend:
-               type: "intern"
+              description: "Authenticate via HTTP Basic against internal users database"
+              http_enabled: true
+              transport_enabled: true
+              order: 0
+              http_authenticator:
+                type: "basic"
+                challenge: false
+              authentication_backend:
+                type: "intern"
             saml_auth_domain2:
-            http_enabled: true
-            transport_enabled: true
-            order: 1
-            http_authenticator:
-               type: saml
-               challenge: true
-               config:
+              http_enabled: true
+              transport_enabled: true
+              order: 1
+              http_authenticator:
+                type: saml
+                challenge: true
+                config:
                   idp:
-                  metadata_file: "/usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/metadata_onelogin.xml"
-                  entity_id: "https://app.onelogin.com/saml/metadata/xxxxxxx"
+                    metadata_file: "/usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/metadata_onelogin.xml"
+                    entity_id: "https://app.onelogin.com/saml/metadata/xxxxxxx"
                   sp:
-                  entity_id: wazuh-saml
-                  kibana_url: https://<WAZUH_DASHBOARD_URL>
+                    entity_id: wazuh-saml
+                  kibana_url: https://<WAZUH_DASHBOARD_ADDRESS>
                   roles_key: Roles
                   exchange_key: 'X.509 Certificate'
-            authentication_backend:
-               type: noop
+              authentication_backend:
+                type: noop
       ...
    
    Ensure to change the following parameters to their corresponding value:

--- a/source/user-manual/wazuh-dashboard/single-sign-on/pingone.rst
+++ b/source/user-manual/wazuh-dashboard/single-sign-on/pingone.rst
@@ -122,36 +122,36 @@ Edit the Wazuh indexer security configuration files. It is recommended to back u
    .. code-block:: console
       :emphasize-lines: 7,10,22,23,25,26,27,28
 
-         authc:
+          authc:
       ...
             basic_internal_auth_domain:
-            description: "Authenticate via HTTP Basic against internal users database"
-            http_enabled: true
-            transport_enabled: true
-            order: 0
-            http_authenticator:
-               type: "basic"
-               challenge: false
-            authentication_backend:
-               type: "intern"
+              description: "Authenticate via HTTP Basic against internal users database"
+              http_enabled: true
+              transport_enabled: true
+              order: 0
+              http_authenticator:
+                type: "basic"
+                challenge: false
+              authentication_backend:
+                type: "intern"
             saml_auth_domain:
-            http_enabled: true
-            transport_enabled: false
-            order: 1
-            http_authenticator:
-               type: saml
-               challenge: true
-               config:
+              http_enabled: true
+              transport_enabled: false
+              order: 1
+              http_authenticator:
+                type: saml
+                challenge: true
+                config:
                   idp:
-                  metadata_file: “/usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/Google_Metadata.xml”
-                  entity_id: “https://accounts.google.com/o/saml2?idpid=C02…”
+                    metadata_file: “/usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/Google_Metadata.xml”
+                    entity_id: “https://accounts.google.com/o/saml2?idpid=C02…”
                   sp:
-                  entity_id: wazuh-saml
-                  kibana_url: https://<WAZUH_DASHBOARD_URL>
+                    entity_id: wazuh-saml
+                  kibana_url: https://<WAZUH_DASHBOARD_ADDRESS>
                   roles_key: Roles
                   exchange_key: 'X509Certificate'
-            authentication_backend:
-               type: noop
+              authentication_backend:
+                type: noop
 
    Ensure to change the following parameters to their corresponding value:
 


### PR DESCRIPTION
## Description
This issue aims to review the section `User manual / Single sign-on.

## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
