### PR TITLE
Fixed the `agent.conf` permissions 

### DIFF
--- a/source/user-manual/reference/centralized-configuration.rst
+++ b/source/user-manual/reference/centralized-configuration.rst
@@ -154,7 +154,7 @@ The following is an example of how a centralized configuration can be done.
 
         # touch /var/ossec/etc/shared/default/agent.conf
         # chown wazuh:wazuh /var/ossec/etc/shared/default/agent.conf
-        # chmod 640 /var/ossec/etc/shared/default/agent.conf
+        # chmod 660 /var/ossec/etc/shared/default/agent.conf
 
     Several configurations may be created based on the ``name``, ``OS`` or ``profile`` of an agent.
 


### PR DESCRIPTION
## Description

This PR fixes the `agent.conf` file permissions and closes #5769. 

## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
