### PR TITLE
Fix Wazuh DB metadata table reference

### DIFF
--- a/source/user-manual/reference/daemons/wazuh-db.rst
+++ b/source/user-manual/reference/daemons/wazuh-db.rst
@@ -151,7 +151,7 @@ Data needed to upgrade the agent's database
 | **value**             | Field value                 | 3                                         |
 +-----------------------+-----------------------------+-------------------------------------------+
 
-.. versionadded:: 4.5.0
+.. versionadded:: 4.4.0
 
 The ``key`` field can also store the following values:
 


### PR DESCRIPTION
|Related issue|Related PR|
|---|---|
|https://github.com/wazuh/wazuh/issues/12930|https://github.com/wazuh/wazuh/pull/15440|

## Description

Updating the "new in version" note for the following `metadata` table fields:

- `last_vacuum_time`
- `last_vacuum_value`

The reason for this change is that issue https://github.com/wazuh/wazuh/issues/12930 was originally pointed to 4.5.0 (original PR https://github.com/wazuh/wazuh/pull/15330), but then we moved it to 4.4.0.

## Checks
- [ ] Compiles without warnings.
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
