### PR TITLE
Added a timestamp as a parameter for the URL to the favicon

### DIFF
--- a/source/_themes/wazuh_doc_theme_v3/layout.html
+++ b/source/_themes/wazuh_doc_theme_v3/layout.html
@@ -242,11 +242,11 @@
     {% endblock css %}
     
     {#- FAVICON -#}
-    <link rel="mask-icon" href="{{ pathto('_static/images/favicon.svg', 1) }}" color="#000000">
-    <link rel="icon" href="{{ pathto('_static/images/favicon.png', 1) }}" media="(prefers-color-scheme:no-preference)" sizes="any" type="image/png"/>
-    <link rel="icon" href="{{ pathto('_static/images/dark-favicon.png', 1) }}" media="(prefers-color-scheme:dark)" sizes="any" type="image/png"/>
-    <link rel="icon" href="{{ pathto('_static/images/favicon.png', 1) }}" media="(prefers-color-scheme:light)" sizes="any" type="image/png"/>
-    <link rel="apple-touch-icon" href="{{ pathto('_static/images/favicon.svg', 1) }}">
+    <link rel="mask-icon" href="{{ pathto('_static/images/favicon.svg', 1) }}?v={{ compilation_ts }}" color="#000000">
+    <link rel="icon" href="{{ pathto('_static/images/favicon.png', 1) }}?v={{ compilation_ts }}" media="(prefers-color-scheme:no-preference)" sizes="any" type="image/png"/>
+    <link rel="icon" href="{{ pathto('_static/images/dark-favicon.png', 1) }}?v={{ compilation_ts }}" media="(prefers-color-scheme:dark)" sizes="any" type="image/png"/>
+    <link rel="icon" href="{{ pathto('_static/images/favicon.png', 1) }}?v={{ compilation_ts }}" media="(prefers-color-scheme:light)" sizes="any" type="image/png"/>
+    <link rel="apple-touch-icon" href="{{ pathto('_static/images/favicon.svg', 1) }}?v={{ compilation_ts }}">
     
     {%- if production and theme_breadcrumb_root_title == 'Documentation' -%}
     {#- Google Tag Manager - Head -#}


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description

This PR adds a parameter to the URL of the favicons to refresh their cached versions.

## Checks
- [x] Compiles without warnings.
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
