### PR TITLE
Fix typo: Integration with external APIs section

### DIFF
--- a/source/user-manual/manager/manual-integration.rst
+++ b/source/user-manual/manager/manual-integration.rst
@@ -101,7 +101,7 @@ This is an example configuration for a custom integration:
     <name>custom-integration</name>
     <hook_url>WEBHOOK</hook_url>
     <level>10</level>
-    <group>multiple_drops|authentication_failures</group>
+    <group>multiple_drops,authentication_failures</group>
     <api_key>APIKEY</api_key> <!-- Replace with your external service API key -->
     <alert_format>json</alert_format>
   </integration>


### PR DESCRIPTION
## Description
This PR aims to fix a typo in the Integration with external APIs section.

## Checks
- [x] Compiles without warnings.
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
