### PR TITLE
Typo in CA certificate Enviroment Value comand

### DIFF
--- a/source/user-manual/deployment-variables/deployment-variables-linux.rst
+++ b/source/user-manual/deployment-variables/deployment-variables-linux.rst
@@ -93,7 +93,7 @@ Examples:
         .. code-block:: console
         
              # WAZUH_MANAGER="10.0.0.2" WAZUH_REGISTRATION_SERVER="10.0.0.2" WAZUH_REGISTRATION_KEY="/var/ossec/etc/sslagent.key" \
-                  WAZUH_REGISTRATION_CERTIFICATE "/var/ossec/etc/sslagent.cert" yum install wazuh-agent
+                  WAZUH_REGISTRATION_CERTIFICATE="/var/ossec/etc/sslagent.cert" yum install wazuh-agent
         
         .. note:: It’s necessary to use both KEY and PEM options to verify agents' identities with the registration server. See the :ref:`Registration Service with host verification - Agent verification with host validation <enrollment_additional_security>` section.
      

--- a/source/user-manual/deployment-variables/deployment-variables-linux.rst
+++ b/source/user-manual/deployment-variables/deployment-variables-linux.rst
@@ -92,7 +92,7 @@ Examples:
         
         .. code-block:: console
         
-             # WAZUH_MANAGER="10.0.0.2" WAZUH_REGISTRATION_SERVER="10.0.0.2" WAZUH_REGISTRATION_KEY "/var/ossec/etc/sslagent.key" \
+             # WAZUH_MANAGER="10.0.0.2" WAZUH_REGISTRATION_SERVER="10.0.0.2" WAZUH_REGISTRATION_KEY="/var/ossec/etc/sslagent.key" \
                   WAZUH_REGISTRATION_CERTIFICATE "/var/ossec/etc/sslagent.cert" yum install wazuh-agent
         
         .. note:: It’s necessary to use both KEY and PEM options to verify agents' identities with the registration server. See the :ref:`Registration Service with host verification - Agent verification with host validation <enrollment_additional_security>` section.

--- a/source/user-manual/deployment-variables/deployment-variables-linux.rst
+++ b/source/user-manual/deployment-variables/deployment-variables-linux.rst
@@ -140,7 +140,7 @@ Examples:
         
         .. code-block:: console
         
-             # WAZUH_MANAGER="10.0.0.2" WAZUH_REGISTRATION_SERVER="10.0.0.2" WAZUH_REGISTRATION_KEY "/var/ossec/etc/sslagent.key" \
+             # WAZUH_MANAGER="10.0.0.2" WAZUH_REGISTRATION_SERVER="10.0.0.2" WAZUH_REGISTRATION_KEY="/var/ossec/etc/sslagent.key" \
                   WAZUH_REGISTRATION_CERTIFICATE "/var/ossec/etc/sslagent.cert" apt-get install wazuh-agent
         
         .. note:: To verify agents identity with the registration server, it's necessary to use both KEY and PEM options. See the    :ref:`Registration Service with host verification - Agent verification with host validation <enrollment_additional_security>` section.

--- a/source/user-manual/deployment-variables/deployment-variables-linux.rst
+++ b/source/user-manual/deployment-variables/deployment-variables-linux.rst
@@ -92,7 +92,7 @@ Examples:
         
         .. code-block:: console
         
-             # WAZUH_MANAGER "10.0.0.2" WAZUH_REGISTRATION_SERVER "10.0.0.2" WAZUH_REGISTRATION_KEY "/var/ossec/etc/sslagent.key" \
+             # WAZUH_MANAGER="10.0.0.2" WAZUH_REGISTRATION_SERVER="10.0.0.2" WAZUH_REGISTRATION_KEY "/var/ossec/etc/sslagent.key" \
                   WAZUH_REGISTRATION_CERTIFICATE "/var/ossec/etc/sslagent.cert" yum install wazuh-agent
         
         .. note:: It’s necessary to use both KEY and PEM options to verify agents' identities with the registration server. See the :ref:`Registration Service with host verification - Agent verification with host validation <enrollment_additional_security>` section.
@@ -140,7 +140,7 @@ Examples:
         
         .. code-block:: console
         
-             # WAZUH_MANAGER "10.0.0.2" WAZUH_REGISTRATION_SERVER "10.0.0.2" WAZUH_REGISTRATION_KEY "/var/ossec/etc/sslagent.key" \
+             # WAZUH_MANAGER="10.0.0.2" WAZUH_REGISTRATION_SERVER="10.0.0.2" WAZUH_REGISTRATION_KEY "/var/ossec/etc/sslagent.key" \
                   WAZUH_REGISTRATION_CERTIFICATE "/var/ossec/etc/sslagent.cert" apt-get install wazuh-agent
         
         .. note:: To verify agents identity with the registration server, it's necessary to use both KEY and PEM options. See the    :ref:`Registration Service with host verification - Agent verification with host validation <enrollment_additional_security>` section.
@@ -191,7 +191,7 @@ Examples:
         
         .. code-block:: console
         
-             # WAZUH_MANAGER "10.0.0.2" WAZUH_REGISTRATION_SERVER "10.0.0.2" WAZUH_REGISTRATION_KEY "/var/ossec/etc/sslagent.key" \
+             # WAZUH_MANAGER="10.0.0.2" WAZUH_REGISTRATION_SERVER="10.0.0.2" WAZUH_REGISTRATION_KEY "/var/ossec/etc/sslagent.key" \
                   WAZUH_REGISTRATION_CERTIFICATE "/var/ossec/etc/sslagent.cert" zypper install wazuh-agent
         
         .. note:: To verify agents identity with the registration server, it's necessary to use both KEY and PEM options. See the    :ref:`Registration Service with host verification - Agent verification with host validation <enrollment_additional_security>` section.

--- a/source/user-manual/deployment-variables/deployment-variables-linux.rst
+++ b/source/user-manual/deployment-variables/deployment-variables-linux.rst
@@ -191,7 +191,7 @@ Examples:
         
         .. code-block:: console
         
-             # WAZUH_MANAGER="10.0.0.2" WAZUH_REGISTRATION_SERVER="10.0.0.2" WAZUH_REGISTRATION_KEY "/var/ossec/etc/sslagent.key" \
+             # WAZUH_MANAGER="10.0.0.2" WAZUH_REGISTRATION_SERVER="10.0.0.2" WAZUH_REGISTRATION_KEY="/var/ossec/etc/sslagent.key" \
                   WAZUH_REGISTRATION_CERTIFICATE "/var/ossec/etc/sslagent.cert" zypper install wazuh-agent
         
         .. note:: To verify agents identity with the registration server, it's necessary to use both KEY and PEM options. See the    :ref:`Registration Service with host verification - Agent verification with host validation <enrollment_additional_security>` section.

--- a/source/user-manual/deployment-variables/deployment-variables-linux.rst
+++ b/source/user-manual/deployment-variables/deployment-variables-linux.rst
@@ -192,7 +192,7 @@ Examples:
         .. code-block:: console
         
              # WAZUH_MANAGER="10.0.0.2" WAZUH_REGISTRATION_SERVER="10.0.0.2" WAZUH_REGISTRATION_KEY="/var/ossec/etc/sslagent.key" \
-                  WAZUH_REGISTRATION_CERTIFICATE "/var/ossec/etc/sslagent.cert" zypper install wazuh-agent
+                  WAZUH_REGISTRATION_CERTIFICATE="/var/ossec/etc/sslagent.cert" zypper install wazuh-agent
         
         .. note:: To verify agents identity with the registration server, it's necessary to use both KEY and PEM options. See the    :ref:`Registration Service with host verification - Agent verification with host validation <enrollment_additional_security>` section.
 

--- a/source/user-manual/deployment-variables/deployment-variables-linux.rst
+++ b/source/user-manual/deployment-variables/deployment-variables-linux.rst
@@ -141,7 +141,7 @@ Examples:
         .. code-block:: console
         
              # WAZUH_MANAGER="10.0.0.2" WAZUH_REGISTRATION_SERVER="10.0.0.2" WAZUH_REGISTRATION_KEY="/var/ossec/etc/sslagent.key" \
-                  WAZUH_REGISTRATION_CERTIFICATE "/var/ossec/etc/sslagent.cert" apt-get install wazuh-agent
+                  WAZUH_REGISTRATION_CERTIFICATE="/var/ossec/etc/sslagent.cert" apt-get install wazuh-agent
         
         .. note:: To verify agents identity with the registration server, it's necessary to use both KEY and PEM options. See the    :ref:`Registration Service with host verification - Agent verification with host validation <enrollment_additional_security>` section.
      


### PR DESCRIPTION
Added missing '=' sign to the command for installing the wazuh agent using env vars. It was missing for apt yum and zypper. This was it is in line with the other commands.

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
<!--
Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->
## Checks
- [X] Compiles without warnings.
- [X] Uses present tense, active voice, and semi-formal registry.
- [X] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [X] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
