### PR TITLE
Change configuration for <global> example

### DIFF
--- a/source/user-manual/reference/ossec-conf/global.rst
+++ b/source/user-manual/reference/ossec-conf/global.rst
@@ -474,8 +474,8 @@ Example:
 
   <agents_disconnection_alert_time>1h</agents_disconnection_alert_time>
 
-Sample configuration
---------------------
+Configuration example
+---------------------
 
 .. code-block:: xml
 

--- a/source/user-manual/reference/ossec-conf/global.rst
+++ b/source/user-manual/reference/ossec-conf/global.rst
@@ -474,21 +474,22 @@ Example:
 
   <agents_disconnection_alert_time>1h</agents_disconnection_alert_time>
 
-Default configuration
----------------------
+Sample configuration
+--------------------
 
 .. code-block:: xml
 
-    <global>
-      <jsonout_output>yes</jsonout_output>
-      <alerts_log>yes</alerts_log>
-      <logall>no</logall>
-      <logall_json>no</logall_json>
-      <email_notification>yes</email_notification>
-      <smtp_server>smtp.example.wazuh.com</smtp_server>
-      <email_from>wazuh@example.wazuh.com</email_from>
-      <email_to>recipient@example.wazuh.com</email_to>
-      <email_maxperhour>12</email_maxperhour>
-      <agents_disconnection_time>10m</agents_disconnection_time>
-      <agents_disconnection_alert_time>0</agents_disconnection_alert_time>
-    </global>
+   <global>
+     <jsonout_output>yes</jsonout_output>
+     <alerts_log>yes</alerts_log>
+     <logall>no</logall>
+     <logall_json>no</logall_json>
+     <email_notification>no</email_notification>
+     <smtp_server>smtp.example.wazuh.com</smtp_server>
+     <email_from>wazuh@example.wazuh.com</email_from>
+     <email_to>recipient@example.wazuh.com</email_to>
+     <email_maxperhour>12</email_maxperhour>
+     <email_log_source>alerts.log</email_log_source>
+     <agents_disconnection_time>10m</agents_disconnection_time>
+     <agents_disconnection_alert_time>0</agents_disconnection_alert_time>
+   </global>


### PR DESCRIPTION
## Description
This PR addresses issue #5836 : 
- It replaces the current code block with the default 4.3 `<global>` configuration lines in https://github.com/wazuh/wazuh/blob/4.3/etc/ossec.conf#L8-L21
- It changes the title from "Default configuration" to "Sample configuration" to avoid a double source for the installation default configuration.

## Checks
- [X] Compiles without warnings.
- [X] Uses present tense, active voice, and semi-formal registry.
- [X] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [X] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
