### PR TITLE
test.com is a bad security practice

### DIFF
--- a/source/user-manual/api/getting-started.rst
+++ b/source/user-manual/api/getting-started.rst
@@ -805,9 +805,9 @@ You can even dump the manager current configuration with the request below (resp
               "logall": "no",
               "logall_json": "no",
               "email_notification": "yes",
-              "email_to": "me@test.com",
-              "smtp_server": "mail.test.com",
-              "email_from": "wazuh@test.com",
+              "email_to": "me@test.example",
+              "smtp_server": "mail.test.example",
+              "email_from": "wazuh@test.example",
               "email_maxperhour": "12",
               "email_log_source": "alerts.log",
               "white_list": [


### PR DESCRIPTION
as a security plattform also documentation should follow best practices for proper example and test domains and e-mail addreses. Please refer to: https://www.rfc-editor.org/rfc/rfc2606.html and https://www.rfc-editor.org/rfc/rfc6761.html

While I wouldn't recommend example.com/org/net - as people might use other example domains on different top-level domains then too... but this might be owned by someone else... I changed the test.com to test.example domains... 

To safely satisfy these needs, four domain names are reserved as
   listed and described below.

                   .test
                .example
                .invalid
              .localhost

      ".test" is recommended for use in testing of current or new DNS
      related code.

      ".example" is recommended for use in documentation or as examples.

      ".invalid" is intended for use in online construction of domain
      names that are sure to be invalid and which it is obvious at a
      glance are invalid.

      The ".localhost" TLD has traditionally been statically defined in
      host DNS implementations as having an A record pointing to the
      loop back IP address and is reserved for such use.  Any other use
      would conflict with widely deployed code which assumes this use.

3. Reserved Example Second Level Domain Names

   The Internet Assigned Numbers Authority (IANA) also currently has the following second level domain names reserved which can be used as examples.

        example.com
        example.net
        example.org

4. IANA Considerations

   IANA has agreed to the four top level domain name reservations specified in this document and will reserve them for the uses indicated.

5. Security Considerations

   Confusion and conflict can be caused by the use of a current or future top level domain name in experimentation or testing, as an example in documentation, to indicate invalid names, or as a synonym for the loop back address.  Test and experimental software can escape and end up being run against the global operational DNS.  Even examples used "only" in documentation can end up being coded and released or cause conflicts due to later real use and the possible acquisition of intellectual property rights in such "example" names.

   The reservation of several top level domain names for these purposes will minimize such confusion and conflict.

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
<!--
Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->
## Checks
- [ ] Compiles without warnings.
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
