### PR TITLE
Update API default configuration example

### DIFF
--- a/source/user-manual/api/configuration.rst
+++ b/source/user-manual/api/configuration.rst
@@ -61,14 +61,17 @@ Here are all the available settings for the ``api.yaml`` configuration file. For
         block_time: 300
         max_request_per_minute: 300
 
-     remote_commands:
-        localfile:
-           enabled: yes
-           exceptions: []
-
-       wodle_command:
-          enabled: yes
-          exceptions: []
+     upload_configuration:
+        remote_commands:
+           localfile:
+              allow: yes
+              exceptions: []
+           wodle_command:
+              allow: yes
+              exceptions: []
+        limits:
+           eps:
+              allow: yes
 
 .. warning::
 


### PR DESCRIPTION

## Description

This PR updates the API default configuration example to include the latest changes on the EPS limits section.

## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
