### PR TITLE
Add TCP ports warning with Ansible deployment

### DIFF
--- a/source/deployment-options/deploying-with-ansible/installation-guide.rst
+++ b/source/deployment-options/deploying-with-ansible/installation-guide.rst
@@ -13,15 +13,19 @@ The objective of this section is to guide users in the installation of an enviro
 `Ansible <https://www.ansible.com/resources/get-started>`_ is an open source software that automates software provisioning, configuration management, and application deployment.
 
 
-.. note::
+Requirements
+------------
   
-   Before we get started with Ansible, confirm the following requirements are met:
+Before we get started with Ansible, confirm the following requirements are met:
 
-	-  **Private network DNS**: If you intend to use hostname instead of IP Address for remote endpoints definitions, be sure you have correctly set up your own DNS server and it corresponds to the FQDN of your endpoints, otherwise use your hosts file.
+-  **Private network DNS**: If you intend to use hostname instead of IP Address for remote endpoints definitions, be sure you have correctly set up your own DNS server and it corresponds to the FQDN of your endpoints. Otherwise use your hosts file.
 
-	-  **Firewall open ports**: Ansible can work with any TCP port. By default, it uses TCP/22 port to work with Linux endpoints. Ensure this port is open in endpoints and/or firewalls.
-  
-	-  **Required ports**: You can access the :ref:`Required ports <default_ports>` list to find out which ports are needed to communicate the Wazuh components with external services such as Ansible. 
+-  **Firewall settings**: Ansible can work with any TCP port. By default, it uses TCP/22 port to work with Linux endpoints. Ensure this port is open in endpoints and/or firewalls. In addition, you need to configure ``iptables``, ``firewalld``, ``ufw``, ``Security Groups``, or any other firewall settings.
+
+-  **Required open ports**: You can access the :ref:`Required ports <default_ports>` list to find out which ports are needed to communicate the Wazuh components with external services such as Ansible. 
+
+
+
 
 
 

--- a/source/deployment-options/deploying-with-ansible/installation-guide.rst
+++ b/source/deployment-options/deploying-with-ansible/installation-guide.rst
@@ -20,15 +20,9 @@ Before we get started with Ansible, confirm the following requirements are met:
 
 -  **Private network DNS**: If you intend to use hostname instead of IP Address for remote endpoints definitions, be sure you have correctly set up your DNS server and that it corresponds to the FQDN of your endpoints. Otherwise, use your hosts file.
 
--  **Firewall settings**: Ansible can work with any TCP port. By default, it uses TCP/22 port to work with Linux endpoints. Ensure this port is open in endpoints and/or firewalls. In addition, you need to configure ``iptables``, ``firewalld``, ``ufw``, ``Security Groups``, or any other firewall settings.
+-  **Firewall settings**: Ansible can work with any TCP port. By default, it uses TCP/22 port to work with Linux endpoints. Ensure this port is open in endpoints and/or firewalls. In addition, you need to use and configure ``iptables``, ``firewalld``, ``ufw``, *Security Groups*, or any other firewall settings.
 
--  **Required open ports**: You can access the :ref:`Required ports <default_ports>` list to find out which ports are needed to communicate the Wazuh components with external services such as Ansible. 
-
-
-
-
-
-
+-  **Required open ports**: You can access the :ref:`Required ports <default_ports>` list to find out which ports you need to communicate the Wazuh components with external services such as Ansible. 
 
 .. toctree::
    :maxdepth: 1

--- a/source/deployment-options/deploying-with-ansible/installation-guide.rst
+++ b/source/deployment-options/deploying-with-ansible/installation-guide.rst
@@ -17,9 +17,14 @@ The objective of this section is to guide users in the installation of an enviro
   
    Before we get started with Ansible, confirm the following requirements are met:
 
-	-  Private network DNS: If you intend to use hostname instead of IP Address for remote endpoints definitions, be sure you have correctly set up your own DNS server and it corresponds to the FQDN of your endpoints, otherwise use your hosts file.
+	-  **Private network DNS**: If you intend to use hostname instead of IP Address for remote endpoints definitions, be sure you have correctly set up your own DNS server and it corresponds to the FQDN of your endpoints, otherwise use your hosts file.
 
-	-  Firewall open ports: Ansible can work with any TCP port. By default, it uses TCP/22 port to work with Linux endpoints. Ensure this port is open in endpoints and/or firewalls.
+	-  **Firewall open ports**: Ansible can work with any TCP port. By default, it uses TCP/22 port to work with Linux endpoints. Ensure this port is open in endpoints and/or firewalls.
+  
+	-  **Required ports**: You can access the :ref:`Required ports <default_ports>` list to find out which ports are needed to communicate the Wazuh components with external services such as Ansible. 
+
+
+
 
 .. toctree::
    :maxdepth: 1

--- a/source/deployment-options/deploying-with-ansible/installation-guide.rst
+++ b/source/deployment-options/deploying-with-ansible/installation-guide.rst
@@ -18,7 +18,7 @@ Requirements
   
 Before we get started with Ansible, confirm the following requirements are met:
 
--  **Private network DNS**: If you intend to use hostname instead of IP Address for remote endpoints definitions, be sure you have correctly set up your own DNS server and it corresponds to the FQDN of your endpoints. Otherwise use your hosts file.
+-  **Private network DNS**: If you intend to use hostname instead of IP Address for remote endpoints definitions, be sure you have correctly set up your DNS server and that it corresponds to the FQDN of your endpoints. Otherwise, use your hosts file.
 
 -  **Firewall settings**: Ansible can work with any TCP port. By default, it uses TCP/22 port to work with Linux endpoints. Ensure this port is open in endpoints and/or firewalls. In addition, you need to configure ``iptables``, ``firewalld``, ``ufw``, ``Security Groups``, or any other firewall settings.
 


### PR DESCRIPTION
## Description
This PR aims to add TCP ports warning with Ansible deployment according to issue #5852.
This PR closes issue #5852.

## Tasks
- [x] Add TCP ports warning with Ansible Deployment
- [x] Ask for a review

## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
