### PR TITLE
Add new setting queue_size inside whodata configuration block

### DIFF
--- a/source/user-manual/reference/ossec-conf/syscheck.rst
+++ b/source/user-manual/reference/ossec-conf/syscheck.rst
@@ -1014,7 +1014,7 @@ Allows disabling the Audit health check during the Whodata engine starting. This
 
 **queue_size**
 
-Sets the maximum capacity of the queue that stores the audit dispatcher events. **Linux systems with Audit**.
+Sets the maximum capacity of the queue that stores the audit dispatcher events. This option applies to **Linux systems with Audit**.
 
 +--------------------+---------------------------------+
 | **Default value**  | 16384                           |
@@ -1022,7 +1022,7 @@ Sets the maximum capacity of the queue that stores the audit dispatcher events. 
 | **Allowed values** | Any number from 10 to 1048576   |
 +--------------------+---------------------------------+
 
-.. warning:: If the queue becomes full, some audit events may be lost. However, the next scheduled scan will generate the missing alerts, without the audit information.
+.. warning:: If the queue fills up, some audit events may be lost. However, the next scheduled scan will generate the missing alerts without the audit information.
 
 For more information, please read :ref:`auditing who-data <who-data-monitoring>`
 

--- a/source/user-manual/reference/ossec-conf/syscheck.rst
+++ b/source/user-manual/reference/ossec-conf/syscheck.rst
@@ -969,6 +969,7 @@ The Whodata options will be configured inside this tag.
         <restart_audit>yes</restart_audit>
         <audit_key>auditkey1,auditkey2</audit_key>
         <startup_healthcheck>yes</startup_healthcheck>
+        <queue_size>100000</queue_size>
     </whodata>
 
 
@@ -1009,6 +1010,19 @@ Allows disabling the Audit health check during the Whodata engine starting. This
 +--------------------+------------+
 
 .. warning:: The health check ensures that the rules required by Whodata can be set in Audit correctly and also that the generated events can be obtained. Disabling the health check may cause functioning problems in Whodata and loss of FIM events.
+
+
+**queue_size**
+
+Sets the maximum capacity of the queue that stores the audit dispatcher events. **Linux systems with Audit**.
+
++--------------------+---------------------------------+
+| **Default value**  | 16384                           |
++--------------------+---------------------------------+
+| **Allowed values** | Any number from 10 to 1048576   |
++--------------------+---------------------------------+
+
+.. warning:: If the queue becomes full, some audit events may be lost. However, the next scheduled scan will generate the missing alerts, without the audit information.
 
 For more information, please read :ref:`auditing who-data <who-data-monitoring>`
 


### PR DESCRIPTION

## Description
This PR is to add the new setting queue_size inside the whodata configuration block, syscheck.

## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
