### PR TITLE
Add multiple force tags clarification

### DIFF
--- a/source/user-manual/reference/ossec-conf/auth.rst
+++ b/source/user-manual/reference/ossec-conf/auth.rst
@@ -88,7 +88,7 @@ force
 
 .. versionadded:: 4.3.0
 
-The agent replacement options are configured inside this tag. All conditions must be satisfied to perform the replacement.
+This tag holds the agent replacement configuration options. All conditions must be satisfied to perform the replacement. If using multiple ``<force>`` tags, the longest ``disconnected_time`` and the longest ``after_registration_time`` must be met.
 
 .. code-block:: xml
 


### PR DESCRIPTION
## Description
This PR clarifies the eventual use of multiple `<force>` tags. It closes #5560 

## Checks
- [ ] Compiles without warnings.
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
