### PR TITLE
Update "Custom rules and decoders" documentation

### DIFF
--- a/source/user-manual/ruleset/custom.rst
+++ b/source/user-manual/ruleset/custom.rst
@@ -12,67 +12,77 @@ It is possible to modify the default rules and decoders from the Wazuh Ruleset a
 
 Adding new decoders and rules
 -------------------------------
-.. note::
-   We will use ``local_decoder.xml`` and ``local_rules.xml`` to implement small changes. For larger scale changes/additions to the stock decoders and rules, we recommend you create a new decoder and/or rule file.
 
 .. note::
-  The ``<id>`` of custom rules will be in the range from 100000 to 120000.
+   
+   The ``<id>`` of custom rules will be in the range from 100000 to 120000.
+
+   Use ``local_decoder.xml`` and ``local_rules.xml`` to implement small changes. For larger scale changes, we recommend creating new decoder and rule files.
+
 
 We are going to describe these procedures using an easy example. Here is a log from a program called ``example``:
-::
 
-   Dec 25 20:45:02 MyHost example[12345]: User 'admin' logged from '192.168.1.100'
+   .. code-block:: 
 
-First, we need to decode this information, so we add the new decoder to ``/var/ossec/etc/decoders/local_decoder.xml``:
-::
+      Dec 25 20:45:02 MyHost example[12345]: User 'admin' logged from '192.168.1.100'
 
-  <decoder name="example">
-    <program_name>^example</program_name>
-  </decoder>
+#. To decode this information, add the new decoder to ``/var/ossec/etc/decoders/local_decoder.xml``:
 
-  <decoder name="example">
-    <parent>example</parent>
-    <regex>User '(\w+)' logged from '(\d+.\d+.\d+.\d+)'</regex>
-    <order>user, srcip</order>
-  </decoder>
+   .. code-block:: xml
 
+      <decoder name="example">
+        <program_name>^example</program_name>
+      </decoder>
 
-Now, we will add the following rule to ``/var/ossec/etc/rules/local_rules.xml``:
-::
-
-  <rule id="100010" level="0">
-    <program_name>example</program_name>
-    <description>User logged</description>
-  </rule>
+      <decoder name="example">
+        <parent>example</parent>
+        <regex>User '(\w+)' logged from '(\d+.\d+.\d+.\d+)'</regex>
+        <order>user, srcip</order>
+      </decoder>
 
 
-We can check if it works by using ``/var/ossec/bin/wazuh-logtest``:
+#. Add the following rule to ``/var/ossec/etc/rules/local_rules.xml``:
 
-.. code-block:: none
-  :class: output
+   .. code-block:: xml
 
-  Type one log per line
+      <rule id="100010" level="0">
+        <program_name>example</program_name>
+        <description>User logged</description>
+      </rule>
 
-  Dec 25 20:45:02 MyHost example[12345]: User 'admin' logged from '192.168.1.100'
 
-  **Phase 1: Completed pre-decoding.
-          full event: 'Dec 25 20:45:02 MyHost example[12345]: User 'admin' logged from '192.168.1.100''
-          timestamp: 'Dec 25 20:45:02'
-          hostname: 'MyHost'
-          program_name: 'example'
+#. Check if it works by using ``/var/ossec/bin/wazuh-logtest``:
 
-  **Phase 2: Completed decoding.
-          name: 'example'
-          dstuser: 'admin'
-          srcip: '192.168.1.100'
+   .. code-block:: none
+     :class: output
+        
 
-  **Phase 3: Completed filtering (rules).
-          id: '100010'
-          level: '0'
-          description: 'User logged'
-          groups: '['local', 'syslog', 'sshd']'
-          firedtimes: '1'
-          mail: 'False'
+      Type one log per line
+
+      Dec 25 20:45:02 MyHost example[12345]: User 'admin' logged from '192.168.1.100'
+
+      **Phase 1: Completed pre-decoding.
+              full event: 'Dec 25 20:45:02 MyHost example[12345]: User 'admin' logged from '192.168.1.100''
+              timestamp: 'Dec 25 20:45:02'
+              hostname: 'MyHost'
+              program_name: 'example'
+
+      **Phase 2: Completed decoding.
+              name: 'example'
+              dstuser: 'admin'
+              srcip: '192.168.1.100'
+
+      **Phase 3: Completed filtering (rules).
+              id: '100010'
+              level: '0'
+              description: 'User logged'
+              groups: '['local', 'syslog', 'sshd']'
+              firedtimes: '1'
+              mail: 'False'
+
+#. Restart the Wazuh manager: 
+
+      .. include:: /_templates/installations/manager/restart_wazuh_manager.rst
 
 Changing an existing rule
 ---------------------------
@@ -84,11 +94,11 @@ You can modify the standard rules.
 
 If we want to change the level value of the SSH rule ``5710`` from 5 to 10, we will do the following:
 
-1. Open the rule file ``/var/ossec/ruleset/rules/0095-sshd_rules.xml``.
+#. Open the rule file ``/var/ossec/ruleset/rules/0095-sshd_rules.xml``.
 
-2. Find and copy the following code from the rule file:
+#. Find and copy the following code from the rule file:
 
-    ::
+   .. code-block:: xml
 
       <rule id="5710" level="5">
         <if_sid>5700</if_sid>
@@ -100,9 +110,9 @@ If we want to change the level value of the SSH rule ``5710`` from 5 to 10, we w
         <group>invalid_login,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_10.6.1,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_AU.6,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
       </rule>
 
-3. Paste the code into ``/var/ossec/etc/rules/local_rules.xml``, modify the level value, and add ``overwrite="yes"`` to indicate that this rule is overwriting an already defined rule:
+#. Paste the code into ``/var/ossec/etc/rules/local_rules.xml``, modify the level value, and add ``overwrite="yes"`` to indicate that this rule is overwriting an already defined rule:
 
-    ::
+   .. code-block:: xml
 
       <rule id="5710" level="10" overwrite="yes">
         <if_sid>5700</if_sid>
@@ -114,9 +124,12 @@ If we want to change the level value of the SSH rule ``5710`` from 5 to 10, we w
         <group>invalid_login,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_10.6.1,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_AU.6,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
       </rule>
 
-.. warning::
-    To maintain consistency between loaded rules, currently it is not possible to overwrite the ``if_sid``, ``if_group``, ``if_level``, ``if_matched_sid``, and ``if_matched_group`` labels. These tags are ignored when they are in an overwrite rule, keeping the original values.
+   .. warning::
+      To maintain consistency between loaded rules, currently it is not possible to overwrite the ``if_sid``, ``if_group``, ``if_level``, ``if_matched_sid``, and ``if_matched_group`` labels. These tags are ignored when they are in an overwrite rule, keeping the original values.
 
+#. Restart the Wazuh manager: 
+
+   .. include:: /_templates/installations/manager/restart_wazuh_manager.rst
 
 Changing an existing decoder
 -----------------------------
@@ -130,11 +143,11 @@ Unfortunately, there is no facility for overwriting decoders in the way describe
 
 If we want to change something in the decoder file ``0310-ssh_decoders.xml``, we will do the following:
 
-1. Copy the decoder file ``/var/ossec/ruleset/decoders/0310-ssh_decoders.xml`` from the default folder to the user folder ``/var/ossec/etc/decoders`` in order to keep the changes.
+#. Copy the decoder file ``/var/ossec/ruleset/decoders/0310-ssh_decoders.xml`` from the default folder to the user folder ``/var/ossec/etc/decoders`` in order to keep the changes.
 
-2. Exclude the original decoder file ``ruleset/decoders/0310-ssh_decoders.xml`` from the OSSEC loading list. To do this, use the tag ``<decoder_exclude>`` in the ``ossec.conf`` file. Thus, the specified decoder will not be loaded from the default decoder folder, and the decoder file saved in the user folder will be loaded instead.
-
-    ::
+#. Exclude the original decoder file ``ruleset/decoders/0310-ssh_decoders.xml`` from the OSSEC loading list. To do this, use the tag ``<decoder_exclude>`` in the ``ossec.conf`` file. Thus, the specified decoder will not be loaded from the default decoder folder, and the decoder file saved in the user folder will be loaded instead.
+ 
+   .. code-block:: xml
 
       <ruleset>
         <!-- Default ruleset -->
@@ -150,7 +163,11 @@ If we want to change something in the decoder file ``0310-ssh_decoders.xml``, we
       </ruleset>
 
 
-3. Perform the changes in the file ``/var/ossec/etc/decoders/0310-ssh_decoders.xml``.
+#. Perform the changes in the file ``/var/ossec/etc/decoders/0310-ssh_decoders.xml``.
 
-    .. warning::
-        Note that at this point, if updates to the public Wazuh Ruleset include changes to 0310-ssh_decoders.xml, they will not apply to you since you are no longer loading that decoder file from the standard location that gets updates.  At some point, you may have to manually migrate your customized material from 0310-ssh_decoders.xml to a newer copy of that file.  Consider internally documenting your changes in 0310-ssh_decoders.xml so that they are easy to find if they have to be migrated later.
+#. Restart the Wazuh manager: 
+
+   .. include:: /_templates/installations/manager/restart_wazuh_manager.rst
+
+   .. warning::
+      Note that at this point, if updates to the public Wazuh Ruleset include changes to ``0310-ssh_decoders.xml``, they will not apply to you since you are no longer loading that decoder file from the standard location that gets updates.  At some point, you may have to manually migrate your customized material from 0310-ssh_decoders.xml to a newer copy of that file.  Consider internally documenting your changes in 0310-ssh_decoders.xml so that they are easy to find if they have to be migrated later.

--- a/source/user-manual/ruleset/custom.rst
+++ b/source/user-manual/ruleset/custom.rst
@@ -8,25 +8,23 @@
 Custom rules and decoders
 ===========================
 
-It is possible to modify the default rules and decoders from the Wazuh Ruleset and also to add new ones in order to increase Wazuh's detection capabilities.
+It's possible to modify the default rules and decoders from the Wazuh ruleset and also to add new ones in order to increase Wazuh detection capabilities.
 
 Adding new decoders and rules
 -------------------------------
 
-.. note::
-   
-   The ``<id>`` of custom rules will be in the range from 100000 to 120000.
+.. note:: Use ID numbers between 100000 and 120000 for custom rules. 
 
-   Use ``local_decoder.xml`` and ``local_rules.xml`` to implement small changes. For larger scale changes, we recommend creating new decoder and rule files.
+.. note:: To make minor adjustments, use the ``local_decoder.xml`` and ``local_rules.xml`` files. We recommend creating new decoder and rule files for changes on a larger scale.
 
 
-We are going to describe these procedures using an easy example. Here is a log from a program called ``example``:
+Check out this example of how to create new decoders and rules. Here's a log from a program called ``example``:
 
    .. code-block:: 
 
       Dec 25 20:45:02 MyHost example[12345]: User 'admin' logged from '192.168.1.100'
 
-#. To decode this information, add the new decoder to ``/var/ossec/etc/decoders/local_decoder.xml``:
+#. Add a new decoder to ``/var/ossec/etc/decoders/local_decoder.xml`` to decode the log information:
 
    .. code-block:: xml
 
@@ -80,6 +78,9 @@ We are going to describe these procedures using an easy example. Here is a log f
               firedtimes: '1'
               mail: 'False'
 
+
+   For testing purposes, ``wazuh-logtest`` takes recent changes in the decoders and rules into account. However, to load them into the event processing pipeline, it's necessary to restart the Wazuh manager.
+
 #. Restart the Wazuh manager: 
 
       .. include:: /_templates/installations/manager/restart_wazuh_manager.rst
@@ -87,12 +88,10 @@ We are going to describe these procedures using an easy example. Here is a log f
 Changing an existing rule
 ---------------------------
 
-You can modify the standard rules.
-
 .. warning::
     Changes to any rule file inside the ``/var/ossec/ruleset/rules`` folder will be lost in the update process. Use the following procedure to preserve your changes.
 
-If we want to change the level value of the SSH rule ``5710`` from 5 to 10, we will do the following:
+You can modify the standard rules. Here's an example of to change the level value of the SSH rule ``5710`` from 5 to 10.
 
 #. Open the rule file ``/var/ossec/ruleset/rules/0095-sshd_rules.xml``.
 
@@ -113,6 +112,7 @@ If we want to change the level value of the SSH rule ``5710`` from 5 to 10, we w
 #. Paste the code into ``/var/ossec/etc/rules/local_rules.xml``, modify the level value, and add ``overwrite="yes"`` to indicate that this rule is overwriting an already defined rule:
 
    .. code-block:: xml
+      :emphasize-lines: 1
 
       <rule id="5710" level="10" overwrite="yes">
         <if_sid>5700</if_sid>
@@ -134,20 +134,19 @@ If we want to change the level value of the SSH rule ``5710`` from 5 to 10, we w
 Changing an existing decoder
 -----------------------------
 
-You can also modify the standard decoders.
-
 .. warning::
     Changes in any decoder file in the ``/var/ossec/ruleset/decoders`` folder will be lost in the update process. Use the following procedure to preserve your changes.
 
-Unfortunately, there is no facility for overwriting decoders in the way described in the rules above. However, we can perform changes in any decoder file as follows:
+Unfortunately, it's not possible to overwrite decoders in the manner described in the rules above. To modify the standard decoders, follow the process described below. 
 
-If we want to change something in the decoder file ``0310-ssh_decoders.xml``, we will do the following:
+If you want to customize the decoder file ``0310-ssh_decoders.xml``, do the following:
 
 #. Copy the decoder file ``/var/ossec/ruleset/decoders/0310-ssh_decoders.xml`` from the default folder to the user folder ``/var/ossec/etc/decoders`` in order to keep the changes.
 
-#. Exclude the original decoder file ``ruleset/decoders/0310-ssh_decoders.xml`` from the OSSEC loading list. To do this, use the tag ``<decoder_exclude>`` in the ``ossec.conf`` file. Thus, the specified decoder will not be loaded from the default decoder folder, and the decoder file saved in the user folder will be loaded instead.
+#. Exclude the original decoder file ``ruleset/decoders/0310-ssh_decoders.xml`` from the loading list. To do this, use the tag ``<decoder_exclude>`` in the ``/var/ossec/etc/ossec.conf`` file. Thus, the specified decoder will not be loaded from the default decoder folder, and the decoder file saved in the user folder will be loaded instead.
  
    .. code-block:: xml
+      :emphasize-lines: 11 
 
       <ruleset>
         <!-- Default ruleset -->
@@ -170,4 +169,4 @@ If we want to change something in the decoder file ``0310-ssh_decoders.xml``, we
    .. include:: /_templates/installations/manager/restart_wazuh_manager.rst
 
    .. warning::
-      Note that at this point, if updates to the public Wazuh Ruleset include changes to ``0310-ssh_decoders.xml``, they will not apply to you since you are no longer loading that decoder file from the standard location that gets updates.  At some point, you may have to manually migrate your customized material from 0310-ssh_decoders.xml to a newer copy of that file.  Consider internally documenting your changes in 0310-ssh_decoders.xml so that they are easy to find if they have to be migrated later.
+      Note that at this point, if updates to the public Wazuh ruleset include changes to ``0310-ssh_decoders.xml``, they will not apply to you since you are no longer loading that decoder file from the standard location that gets updates.  At some point, you may have to manually migrate your customized material from ``0310-ssh_decoders.xml`` to a newer copy of that file.  Consider internally documenting your changes in ``0310-ssh_decoders.xml`` so that they are easy to find if they have to be migrated later.

--- a/source/user-manual/ruleset/custom.rst
+++ b/source/user-manual/ruleset/custom.rst
@@ -175,4 +175,4 @@ For example, if you want to customize decoders in the ``0310-ssh_decoders.xml`` 
    .. include:: /_templates/installations/manager/restart_wazuh_manager.rst
 
    .. warning::
-      Note that at this point, if updates to the public Wazuh ruleset include changes to ``0310-ssh_decoders.xml``, they will not apply to you since you are no longer loading that decoder file from the standard location that gets updates.  At some point, you may have to manually migrate your customized material from ``0310-ssh_decoders.xml`` to a newer copy of that file.  Consider internally documenting your changes in ``0310-ssh_decoders.xml`` so that they are easy to find if they have to be migrated later.
+      Since you're excluding the original decoder file, you don't benefit from  any updates it might get.  Your custom file remains unchanged during upgrades so consider applying relevant changes manually. 

--- a/source/user-manual/ruleset/custom.rst
+++ b/source/user-manual/ruleset/custom.rst
@@ -8,7 +8,12 @@
 Custom rules and decoders
 ===========================
 
-It's possible to modify the default rules and decoders from the Wazuh ruleset and also to add new ones in order to increase Wazuh detection capabilities.
+Customize the Wazuh ruleset to fit your needs and enhance detection capabilities. To achieve this, you can:
+
+- Modify the default rules and decoders. 
+- Add new custom rules and decoders.  
+
+Find detailed instructions and examples of how to customize the ruleset in the sections below. 
 
 Adding new decoders and rules
 -------------------------------
@@ -79,9 +84,9 @@ Check out this example of how to create new decoders and rules. Here's a log fro
               mail: 'False'
 
 
-   For testing purposes, ``wazuh-logtest`` takes recent changes in the decoders and rules into account. However, to load them into the event processing pipeline, it's necessary to restart the Wazuh manager.
+   To test your rules and decoders using ``wazuh-logtest``, it's enough to save the changes. However, you need to restart the Wazuh manager to generate alerts based on these changes.  
 
-#. Restart the Wazuh manager: 
+#. Restart the Wazuh manager to load the updated rules and decoders:
 
       .. include:: /_templates/installations/manager/restart_wazuh_manager.rst
 
@@ -91,7 +96,9 @@ Changing an existing rule
 .. warning::
     Changes to any rule file inside the ``/var/ossec/ruleset/rules`` folder will be lost in the update process. Use the following procedure to preserve your changes.
 
-You can modify the standard rules. Here's an example of to change the level value of the SSH rule ``5710`` from 5 to 10.
+You can change the default Wazuh rules. To do so, we recommend copying the rules to a file in the ``/var/ossec/etc/rules/`` directory, making the necessary changes, and adding the ``overwrite="yes"`` tag to the modified rules. These steps guarantee that your changes won't be lost during updates.
+
+Here's an example of to change the level value of the SSH rule ``5710`` from 5 to 10.
 
 #. Open the rule file ``/var/ossec/ruleset/rules/0095-sshd_rules.xml``.
 
@@ -125,9 +132,9 @@ You can modify the standard rules. Here's an example of to change the level valu
       </rule>
 
    .. warning::
-      To maintain consistency between loaded rules, currently it is not possible to overwrite the ``if_sid``, ``if_group``, ``if_level``, ``if_matched_sid``, and ``if_matched_group`` labels. These tags are ignored when they are in an overwrite rule, keeping the original values.
+      To maintain consistency between loaded rules, currently it's not possible to overwrite the ``if_sid``, ``if_group``, ``if_level``, ``if_matched_sid``, and ``if_matched_group`` labels. These tags are ignored when they are in an overwrite rule, keeping the original values.
 
-#. Restart the Wazuh manager: 
+#. Restart the Wazuh manager to load the updated rules:
 
    .. include:: /_templates/installations/manager/restart_wazuh_manager.rst
 
@@ -137,13 +144,14 @@ Changing an existing decoder
 .. warning::
     Changes in any decoder file in the ``/var/ossec/ruleset/decoders`` folder will be lost in the update process. Use the following procedure to preserve your changes.
 
-Unfortunately, it's not possible to overwrite decoders in the manner described in the rules above. To modify the standard decoders, follow the process described below. 
 
-If you want to customize the decoder file ``0310-ssh_decoders.xml``, do the following:
+To change a default decoder, you can rewrite its file in the ``/var/ossec/etc/decoders`` directory, make the changes, and exclude the original decoder file from the loading list. 
+
+If you want to customize the decoder file ``0310-ssh_decoders.xml``, follow these steps: 
 
 #. Copy the decoder file ``/var/ossec/ruleset/decoders/0310-ssh_decoders.xml`` from the default folder to the user folder ``/var/ossec/etc/decoders`` in order to keep the changes.
 
-#. Exclude the original decoder file ``ruleset/decoders/0310-ssh_decoders.xml`` from the loading list. To do this, use the tag ``<decoder_exclude>`` in the ``/var/ossec/etc/ossec.conf`` file. Thus, the specified decoder will not be loaded from the default decoder folder, and the decoder file saved in the user folder will be loaded instead.
+#. Use the ``<decoder_exclude>`` tag  in the ``/var/ossec/etc/ossec.conf`` configuration file to exclude the original decoder file ``ruleset/decoders/0310-ssh_decoders.xml`` from the loading list. Thus, the specified decoder will not be loaded from the default decoder folder, and the decoder file saved in the user folder will be loaded instead.
  
    .. code-block:: xml
       :emphasize-lines: 11 
@@ -164,7 +172,7 @@ If you want to customize the decoder file ``0310-ssh_decoders.xml``, do the foll
 
 #. Perform the changes in the file ``/var/ossec/etc/decoders/0310-ssh_decoders.xml``.
 
-#. Restart the Wazuh manager: 
+#. Restart the Wazuh manager so the changes take effect:
 
    .. include:: /_templates/installations/manager/restart_wazuh_manager.rst
 

--- a/source/user-manual/ruleset/custom.rst
+++ b/source/user-manual/ruleset/custom.rst
@@ -13,7 +13,7 @@ Customize the Wazuh ruleset to fit your needs and enhance detection capabilities
 - Modify the default rules and decoders. 
 - Add new custom rules and decoders.  
 
-Find detailed instructions and examples of how to customize the ruleset in the sections below. 
+Find detailed instructions and examples on how to customize the ruleset in the sections below. 
 
 Adding new decoders and rules
 -------------------------------
@@ -23,7 +23,7 @@ Adding new decoders and rules
 .. note:: To make minor adjustments, use the ``local_decoder.xml`` and ``local_rules.xml`` files. We recommend creating new decoder and rule files for changes on a larger scale.
 
 
-Check out this example of how to create new decoders and rules. Here's a log from a program called ``example``:
+Check out this example on how to create new decoders and rules. The following log corresponds to a program called ``example``:
 
    .. code-block:: 
 
@@ -96,7 +96,7 @@ Changing an existing rule
 
 You can change the default Wazuh rules. To do so, we recommend copying the rules to a file in the ``/var/ossec/etc/rules/`` directory, making the necessary changes, and adding the ``overwrite="yes"`` tag to the modified rules. These steps guarantee that your changes won't be lost during updates.
 
-Here's an example of to change the level value of the SSH rule ``5710`` from 5 to 10.
+Here's an example on how to change the level value of the SSH rule ``5710`` from 5 to 10.
 
 #. Open the rule file ``/var/ossec/ruleset/rules/0095-sshd_rules.xml``.
 

--- a/source/user-manual/ruleset/custom.rst
+++ b/source/user-manual/ruleset/custom.rst
@@ -54,11 +54,9 @@ Check out this example of how to create new decoders and rules. Here's a log fro
       </rule>
 
 
-#. Check if it works by using ``/var/ossec/bin/wazuh-logtest``:
+#. Run ``/var/ossec/bin/wazuh-logtest``. Input the example log above to test the decoder and rule:
 
    .. code-block:: none
-     :class: output
-        
 
       Type one log per line
 
@@ -84,7 +82,7 @@ Check out this example of how to create new decoders and rules. Here's a log fro
               mail: 'False'
 
 
-   To test your rules and decoders using ``wazuh-logtest``, it's enough to save the changes. However, you need to restart the Wazuh manager to generate alerts based on these changes.  
+   To test your rules and decoders using ``wazuh-logtest``, it's enough to save the changes made to the decoder and rule files. However, you need to restart the Wazuh manager to generate alerts based on these changes.  
 
 #. Restart the Wazuh manager to load the updated rules and decoders:
 
@@ -94,7 +92,7 @@ Changing an existing rule
 ---------------------------
 
 .. warning::
-    Changes to any rule file inside the ``/var/ossec/ruleset/rules`` folder will be lost in the update process. Use the following procedure to preserve your changes.
+    Changes to any rule file inside the ``/var/ossec/ruleset/rules`` folder are lost in the update process. Use the following procedure to preserve your changes.
 
 You can change the default Wazuh rules. To do so, we recommend copying the rules to a file in the ``/var/ossec/etc/rules/`` directory, making the necessary changes, and adding the ``overwrite="yes"`` tag to the modified rules. These steps guarantee that your changes won't be lost during updates.
 
@@ -102,7 +100,7 @@ Here's an example of to change the level value of the SSH rule ``5710`` from 5 t
 
 #. Open the rule file ``/var/ossec/ruleset/rules/0095-sshd_rules.xml``.
 
-#. Find and copy the following code from the rule file:
+#. Find and copy the rule definition for rule id ``5710``:
 
    .. code-block:: xml
 
@@ -116,7 +114,7 @@ Here's an example of to change the level value of the SSH rule ``5710`` from 5 t
         <group>invalid_login,authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,pci_dss_10.6.1,gpg13_7.1,gdpr_IV_35.7.d,gdpr_IV_32.2,hipaa_164.312.b,nist_800_53_AU.14,nist_800_53_AC.7,nist_800_53_AU.6,tsc_CC6.1,tsc_CC6.8,tsc_CC7.2,tsc_CC7.3,</group>
       </rule>
 
-#. Paste the code into ``/var/ossec/etc/rules/local_rules.xml``, modify the level value, and add ``overwrite="yes"`` to indicate that this rule is overwriting an already defined rule:
+#. Paste the copied rule definition into ``/var/ossec/etc/rules/local_rules.xml``. Modify the level value, and add ``overwrite="yes"`` to indicate that this rule is overwriting an already defined rule:
 
    .. code-block:: xml
       :emphasize-lines: 1
@@ -142,16 +140,16 @@ Changing an existing decoder
 -----------------------------
 
 .. warning::
-    Changes in any decoder file in the ``/var/ossec/ruleset/decoders`` folder will be lost in the update process. Use the following procedure to preserve your changes.
+    Changes in any decoder file in the ``/var/ossec/ruleset/decoders`` folder are lost in the update process. Use the following procedure to preserve your changes.
 
 
 To change a default decoder, you can rewrite its file in the ``/var/ossec/etc/decoders`` directory, make the changes, and exclude the original decoder file from the loading list. 
 
-If you want to customize the decoder file ``0310-ssh_decoders.xml``, follow these steps: 
+For example, if you want to customize decoders in the ``0310-ssh_decoders.xml`` file, follow these steps: 
 
-#. Copy the decoder file ``/var/ossec/ruleset/decoders/0310-ssh_decoders.xml`` from the default folder to the user folder ``/var/ossec/etc/decoders`` in order to keep the changes.
+#. Copy the decoder file ``/var/ossec/ruleset/decoders/0310-ssh_decoders.xml`` to the user folder ``/var/ossec/etc/decoders``. This keeps the changes you make when updating to a newer version.
 
-#. Use the ``<decoder_exclude>`` tag  in the ``/var/ossec/etc/ossec.conf`` configuration file to exclude the original decoder file ``ruleset/decoders/0310-ssh_decoders.xml`` from the loading list. Thus, the specified decoder will not be loaded from the default decoder folder, and the decoder file saved in the user folder will be loaded instead.
+#. Edit the ``/var/ossec/etc/ossec.conf`` configuration file. Set the ``<decoder_exclude>`` tag to exclude the original ``ruleset/decoders/0310-ssh_decoders.xml`` decoder file from the loading list. With this configuration, Wazuh loads the decoder file located in the user folder and not the file in the default folder.
  
    .. code-block:: xml
       :emphasize-lines: 11 
@@ -170,7 +168,7 @@ If you want to customize the decoder file ``0310-ssh_decoders.xml``, follow thes
       </ruleset>
 
 
-#. Perform the changes in the file ``/var/ossec/etc/decoders/0310-ssh_decoders.xml``.
+#. Make changes to ``/var/ossec/etc/decoders/0310-ssh_decoders.xml``.
 
 #. Restart the Wazuh manager so the changes take effect:
 


### PR DESCRIPTION

## Description

This PR adds the instruction to restart the Wazuh manager after editing the rules and decoders. This PR closes #5875.  

In this PR we also change wording, change the code-block types, add numbering to the steps, among others.  

## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
