### PR TITLE
Fix HP-UX Wazuh agent decompression command

### DIFF
--- a/source/installation-guide/wazuh-agent/wazuh-agent-package-hpux.rst
+++ b/source/installation-guide/wazuh-agent/wazuh-agent-package-hpux.rst
@@ -25,7 +25,7 @@ The installed agent runs on the endpoint you want to monitor and communicates wi
 
    .. code-block:: console
    
-       # tar -xvf wazuh-agent-|WAZUH_CURRENT_HPUX|-|WAZUH_REVISION_HPUX|-hpux-11v3-ia64.tar -C /
+       # tar -xvf wazuh-agent-|WAZUH_CURRENT_HPUX|-|WAZUH_REVISION_HPUX|-hpux-11v3-ia64.tar
 
 
 The installation process is now complete, and the Wazuh agent is successfully installed on your HP-UX endpoint. The next step is to register and configure the agent to communicate with the Wazuh server. To perform this action, see the :doc:`Linux/Unix agent enrollment via agent configuration </user-manual/agent-enrollment/via-agent-configuration/linux-endpoint>` section. To learn more about agent enrollment, visit :doc:`Wazuh agent enrollment </user-manual/agent-enrollment/index>`.


### PR DESCRIPTION
Related issue: Closing #5976 

## Description

This PR aims to rollback the command that uncompresses HP-UX Wazuh agent due to a bug on `tar` command

## Checks
- [x] Compiles without warnings.
- [x] ~Uses present tense, active voice, and semi-formal registry.~
- [x] ~Uses short, simple sentences.~
- [x] ~Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.~
- [x] ~Uses three spaces indentation.~
- [x] ~Adds or updates meta descriptions accordingly.~
- [x] ~Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).~
