### PR TITLE
Add var requirement in ruleset

### DIFF
--- a/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/rules.rst
@@ -2087,7 +2087,7 @@ Example:
 var
 ^^^
 
-Defines a variable that may be used in any place of the same file.
+Defines a variable that can be used in any place within the same file. It must be defined at the base level of the ruleset, not inside a tagged section.
 
 +----------------+------------------------+
 | Attribute      | Value                  |
@@ -2099,16 +2099,16 @@ Example:
 
   .. code-block:: xml
 
-     <var name="joe_folder">/home/joe/</var>
+    <var name="joe_folder">/home/joe/</var>
 
-      <group name="local,">
+    <group name="local,">
 
-        <rule id="100001" level="5">
-          <if_sid>550</if_sid>
-          <field name="file">^$joe_folder</field>
-          <description>A Joe's file was modified.</description>
-          <group>ossec,pci_dss_10.6.1,gpg13_10.1,gdpr_IV_35.7.d,</group>
-        </rule>
+      <rule id="100001" level="5">
+        <if_sid>550</if_sid>
+        <field name="file">^$joe_folder</field>
+        <description>A Joe's file was modified.</description>
+        <group>ossec,pci_dss_10.6.1,gpg13_10.1,gdpr_IV_35.7.d,</group>
+      </rule>
 
     </group>
 


### PR DESCRIPTION
|  Related issue  |
|----------------|
| Closes [#16310](https://github.com/wazuh/wazuh/issues/16032) |


## Description
This PR :

- Adds specification of requirement that a `var` in the ruleset must be defined at base level
- Fixes some indentation on the given example

## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
