### PR TITLE
Review syscollector alerts note

### DIFF
--- a/source/user-manual/capabilities/syscollector.rst
+++ b/source/user-manual/capabilities/syscollector.rst
@@ -399,9 +399,9 @@ The following table shows the operating systems that this module currently suppo
 Using Syscollector information to trigger alerts
 ------------------------------------------------
 
-.. warning::
+.. note::
    
-   This functionality is not currently supported. It will be available starting with version 4.4.
+   Enabled again in Wazuh |WAZUH_CURRENT_MINOR|. All the information required for these alerts is now available in version |WAZUH_CURRENT_MINOR| and allows this feature.
 
 Since Wazuh 3.9 version, ``Syscollector`` module information can be used to trigger alerts and show that information in the alerts' description.
 
@@ -435,7 +435,7 @@ As an example, the rules in the following set of custom rules trigger when a por
       </rule>
     </group>
 
-.. warning::
+.. note::
 
     The tag ``<if_sid>221</if_sid>`` is necessary because the events from Syscollector are muted by default with that rule.
 

--- a/source/user-manual/capabilities/syscollector.rst
+++ b/source/user-manual/capabilities/syscollector.rst
@@ -401,7 +401,7 @@ Using Syscollector information to trigger alerts
 
 .. note::
    
-   Enabled again in Wazuh |WAZUH_CURRENT_MINOR|. All the information required for these alerts is now available in version |WAZUH_CURRENT_MINOR| and allows this feature.
+   Enabled again in Wazuh |WAZUH_CURRENT_MINOR|. All the information required for these alerts is now available and allows this feature.
 
 Since Wazuh 3.9 version, ``Syscollector`` module information can be used to trigger alerts and show that information in the alerts' description.
 


### PR DESCRIPTION
## Description
This PR adapts a note about alerting using syscollector information. Since development has finished it informs the reader that this 3.9 functionality is back and available.  

## Checks
- [X] Compiles without warnings.
- [X] Uses present tense, active voice, and semi-formal registry.
- [X] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [X] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
