### PR TITLE
Fit root privileges notes to docs writing style

### DIFF
--- a/source/deployment-options/deploying-with-puppet/setup-puppet/index.rst
+++ b/source/deployment-options/deploying-with-puppet/setup-puppet/index.rst
@@ -16,7 +16,8 @@ Before we get started with Puppet, confirm that the following network requiremen
 - **Firewall open ports**: The Puppet master must be reachable on TCP port 8140.
 
 .. note::
-    This guide has been made using Puppet version 7.16. Root user privileges are required to execute all the commands described below.
+
+   We made this guide using Puppet version 7.16. You need root user privileges to run all the commands described below.
 
 .. topic:: Contents
 

--- a/source/deployment-options/docker/docker-installation.rst
+++ b/source/deployment-options/docker/docker-installation.rst
@@ -16,9 +16,7 @@ The first thing you need to do is to set up a system with the requirements neede
       :depth: 1
       :backlinks: none
 
-.. note::
-   
-   You need root user privileges to execute all the commands described below.
+.. note:: You need root user privileges to run all the commands described below.
 
 Requirements
 ------------

--- a/source/deployment-options/elastic-stack/all-in-one-deployment/index.rst
+++ b/source/deployment-options/elastic-stack/all-in-one-deployment/index.rst
@@ -10,8 +10,7 @@ All-in-one deployment
 
 This document guides through an installation of the Wazuh server and Elastic Stack components in an all-in-one configuration. This guide provides instructions to configure the official repositories to do the installations, alternatively, all the available packages can be found :doc:`here </installation-guide/packages-list>`.
 
-.. note:: Root user privileges are required to execute all the commands described below.
-
+.. note:: You need root user privileges to run all the commands described below.
 
 Installing prerequisites
 ------------------------

--- a/source/deployment-options/elastic-stack/distributed-deployment/elasticsearch-cluster/elasticsearch-multi-node-cluster.rst
+++ b/source/deployment-options/elastic-stack/distributed-deployment/elasticsearch-cluster/elasticsearch-multi-node-cluster.rst
@@ -12,8 +12,7 @@ Elasticsearch is a highly scalable full-text search and analytics engine. This d
 
 For resilience, in case Elasticsearch nodes become unavailable, it is recommended to have an odd number of master eligible nodes, please take this into consideration when deciding the configuration of your Elasticsearch cluster. 
 
-.. note:: Root user privileges are necessary to execute all the commands described below.
-
+.. note:: You need root user privileges to run all the commands described below.
 
 Installing Elasticsearch
 ------------------------

--- a/source/deployment-options/elastic-stack/distributed-deployment/elasticsearch-cluster/elasticsearch-single-node-cluster.rst
+++ b/source/deployment-options/elastic-stack/distributed-deployment/elasticsearch-cluster/elasticsearch-single-node-cluster.rst
@@ -10,8 +10,7 @@ Elasticsearch single-node cluster
 
 This document will explain how to install the Elastic Stack components in a single-node cluster.
 
-.. note:: Root user privileges are necessary to execute all the commands described below.
-
+.. note:: You need root user privileges to run all the commands described below.
 
 Installing Elasticsearch
 ------------------------

--- a/source/deployment-options/elastic-stack/distributed-deployment/kibana/index.rst
+++ b/source/deployment-options/elastic-stack/distributed-deployment/kibana/index.rst
@@ -11,7 +11,7 @@ Kibana
 Kibana is a flexible and intuitive web interface for mining and visualizing the events and archives stored in Elasticsearch.
 
 
-.. note:: Root user privileges are required to run all the commands described below.
+.. note:: You need root user privileges to run all the commands described below.
 
 Prerequisites
 ~~~~~~~~~~~~~

--- a/source/deployment-options/elastic-stack/distributed-deployment/wazuh-cluster/wazuh-multi-node-cluster.rst
+++ b/source/deployment-options/elastic-stack/distributed-deployment/wazuh-cluster/wazuh-multi-node-cluster.rst
@@ -9,7 +9,7 @@ Wazuh multi-node cluster
 
 This document will go through the installation of the Wazuh server components in a multi-node cluster.
 
-.. note:: Root user privileges are required to execute all the commands described below.
+.. note:: You need root user privileges to run all the commands described below.
 
 Prerequisites
 -------------

--- a/source/deployment-options/elastic-stack/distributed-deployment/wazuh-cluster/wazuh-single-node-cluster.rst
+++ b/source/deployment-options/elastic-stack/distributed-deployment/wazuh-cluster/wazuh-single-node-cluster.rst
@@ -9,7 +9,7 @@ Wazuh single-node cluster
 
 This document will go through the installation of the Wazuh server components in a single-node cluster.
 
-.. note:: Root user privileges are required to execute all the commands described below.
+.. note:: You need root user privileges to run all the commands described below.
 
 Prerequisites
 -------------

--- a/source/deployment-options/offline-installation.rst
+++ b/source/deployment-options/offline-installation.rst
@@ -10,9 +10,7 @@ You can install Wazuh even when there is no connection to the Internet. Installi
 
 For more information about the hardware requirements and the recommended operating systems, check the :ref:`Requirements <installation_requirements>` section.
 
-.. note::
-
-    Root privileges are required to execute all the commands.
+.. note:: You need root user privileges to run all the commands described below.
 
 Prerequisites
 -------------

--- a/source/deployment-options/splunk/splunk-basic.rst
+++ b/source/deployment-options/splunk/splunk-basic.rst
@@ -8,10 +8,7 @@ Install Splunk in an all-in-one architecture
 
 This document will guide you through the installation process for an all-in-one Wazuh Splunk server.
 
-.. note::
-
-   Most of the commands described below need to be executed with root user privileges.
-
+.. note:: You need root user privileges to run all the commands described below.
 
 These are the two main components in this type of multi-tier server:
 

--- a/source/deployment-options/splunk/splunk-distributed.rst
+++ b/source/deployment-options/splunk/splunk-distributed.rst
@@ -14,9 +14,7 @@ Prerequisites
 #. A Wazuh manager cluster.
 #. A Splunk cluster.
 
-.. note::
-
-   Most of the commands described below need to be executed with root user privileges.
+.. note:: You need root user privileges to run all the commands described below.
 
 .. note::
 

--- a/source/deployment-options/splunk/splunk-minimal-distributed.rst
+++ b/source/deployment-options/splunk/splunk-minimal-distributed.rst
@@ -8,9 +8,7 @@ Install a minimal Splunk distributed architecture
 
 This document will guide you through the installation process for a multi-tier server.
 
-.. note::
-
-   Most of the commands described below need to be executed with root user privileges.
+.. note:: You need root user privileges to run all the commands described below.
 
 These are the two main components in this type of multi-tier server:
 

--- a/source/deployment-options/splunk/splunk-wazuh.rst
+++ b/source/deployment-options/splunk/splunk-wazuh.rst
@@ -8,9 +8,7 @@ Wazuh manager installation
 
 This document will go through the installation of the Wazuh manager.
 
-.. note::
-
-   Root user privileges are required to run all the commands described below.
+.. note:: You need root user privileges to run all the commands described below.
 
 Prerequisites
 -------------

--- a/source/deployment-options/wazuh-from-sources/wazuh-agent/index.rst
+++ b/source/deployment-options/wazuh-from-sources/wazuh-agent/index.rst
@@ -14,7 +14,7 @@ The Wazuh agent is a single and lightweight monitoring software. It is a multi-p
 
         .. note::
         
-            All the commands described below need to be executed with root user privileges. Since Wazuh 3.5, it is necessary to have an Internet connection when following this process.
+           You need root user privileges to run all the commands described below. Since Wazuh 3.5, it is necessary to have an Internet connection when following this process.
 
         .. note::
         

--- a/source/installation-guide/wazuh-agent/wazuh-agent-package-linux.rst
+++ b/source/installation-guide/wazuh-agent/wazuh-agent-package-linux.rst
@@ -12,7 +12,7 @@ The agent runs on the host you want to monitor and communicates with the Wazuh s
 
 The deployment of a Wazuh agent on a Linux system uses deployment variables that facilitate the task of installing, registering, and configuring the agent. Alternatively, if you want to download the Wazuh agent package directly, see the :doc:`packages list </installation-guide/packages-list>` section. 
 
-.. note:: To execute all the commands, root user privileges are required.
+.. note:: You need root user privileges to run all the commands described below.
 
 Add the Wazuh repository
 -------------------------

--- a/source/installation-guide/wazuh-agent/wazuh-agent-package-macos.rst
+++ b/source/installation-guide/wazuh-agent/wazuh-agent-package-macos.rst
@@ -10,7 +10,7 @@ Installing Wazuh agents on macOS endpoints
 
 The agent runs on the endpoint you want to monitor and communicates with the Wazuh server, sending data in near real-time through an encrypted and authenticated.
 
-.. note:: To execute all the commands, root user privileges are required.
+.. note:: You need root user privileges to run all the commands described below.
 
 #. To start the installation process, download the `Wazuh agent for macOS <https://packages.wazuh.com/|WAZUH_CURRENT_MAJOR_OSX|/macos/wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg>`_. The package is suitable for macOS Sierra or later. 
 

--- a/source/installation-guide/wazuh-dashboard/step-by-step.rst
+++ b/source/installation-guide/wazuh-dashboard/step-by-step.rst
@@ -10,7 +10,7 @@ Installing the Wazuh dashboard step by step
 
 Install and configure the Wazuh dashboard following step-by-step instructions. The Wazuh dashboard is a web interface for mining and visualizing the Wazuh server alerts and archived events.
 
-.. note:: Root user privileges are required to run the commands described below.
+.. note:: You need root user privileges to run all the commands described below.
 
 Wazuh dashboard installation
 ----------------------------

--- a/source/installation-guide/wazuh-indexer/installation-assistant.rst
+++ b/source/installation-guide/wazuh-indexer/installation-assistant.rst
@@ -20,8 +20,7 @@ The installation process is divided into three stages.
 
 #. Cluster initialization
 
-.. note:: Root user privileges are required to run the commands described below.
-
+.. note:: You need root user privileges to run all the commands described below.
 
 1. Initial configuration
 ------------------------

--- a/source/installation-guide/wazuh-indexer/step-by-step.rst
+++ b/source/installation-guide/wazuh-indexer/step-by-step.rst
@@ -17,7 +17,7 @@ The installation process is divided into three stages.
 #. Cluster initialization
 
 
-.. note:: Root user privileges are required to run the commands described below.
+.. note:: You need root user privileges to run all the commands described below.
 
 1. Certificates creation
 ------------------------

--- a/source/installation-guide/wazuh-server/step-by-step.rst
+++ b/source/installation-guide/wazuh-server/step-by-step.rst
@@ -14,7 +14,7 @@ The installation process is divided into two stages.
 
 #. Cluster configuration for multi-node deployment 
 
-.. note:: Root user privileges are required to run the commands described below.
+.. note:: You need root user privileges to run all the commands described below.
 
 1. Wazuh server node installation
 ----------------------------------

--- a/source/learning-wazuh/build-lab/install-wazuh-central-components.rst
+++ b/source/learning-wazuh/build-lab/install-wazuh-central-components.rst
@@ -18,9 +18,7 @@ To set your Learning Wazuh environment, you can install the Wazuh central compon
 
 Check our :ref:`Installation guide <installation_guide>` for more details and other installation options.
 
-.. note::
-   
-   Root user privileges are required to execute all the commands below.
+.. note:: You need root user privileges to run all the commands described below.
 
 Install Wazuh using the Wazuh installation assistant
 ----------------------------------------------------

--- a/source/migration-guide/wazuh-dashboard.rst
+++ b/source/migration-guide/wazuh-dashboard.rst
@@ -12,9 +12,7 @@ Follow this guide to migrate from Open Distro for Elasticsearch Kibana 1.13 to t
 
 To guarantee a correct operation of Wazuh, make sure to also migrate from Open Distro for Elasticsearch to the Wazuh indexer. To learn more, see the :doc:`Migrating to the Wazuh indexer </migration-guide/wazuh-indexer>` documentation. 
 
-
-.. note:: Root user privileges are required to execute all the commands described below.
-
+.. note:: You need root user privileges to run all the commands described below.
 
 #. Stop the Kibana service. 
 

--- a/source/migration-guide/wazuh-indexer.rst
+++ b/source/migration-guide/wazuh-indexer.rst
@@ -10,7 +10,7 @@ Migrating to the Wazuh indexer
 
 Follow this guide to migrate from Open Distro for Elasticsearch 1.13 to the Wazuh indexer. These instructions are intended for a standard Wazuh installation, you may need to make some changes to adapt them to your environment.
 
-.. note:: Root user privileges are required to execute all the commands described below.
+.. note:: You need root user privileges to run all the commands described below.
 
 #. Disable shard allocation to prevent Elasticsearch from replicating shards as you shut down nodes. Replace ``<elasticsearch_IP>`` with your Elasticsearch IP address or hostname, and ``<username>:<password>`` with your Elasticsearch username and password.  
 

--- a/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-elastic-stack.rst
+++ b/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-elastic-stack.rst
@@ -14,9 +14,7 @@ This section guides through the upgrade process of the Wazuh server, Elasticsear
    
    This guide is meant for upgrades from 7.x to 7.y. The upgrade instructions for Elastic Stack versions prior to 7.0 can be found in the :ref:`Upgrading Elastic Stack from a legacy version <upgrading_elastic_stack_legacy>` section.
 
-.. note::
-   
-   Root user privileges are required to execute all the commands described below.
+.. note:: You need root user privileges to run all the commands described below.
 
 Preparing the upgrade
 ---------------------

--- a/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-open-distro.rst
+++ b/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-open-distro.rst
@@ -10,9 +10,7 @@ Wazuh and Open Distro for Elasticsearch
 
 This section guides through the upgrade process of the Wazuh server, Elasticsearch, and Kibana for the *Open Distro for Elasticsearch* distribution. 
 
-.. note::
-   
-   Root user privileges are required to execute all the commands described below.
+.. note:: You need root user privileges to run all the commands described below.
 
 Preparing the upgrade
 ---------------------

--- a/source/upgrade-guide/upgrading-central-components.rst
+++ b/source/upgrade-guide/upgrading-central-components.rst
@@ -8,9 +8,7 @@ Wazuh central components
 
 This section guides through the upgrade process of the Wazuh indexer, the Wazuh server, and the Wazuh dashboard. To migrate from Open Distro for Elasticsearch 1.13 to the Wazuh indexer and dashboard components, read the corresponding :doc:`/migration-guide/wazuh-indexer` and :doc:`/migration-guide/wazuh-dashboard` sections.
 
-.. note::
-   
-   Root user privileges are required to execute all the commands described below.
+.. note:: You need root user privileges to run all the commands described below.
 
 Preparing the upgrade
 ---------------------

--- a/source/upgrade-guide/wazuh-agent/linux.rst
+++ b/source/upgrade-guide/wazuh-agent/linux.rst
@@ -9,9 +9,7 @@ Ugrading Wazuh agents on Linux systems
 
 Select your package manager and follow the instructions to upgrade the Wazuh agent locally. If you want to perform a remote upgrade, check the :doc:`Remote agent upgrade </user-manual/agents/remote-upgrading/upgrading-agent>` section to learn more. 
 
-.. note::
-   
-   Root user privileges are required to execute all the commands described below.
+.. note:: You need root user privileges to run all the commands described below.
 
 .. tabs::
 

--- a/source/user-manual/capabilities/system-calls-monitoring/how-it-works.rst
+++ b/source/user-manual/capabilities/system-calls-monitoring/how-it-works.rst
@@ -19,9 +19,7 @@ Audit uses a set of rules to define what is to be captured in the log files. The
 
 Audit rules can be specified interactively with the *auditctl* command-line utility, but to make changes persistent, edit */etc/audit/audit.rules*.
 
-.. warning::
-   All commands that interact with the Audit service and the Audit log files require root privileges, so you will need to be root or use sudo to execute these commands.
-
+.. note:: You need root user privileges to run all the commands described below.
 
 Control rules
 --------------

--- a/source/user-manual/uninstall/central-components.rst
+++ b/source/user-manual/uninstall/central-components.rst
@@ -18,7 +18,7 @@ This will remove the Wazuh indexer, the Wazuh server, and the Wazuh dashboard.
 
 If you want to uninstall one specific central component, follow the instructions below.
 
-.. note:: Root user privileges are required to execute all the commands described below.
+.. note:: You need root user privileges to run all the commands described below.
 
 .. _uninstall_dashboard:
 


### PR DESCRIPTION
## Description
This PR changes "Root user privileges required" notes to fit Wazuh docs writing style.

## Checks
- [X] Compiles without warnings.
- [X] Uses present tense, active voice, and semi-formal registry.
- [X] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [X] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
