### PR TITLE
Update the Single sign-on documentation

### DIFF
--- a/source/user-manual/user-administration/single-sign-on/azure-active-directory.rst
+++ b/source/user-manual/user-administration/single-sign-on/azure-active-directory.rst
@@ -282,7 +282,7 @@ Wazuh dashboard configuration
    .. code-block:: console  
 
       opensearch_security.auth.type: "saml"
-      server.xsrf.whitelist: ["/_plugins/_security/saml/acs", "/_plugins/_security/saml/logout", "/_opendistro/_security/saml/acs", "/_opendistro/_security/saml/logout", "/_opendistro/_security/saml/acs/idpinitiated"]
+      server.xsrf.allowlist: ["/_plugins/_security/saml/acs", "/_plugins/_security/saml/logout", "/_opendistro/_security/saml/acs", "/_opendistro/_security/saml/logout", "/_opendistro/_security/saml/acs/idpinitiated"]
 
    .. note::
       :class: not-long

--- a/source/user-manual/user-administration/single-sign-on/google.rst
+++ b/source/user-manual/user-administration/single-sign-on/google.rst
@@ -249,7 +249,7 @@ Wazuh dashboard configuration
    .. code-block:: console  
 
       opensearch_security.auth.type: "saml"
-      server.xsrf.whitelist: ["/_plugins/_security/saml/acs", "/_plugins/_security/saml/logout", "/_opendistro/_security/saml/acs", "/_opendistro/_security/saml/logout", "/_opendistro/_security/saml/acs/idpinitiated"]
+      server.xsrf.allowlist: ["/_plugins/_security/saml/acs", "/_plugins/_security/saml/logout", "/_opendistro/_security/saml/acs", "/_opendistro/_security/saml/logout", "/_opendistro/_security/saml/acs/idpinitiated"]
 
    .. note::
       :class: not-long

--- a/source/user-manual/user-administration/single-sign-on/jumpcloud.rst
+++ b/source/user-manual/user-administration/single-sign-on/jumpcloud.rst
@@ -250,7 +250,7 @@ Wazuh dashboard configuration
    .. code-block:: console  
 
       opensearch_security.auth.type: "saml"
-      server.xsrf.whitelist: ["/_plugins/_security/saml/acs", "/_plugins/_security/saml/logout", "/_opendistro/_security/saml/acs", "/_opendistro/_security/saml/logout", "/_opendistro/_security/saml/acs/idpinitiated"]
+      server.xsrf.allowlist: ["/_plugins/_security/saml/acs", "/_plugins/_security/saml/logout", "/_opendistro/_security/saml/acs", "/_opendistro/_security/saml/logout", "/_opendistro/_security/saml/acs/idpinitiated"]
 
    .. note::
       :class: not-long

--- a/source/user-manual/user-administration/single-sign-on/keycloak.rst
+++ b/source/user-manual/user-administration/single-sign-on/keycloak.rst
@@ -357,7 +357,7 @@ Wazuh dashboard configuration
    .. code-block:: console  
 
       opensearch_security.auth.type: "saml"
-      server.xsrf.whitelist: ["/_plugins/_security/saml/acs", "/_plugins/_security/saml/logout", "/_opendistro/_security/saml/acs", "/_opendistro/_security/saml/logout", "/_opendistro/_security/saml/acs/idpinitiated"]
+      server.xsrf.allowlist: ["/_plugins/_security/saml/acs", "/_plugins/_security/saml/logout", "/_opendistro/_security/saml/acs", "/_opendistro/_security/saml/logout", "/_opendistro/_security/saml/acs/idpinitiated"]
 
 
    .. note::

--- a/source/user-manual/user-administration/single-sign-on/okta.rst
+++ b/source/user-manual/user-administration/single-sign-on/okta.rst
@@ -283,7 +283,7 @@ Wazuh dashboard configuration
    .. code-block:: console  
 
       opensearch_security.auth.type: "saml"
-      server.xsrf.whitelist: ["/_plugins/_security/saml/acs", "/_plugins/_security/saml/logout", "/_opendistro/_security/saml/acs", "/_opendistro/_security/saml/logout", "/_opendistro/_security/saml/acs/idpinitiated"]
+      server.xsrf.allowlist: ["/_plugins/_security/saml/acs", "/_plugins/_security/saml/logout", "/_opendistro/_security/saml/acs", "/_opendistro/_security/saml/logout", "/_opendistro/_security/saml/acs/idpinitiated"]
 
    .. note::
       :class: not-long

--- a/source/user-manual/user-administration/single-sign-on/onelogin.rst
+++ b/source/user-manual/user-administration/single-sign-on/onelogin.rst
@@ -283,7 +283,7 @@ Wazuh dashboard configuration
    .. code-block:: console  
 
       opensearch_security.auth.type: "saml"
-      server.xsrf.whitelist: ["/_plugins/_security/saml/acs", "/_plugins/_security/saml/logout", "/_opendistro/_security/saml/acs", "/_opendistro/_security/saml/logout", "/_opendistro/_security/saml/acs/idpinitiated"]
+      server.xsrf.allowlist: ["/_plugins/_security/saml/acs", "/_plugins/_security/saml/logout", "/_opendistro/_security/saml/acs", "/_opendistro/_security/saml/logout", "/_opendistro/_security/saml/acs/idpinitiated"]
 
    .. note::
       :class: not-long

--- a/source/user-manual/user-administration/single-sign-on/pingone.rst
+++ b/source/user-manual/user-administration/single-sign-on/pingone.rst
@@ -251,7 +251,7 @@ Wazuh dashboard configuration
    .. code-block:: console  
 
       opensearch_security.auth.type: "saml"
-      server.xsrf.whitelist: ["/_plugins/_security/saml/acs", "/_plugins/_security/saml/logout", "/_opendistro/_security/saml/acs", "/_opendistro/_security/saml/logout", "/_opendistro/_security/saml/acs/idpinitiated"]
+      server.xsrf.allowlist: ["/_plugins/_security/saml/acs", "/_plugins/_security/saml/logout", "/_opendistro/_security/saml/acs", "/_opendistro/_security/saml/logout", "/_opendistro/_security/saml/acs/idpinitiated"]
 
    .. note::
       :class: not-long


### PR DESCRIPTION
## Description

This PR updates the Wazuh v4.4.0 Single sign-on documentation and replaces the deprecated setting `server.xsrf.whitelist` with `server.xsrf.allowlist`.

This change in nomenclature is an OpenSearch 2.0 breaking change: https://opensearch.org/docs/latest/breaking-changes/


## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
