### PR TITLE
Turn clarification into a step

### DIFF
--- a/source/deployment-options/elastic-stack/distributed-deployment/kibana/index.rst
+++ b/source/deployment-options/elastic-stack/distributed-deployment/kibana/index.rst
@@ -103,6 +103,21 @@ Kibana installation and configuration
     .. include:: /_templates/installations/basic/elastic/common/enable_kibana.rst
 
 
+
+   **Only for distributed deployments**  
+   
+         Edit the ``/usr/share/kibana/data/wazuh/config/wazuh.yml`` file and replace the ``url`` value with the IP address or hostname of the Wazuh server master node.
+         
+         .. code-block:: yaml
+         
+            hosts:
+              - default:
+                  url: https://localhost
+                  port: 55000
+                  username: wazuh-wui
+                  password: wazuh-wui
+                  run_as: false
+
 #. Access the web interface using the password generated during the Elasticsearch installation process: 
 
   .. code-block:: none
@@ -113,19 +128,6 @@ Kibana installation and configuration
 
 
   Upon the first access to Kibana, the browser shows a warning message stating that the certificate was not issued by a trusted authority. An exception can be added in the advanced options of the web browser or,  for increased security, the ``root-ca.pem`` file previously generated can be imported to the certificate manager of the browser.  Alternatively, a certificate from a trusted authority can be configured.
-
-With the first access attempt, the Wazuh Kibana plugin may prompt a message that indicates that it cannot communicate with the Wazuh API. To solve this issue, edit the file ``/usr/share/kibana/data/wazuh/config/wazuh.yml`` and replace the ``url`` with the Wazuh server's address: 
-
-.. code-block:: yaml
-
-  hosts:
-    - default:
-       url: https://localhost
-       port: 55000
-       username: wazuh-wui
-       password: wazuh-wui
-       run_as: false
-
 
 Disabling repositories
 ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Description
This adds a step to the Kibana installation guide for distributed deployments in the same way it's already done for the Wazuh dashboard. It closes #5806 

## Checks
- [X] Compiles without warnings.
- [X] Uses present tense, active voice, and semi-formal registry.
- [X] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [X] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).