### PR TITLE
Add note to guess group setting

### DIFF
--- a/source/user-manual/reference/internal-options.rst
+++ b/source/user-manual/reference/internal-options.rst
@@ -812,6 +812,9 @@ Remoted
 +-----------------------------------+---------------+--------------------------------------------------------------+
 | **remoted.guess_agent_group**     | Description   | Toggle to enable or disable the guessing of the group to     |
 |                                   |               | which the agent belongs when registering it again.           |
+|                                   |               |                                                              |
+|                                   |               | .. note:: Since version 4.4.0, in a cluster architecture,    |
+|                                   |               |           this setting only applies to the master node.      |
 +                                   +---------------+--------------------------------------------------------------+
 |                                   | Default value | 0                                                            |
 +                                   +---------------+--------------------------------------------------------------+


### PR DESCRIPTION
## Description

After the changes implemented as part of https://github.com/wazuh/wazuh/issues/16114, now the setting `remoted.guess_agent_group` only applies to the master node in a cluster architecture.

## Checks
- [ ] Compiles without warnings.
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
