### PR TITLE
Add missing tabs to the documentation

### DIFF
--- a/source/amazon/services/prerequisites/dependencies.rst
+++ b/source/amazon/services/prerequisites/dependencies.rst
@@ -20,32 +20,36 @@ Python
 
 The AWS module requires Python 3. It is compatible with Python 3.6 to Python 3.9. Future Python releases should maintain compatibility although it cannot be guaranteed.
 
-a) For CentOS/RHEL/Fedora operating systems:
+.. tabs::
 
-.. code-block:: console
+   .. group-tab:: Yum
 
-  # yum update && yum install python3
+      .. code-block:: console
 
-b) For Debian/Ubuntu operating systems:
+         # yum update && yum install python3
 
-.. code-block:: console
+   .. group-tab:: APT
 
-  # apt-get update && apt-get install python3
+      .. code-block:: console
+
+         # apt-get update && apt-get install python3
+
 
 The required modules can be installed with Pip, the Python package manager. Most UNIX distributions have this tool available in their software repositories:
 
-a) For CentOS/RHEL/Fedora operating systems:
+.. tabs::
 
-.. code-block:: console
+   .. group-tab:: Yum
 
-  # yum update && yum install python3-pip
+      .. code-block:: console
 
+         # yum update && yum install python3-pip
 
-b) For Debian/Ubuntu operating systems:
+   .. group-tab:: APT
 
-.. code-block:: console
+      .. code-block:: console
 
-  # apt-get update && apt-get install python3-pip
+         # apt-get update && apt-get install python3-pip
 
 It is recommended to use a pip version greater than or equal to 19.3 to ease the installation of the required dependencies.
 

--- a/source/azure/activity-services/prerequisites/dependencies.rst
+++ b/source/azure/activity-services/prerequisites/dependencies.rst
@@ -21,32 +21,37 @@ Python
 
 The Azure module requires Python 3. It is compatible with Python 3.6 to Python 3.9. Future Python releases should maintain compatibility although it cannot be guaranteed.
 
-a) For CentOS/RHEL/Fedora operating systems:
+.. tabs::
 
-.. code-block:: console
+   .. group-tab:: Yum
 
-  # yum update && yum install python3
+      .. code-block:: console
 
-b) For Debian/Ubuntu operating systems:
+         # yum update && yum install python3
 
-.. code-block:: console
+   .. group-tab:: APT
 
-  # apt-get update && apt-get install python3
+      .. code-block:: console
+
+         # apt-get update && apt-get install python3
+
 
 The required modules can be installed with Pip, the Python package manager. Most of UNIX distributions have this tool available in their software repositories:
 
-a) For CentOS/RHEL/Fedora operating systems:
+.. tabs::
 
-.. code-block:: console
+   .. group-tab:: Yum
 
-  # yum update && yum install python3-pip
+      .. code-block:: console
 
+         # yum update && yum install python3-pip
 
-b) For Debian/Ubuntu operating systems:
+   .. group-tab:: APT
 
-.. code-block:: console
+      .. code-block:: console
 
-  # apt-get update && apt-get install python3-pip
+         # apt-get update && apt-get install python3-pip
+
 
 It is recommended to use a pip version greater than or equal to 19.3 to ease the installation of the required dependencies.
 

--- a/source/container-security/docker-monitor/dependencies.rst
+++ b/source/container-security/docker-monitor/dependencies.rst
@@ -21,17 +21,20 @@ Python
 
 The Docker listener module requires Python 3. It is compatible with Python 3.6 to Python 3.9. Future Python releases should maintain compatibility although it cannot be guaranteed.
 
-a) For CentOS/RHEL/Fedora operating systems:
+.. tabs::
 
-.. code-block:: console
+   .. group-tab:: Yum
 
-  # yum update && yum install python3
+      .. code-block:: console
 
-b) For Debian/Ubuntu operating systems:
+         # yum update && yum install python3
 
-.. code-block:: console
+   .. group-tab:: APT
 
-  # apt-get update && apt-get install python3
+      .. code-block:: console
+
+         # apt-get update && apt-get install python3
+
 
 It is recommended to use a pip version greater than or equal to 19.3 to ease the installation of the required dependencies.
 
@@ -44,18 +47,19 @@ Pip
 
 The required modules can be installed with Pip, the Python package manager. Most of UNIX distributions have this tool available in their software repositories:
 
-a) For CentOS/RHEL/Fedora operating systems:
+.. tabs::
 
-.. code-block:: console
+   .. group-tab:: Yum
 
-  # yum update && yum install python3-pip
+      .. code-block:: console
 
+         # yum update && yum install python3-pip
 
-b) For Debian/Ubuntu operating systems:
+   .. group-tab:: APT
 
-.. code-block:: console
+      .. code-block:: console
 
-  # apt-get update && apt-get install python3-pip
+         # apt-get update && apt-get install python3-pip
 
 
 Python Docker Library

--- a/source/deployment-options/deploying-with-ansible/guide/install-ansible.rst
+++ b/source/deployment-options/deploying-with-ansible/guide/install-ansible.rst
@@ -143,13 +143,13 @@ Our Ansible server will need to connect to the other endpoints. Let’s see how 
 
       .. tabs::
           
-         .. group-tab:: CentOS/RHEL/Fedora
+         .. group-tab:: Yum
 
             .. code-block:: console
 
                # yum install openssh-server
 
-         .. group-tab:: Ubuntu/Debian
+         .. group-tab:: APT
 
             .. code-block:: console
 

--- a/source/deployment-options/deploying-with-ansible/guide/install-ansible.rst
+++ b/source/deployment-options/deploying-with-ansible/guide/install-ansible.rst
@@ -143,13 +143,13 @@ Our Ansible server will need to connect to the other endpoints. Let’s see how 
 
       .. tabs::
           
-         .. group-tab:: Yum
+         .. group-tab:: CentOS/RHEL/Fedora
 
             .. code-block:: console
 
                # yum install openssh-server
 
-         .. group-tab:: APT
+         .. group-tab:: Ubuntu/Debian
 
             .. code-block:: console
 

--- a/source/deployment-options/docker/docker-installation.rst
+++ b/source/deployment-options/docker/docker-installation.rst
@@ -98,13 +98,13 @@ For Linux/Unix machines, Docker requires an amd64 architecture system running ke
 
     .. tabs::
 
-      .. group-tab:: For Systemd
+      .. group-tab:: Systemd
 
          .. code-block:: console
 
             # systemctl start docker
 
-      .. group-tab:: For SysV init
+      .. group-tab:: SysV init
 
          .. code-block:: console
 

--- a/source/gcp/prerequisites/dependencies.rst
+++ b/source/gcp/prerequisites/dependencies.rst
@@ -19,32 +19,37 @@ Python
 
 The GCP module requires Python 3. It is compatible with Python 3.6 to Python 3.9. Future Python releases should maintain compatibility although it cannot be guaranteed.
 
-a) For CentOS/RHEL/Fedora operating systems:
+.. tabs::
 
-.. code-block:: console
+   .. group-tab:: Yum
 
-  # yum update && yum install python3
+      .. code-block:: console
 
-b) For Debian/Ubuntu operating systems:
+         # yum update && yum install python3
 
-.. code-block:: console
+   .. group-tab:: APT
 
-  # apt-get update && apt-get install python3
+      .. code-block:: console
+
+         # apt-get update && apt-get install python3
+
 
 The required modules can be installed with Pip, the Python package manager. Most of UNIX distributions have this tool available in their software repositories:
 
-a) For CentOS/RHEL/Fedora operating systems:
+.. tabs::
 
-.. code-block:: console
+   .. group-tab:: Yum
 
-  # yum update && yum install python3-pip
+      .. code-block:: console
 
+         # yum update && yum install python3-pip
 
-b) For Debian/Ubuntu operating systems:
+   .. group-tab:: APT
 
-.. code-block:: console
+      .. code-block:: console
 
-  # apt-get update && apt-get install python3-pip
+         # apt-get update && apt-get install python3-pip
+
 
 It is recommended to use a pip version greater than or equal to 19.3 to ease the installation of the required dependencies.
 

--- a/source/user-manual/agents/remote-upgrading/create-custom-wpk/generate-wpk-package-manually.rst
+++ b/source/user-manual/agents/remote-upgrading/create-custom-wpk/generate-wpk-package-manually.rst
@@ -28,17 +28,20 @@ Linux WPK
 
 #. Install the development tools and compilers. In Linux, this can easily be done using your distribution package manager. 
 
-   - For RPM-based distributions:
+.. tabs::
+
+   .. group-tab:: Yum
 
       .. code-block:: console
-      
-        # yum install make gcc policycoreutils-python automake autoconf libtool unzip
 
-   - For Debian-based distributions:
+         # yum install make gcc policycoreutils-python automake autoconf libtool unzip
+
+   .. group-tab:: APT
 
       .. code-block:: console
-      
-        # apt-get install make gcc libc6-dev curl policycoreutils automake autoconf libtool unzip
+
+         # apt-get install make gcc libc6-dev curl policycoreutils automake autoconf libtool unzip
+
 
 #. Download and extract the latest version. 
 
@@ -103,17 +106,20 @@ Windows WPK
 
 #. Install the development tools and compilers. In Linux, this can easily be done using your distribution package manager. 
 
-   - For RPM-based distributions:
+.. tabs::
+
+   .. group-tab:: Yum
 
       .. code-block:: console
-      
-        # yum install make gcc policycoreutils-python automake autoconf libtool unzip
 
-   - For Debian-based distributions:
+         # yum install make gcc policycoreutils-python automake autoconf libtool unzip
+
+   .. group-tab:: APT
 
       .. code-block:: console
-      
-        # apt-get install make gcc libc6-dev curl policycoreutils automake autoconf libtool unzip
+
+         # apt-get install make gcc libc6-dev curl policycoreutils automake autoconf libtool unzip
+
 
 #. Download and extract the latest version of Wazuh sources. 
 
@@ -154,17 +160,20 @@ macOS WPK
 
 #. Install development tools and compilers. In Linux, this can easily be done using your distribution package manager.
 
-   - For RPM-based distributions:
+.. tabs::
+
+   .. group-tab:: Yum
 
       .. code-block:: console
-      
-        # yum install make gcc policycoreutils-python automake autoconf libtool unzip
 
-    - For Debian-based distributions:
+         # yum install make gcc policycoreutils-python automake autoconf libtool unzip
+
+   .. group-tab:: APT
 
       .. code-block:: console
 
          # apt-get install make gcc libc6-dev curl policycoreutils automake autoconf libtool unzip
+
 
 #. Download and extract the latest version of Wazuh sources.
 

--- a/source/user-manual/agents/remote-upgrading/create-custom-wpk/generate-wpk-package-manually.rst
+++ b/source/user-manual/agents/remote-upgrading/create-custom-wpk/generate-wpk-package-manually.rst
@@ -28,19 +28,19 @@ Linux WPK
 
 #. Install the development tools and compilers. In Linux, this can easily be done using your distribution package manager. 
 
-.. tabs::
+   .. tabs::
 
-   .. group-tab:: Yum
+      .. group-tab:: Yum
 
-      .. code-block:: console
+         .. code-block:: console
 
-         # yum install make gcc policycoreutils-python automake autoconf libtool unzip
+            # yum install make gcc policycoreutils-python automake autoconf libtool unzip
 
-   .. group-tab:: APT
+      .. group-tab:: APT
 
-      .. code-block:: console
+         .. code-block:: console
 
-         # apt-get install make gcc libc6-dev curl policycoreutils automake autoconf libtool unzip
+            # apt-get install make gcc libc6-dev curl policycoreutils automake autoconf libtool unzip
 
 
 #. Download and extract the latest version. 
@@ -106,19 +106,19 @@ Windows WPK
 
 #. Install the development tools and compilers. In Linux, this can easily be done using your distribution package manager. 
 
-.. tabs::
+   .. tabs::
 
-   .. group-tab:: Yum
+      .. group-tab:: Yum
 
-      .. code-block:: console
+         .. code-block:: console
 
-         # yum install make gcc policycoreutils-python automake autoconf libtool unzip
+            # yum install make gcc policycoreutils-python automake autoconf libtool unzip
 
-   .. group-tab:: APT
+      .. group-tab:: APT
 
-      .. code-block:: console
+         .. code-block:: console
 
-         # apt-get install make gcc libc6-dev curl policycoreutils automake autoconf libtool unzip
+            # apt-get install make gcc libc6-dev curl policycoreutils automake autoconf libtool unzip
 
 
 #. Download and extract the latest version of Wazuh sources. 
@@ -160,19 +160,19 @@ macOS WPK
 
 #. Install development tools and compilers. In Linux, this can easily be done using your distribution package manager.
 
-.. tabs::
+   .. tabs::
 
-   .. group-tab:: Yum
+      .. group-tab:: Yum
 
-      .. code-block:: console
+         .. code-block:: console
 
-         # yum install make gcc policycoreutils-python automake autoconf libtool unzip
+            # yum install make gcc policycoreutils-python automake autoconf libtool unzip
 
-   .. group-tab:: APT
+      .. group-tab:: APT
 
-      .. code-block:: console
+         .. code-block:: console
 
-         # apt-get install make gcc libc6-dev curl policycoreutils automake autoconf libtool unzip
+            # apt-get install make gcc libc6-dev curl policycoreutils automake autoconf libtool unzip
 
 
 #. Download and extract the latest version of Wazuh sources.

--- a/source/user-manual/api/getting-started.rst
+++ b/source/user-manual/api/getting-started.rst
@@ -15,17 +15,20 @@ Starting and stopping the Wazuh API
 
 The Wazuh API will be installed along with the Wazuh manager by default. To control or check the **wazuh-api**, use the **wazuh-manager** service with the ``systemctl`` or ``service`` command:
 
-**Systemd systems**
+.. tabs::
 
-.. code-block:: console
+   .. group-tab:: Systemd
 
-    # systemctl start/status/stop/restart wazuh-manager
+      .. code-block:: console
 
-**SysVinit systems**
+         # systemctl start/status/stop/restart wazuh-manager
 
-.. code-block:: console
+   .. group-tab:: SysV init
 
-    # service wazuh-manager start/status/stop/restart
+      .. code-block:: console
+
+         # service wazuh-manager start/status/stop/restart
+
 
 .. note::
     The -k parameter applied to API requests is used to avoid the server connection verification by using server certificates. If these are valid, this parameter can be removed.

--- a/source/user-manual/capabilities/policy-monitoring/ciscat/ciscat.rst
+++ b/source/user-manual/capabilities/policy-monitoring/ciscat/ciscat.rst
@@ -32,33 +32,36 @@ The CIS-CAT Wazuh module integrates CIS benchmark assessments into Wazuh agents 
 
 CIS-CAT Pro is written in Java, so it requires a Java Runtime Environment in order to execute it. Currently, the JRE versions supported in CIS-CAT are JRE 6, 7, and 8. Follow these steps to install the OpenJDK platform:
 
-a) For CentOS/RHEL/Fedora:
+.. tabs::
 
-.. code-block:: console
+   .. group-tab:: Yum
 
-  # yum install java-1.8.0-openjdk
+      .. code-block:: console
 
-b) For Debian/Ubuntu:
+         # yum install java-1.8.0-openjdk
 
-.. code-block:: console
+   .. group-tab:: APT
 
-  # apt-get update && apt-get install openjdk-8-jre
+      .. code-block:: console
+
+         # apt-get update && apt-get install openjdk-8-jre
+
+   .. group-tab:: Windows
   
-c) For Windows:
-  
-  1. Download the MSI-based installer of `OpenJDK 8 <https://developers.redhat.com/products/openjdk/download>`_ for your Windows architecture.
-  
-  2. Run the installer and follow the on-screen instructions to install OpenJDK 8.
-  
-  3. Set Environment Variables:
-  
-    - Go to Control Panel -> System and Security -> System -> Advanced system settings -> Environment Variables.
-    
-    - Under System Variables, create or edit ``JAVA_HOME`` variable and add the installation path of the JDK. Example: ``C:\Program Files\java-1.8.0``.
-    
-    - Apply changes.
-    
-    - Open up the Command Prompt and type ``java -version`` to check the newly installed version.
+      1. Download the MSI-based installer of `OpenJDK 8 <https://developers.redhat.com/products/openjdk/download>`_ for your Windows architecture.
+      
+      2. Run the installer and follow the on-screen instructions to install OpenJDK 8.
+      
+      3. Set Environment Variables:
+      
+         - Go to Control Panel -> System and Security -> System -> Advanced system settings -> Environment Variables.
+        
+         - Under System Variables, create or edit ``JAVA_HOME`` variable and add the installation path of the JDK. Example: ``C:\Program Files\java-1.8.0``.
+        
+         - Apply changes.
+        
+         - Open up the Command Prompt and type ``java -version`` to check the newly installed version.
+
 
 .. note::
   If version 8 of the Java Runtime Environment is not available for your operating system, use version 7 or 6 instead.

--- a/source/user-manual/capabilities/policy-monitoring/openscap/how-it-works.rst
+++ b/source/user-manual/capabilities/policy-monitoring/openscap/how-it-works.rst
@@ -27,17 +27,20 @@ This wodle is executed on the agent, so each agent must meet the following requi
     OpenSCAP
     In order to perform SCAP evaluations, we need the scanner. As we mentioned above, we use OpenSCAP. You can install it with this command:
 
-      a) For RPM-based distributions:
+      .. tabs::
 
-        .. code-block:: console
+        .. group-tab:: Yum
 
-          # yum install openscap-scanner
+            .. code-block:: console
 
-      b) For Debian-based distributions:
+              # yum install openscap-scanner
 
-        .. code-block:: console
+        .. group-tab:: APT
 
-          # apt-get install libopenscap8 xsltproc
+            .. code-block:: console
+
+              # apt-get install libopenscap8 xsltproc
+
 
     Python 2.6+
     Python is a core part of this wodle. Currently, all Linux distributions come with python, so it should not be an inconvenience.

--- a/source/user-manual/capabilities/system-calls-monitoring/audit-configuration.rst
+++ b/source/user-manual/capabilities/system-calls-monitoring/audit-configuration.rst
@@ -65,17 +65,20 @@ Installing Audit
 
 In order to use the Audit system, you must have the audit package installed on your system. If you do not have this  package installed, execute the following command as the root user to install it.
 
-Red Hat, CentOS and Fedora:
+.. tabs::
 
-.. code-block:: console
+   .. group-tab:: Yum
 
-    # yum install audit
+      .. code-block:: console
 
-Debian and Ubuntu based Linux distributions:
+         # yum install audit
 
-.. code-block:: console
+   .. group-tab:: APT
 
-    # apt-get install auditd
+      .. code-block:: console
+
+         # apt-get install auditd
+
 
 Editing ossec.conf
 ~~~~~~~~~~~~~~~~~~

--- a/source/user-manual/manager/manual-database-output.rst
+++ b/source/user-manual/manager/manual-database-output.rst
@@ -23,31 +23,37 @@ Prerequisites
 
   a) For MySQL:
 
-    RPM:
+   .. tabs::
 
-    .. code-block:: console
+      .. group-tab:: Yum
 
-      # yum install mysql-devel
+         .. code-block:: console
 
-    Debian:
+            # yum install mysql-devel
 
-    .. code-block:: console
+      .. group-tab:: APT
 
-      # apt-get install libmysqlclient-dev
+         .. code-block:: console
+
+            # apt-get install libmysqlclient-dev
+
 
   b) For PostgreSQL:
 
-    RPM:
+   .. tabs::
 
-    .. code-block:: console
+      .. group-tab:: Yum
 
-      # yum install postgresql-devel
+         .. code-block:: console
 
-    Debian:
+            # yum install postgresql-devel
 
-    .. code-block:: console
+      .. group-tab:: APT
 
-      # apt-get install libpq-dev
+         .. code-block:: console
+
+            # apt-get install libpq-dev
+
 
 Installation
 ------------

--- a/source/user-manual/manager/manual-email-report/smtp-authentication.rst
+++ b/source/user-manual/manager/manual-email-report/smtp-authentication.rst
@@ -12,19 +12,19 @@ If your SMTP server uses authentication (like Gmail, for instance), a server rel
 
 #. Install the needed packages:
 
-.. tabs::
+   .. tabs::
 
-   .. group-tab:: APT
+      .. group-tab:: APT
 
-      .. code-block:: console
+         .. code-block:: console
 
-          # apt-get install postfix mailutils libsasl2-2 ca-certificates libsasl2-modules
+            # apt-get install postfix mailutils libsasl2-2 ca-certificates libsasl2-modules
 
-   .. group-tab:: Yum
+      .. group-tab:: Yum
 
-      .. code-block:: console
+         .. code-block:: console
 
-          # yum update && yum install postfix mailx cyrus-sasl cyrus-sasl-plain
+            # yum update && yum install postfix mailx cyrus-sasl cyrus-sasl-plain
 
 
 #. Configure Postfix in the ``/etc/postfix/main.cf`` file adding these lines to the end of the file:

--- a/source/user-manual/manager/manual-email-report/smtp-authentication.rst
+++ b/source/user-manual/manager/manual-email-report/smtp-authentication.rst
@@ -12,17 +12,19 @@ If your SMTP server uses authentication (like Gmail, for instance), a server rel
 
 #. Install the needed packages:
 
-   Ubuntu
+.. tabs::
 
-   .. code-block:: console
+   .. group-tab:: APT
 
-      # apt-get install postfix mailutils libsasl2-2 ca-certificates libsasl2-modules
+      .. code-block:: console
 
-   CentOS
+          # apt-get install postfix mailutils libsasl2-2 ca-certificates libsasl2-modules
 
-   .. code-block:: console
+   .. group-tab:: Yum
 
-      # yum update && yum install postfix mailx cyrus-sasl cyrus-sasl-plain
+      .. code-block:: console
+
+         # yum update && yum install postfix mailx cyrus-sasl cyrus-sasl-plain
 
 
 #. Configure Postfix in the ``/etc/postfix/main.cf`` file adding these lines to the end of the file:

--- a/source/user-manual/manager/manual-email-report/smtp-authentication.rst
+++ b/source/user-manual/manager/manual-email-report/smtp-authentication.rst
@@ -24,7 +24,7 @@ If your SMTP server uses authentication (like Gmail, for instance), a server rel
 
       .. code-block:: console
 
-         # yum update && yum install postfix mailx cyrus-sasl cyrus-sasl-plain
+          # yum update && yum install postfix mailx cyrus-sasl cyrus-sasl-plain
 
 
 #. Configure Postfix in the ``/etc/postfix/main.cf`` file adding these lines to the end of the file:

--- a/source/user-manual/manager/manual-email-report/smtp-authentication.rst
+++ b/source/user-manual/manager/manual-email-report/smtp-authentication.rst
@@ -14,18 +14,17 @@ If your SMTP server uses authentication (like Gmail, for instance), a server rel
 
    .. tabs::
 
-      .. group-tab:: APT
-
-         .. code-block:: console
-
-            # apt-get install postfix mailutils libsasl2-2 ca-certificates libsasl2-modules
-
       .. group-tab:: Yum
 
          .. code-block:: console
 
             # yum update && yum install postfix mailx cyrus-sasl cyrus-sasl-plain
 
+      .. group-tab:: APT
+
+         .. code-block:: console
+
+            # apt-get install postfix mailutils libsasl2-2 ca-certificates libsasl2-modules
 
 #. Configure Postfix in the ``/etc/postfix/main.cf`` file adding these lines to the end of the file:
 


### PR DESCRIPTION
## Description
This issue aims to add missing tabs to the documentation.
This PR closes the Issue #5851.

## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
