### PR TITLE
Add a symbolic link to the puppetserver binary

### DIFF
--- a/source/deployment-options/deploying-with-puppet/setup-puppet/install-puppet-master.rst
+++ b/source/deployment-options/deploying-with-puppet/setup-puppet/install-puppet-master.rst
@@ -35,7 +35,7 @@ Create a symbolic link between the installed binary file and your default binary
   .. code-block:: console
 
     # ln -s /opt/puppetlabs/bin/puppet /bin
-
+    # ln -s /opt/puppetlabs/server/bin/puppetserver /bin
 
 Installation on Debian/Ubuntu
 -----------------------------


### PR DESCRIPTION
## Description
This PR aims to add a symbolic link to the `puppetserver` binary according to issue #5828.
This PR closes issue #5828.

## Tasks
- [x] Add a symbolic link to the `puppetserver` binary
- [x] Ask for a review

## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
