### PR TITLE
Fix issues with offline vulnerability detection feed configurations

### DIFF
--- a/source/user-manual/capabilities/vulnerability-detection/offline-update.rst
+++ b/source/user-manual/capabilities/vulnerability-detection/offline-update.rst
@@ -395,73 +395,73 @@ Sample Configuration
 
 .. code-block:: xml
 
-  <ossec_config>
-    <vulnerability-detector>
-      <enabled>yes</enabled>
-      <interval>5m</interval>
-      <min_full_scan_interval>6h</min_full_scan_interval>
-      <run_on_start>yes</run_on_start>
-  
-      <!-- Ubuntu OS vulnerabilities -->
-      <provider name="canonical">
-          <enabled>yes</enabled>
-          <os path="/local_path/com.ubuntu.jammy.cve.oval.xml.bz2">jammy</os>
-          <os path="/local_path/com.ubuntu.focal.cve.oval.xml.bz2">focal</os>
-          <os path="/local_path/com.ubuntu.bionic.cve.oval.xml.bz2">bionic</os>
-          <os path="/local_path/com.ubuntu.xenial.cve.oval.xml.bz2">xenial</os>
-          <os path="/local_path/com.ubuntu.trusty.cve.oval.xml.bz2">trusty</os>
-          <update_interval>1h</update_interval>
-      </provider>
-  
-      <!-- Debian OS vulnerabilities -->
-      <provider name="debian">
-          <enabled>yes</enabled>
-          <os path="/local_path/oval-definitions-bullseye.xml">bullseye</os>
-          <os path="/local_path/oval-definitions-buster.xml">buster</os>
-          <os path="/local_path/oval-definitions-stretch.xml">stretch</os>
-          <path>/local_path/security_tracker_local.json</path>
-          <update_interval>1h</update_interval>
-      </provider>
-  
-      <!-- RedHat OS vulnerabilities -->
-      <provider name="redhat">
-          <enabled>yes</enabled>
-          <os path="/local_path/com.redhat.rhsa-RHEL5.xml.bz2">5</os>
-          <os path="/local_path/rhel-6-including-unpatched.oval.xml.bz2">6</os>
-          <os path="/local_path/rhel-7-including-unpatched.oval.xml.bz2">7</os>
-          <os path="/local_path/rhel-8-including-unpatched.oval.xml.bz2">8</os>
-          <os path="/local_path/rhel-9-including-unpatched.oval.xml.bz2">9</os>
-          <path>/local_path/rh-feed/redhat-feed[[:digit:]]\+\.json$</path>
-          <update_interval>1h</update_interval>
-      </provider>
-  
-      <!-- Arch OS vulnerabilities -->
-      <provider name="arch">
-          <enabled>yes</enabled>
-          <path>/local_path/all\.json$</path>
-          <update_interval>1h</update_interval>
-      </provider>
-  
-      <!-- Amazon Linux OS vulnerabilities -->
-      <provider name="alas">
-          <enabled>yes</enabled>
-          <os path="/local_path/updates_amazon-linux.json.gz">amazon-linux</os>
-          <os path="/local_path/updates_amazon-linux-2.json.gz">amazon-linux-2</os>
-          <update_interval>1h</update_interval>
-      </provider>
-  
-      <!-- Windows OS vulnerabilities -->
-      <provider name="msu">
-          <enabled>yes</enabled>
-          <path>/local_path/msu-updates\.json\.gz$</path>
-          <update_interval>1h</update_interval>
-      </provider>
-  
-      <!-- Aggregate vulnerabilities -->
-      <provider name="nvd">
-          <enabled>yes</enabled>
-          <path>/local_path/nvd-feed/nvd-feed[[:digit:]]\{4\}\.json\.gz$</path>
-          <update_interval>1h</update_interval>
-      </provider>
-    </vulnerability-detector>
-  </ossec_config>
+   <ossec_config>
+     <vulnerability-detector>
+       <enabled>yes</enabled>
+       <interval>5m</interval>
+       <min_full_scan_interval>6h</min_full_scan_interval>
+       <run_on_start>yes</run_on_start>
+   
+       <!-- Ubuntu OS vulnerabilities -->
+       <provider name="canonical">
+           <enabled>yes</enabled>
+           <os path="/local_path/com.ubuntu.jammy.cve.oval.xml.bz2">jammy</os>
+           <os path="/local_path/com.ubuntu.focal.cve.oval.xml.bz2">focal</os>
+           <os path="/local_path/com.ubuntu.bionic.cve.oval.xml.bz2">bionic</os>
+           <os path="/local_path/com.ubuntu.xenial.cve.oval.xml.bz2">xenial</os>
+           <os path="/local_path/com.ubuntu.trusty.cve.oval.xml.bz2">trusty</os>
+           <update_interval>1h</update_interval>
+       </provider>
+   
+       <!-- Debian OS vulnerabilities -->
+       <provider name="debian">
+           <enabled>yes</enabled>
+           <os path="/local_path/oval-definitions-bullseye.xml">bullseye</os>
+           <os path="/local_path/oval-definitions-buster.xml">buster</os>
+           <os path="/local_path/oval-definitions-stretch.xml">stretch</os>
+           <path>/local_path/security_tracker_local.json</path>
+           <update_interval>1h</update_interval>
+       </provider>
+   
+       <!-- RedHat OS vulnerabilities -->
+       <provider name="redhat">
+           <enabled>yes</enabled>
+           <os path="/local_path/com.redhat.rhsa-RHEL5.xml.bz2">5</os>
+           <os path="/local_path/rhel-6-including-unpatched.oval.xml.bz2">6</os>
+           <os path="/local_path/rhel-7-including-unpatched.oval.xml.bz2">7</os>
+           <os path="/local_path/rhel-8-including-unpatched.oval.xml.bz2">8</os>
+           <os path="/local_path/rhel-9-including-unpatched.oval.xml.bz2">9</os>
+           <path>/local_path/rh-feed/redhat-feed[[:digit:]]\+\.json$</path>
+           <update_interval>1h</update_interval>
+       </provider>
+   
+       <!-- Arch OS vulnerabilities -->
+       <provider name="arch">
+           <enabled>yes</enabled>
+           <path>/local_path/all\.json$</path>
+           <update_interval>1h</update_interval>
+       </provider>
+   
+       <!-- Amazon Linux OS vulnerabilities -->
+       <provider name="alas">
+           <enabled>yes</enabled>
+           <os path="/local_path/updates_amazon-linux.json.gz">amazon-linux</os>
+           <os path="/local_path/updates_amazon-linux-2.json.gz">amazon-linux-2</os>
+           <update_interval>1h</update_interval>
+       </provider>
+   
+       <!-- Windows OS vulnerabilities -->
+       <provider name="msu">
+           <enabled>yes</enabled>
+           <path>/local_path/msu-updates\.json\.gz$</path>
+           <update_interval>1h</update_interval>
+       </provider>
+   
+       <!-- Aggregate vulnerabilities -->
+       <provider name="nvd">
+           <enabled>yes</enabled>
+           <path>/local_path/nvd-feed/nvd-feed[[:digit:]]\{4\}\.json\.gz$</path>
+           <update_interval>1h</update_interval>
+       </provider>
+     </vulnerability-detector>
+   </ossec_config>

--- a/source/user-manual/capabilities/vulnerability-detection/offline-update.rst
+++ b/source/user-manual/capabilities/vulnerability-detection/offline-update.rst
@@ -388,3 +388,80 @@ To update locally, the path to those files must be indicated by a POSIX regular 
         <path>/local_path/msu-updates\.json\.gz$</path>
         <update_interval>1h</update_interval>
     </provider>
+
+
+Sample Configuration
+^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: xml
+
+  <ossec_config>
+    <vulnerability-detector>
+      <enabled>yes</enabled>
+      <interval>5m</interval>
+      <min_full_scan_interval>6h</min_full_scan_interval>
+      <run_on_start>yes</run_on_start>
+  
+      <!-- Ubuntu OS vulnerabilities -->
+      <provider name="canonical">
+          <enabled>yes</enabled>
+          <os path="/local_path/com.ubuntu.jammy.cve.oval.xml.bz2">jammy</os>
+          <os path="/local_path/com.ubuntu.focal.cve.oval.xml.bz2">focal</os>
+          <os path="/local_path/com.ubuntu.bionic.cve.oval.xml.bz2">bionic</os>
+          <os path="/local_path/com.ubuntu.xenial.cve.oval.xml.bz2">xenial</os>
+          <os path="/local_path/com.ubuntu.trusty.cve.oval.xml.bz2">trusty</os>
+          <update_interval>1h</update_interval>
+      </provider>
+  
+      <!-- Debian OS vulnerabilities -->
+      <provider name="debian">
+          <enabled>yes</enabled>
+          <os path="/local_path/oval-definitions-bullseye.xml">bullseye</os>
+          <os path="/local_path/oval-definitions-buster.xml">buster</os>
+          <os path="/local_path/oval-definitions-stretch.xml">stretch</os>
+          <path>/local_path/security_tracker_local.json</path>
+          <update_interval>1h</update_interval>
+      </provider>
+  
+      <!-- RedHat OS vulnerabilities -->
+      <provider name="redhat">
+          <enabled>yes</enabled>
+          <os path="/local_path/com.redhat.rhsa-RHEL5.xml.bz2">5</os>
+          <os path="/local_path/rhel-6-including-unpatched.oval.xml.bz2">6</os>
+          <os path="/local_path/rhel-7-including-unpatched.oval.xml.bz2">7</os>
+          <os path="/local_path/rhel-8-including-unpatched.oval.xml.bz2">8</os>
+          <os path="/local_path/rhel-9-including-unpatched.oval.xml.bz2">9</os>
+          <path>/local_path/rh-feed/redhat-feed[[:digit:]]\+\.json$</path>
+          <update_interval>1h</update_interval>
+      </provider>
+  
+      <!-- Arch OS vulnerabilities -->
+      <provider name="arch">
+          <enabled>yes</enabled>
+          <path>/local_path/all\.json$</path>
+          <update_interval>1h</update_interval>
+      </provider>
+  
+      <!-- Amazon Linux OS vulnerabilities -->
+      <provider name="alas">
+          <enabled>yes</enabled>
+          <os path="/local_path/updates_amazon-linux.json.gz">amazon-linux</os>
+          <os path="/local_path/updates_amazon-linux-2.json.gz">amazon-linux-2</os>
+          <update_interval>1h</update_interval>
+      </provider>
+  
+      <!-- Windows OS vulnerabilities -->
+      <provider name="msu">
+          <enabled>yes</enabled>
+          <path>/local_path/msu-updates\.json\.gz$</path>
+          <update_interval>1h</update_interval>
+      </provider>
+  
+      <!-- Aggregate vulnerabilities -->
+      <provider name="nvd">
+          <enabled>yes</enabled>
+          <path>/local_path/nvd-feed/nvd-feed[[:digit:]]\{4\}\.json\.gz$</path>
+          <update_interval>1h</update_interval>
+      </provider>
+    </vulnerability-detector>
+  </ossec_config>

--- a/source/user-manual/capabilities/vulnerability-detection/offline-update.rst
+++ b/source/user-manual/capabilities/vulnerability-detection/offline-update.rst
@@ -128,7 +128,7 @@ In order to use a local feed file, just use the ``path`` option which must be in
 
     <provider name="debian">
         <enabled>yes</enabled>
-        <path>/local_path/security_tracker_local\.json$</path>
+        <path>/local_path/security_tracker_local.json</path>
         <update_interval>1h</update_interval>
     </provider>
 

--- a/source/user-manual/capabilities/vulnerability-detection/offline-update.rst
+++ b/source/user-manual/capabilities/vulnerability-detection/offline-update.rst
@@ -349,7 +349,7 @@ Finally, you will have the feed divided into a succession of numbered files whos
 
     <provider name="nvd">
         <enabled>yes</enabled>
-        <path>/local_path/nvd-feed[[:digit:]]\{4\}\.json\.gz$</path>
+        <path>/local_path/nvd-feed/nvd-feed[[:digit:]]\{4\}\.json\.gz$</path>
         <update_interval>1h</update_interval>
     </provider>
 

--- a/source/user-manual/capabilities/vulnerability-detection/offline-update.rst
+++ b/source/user-manual/capabilities/vulnerability-detection/offline-update.rst
@@ -232,7 +232,7 @@ Finally, you will have the feed divided into a succession of numbered files whos
 
     <provider name="redhat">
         <enabled>yes</enabled>
-        <path>/local_path/rh-feed/redhat-feed[[:digit:]]+\.json$</path>
+        <path>/local_path/rh-feed/redhat-feed[[:digit:]]\+\.json$</path>
         <update_interval>1h</update_interval>
     </provider>
 


### PR DESCRIPTION
## Description
The offline vulnerability update section had three configuration errors that broke functionality
  - The RedHat feed was missing a `\` before the `+`modifier that indicated a filename with 1 or more digit
  - The nvd-feed was downloaded into a folder and the folder's path was not correctly referenced
  - The Debian Security Tracker feed used escaped characters to refer to a single file and it would break the configuration

Additionally this PR adds a Sample configuration at the end of the document to demonstrate without room for ambiguity how to configure a fully offline vulnerability detection feed update.

This PR is related to https://github.com/wazuh/wazuh-documentation/pull/5352 

## Checks
- [X] Compiles without warnings.
- [X] Uses present tense, active voice, and semi-formal registry.
- [X] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [X] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
