### PR TITLE
Change config.yml template to fix bug in wazuh-packages

### DIFF
--- a/source/_templates/installations/indexer/common/generate_certificates.rst
+++ b/source/_templates/installations/indexer/common/generate_certificates.rst
@@ -15,30 +15,30 @@
           # Wazuh indexer nodes
           indexer:
             - name: node-1
-              ip: <indexer-node-ip>
+              ip: "<indexer-node-ip>"
             #- name: node-2
-            #  ip: <indexer-node-ip>
+            #  ip: "<indexer-node-ip>"
             #- name: node-3
-            #  ip: <indexer-node-ip>
+            #  ip: "<indexer-node-ip>"
 
           # Wazuh server nodes
           # If there is more than one Wazuh server 
           # node, each one must have a node_type
           server:
             - name: wazuh-1
-              ip: <wazuh-manager-ip>
+              ip: "<wazuh-manager-ip>"
             #  node_type: master
             #- name: wazuh-2
-            #  ip: <wazuh-manager-ip>
+            #  ip: "<wazuh-manager-ip>"
             #  node_type: worker
             #- name: wazuh-3
-            #  ip: <wazuh-manager-ip>
+            #  ip: "<wazuh-manager-ip>"
             #  node_type: worker
 
           # Wazuh dashboard nodes
           dashboard:
             - name: dashboard
-              ip: <dashboard-node-ip>
+              ip: "<dashboard-node-ip>"
 
            
       To learn more about how to create and configure the certificates, see the :doc:`/user-manual/certificates` section.

--- a/source/deployment-options/offline-installation.rst
+++ b/source/deployment-options/offline-installation.rst
@@ -40,7 +40,7 @@ Download the packages and configuration files
 
 #. Edit ``config.yml`` to prepare the certificates creation.
 
-   -  If you are performing an all-in-one deployment, replace ``<indexer-node-ip>``, ``<wazuh-manager-ip>``, and ``<dashboard-node-ip>`` with ``127.0.0.1``.
+   -  If you are performing an all-in-one deployment, replace ``"<indexer-node-ip>"``, ``"<wazuh-manager-ip>"``, and ``"<dashboard-node-ip>"`` with ``127.0.0.1``.
         
    -  If you are performing a distributed deployment, replace the node names and IP values with the corresponding names and IP addresses. You need to do this for all the Wazuh server, the Wazuh indexer, and the Wazuh dashboard nodes. Add as many node fields as needed.
 

--- a/source/installation-guide/wazuh-indexer/installation-assistant.rst
+++ b/source/installation-guide/wazuh-indexer/installation-assistant.rst
@@ -43,30 +43,30 @@ Indicate your deployment configuration, create the SSL certificates to encrypt c
           # Wazuh indexer nodes
           indexer:
             - name: node-1
-              ip: <indexer-node-ip>
+              ip: "<indexer-node-ip>"
             #- name: node-2
-            #  ip: <indexer-node-ip>
+            #  ip: "<indexer-node-ip>"
             #- name: node-3
-            #  ip: <indexer-node-ip>
+            #  ip: "<indexer-node-ip>"
 
           # Wazuh server nodes
           # If there is more than one Wazuh server
           # node, each one must have a node_type
           server:
             - name: wazuh-1
-              ip: <wazuh-manager-ip>
+              ip: "<wazuh-manager-ip>"
             #  node_type: master
             #- name: wazuh-2
-            #  ip: <wazuh-manager-ip>
+            #  ip: "<wazuh-manager-ip>"
             #  node_type: worker
             #- name: wazuh-3
-            #  ip: <wazuh-manager-ip>
+            #  ip: "<wazuh-manager-ip>"
             #  node_type: worker
 
           # Wazuh dashboard nodes
           dashboard:
             - name: dashboard
-              ip: <dashboard-node-ip>
+              ip: "<dashboard-node-ip>"
 
 
 #. Run the assistant with the option ``--generate-config-files`` to generate the  Wazuh cluster key, certificates, and passwords necessary for installation. You can find these files in ``./wazuh-install-files.tar``.

--- a/source/user-manual/certificates.rst
+++ b/source/user-manual/certificates.rst
@@ -41,30 +41,30 @@ To create the certificates, edit the ``config.yml`` file and replace the node na
           # Wazuh indexer nodes
           indexer:
             - name: node-1
-              ip: <indexer-node-ip>
+              ip: "<indexer-node-ip>"
             #- name: node-2
-            #  ip: <indexer-node-ip>
+            #  ip: "<indexer-node-ip>"
             #- name: node-3
-            #  ip: <indexer-node-ip>
+            #  ip: "<indexer-node-ip>"
 
           # Wazuh server nodes
           # If there is more than one Wazuh server
           # node, each one must have a node_type
           server:
             - name: wazuh-1
-              ip: <wazuh-manager-ip>
+              ip: "<wazuh-manager-ip>"
             #  node_type: master
             #- name: wazuh-2
-            #  ip: <wazuh-manager-ip>
+            #  ip: "<wazuh-manager-ip>"
             #  node_type: worker
             #- name: wazuh-3
-            #  ip: <wazuh-manager-ip>
+            #  ip: "<wazuh-manager-ip>"
             #  node_type: worker
 
           # Wazuh dashboard nodes
           dashboard:
             - name: dashboard
-              ip: <dashboard-node-ip>
+              ip: "<dashboard-node-ip>"
 
 
 After configuring the ``config.yml``, run the script with option ``-A`` to create all the certificates. 


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh-packages/issues/1959 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
<!--
Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->
This PR adds double-quotes around every IP placeholder in file `config.yml` as in PR https://github.com/wazuh/wazuh-packages/pull/1992. This has been done to prevent errors in parsing Yaml, as `>` is part of the Yaml syntaxis.

## Checks
- [x] Compiles without warnings.
