### PR TITLE
Remove <path> option from AWS-S3 wodle configuration

### DIFF
--- a/source/amazon/services/supported-services/vpc.rst
+++ b/source/amazon/services/supported-services/vpc.rst
@@ -48,7 +48,6 @@ Wazuh configuration
         <skip_on_error>yes</skip_on_error>
         <bucket type="vpcflow">
           <name>wazuh-aws-wodle</name>
-          <path>vpc</path>
           <aws_profile>default</aws_profile>
         </bucket>
       </wodle>


### PR DESCRIPTION
## Description
This PR removes the `<path>` option as requested. This closes issue #5726 

## Checks
- [X] Compiles without warnings.
- [X] Uses present tense, active voice, and semi-formal registry.
- [X] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [X] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
