### PR TITLE
Fix EICAR URL

### DIFF
--- a/source/proof-of-concept-guide/detect-remove-malware-virustotal.rst
+++ b/source/proof-of-concept-guide/detect-remove-malware-virustotal.rst
@@ -181,7 +181,7 @@ Steps to generate the alerts
     .. code-block:: console
 
         # cd /root
-        # curl -LO http://www.eicar.org/download/eicar.com && ls -lah eicar.com
+        # curl -LO https://secure.eicar.org/eicar.com && ls -lah eicar.com
 
 Query the alerts
 ----------------

--- a/source/user-manual/capabilities/active-response/ar-use-cases/removing-malware.rst
+++ b/source/user-manual/capabilities/active-response/ar-use-cases/removing-malware.rst
@@ -190,7 +190,7 @@ To test that everything is working correctly, generate an alert using the EICAR 
 .. code-block:: none
 
   cd /root
-  curl -LO http://www.eicar.org/download/eicar.com
+  curl -LO https://secure.eicar.org/eicar.com
 
 
 


### PR DESCRIPTION
## Description
This issue aims to fix the broken EICAR download link in the documentation.
based on PR [#5499](https://github.com/wazuh/wazuh-documentation/pull/5499).

## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
