### PR TITLE
Moved remove_from_bucket from wodle to bucket

### DIFF
--- a/source/proof-of-concept-guide/aws-infrastructure-monitoring.rst
+++ b/source/proof-of-concept-guide/aws-infrastructure-monitoring.rst
@@ -52,7 +52,6 @@ Wazuh server
 
       <wodle name="aws-s3">
         <disabled>no</disabled>
-        <remove_from_bucket>no</remove_from_bucket>
         <interval>30m</interval>
         <run_on_start>yes</run_on_start>
         <skip_on_error>no</skip_on_error>

--- a/source/proof-of-concept-guide/aws-infrastructure-monitoring.rst
+++ b/source/proof-of-concept-guide/aws-infrastructure-monitoring.rst
@@ -48,7 +48,7 @@ Wazuh server
 #. Enable the Wazuh AWS module in the ``/var/ossec/etc/ossec.conf`` configuration file on the Wazuh server. Add only the AWS buckets of interest. Read our guide on how to :doc:`Configure AWS credentials </amazon/services/prerequisites/credentials>`:
 
    .. code-block:: xml
-      :emphasize-lines: 9, 10
+      :emphasize-lines: 8, 9
 
       <wodle name="aws-s3">
         <disabled>no</disabled>

--- a/source/user-manual/reference/ossec-conf/wodle-s3.rst
+++ b/source/user-manual/reference/ossec-conf/wodle-s3.rst
@@ -395,7 +395,7 @@ Usage example:
 .. _bucket_remove_from_bucket:
 
 remove_from_bucket
-~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^
 
 A value to determine if each log file is deleted once it has been collected by the module.
 
@@ -675,6 +675,7 @@ Example of configuration
           <aws_account_id>123456789012</aws_account_id>
           <aws_account_alias>dev1-account</aws_account_alias>
           <discard_regex field="data.configurationItemStatus">REJECT</discard_regex>
+          <remove_from_bucket>yes<remove_from_bucket>
       </bucket>
       <bucket type="cloudtrail">
           <name>s3-dev-bucket</name>
@@ -702,6 +703,7 @@ Example of configuration
           <aws_account_id>11112222333</aws_account_id>
           <aws_account_alias>prod-account</aws_account_alias>
           <discard_regex field="data.configurationItemStatus">REJECT</discard_regex>
+          <remove_from_bucket>yes<remove_from_bucket>
       </bucket>
       <service type="cloudwatchlogs">
           <access_key>insert_access_key</access_key>

--- a/source/user-manual/reference/ossec-conf/wodle-s3.rst
+++ b/source/user-manual/reference/ossec-conf/wodle-s3.rst
@@ -132,18 +132,6 @@ Time of the day to run the scan. It has to be in the hh:mm format.
 
     If only the ``time`` option is set, the interval value must be a multiple of days, weeks, or months. By default, the interval is set to a day.
 
-remove_from_bucket
-~~~~~~~~~~~~~~~~~~
-
-Delete each log file from the S3 bucket once it has been collected by the module.
-
-+--------------------+-----------------------+
-| **Default value**  | no                    |
-+--------------------+-----------------------+
-| **Allowed values** | yes, no               |
-+--------------------+-----------------------+
-| **Mandatory**      | no                    |
-+--------------------+-----------------------+
 
 .. _buckets:
 
@@ -191,6 +179,9 @@ The available types are:  ``cloudtrail``, ``guardduty``, ``vpcflow``, ``config``
 | :ref:`bucket_aws_organization_id`      | Name of AWS organization                                    | Optional (only works with CloudTrail buckets) |
 +----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
 | :ref:`bucket_discard_regex`            | A regex value to determine if an event should be discarded  | Optional                                      |
++----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
+| :ref:`bucket_remove_from_bucket`       | A value to determine if each log file is deleted once it    | Optional                                      |
+|                                        | has been collected by the module                            |                                               |
 +----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
 | :ref:`bucket_sts_endpoint`             | The AWS Security Token Service VPC endpoint URL             | Optional                                      |
 +----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
@@ -400,6 +391,19 @@ Usage example:
 .. code-block:: console
 
     <discard_regex field="data.configurationItemStatus">REJECT</discard_regex>
+
+.. _bucket_remove_from_bucket:
+
+remove_from_bucket
+~~~~~~~~~~~~~~~~~~
+
+A value to determine if each log file is deleted once it has been collected by the module.
+
++--------------------+-----------------------+
+| **Default value**  | no                    |
++--------------------+-----------------------+
+| **Allowed values** | yes, no               |
++--------------------+-----------------------+
 
 
 .. _bucket_sts_endpoint:
@@ -658,7 +662,6 @@ Example of configuration
 
   <wodle name="aws-s3">
       <disabled>no</disabled>
-      <remove_from_bucket>no</remove_from_bucket>
       <interval>10m</interval>
       <run_on_start>no</run_on_start>
       <skip_on_error>no</skip_on_error>


### PR DESCRIPTION

|  Related issue  |
|----------------|
| Closes #4921 |


## Description
This PR :

- Removes the option `<remove_from_bucket>` from the aws-s3 wodle configuration
- Removes the use of this option from being used in examples across the documentation
- Adds the option `<remove_from_bucket>` to the aws-s3 bucket configuration

## Checks
- [ ] Compiles without warnings.
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
