### PR TITLE
Clarify how to use the `rule_groups` setting in active response 

### DIFF
--- a/source/user-manual/reference/ossec-conf/active-response.rst
+++ b/source/user-manual/reference/ossec-conf/active-response.rst
@@ -127,7 +127,9 @@ Defines the rule group that a rule must belong to one for the command to be exec
 +--------------------+---------------------------------------------------------------------------------------------+
 
 .. note::
-	All groups must end with a comma.
+	
+  If the group name ends with a comma, you can add it to avoid partial matches. This is usually the case in our default ruleset. 
+
 
 rules_id
 ^^^^^^^^

--- a/source/user-manual/reference/ossec-conf/active-response.rst
+++ b/source/user-manual/reference/ossec-conf/active-response.rst
@@ -128,7 +128,7 @@ Defines the rule group that a rule must belong to one for the command to be exec
 
 .. note::
 	
-  If the group name ends with a comma, you can add it to avoid partial matches. This is usually the case in our default ruleset. 
+   If the group name ends with a comma, you can add it to avoid partial matches. This is usually the case in our default ruleset. 
 
 
 rules_id

--- a/source/user-manual/reference/ossec-conf/active-response.rst
+++ b/source/user-manual/reference/ossec-conf/active-response.rst
@@ -118,17 +118,17 @@ Defines a minimum severity level required for the command to be executed.
 rules_group
 ^^^^^^^^^^^
 
-Defines the rule group that a rule must belong to one for the command to be executed.
+Defines the rule group that a rule must belong to for the execution of the command.
 
-+--------------------+---------------------------------------------------------------------------------------------+
-| **Default value**  | n/a                                                                                         |
-+--------------------+---------------------------------------------------------------------------------------------+
-| **Allowed values** | Any rule group is allowed. Multiple groups should be separated with a pipe character (“|”). |
-+--------------------+---------------------------------------------------------------------------------------------+
++--------------------+------------------------------------------------------------------------------------------+
+| **Default value**  | n/a                                                                                      |
++--------------------+------------------------------------------------------------------------------------------+
+| **Allowed values** | Any group string. For multiple groups, separate the strings with a pipe character ``|``. |
++--------------------+------------------------------------------------------------------------------------------+
 
 .. note::
 	
-   If the group name ends with a comma, you can add it to avoid partial matches. This is usually the case in our default ruleset. 
+   Add a comma at the end of the string to avoid considering it a sub-string open for partial matches. For example, the string ``authentication`` matches rule groups ``authentication``, ``authentication_success``, and ``authentication_failure`` while the string ``authentication,`` matches only rule group ``authentication``. 
 
 
 rules_id

--- a/source/user-manual/reference/ossec-conf/active-response.rst
+++ b/source/user-manual/reference/ossec-conf/active-response.rst
@@ -128,7 +128,7 @@ Defines the rule group that a rule must belong to for the execution of the comma
 
 .. note::
 	
-   To avoid partial matches, add a comma at the end of the group string. For example, ``<rules_group>group_a,|group_b,|group_c,</rules_group>`` Also, check that the rule group in your rules definitions ends with a comma, as well. This is usually the case in the Wazuh default ruleset. For example, ``<group>group_b,</group>``.
+   To avoid partial matches, add a comma at the end of the group string. For example, ``<rules_group>group_a,|group_b,|group_c,</rules_group>`` Also, check that the rule group in your rules definitions ends with a comma as well. This is usually the case in the Wazuh default ruleset. For example, ``<group>group_b,</group>``.
    
    Not ending the group string with a comma implies that the group string is a substring open for partial matches.  For example, the group string ``authentication`` matches rule groups ``authentication``, ``authentication_success``, and ``authentication_failure`` while the group string ``authentication,`` matches only rule group ``authentication``.
 

--- a/source/user-manual/reference/ossec-conf/active-response.rst
+++ b/source/user-manual/reference/ossec-conf/active-response.rst
@@ -128,7 +128,9 @@ Defines the rule group that a rule must belong to for the execution of the comma
 
 .. note::
 	
-   To avoid partial matches, add a comma at the end of the group string. For example, ``<rules_group>group_a,|group_b,|group_c,</rules_group>`` Also, check that the rule group in your rules definitions ends with a comma, as well. For example, ``<group>group_b,</group>``. Not ending the group string with a comma implies that the group string is a substring open for partial matches.  For example, the group string ``authentication`` matches rule groups ``authentication``, ``authentication_success``, and ``authentication_failure`` while the group string ``authentication,`` matches only rule group ``authentication``.
+   To avoid partial matches, add a comma at the end of the group string. For example, ``<rules_group>group_a,|group_b,|group_c,</rules_group>`` Also, check that the rule group in your rules definitions ends with a comma, as well. This is usually the case in the Wazuh default ruleset. For example, ``<group>group_b,</group>``.
+   
+   Not ending the group string with a comma implies that the group string is a substring open for partial matches.  For example, the group string ``authentication`` matches rule groups ``authentication``, ``authentication_success``, and ``authentication_failure`` while the group string ``authentication,`` matches only rule group ``authentication``.
 
 rules_id
 ^^^^^^^^

--- a/source/user-manual/reference/ossec-conf/active-response.rst
+++ b/source/user-manual/reference/ossec-conf/active-response.rst
@@ -128,8 +128,7 @@ Defines the rule group that a rule must belong to for the execution of the comma
 
 .. note::
 	
-   Add a comma at the end of the string to avoid considering it a sub-string open for partial matches. For example, the string ``authentication`` matches rule groups ``authentication``, ``authentication_success``, and ``authentication_failure`` while the string ``authentication,`` matches only rule group ``authentication``. 
-
+   To avoid partial matches, add a comma at the end of the group string. For example, ``<rules_group>group_a,|group_b,|group_c,</rules_group>`` Also, check that the rule group in your rules definitions ends with a comma, as well. For example, ``<group>group_b,</group>``. Not ending the group string with a comma implies that the group string is a substring open for partial matches.  For example, the group string ``authentication`` matches rule groups ``authentication``, ``authentication_success``, and ``authentication_failure`` while the group string ``authentication,`` matches only rule group ``authentication``.
 
 rules_id
 ^^^^^^^^

--- a/source/user-manual/reference/ossec-conf/active-response.rst
+++ b/source/user-manual/reference/ossec-conf/active-response.rst
@@ -128,7 +128,7 @@ Defines the rule group that a rule must belong to for the execution of the comma
 
 .. note::
 	
-   To avoid partial matches, add a comma at the end of the group string. For example, ``<rules_group>group_a,|group_b,|group_c,</rules_group>`` Also, check that the rule group in your rules definitions ends with a comma as well. This is usually the case in the Wazuh default ruleset. For example, ``<group>group_b,</group>``.
+   To avoid partial matches, add a comma at the end of the group string. For example, ``<rules_group>group_a,|group_b,|group_c,</rules_group>`` Also, check that the rule group in your rule definitions ends with a comma as well. This is usually the case in the Wazuh default ruleset. For example, ``<group>group_b,</group>``.
    
    Not ending the group string with a comma implies that the group string is a substring open for partial matches.  For example, the group string ``authentication`` matches rule groups ``authentication``, ``authentication_success``, and ``authentication_failure`` while the group string ``authentication,`` matches only rule group ``authentication``.
 


### PR DESCRIPTION
## Description

This PR clarifies the use of commas in the `rule_groups` setting for active response. This PR closes #2705. 

## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
