### PR TITLE
Review syscollector alerts note

### DIFF
--- a/source/user-manual/capabilities/syscollector.rst
+++ b/source/user-manual/capabilities/syscollector.rst
@@ -426,7 +426,9 @@ The following table shows the operating systems that this module currently suppo
 Using Syscollector information to trigger alerts
 ------------------------------------------------
 
-.. note:: This capability is not available in Wazuh 4.2 but will be included in a future version. 
+.. warning::
+
+   Disabled in Wazuh |WAZUH_LATEST_MINOR|. *Syscollector* doesn't support this feature in version |WAZUH_LATEST_MINOR|. A new version of Wazuh that makes available all the information required for these alerts is under development.
 
 Since Wazuh 3.9 version, ``Syscollector`` module information can be used to trigger alerts and show that information in the alerts' description.
 
@@ -443,7 +445,7 @@ As an example, this rule will be triggered when the interface ``eth0`` of an age
       <description>eth0 interface enabled. IP: $(netinfo.iface.ipv4.address)</description>
     </rule>
 
-.. warning::
+.. note::
 
     The tag ``<if_sid>221</if_sid>`` is necessary because the events from Syscollector are muted by default with that rule.
 

--- a/source/user-manual/capabilities/syscollector.rst
+++ b/source/user-manual/capabilities/syscollector.rst
@@ -428,7 +428,7 @@ Using Syscollector information to trigger alerts
 
 .. warning::
 
-   Disabled in Wazuh |WAZUH_LATEST_MINOR|. *Syscollector* doesn't support this feature in version |WAZUH_LATEST_MINOR|. A new version of Wazuh that makes available all the information required for these alerts is under development.
+   Disabled in Wazuh |WAZUH_LATEST_MINOR|. Currently, *Syscollector* doesn't support this feature. A new version of Wazuh that makes available all the information required for these alerts is under development.
 
 Since Wazuh 3.9 version, ``Syscollector`` module information can be used to trigger alerts and show that information in the alerts' description.
 


### PR DESCRIPTION
## Description
This PR adapts a note about alerting using syscollector information. It informs the reader that this 3.9 functionality isn't available until 4.4 development finishes.

## Checks
- [X] Compiles without warnings.
- [X] Uses present tense, active voice, and semi-formal registry.
- [X] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [X] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
