### PR TITLE
Change the links on the section: Restore the Wazuh alerts from Wazuh 2.x

### DIFF
--- a/source/upgrade-guide/legacy/upgrading-wazuh-server/restore-alerts-from-2.x-to-3.x.rst
+++ b/source/upgrade-guide/legacy/upgrading-wazuh-server/restore-alerts-from-2.x-to-3.x.rst
@@ -10,7 +10,7 @@ Restore the Wazuh alerts from Wazuh 2.x
 
 After upgrading Wazuh from 2.x to 3.x, the old alerts will not be lost. However, they cannot be visualized in Kibana due to a change in the Wazuh alerts' template. In order to access the old alerts and visualize them along with the new ones, the indices need to be reindexed to apply the new mapping.
 
-To do so, download the ``restore_alerts.sh`` script `(the script is available here) <https://github.com/wazuh/wazuh/blob/v3.13.6/extensions/elasticsearch/restore_alerts/restore_alerts.sh>`_ and Logstash's configuration file called ``restore_alerts.conf`` `(the configuration file is available here) <https://github.com/wazuh/wazuh/blob/v3.13.6/extensions/elasticsearch/restore_alerts/restore_alerts.conf>`_:
+To do so, download the `restore_alerts.sh <https://github.com/wazuh/wazuh/blob/3.13/extensions/elasticsearch/restore_alerts/restore_alerts.sh>`_ script and the Logstash configuration file called `restore_alerts.conf <https://github.com/wazuh/wazuh/blob/3.13/extensions/elasticsearch/restore_alerts/restore_alerts.conf>`_:
 
     .. code-block:: console
 

--- a/source/upgrade-guide/legacy/upgrading-wazuh-server/restore-alerts-from-2.x-to-3.x.rst
+++ b/source/upgrade-guide/legacy/upgrading-wazuh-server/restore-alerts-from-2.x-to-3.x.rst
@@ -10,7 +10,7 @@ Restore the Wazuh alerts from Wazuh 2.x
 
 After upgrading Wazuh from 2.x to 3.x, the old alerts will not be lost. However, they cannot be visualized in Kibana due to a change in the Wazuh alerts' template. In order to access the old alerts and visualize them along with the new ones, the indices need to be reindexed to apply the new mapping.
 
-To do so, download the ``restore_alerts.sh`` script `(the script is available here) <https://github.com/wazuh/wazuh/tree/master/extensions/elasticsearch/restore_alerts/restore_alerts.sh>`_ and Logstash's configuration file called ``restore_alerts.conf`` `(the configuration file is available here) <https://github.com/wazuh/wazuh/tree/master/extensions/elasticsearch/restore_alerts/restore_alerts.conf>`_:
+To do so, download the ``restore_alerts.sh`` script `(the script is available here) <https://github.com/wazuh/wazuh/blob/v3.13.6/extensions/elasticsearch/restore_alerts/restore_alerts.sh>`_ and Logstash's configuration file called ``restore_alerts.conf`` `(the configuration file is available here) <https://github.com/wazuh/wazuh/blob/v3.13.6/extensions/elasticsearch/restore_alerts/restore_alerts.conf>`_:
 
     .. code-block:: console
 


### PR DESCRIPTION
## Description
This issue aims to Change the links in the section: `Restore the Wazuh alerts from Wazuh 2.x`:
 
- The links to the files mentioned in this section are not working: [Restore the Wazuh alerts from Wazuh 2.x](https://documentation.wazuh.com/current/upgrade-guide/legacy/upgrading-wazuh-server/restore-alerts-from-2.x-to-3.x.html#restore-the-wazuh-alerts-from-wazuh-2-x):
   - [restore_alerts.sh](https://github.com/wazuh/wazuh/tree/master/extensions/elasticsearch/restore_alerts/restore_alerts.sh)
   - [restore_alerts.conf](https://github.com/wazuh/wazuh/tree/master/extensions/elasticsearch/restore_alerts/restore_alerts.conf)
- The master branch no longer contains such files. Instead, we need to change the links and use the ones on this [path](https://github.com/wazuh/wazuh/tree/v3.13.6/extensions/elasticsearch/restore_alerts):
   - [restore_alerts.sh](https://github.com/wazuh/wazuh/blob/v3.13.6/extensions/elasticsearch/restore_alerts/restore_alerts.sh)
   - [restore_alerts.conf](https://github.com/wazuh/wazuh/blob/v3.13.6/extensions/elasticsearch/restore_alerts/restore_alerts.conf)

## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
