### PR TITLE
Add storage in disk option for remoted groups generation

### DIFF
--- a/source/user-manual/reference/internal-options.rst
+++ b/source/user-manual/reference/internal-options.rst
@@ -746,9 +746,15 @@ Remoted
 +-----------------------------------+---------------+--------------------------------------------------------------+
 |  **remoted.merge_shared**         | Description   | Merge shared configuration to be broadcast to agents.        |
 +                                   +---------------+--------------------------------------------------------------+
-|                                   | Default Value | 1 ( Enabled )                                                |
+|                                   | Default Value | 1 (Enabled)                                                  |
 +                                   +---------------+--------------------------------------------------------------+
-|                                   | Allowed Value | 1 ( Enabled ) or 0 (Disabled)                                |
+|                                   | Allowed Value | 1 (Enabled), 0 (Disabled)                                    |
++-----------------------------------+---------------+--------------------------------------------------------------+
+|  **remoted.disk_storage**         | Description   | Store the temporary shared configuration file on disk.       |
++                                   +---------------+--------------------------------------------------------------+
+|                                   | Default Value | 0 (No, store in memory)                                      |
++                                   +---------------+--------------------------------------------------------------+
+|                                   | Allowed Value | 1 (Yes, store on disk), 0 (No, store in memory)              |
 +-----------------------------------+---------------+--------------------------------------------------------------+
 |   **remoted.shared_reload**       | Description   | Number of seconds between reloading of shared files.         |
 +                                   +---------------+--------------------------------------------------------------+


### PR DESCRIPTION
## Description

This PR adds the new internal setting `remoted.disk_storage`.

These are the allowed values:

- `0` No, store in memory (default)
- `1` Yes, store on disk

## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
