### PR TITLE
Add documentation

### DIFF
--- a/source/deployment-options/docker/wazuh-container.rst
+++ b/source/deployment-options/docker/wazuh-container.rst
@@ -276,7 +276,7 @@ It is possible to generate a hash using the same Docker image, type in a secure 
    docker run --rm -ti wazuh/wazuh-indexer:|WAZUH_CURRENT| bash /usr/share/wazuh-indexer/plugins/opensearch-security/tools/hash.sh
 
 
-If you decide to update __kibanaserver__'s password, do not forget to set the __DASHBOARD_PASSWORD__ environment variable for the dashboard container.
+If you decide to update **kibanaserver**'s password, do not forget to set the ``DASHBOARD_PASSWORD`` environment variable for the dashboard container.
 
 .. code-block:: yaml
 

--- a/source/deployment-options/docker/wazuh-container.rst
+++ b/source/deployment-options/docker/wazuh-container.rst
@@ -276,6 +276,14 @@ It is possible to generate a hash using the same Docker image, type in a secure 
    docker run --rm -ti wazuh/wazuh-indexer:|WAZUH_CURRENT| bash /usr/share/wazuh-indexer/plugins/opensearch-security/tools/hash.sh
 
 
+If you decide to update __kibanaserver__'s password, do not forget to set the __DASHBOARD_PASSWORD__ environment variable for the dashboard container.
+
+.. code-block:: yaml
+
+ environment:
+   - DASHBOARD_PASSWORD=your_new_password
+
+
 Exposed ports
 -------------
 

--- a/source/user-manual/securing-wazuh/wazuh-indexer.rst
+++ b/source/user-manual/securing-wazuh/wazuh-indexer.rst
@@ -133,3 +133,7 @@ The options ``-au`` and ``-ap`` are necessary to change the passwords for the AP
 
 In distributed deployments you will need to change the passwords in the nodes running Wazuh dashboard and Filebeat, you can use ``wazuh-passwords-tool.sh`` to do this.
 
+With docker images
+---------------------------------
+
+When using Wazuh's Docker images, if you change __kibanaserver__'s password, you need to set the __DASHBOARD_PASSWORD__ environment variable for the dashboard container.

--- a/source/user-manual/securing-wazuh/wazuh-indexer.rst
+++ b/source/user-manual/securing-wazuh/wazuh-indexer.rst
@@ -133,7 +133,4 @@ The options ``-au`` and ``-ap`` are necessary to change the passwords for the AP
 
 In distributed deployments you will need to change the passwords in the nodes running Wazuh dashboard and Filebeat, you can use ``wazuh-passwords-tool.sh`` to do this.
 
-With docker images
----------------------------------
-
-When using Wazuh's Docker images, if you change __kibanaserver__'s password, you need to set the __DASHBOARD_PASSWORD__ environment variable for the dashboard container.
+.. note:: If you're using Docker, read the :doc:`Wazuh Docker deployment page <../../deployment-options/docker/wazuh-container>` for more information.


### PR DESCRIPTION
## Description

I'm running Wazuh in docker and when following the [securing Wazuh guide](https://documentation.wazuh.com/current/user-manual/securing-wazuh/wazuh-indexer.html), I did not find information about the **kibanaserver** user when you change its default password. So the dashboard could not connect to the indexer. Turns out it was a simple fix, described [in this issue](https://github.com/wazuh/wazuh-docker/issues/712#issuecomment-1230398426), since the [entrypoint](https://github.com/wazuh/wazuh-docker/blob/379bbb4096e9b1047fef573ec3fadadce741e298/build-docker-images/wazuh-dashboard/config/entrypoint.sh#L6) for the dashboard image relies on an environment variable `DASHBOARD_PASSWORD`, I just had to set it to the correct value.

My addition simply describes the solution for this use case. I'm not sure if putting that information in both those places is useful/right. Will be happy to make any required changes!

## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.