### PR TITLE
Change OSquery repo and version and add dependency text.

### DIFF
--- a/source/user-manual/capabilities/osquery.rst
+++ b/source/user-manual/capabilities/osquery.rst
@@ -45,15 +45,17 @@ A complete list of all the available tables can be found `here <https://osquery.
 Configuration
 -------------
 
-You need a working Osquery installation in your system. See `downloads page <https://osquery.io/downloads/official/4.1.2>`_ for details.
+You need a working Osquery installation in your system. See `downloads page <https://osquery.io/downloads/official/>`_ for details.
 
 Red Hat, CentOS and Fedora:
+
+-  For some distributions, you might need to install ``yum-utils`` first.
 
 .. code-block:: console
 
     # curl -L https://pkg.osquery.io/rpm/GPG | tee /etc/pki/rpm-gpg/RPM-GPG-KEY-osquery
     # yum-config-manager --add-repo https://pkg.osquery.io/rpm/osquery-s3-rpm.repo
-    # yum-config-manager --enable osquery-s3-rpm
+    # yum-config-manager --enable osquery-s3-rpm-repo
     # yum install osquery
 
 Debian and Ubuntu based Linux distributions:


### PR DESCRIPTION
## Description
This PR closes #5091 .

- It adds a mention to `yum-utils` as a required dependency for installing OSQUery.
- It updates the OSQuery downloads page link to the current version.
- It updates to the current available OSQuery repository

## Checks
- [X] Compiles without warnings.
- [X] Uses present tense, active voice, and semi-formal registry.
- [X] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [X] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
