### PR TITLE
Update profiles Troubleshooting section

### DIFF
--- a/source/amazon/services/prerequisites/credentials.rst
+++ b/source/amazon/services/prerequisites/credentials.rst
@@ -48,7 +48,7 @@ Depending on the service that will be monitored, the Wazuh user will need a diff
 Authenticating options
 ----------------------
 
-Credentials can be loaded from different locations, you can either specify the credentials as they are in the previous block of configuration, assume an IAM role, or load them from other `Boto3 supported locations <http://boto3.readthedocs.io/en/latest/guide/configuration.html#configuring-credentials>`_.
+Credentials can be loaded from different locations, you can either specify the credentials as they are in the previous block of configuration, assume an IAM role, or load them from other `Boto3 supported locations <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#configuring-credentials>`__.
 
 .. _aws_profile:
 

--- a/source/amazon/services/prerequisites/credentials.rst
+++ b/source/amazon/services/prerequisites/credentials.rst
@@ -8,7 +8,7 @@
 Configuring AWS credentials
 ===========================
 
-In order to make the Wazuh AWS module pull log data from the different services, it will be necessary to provide access credentials so it can connect to them.
+In order to make the Wazuh AWS module pull log data from the different services, it's necessary to provide access credentials to connect to them. The ``.aws/credentials`` file must be placed at the correct location. You need to create the credentials file using ``root``. The root user is the one that runs *wazuh-modulesd*. Thus, the correct location is ``/root/.aws/credentials``, the home directory of the root user.
 
 There are multiple ways to configure the AWS credentials:
 
@@ -55,7 +55,7 @@ Credentials can be loaded from different locations, you can either specify the c
 Profiles
 ^^^^^^^^
 
-You can define profiles in your credentials file (``~/.aws/credentials``) and specify those profiles on the bucket configuration.
+You can define profiles in ``/root/.aws/credentials`` and specify those profiles on the bucket configuration.
 
 .. note::
   A region must be also specified on the ``credentials`` file in order to make it work.

--- a/source/amazon/services/prerequisites/credentials.rst
+++ b/source/amazon/services/prerequisites/credentials.rst
@@ -48,7 +48,7 @@ Depending on the service that will be monitored, the Wazuh user will need a diff
 Authenticating options
 ----------------------
 
-Credentials can be loaded from different locations, you can either specify the credentials as they are in the previous block of configuration, assume an IAM role, or load them from other `Boto3 supported locations <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#configuring-credentials>`__.
+Credentials can be loaded from different locations. You can either specify the credentials as they are in the previous block of configuration, assume an IAM role, or load them from other `Boto3 supported locations <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#configuring-credentials>`__.
 
 .. _aws_profile:
 

--- a/source/amazon/services/troubleshooting.rst
+++ b/source/amazon/services/troubleshooting.rst
@@ -139,7 +139,7 @@ The module does not work and the following error messages appear in the ``ossec.
 
 **Solution**
 
-Make sure the profile value specified in the configuration matches with an existing one placed in the ``~/.aws/credentials`` file, being ``~/`` the root user's home directory (``/root/``) which is the one that executes the module. Check the :ref:`Configuring AWS credentials <aws_profile>` section to learn more about how to configure a profile for authentication.
+Make sure the profile value specified in the configuration matches with an existing one placed in ``/root/.aws/credentials``. Check the :ref:`Configuring AWS credentials <aws_profile>` section to learn more about how to configure a profile for authentication.
 
 The security token included in the request is invalid
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/amazon/services/troubleshooting.rst
+++ b/source/amazon/services/troubleshooting.rst
@@ -139,7 +139,7 @@ The module does not work and the following error messages appear in the ``ossec.
 
 **Solution**
 
-Make sure the profile value specified in the configuration matches with an existing one placed in ``/root/.aws/credentials``. Check the :ref:`Configuring AWS credentials <aws_profile>` section to learn more about how to configure a profile for authentication.
+Ensure the profile value specified in the configuration matches an existing one placed in ``/root/.aws/credentials``. Check the :ref:`Configuring AWS credentials <aws_profile>` section to learn more about configuring a profile for authentication.
 
 The security token included in the request is invalid
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/amazon/services/troubleshooting.rst
+++ b/source/amazon/services/troubleshooting.rst
@@ -139,8 +139,7 @@ The module does not work and the following error messages appear in the ``ossec.
 
 **Solution**
 
-Make sure the profile value specified in the configuration matches with an existing one placed in the ``~/.aws/credentials`` file. Check the :ref:`Configuring AWS credentials <aws_profile>` section to learn more about how to configure a profile for authentication.
-
+Make sure the profile value specified in the configuration matches with an existing one placed in the ``~/.aws/credentials`` file, being ``~/`` the root user's home directory (``/root/``) which is the one that executes the module. Check the :ref:`Configuring AWS credentials <aws_profile>` section to learn more about how to configure a profile for authentication.
 
 The security token included in the request is invalid
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/cloud-service/cold-storage/access.rst
+++ b/source/cloud-service/cold-storage/access.rst
@@ -46,7 +46,7 @@ The following example describes the steps to follow to list the files of your co
          }
       }
 
-3. Using the AWS-CLI tool to list the files, add the token to the AWS credentials file ``~/.aws/credentials``.
+3. Using the AWS-CLI tool to list the files, add the token to the AWS credentials file ``/root/.aws/credentials``.
 
    .. code-block:: console
       

--- a/source/cloud-service/cold-storage/access.rst
+++ b/source/cloud-service/cold-storage/access.rst
@@ -46,7 +46,7 @@ The following example describes the steps to follow to list the files of your co
          }
       }
 
-3. Using the AWS-CLI tool to list the files, add the token to the AWS credentials file ``/root/.aws/credentials``.
+3. Using the AWS-CLI tool to list the files, add the token to the AWS credentials file ``~/.aws/credentials``.
 
    .. code-block:: console
       


### PR DESCRIPTION
## Description
This PR  closes #5858. It updates the `The config profile could not be found` section from the AWS `Troubleshooting` page in order to clearly describe where the `credentials` file should be.

## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
