### PR TITLE
Update the "Creating and setting a Wazuh admin user" instructions - Cloud service documentation

### DIFF
--- a/source/cloud-service/your-environment/manage-auth.rst
+++ b/source/cloud-service/your-environment/manage-auth.rst
@@ -32,7 +32,7 @@ Follow these steps to create an internal user and map it to its appropriate role
 
 #. :ref:`Log into your WUI <cloud_wui_access>` as administrator.
 
-#. Click the upper-left menu icon to open the options, select **Security**, and then **Internal users** to open the internal users' page.
+#. Click the upper-left menu icon **☰** to open the options, select **Security**, and then **Internal users** to open the internal users' page.
 
 #. Click **Create internal user**, complete the empty fields with the requested information, and click **Create** to complete the action.
 
@@ -61,19 +61,25 @@ Follow these steps to create an internal user, create a new role mapping, and gi
 
 #. :ref:`Log into your WUI <cloud_wui_access>` as administrator.
 
-#. Click the upper-left menu icon to open the options, select **Security**, and then **Internal users** to open the internal users' page.
+#. Click the upper-left menu icon **☰** to open the options, select **Security**, and then **Internal users** to open the internal users' page.
 
 #. Click **Create internal user**, complete the empty fields with the requested information, and click **Create** to complete the action.
 
 #. To map the user to the appropriate role, follow these steps:
 
-   #. Click the upper-left menu icon to open the options, select **Security**, and then **Roles** to open the roles page.
+   #. Click the upper-left menu icon **☰** to open the options, select **Security**, and then **Roles** to open the roles page.
 
    #. Search for the **all_access** role in the roles list and select it to open the details window.
 
+   #. Click **Duplicate role**, assign a name to the new role, then click **Create** to confirm the action.
+
+   #. Select the newly created role. 
+   
    #. Select the **Mapped users** tab and click **Manage mapping**.
    
    #. Add the user you created in the previous steps and click **Map** to confirm the action.
+
+   .. note:: Reserved roles are restricted for any permission customizations. You can create a custom role with the same permissions or duplicate a reserved role for further customization.   
 
 #. To map the user with Wazuh, follow these steps:
    
@@ -95,13 +101,13 @@ Follow these steps to create an internal user, create a new role mapping, and gi
 
 #. :ref:`Log into your WUI <cloud_wui_access>` as administrator.
 
-#. Click the upper-left menu icon to open the options, select **Security**, and then **Internal users** to open the internal users' page.
+#. Click the upper-left menu icon **☰** to open the options, select **Security**, and then **Internal users** to open the internal users' page.
 
 #. Click **Create internal user**, complete the empty fields with the requested information, and click **Create** to complete the action.
 
 #. To map the user to the appropriate role, follow these steps:
 
-   #. Click the upper-left menu icon to open the options, select **Security**, and then **Roles** to open the roles page.
+   #. Click the upper-left menu icon **☰** to open the options, select **Security**, and then **Roles** to open the roles page.
 
    #. Click **Create role**, complete the empty fields with the following parameters, and then click **Create** to complete the task. 
      

--- a/source/cloud-service/your-environment/manage-auth.rst
+++ b/source/cloud-service/your-environment/manage-auth.rst
@@ -69,13 +69,13 @@ Follow these steps to create an internal user, create a new role mapping, and gi
 
    #. Click the upper-left menu icon **☰** to open the options, select **Security**, and then **Roles** to open the roles page.
 
-   #. Search for the **all_access** role in the roles list and select it to open the details window.
+   #. Search for the **all_access** role in the roles list and select it.
 
-   #. Click **Duplicate role**, assign a name to the new role, then click **Create** to confirm the action.
+   #. Click **Actions** and select **Duplicate**.
 
-   #. Select the newly created role. 
-   
-   #. Select the **Mapped users** tab and click **Manage mapping**.
+   #. Assign a name to the new role, then click **Create** to confirm the action.
+
+   #. On the newly created role page, select the **Mapped users** tab and click **Manage mapping**.
    
    #. Add the user you created in the previous steps and click **Map** to confirm the action.
 


### PR DESCRIPTION
## Description

It's no longer possible to map a new user to the default `all_access` role. When trying to do so, an error message appears stating "save error - Forbidden" (see image below). 

This PR  adds instructions to duplicate the `all_access` role and use that new role to map the new admin user.  

It also adds the upper-left menu icon "☰" to help the user navigate through the different Wazuh dashboard menus. 

**Screenshots** 

Error message when trying to map a new user to the default `all_access` role: 

![image](https://user-images.githubusercontent.com/61882981/217565149-9298b8df-ddef-4619-9e28-1baafe970af4.png)

Updated instructions: 

![image](https://user-images.githubusercontent.com/61882981/221145434-8eee90c3-f12b-4aa9-8330-ff55ab7a0481.png)


## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
