### PR TITLE
Add warning to last step

### DIFF
--- a/source/user-manual/wazuh-dashboard/single-sign-on/azure-active-directory.rst
+++ b/source/user-manual/wazuh-dashboard/single-sign-on/azure-active-directory.rst
@@ -287,6 +287,10 @@ Wazuh dashboard configuration
 
 #. Change the logout configuration in the Wazuh dashboard. 
 
+   .. warning::
+   
+      This step should not be done in versions equal or higher than 4.3.10
+
    Edit the ``path: /auth/logout`` section of the ``/usr/share/wazuh-dashboard/plugins/securityDashboards/server/auth/types/saml/routes.js`` file. It is recommended to back up this file before the configuration is changed. The configuration must be similar to this:
 
    .. code-block:: console  

--- a/source/user-manual/wazuh-dashboard/single-sign-on/google.rst
+++ b/source/user-manual/wazuh-dashboard/single-sign-on/google.rst
@@ -249,6 +249,10 @@ Wazuh dashboard configuration
 
 #. Change the logout configuration in the Wazuh dashboard. 
 
+   .. warning::
+   
+      This step should not be done in versions equal or higher than 4.3.10
+
    To change the logout configuration, edit the ``path: /auth/logout`` section of the ``route.js`` file. The file path is ``/usr/share/wazuh-dashboard/plugins/securityDashboards/server/auth/types/saml/routes.js``. It is recommended to back up this file before the configuration is changed. The configuration must be similar to this:
 
    .. code-block:: console

--- a/source/user-manual/wazuh-dashboard/single-sign-on/okta.rst
+++ b/source/user-manual/wazuh-dashboard/single-sign-on/okta.rst
@@ -287,6 +287,10 @@ Wazuh dashboard configuration
 
 #. Change the logout configuration in the Wazuh dashboard. 
    
+   .. warning::
+   
+      This step should not be done in versions equal or higher than 4.3.10
+
    To change the logout configuration, replace the ``this.router.get({path: `auth/logout``` section of the ``/usr/share/wazuh-dashboard/plugins/securityDashboards/server/auth/types/saml/routes.js`` file with the following setting. It is recommended to back up this file before the configuration is changed.
 
    .. code-block:: console
@@ -333,7 +337,7 @@ Wazuh dashboard configuration
 #. Restart the Wazuh dashboard service.
 
        .. include:: /_templates/common/restart_dashboard.rst
-
+ 
 #. Test the configuration.
 
    To test the Okta SSO configuration, go to your Wazuh dashboard URL and log in with your Okta account.

--- a/source/user-manual/wazuh-dashboard/single-sign-on/onelogin.rst
+++ b/source/user-manual/wazuh-dashboard/single-sign-on/onelogin.rst
@@ -280,6 +280,10 @@ Wazuh dashboard configuration
 
 #. Change the logout configuration in the Wazuh dashboard. 
 
+   .. warning::
+   
+      This step should not be done in versions equal or higher than 4.3.10
+
    To change the logout configuration, edit the ``path: /auth/logout`` section of the ``route.js`` file. The file path is ``/usr/share/wazuh-dashboard/plugins/securityDashboards/server/auth/types/saml/routes.js``. It is recommended to back up this file before the configuration is changed. The configuration must be similar to this:
   
    .. code-block:: console


### PR DESCRIPTION

## Description
This PR adds a message to warn the users that a step documented in some SSO documentations should not be done in versions equal or higher than 4.3.10. 

This is because that step was a workaround for an issue that will be resolved on 4.3.10 on this PR https://github.com/wazuh/wazuh-kibana-app/pull/4815

If the users make this change on 4.3.10 or higher, the logout will not work anymore on any site of the application, for that reason is important to mark that it `should not be done` and not that `is not necessary`.
## Checks
- [ ] Compiles without warnings.
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
