### PR TITLE
Declare queue_size global option as deprecated

### DIFF
--- a/source/user-manual/reference/ossec-conf/global.rst
+++ b/source/user-manual/reference/ossec-conf/global.rst
@@ -46,6 +46,7 @@ Options
 - `geoipdb`_
 - `rotate_interval`_
 - `max_output_size`_
+- `queue_size`_
 - `agents_disconnection_time`_
 - `agents_disconnection_alert_time`_
 
@@ -428,6 +429,7 @@ Example:
 
 queue_size
 ^^^^^^^^^^
+.. deprecated:: 3.7.0
 
 This sets the size of the message input buffer in Analysisd (number of events).
 

--- a/source/user-manual/reference/ossec-conf/global.rst
+++ b/source/user-manual/reference/ossec-conf/global.rst
@@ -46,7 +46,6 @@ Options
 - `geoipdb`_
 - `rotate_interval`_
 - `max_output_size`_
-- `queue_size`_
 - `agents_disconnection_time`_
 - `agents_disconnection_alert_time`_
 
@@ -427,23 +426,6 @@ Example:
 
   <max_output_size>20M</max_output_size>
 
-queue_size
-^^^^^^^^^^
-.. deprecated:: 3.7.0
-
-This sets the size of the message input buffer in Analysisd (number of events).
-
-+-------------------------+---------------------------------------------------------------------------------------+
-| **Default value**       | 131072                                                                                |
-+-------------------------+---------------------------------------------------------------------------------------+
-| **Allowed values**      | A positive number. The minimum allowed is 1. The recommended range is [16384..262144] |
-+-------------------------+---------------------------------------------------------------------------------------+
-
-Example:
-
-.. code-block:: xml
-
-  <queue_size>16384</queue_size>
 
 .. _reference_agents_disconnection_time:
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
|Related PR|
|---|
|https://github.com/wazuh/wazuh/pull/2729|

The development PR above deprecated option `<queue_size>` in version 3.7.0. Then we removed that option reference from the documentation by #990. However, it still appears in the 4.x documentation.

This PR aims to mark `<queue_size>` as deprectated.

## Checks
- [ ] Compiles without warnings.
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirect.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
