### PR TITLE
Update securing-api.rst

### DIFF
--- a/source/user-manual/api/securing-api.rst
+++ b/source/user-manual/api/securing-api.rst
@@ -8,7 +8,7 @@
 Securing the Wazuh API
 ======================
 
-The communication between the Wazuh UI and the Wazuh API is encrypted with HTTPS by default, which means that if the users do not provide their own private key and certificate then the Wazuh API will generate its own during the first run. Additionally, the Wazuh API users ``wazuh`` and ``wazuh-wui`` are created by default, with ``wazuh`` and ``wazuh-wui`` as their passwords, respectively. Because of that, it is very important to secure the Wazuh API once the Wazuh Manager has been installed.
+The communication between the Wazuh UI and the Wazuh API is encrypted with HTTPS by default, which means that if the users do not provide their own private key and certificate then the Wazuh API will generate its own during the first run. Additionally, the Wazuh API user ``wazuh`` is created by default, with a unique enrollment password created at install time. This password can be found in the Dashboard config file, whose default location is at ```/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml``, under the "hosts" section. It is very important to secure the Wazuh API once the Wazuh Manager has been installed.
 
 .. warning::
   It is highly recommended to change the default passwords and to use your own certificate since the one created by the Wazuh API is self-signed.
@@ -44,7 +44,7 @@ Recommended changes to secure the Wazuh API
 
       .. include:: /_templates/common/restart_manager.rst
 
-#. Change the default password of the admin users (**wazuh** and **wazuh-wui**): 
+#. Change the default password of the admin users: 
 
     The default password can be changed using the following Wazuh API request: :api-ref:`PUT /security/users/{user_id} <operation/api.controllers.security_controller.update_user>`
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
The current securing-api documentation states that the Wazuh API will be initialized with a default password of "wazuh-wui". This is no longer the case, as Wazuh now creates a unique enrollment password for the API user. I have proposed a change to this page to reflect this change, which will prevent users entering incorrect API credentials for their first use of the API, as well as give them information on where to find their enrollment password so that they can successfully access the API.
## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
