### PR TITLE
Adjust SysV init instructions 

### DIFF
--- a/source/_templates/installations/basic/check_services_certificates.rst
+++ b/source/_templates/installations/basic/check_services_certificates.rst
@@ -23,7 +23,7 @@ Check the Wazuh manager service:
       # systemctl status wazuh-manager
 
 
-  .. tab:: SysV Init
+  .. tab:: SysV init
 
     .. code-block:: console
 
@@ -44,7 +44,7 @@ Check the Wazuh API service:
       # systemctl status wazuh-api
 
 
-  .. tab:: SysV Init
+  .. tab:: SysV init
 
     .. code-block:: console
 
@@ -65,7 +65,7 @@ Check the Filebeat service:
       # systemctl status filebeat
 
 
-  .. tab:: SysV Init
+  .. tab:: SysV init
 
     .. code-block:: console
 

--- a/source/_templates/installations/basic/elastic/common/enable_elasticsearch.rst
+++ b/source/_templates/installations/basic/elastic/common/enable_elasticsearch.rst
@@ -14,7 +14,7 @@
 
 
 
-  .. tab:: SysV Init
+  .. tab:: SysV init
 
     Choose one option according to the OS used:
 

--- a/source/_templates/installations/basic/elastic/common/enable_filebeat.rst
+++ b/source/_templates/installations/basic/elastic/common/enable_filebeat.rst
@@ -14,7 +14,7 @@
 
 
 
-  .. tab:: SysV Init
+  .. tab:: SysV init
 
     Choose one option according to the OS used:
 

--- a/source/_templates/installations/basic/elastic/common/enable_kibana.rst
+++ b/source/_templates/installations/basic/elastic/common/enable_kibana.rst
@@ -14,7 +14,7 @@
 
 
 
-  .. tab:: SysV Init
+  .. tab:: SysV init
 
     Choose one option according to the OS used:
 

--- a/source/_templates/installations/basic/elastic/common/stop_elasticsearch.rst
+++ b/source/_templates/installations/basic/elastic/common/stop_elasticsearch.rst
@@ -8,7 +8,7 @@
 
          # systemctl stop elasticsearch
 
-   .. group-tab:: SysV Init
+   .. group-tab:: SysV init
 
       .. code-block:: console
 

--- a/source/_templates/installations/basic/elastic/common/stop_filebeat.rst
+++ b/source/_templates/installations/basic/elastic/common/stop_filebeat.rst
@@ -8,7 +8,7 @@
 
          # systemctl stop filebeat      
 
-   .. group-tab:: SysV Init
+   .. group-tab:: SysV init
 
       .. code-block:: console
 

--- a/source/_templates/installations/basic/elastic/common/stop_kibana_filebeat.rst
+++ b/source/_templates/installations/basic/elastic/common/stop_kibana_filebeat.rst
@@ -9,7 +9,7 @@
          # systemctl stop filebeat
          # systemctl stop kibana
 
-   .. group-tab:: SysV Init
+   .. group-tab:: SysV init
 
       .. code-block:: console
 

--- a/source/_templates/installations/basic/wazuh/common/restart_wazuh_manager.rst
+++ b/source/_templates/installations/basic/wazuh/common/restart_wazuh_manager.rst
@@ -11,7 +11,7 @@
       # systemctl restart wazuh-manager
 
 
-  .. tab:: SysV Init
+  .. tab:: SysV init
 
     .. code-block:: console
 

--- a/source/_templates/installations/basic/wazuh/common/start_wazuh_api.rst
+++ b/source/_templates/installations/basic/wazuh/common/start_wazuh_api.rst
@@ -11,7 +11,7 @@
       # systemctl start wazuh-api
 
 
-  .. tab:: SysV Init
+  .. tab:: SysV init
 
     .. code-block:: console
 

--- a/source/_templates/installations/check_services_certificates.rst
+++ b/source/_templates/installations/check_services_certificates.rst
@@ -23,7 +23,7 @@ Check the Wazuh manager service:
       # systemctl status wazuh-manager
 
 
-  .. group-tab:: SysV Init
+  .. group-tab:: SysV init
 
     .. code-block:: console
 
@@ -44,7 +44,7 @@ Check the Wazuh API service:
       # systemctl status wazuh-api
 
 
-  .. group-tab:: SysV Init
+  .. group-tab:: SysV init
 
     .. code-block:: console
 
@@ -65,7 +65,7 @@ Check the Filebeat service:
       # systemctl status filebeat
 
 
-  .. group-tab:: SysV Init
+  .. group-tab:: SysV init
 
     .. code-block:: console
 

--- a/source/_templates/installations/dashboard/enable_dashboard.rst
+++ b/source/_templates/installations/dashboard/enable_dashboard.rst
@@ -14,7 +14,7 @@
 
 
 
-  .. group-tab:: SysV Init
+  .. group-tab:: SysV init
 
     Choose one option according to your operating system:
 

--- a/source/_templates/installations/elastic/common/enable_elasticsearch.rst
+++ b/source/_templates/installations/elastic/common/enable_elasticsearch.rst
@@ -25,7 +25,7 @@
 
 
 
-  .. group-tab:: SysV Init
+  .. group-tab:: SysV init
 
     Choose one option according to the operating system used.
 

--- a/source/_templates/installations/elastic/common/enable_filebeat.rst
+++ b/source/_templates/installations/elastic/common/enable_filebeat.rst
@@ -14,7 +14,7 @@
 
 
 
-  .. group-tab:: SysV Init
+  .. group-tab:: SysV init
 
     Choose one option according to the operating system used.
 

--- a/source/_templates/installations/elastic/common/enable_kibana.rst
+++ b/source/_templates/installations/elastic/common/enable_kibana.rst
@@ -14,7 +14,7 @@
 
 
 
-  .. group-tab:: SysV Init
+  .. group-tab:: SysV init
 
     Choose one option according to your operating system:
 

--- a/source/_templates/installations/filebeat/common/enable_filebeat.rst
+++ b/source/_templates/installations/filebeat/common/enable_filebeat.rst
@@ -14,7 +14,7 @@
 
 
 
-  .. group-tab:: SysV Init
+  .. group-tab:: SysV init
 
     Choose one option according to the operating system used.
 

--- a/source/_templates/installations/indexer/common/enable_indexer.rst
+++ b/source/_templates/installations/indexer/common/enable_indexer.rst
@@ -14,7 +14,7 @@
 
 
 
-  .. group-tab:: SysV Init
+  .. group-tab:: SysV init
 
     Choose one option according to the operating system used.
 

--- a/source/_templates/installations/manager/restart_wazuh_manager.rst
+++ b/source/_templates/installations/manager/restart_wazuh_manager.rst
@@ -11,7 +11,7 @@
       # systemctl restart wazuh-manager
 
 
-  .. group-tab:: SysV Init
+  .. group-tab:: SysV init
 
     .. code-block:: console
 

--- a/source/_templates/installations/wazuh/common/check_wazuh_dashboard.rst
+++ b/source/_templates/installations/wazuh/common/check_wazuh_dashboard.rst
@@ -11,7 +11,7 @@
       # systemctl status wazuh-dashboard
 
 
-  .. group-tab:: SysV Init
+  .. group-tab:: SysV init
 
     .. code-block:: console
 

--- a/source/_templates/installations/wazuh/common/check_wazuh_manager.rst
+++ b/source/_templates/installations/wazuh/common/check_wazuh_manager.rst
@@ -8,7 +8,7 @@
 
       # systemctl status wazuh-manager
 
-  .. group-tab:: SysV Init
+  .. group-tab:: SysV init
 
     .. code-block:: console
 

--- a/source/_templates/installations/wazuh/common/disable_wazuh_agent_service.rst
+++ b/source/_templates/installations/wazuh/common/disable_wazuh_agent_service.rst
@@ -12,7 +12,7 @@
       # systemctl daemon-reload
 
 
-  .. group-tab:: SysV Init
+  .. group-tab:: SysV init
 
     Choose one option according to your operating system.
 

--- a/source/_templates/installations/wazuh/common/disable_wazuh_manager_service.rst
+++ b/source/_templates/installations/wazuh/common/disable_wazuh_manager_service.rst
@@ -12,7 +12,7 @@
       # systemctl daemon-reload
 
 
-  .. group-tab:: SysV Init
+  .. group-tab:: SysV init
 
     Choose one option according to your operating system.
 

--- a/source/_templates/installations/wazuh/common/enable_wazuh_agent_service.rst
+++ b/source/_templates/installations/wazuh/common/enable_wazuh_agent_service.rst
@@ -13,7 +13,7 @@
       # systemctl start wazuh-agent
 
 
-  .. group-tab:: SysV Init
+  .. group-tab:: SysV init
 
     Choose one option according to your operating system.
 

--- a/source/_templates/installations/wazuh/common/enable_wazuh_manager_service.rst
+++ b/source/_templates/installations/wazuh/common/enable_wazuh_manager_service.rst
@@ -13,7 +13,7 @@
       # systemctl start wazuh-manager
 
 
-  .. group-tab:: SysV Init
+  .. group-tab:: SysV init
 
     Choose one option according to your operating system:
 

--- a/source/_templates/installations/wazuh/common/restart_wazuh_manager.rst
+++ b/source/_templates/installations/wazuh/common/restart_wazuh_manager.rst
@@ -11,7 +11,7 @@
       # systemctl restart wazuh-manager
 
 
-  .. group-tab:: SysV Init
+  .. group-tab:: SysV init
 
     .. code-block:: console
 

--- a/source/deployment-options/deploying-with-ansible/guide/install-ansible.rst
+++ b/source/deployment-options/deploying-with-ansible/guide/install-ansible.rst
@@ -165,7 +165,7 @@ Our Ansible server will need to connect to the other endpoints. Let’s see how 
 
                # systemctl start sshd
 
-         .. group-tab:: SysV Init:
+         .. group-tab:: SysV init:
 
             .. code-block:: console
 
@@ -227,7 +227,7 @@ Our Ansible server will need to connect to the other endpoints. Let’s see how 
 
                # systemctl restart sshd
 
-         .. group-tab:: SysV Init:
+         .. group-tab:: SysV init:
 
             .. code-block:: console
 

--- a/source/deployment-options/deploying-with-ansible/guide/install-ansible.rst
+++ b/source/deployment-options/deploying-with-ansible/guide/install-ansible.rst
@@ -165,7 +165,7 @@ Our Ansible server will need to connect to the other endpoints. Let’s see how 
 
                # systemctl start sshd
 
-         .. group-tab:: SysV init:
+         .. group-tab:: SysV init
 
             .. code-block:: console
 
@@ -227,7 +227,7 @@ Our Ansible server will need to connect to the other endpoints. Let’s see how 
 
                # systemctl restart sshd
 
-         .. group-tab:: SysV init:
+         .. group-tab:: SysV init
 
             .. code-block:: console
 

--- a/source/deployment-options/deploying-with-puppet/setup-puppet/install-puppet-master.rst
+++ b/source/deployment-options/deploying-with-puppet/setup-puppet/install-puppet-master.rst
@@ -117,17 +117,19 @@ For Ubuntu/Debian machines, in case puppetserver does not start. Edit the puppet
 
 Then, start your Puppet Server:
 
-  a) For Systemd:
+   .. tabs::
 
-    .. code-block:: console
+         .. group-tab:: Systemd 
 
-      # systemctl start puppetserver
-      # systemctl enable puppetserver
-      # systemctl status puppetserver
+            .. code-block:: console
 
-  b) For SysV init:
+               # systemctl start puppetserver
+               # systemctl enable puppetserver
+               # systemctl status puppetserver
 
-    .. code-block:: console
+         .. group-tab:: SysV init
 
-      # service puppetserver start
-      # update-rc.d puppetserver
+            .. code-block:: console
+
+               # service puppetserver start
+               # update-rc.d puppetserver

--- a/source/deployment-options/deploying-with-puppet/setup-puppet/install-puppet-master.rst
+++ b/source/deployment-options/deploying-with-puppet/setup-puppet/install-puppet-master.rst
@@ -125,7 +125,7 @@ Then, start your Puppet Server:
       # systemctl enable puppetserver
       # systemctl status puppetserver
 
-  b) For SysV Init:
+  b) For SysV init:
 
     .. code-block:: console
 

--- a/source/deployment-options/docker/docker-installation.rst
+++ b/source/deployment-options/docker/docker-installation.rst
@@ -104,7 +104,7 @@ For Linux/Unix machines, Docker requires an amd64 architecture system running ke
 
             # systemctl start docker
 
-      .. group-tab:: For SysV Init
+      .. group-tab:: For SysV init
 
          .. code-block:: console
 

--- a/source/deployment-options/splunk/splunk-wazuh.rst
+++ b/source/deployment-options/splunk/splunk-wazuh.rst
@@ -50,7 +50,7 @@ Choose the corresponding tab to configure the installation as a single-node or m
                   # systemctl enable wazuh-manager
                   # systemctl start wazuh-manager
 
-            .. group-tab:: SysV Init
+            .. group-tab:: SysV init
 
                Choose one option according to your operating system:
 

--- a/source/deployment-options/wazuh-from-sources/wazuh-agent/index.rst
+++ b/source/deployment-options/wazuh-from-sources/wazuh-agent/index.rst
@@ -174,7 +174,7 @@ The Wazuh agent is a single and lightweight monitoring software. It is a multi-p
         
         .. tabs::
           
-            .. tab:: SysV init:
+            .. tab:: SysV init
 
                 .. code-block:: console
 

--- a/source/deployment-options/wazuh-from-sources/wazuh-agent/index.rst
+++ b/source/deployment-options/wazuh-from-sources/wazuh-agent/index.rst
@@ -174,7 +174,7 @@ The Wazuh agent is a single and lightweight monitoring software. It is a multi-p
         
         .. tabs::
           
-            .. tab:: SysV Init:
+            .. tab:: SysV init:
 
                 .. code-block:: console
 

--- a/source/deployment-options/wazuh-from-sources/wazuh-server/index.rst
+++ b/source/deployment-options/wazuh-from-sources/wazuh-server/index.rst
@@ -143,7 +143,7 @@ Installing the Wazuh manager
 
                 # systemctl start wazuh-manager
 
-        .. group-tab:: SysV Init
+        .. group-tab:: SysV init
 
             .. code-block:: console
 
@@ -185,7 +185,7 @@ Uninstall
 
    .. tabs::
      
-       .. group-tab:: SysV Init
+       .. group-tab:: SysV init
    
            .. code-block:: console
    

--- a/source/upgrade-guide/legacy/upgrading-elastic-stack/from-2.x-to-5.x.rst
+++ b/source/upgrade-guide/legacy/upgrading-elastic-stack/from-2.x-to-5.x.rst
@@ -116,7 +116,7 @@ Follow these steps to upgrade Elastic Stack to version 5.x:
             # systemctl stop elasticsearch
             # systemctl stop kibana
 
-      .. group-tab:: SysV Init
+      .. group-tab:: SysV init
 
         .. code-block:: console
 

--- a/source/upgrade-guide/upgrading-central-components.rst
+++ b/source/upgrade-guide/upgrading-central-components.rst
@@ -48,7 +48,7 @@ In the case Wazuh is installed in a multi-node cluster configuration, repeat the
             # systemctl stop filebeat
             # systemctl stop wazuh-dashboard
 
-      .. tab:: SysV Init
+      .. tab:: SysV init
 
          .. code-block:: console
 
@@ -92,7 +92,7 @@ In the case of having a Wazuh indexer cluster with multiple nodes, the cluster w
 
             # systemctl stop wazuh-indexer
 
-      .. tab:: SysV Init
+      .. tab:: SysV init
 
          .. code-block:: console
 

--- a/source/user-manual/elasticsearch/elastic-tuning.rst
+++ b/source/user-manual/elasticsearch/elastic-tuning.rst
@@ -51,7 +51,7 @@ Elasticsearch malfunctions when the system is swapping memory. It is crucial for
             LimitMEMLOCK=infinity
             EOF
 
-        .. group-tab:: SysV Init
+        .. group-tab:: SysV init
 
           Edit the proper file ``/etc/sysconfig/elasticsearch`` for RPM or ``/etc/default/elasticsearch`` for Debian:
 
@@ -96,7 +96,7 @@ Elasticsearch malfunctions when the system is swapping memory. It is crucial for
 
 
 
-    .. group-tab:: SysV Init
+    .. group-tab:: SysV init
 
 
       .. code-block:: console


### PR DESCRIPTION
## Description
This issue aims to adjust `SysV init` instructions throughout the documentation.

## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
