### PR TITLE
Fixed the indentation of the Wazuh dashboard configuration file example

### DIFF
--- a/source/installation-guide/wazuh-dashboard/step-by-step.rst
+++ b/source/installation-guide/wazuh-dashboard/step-by-step.rst
@@ -106,6 +106,7 @@ Starting the Wazuh dashboard service
           Edit the ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` file and replace the ``url`` value with the IP address or hostname of the Wazuh server master node.
           
             .. code-block:: yaml
+               :emphasize-lines: 3
             
                hosts:
                  - default:

--- a/source/installation-guide/wazuh-dashboard/step-by-step.rst
+++ b/source/installation-guide/wazuh-dashboard/step-by-step.rst
@@ -107,13 +107,14 @@ Starting the Wazuh dashboard service
           
             .. code-block:: yaml
             
-              hosts:
-                - default:
-                  url: https://localhost
-                  port: 55000
-                  username: wazuh-wui
-                  password: wazuh-wui
-                  run_as: false
+               hosts:
+                 - default:
+                     url: https://localhost
+                     port: 55000
+                     username: wazuh-wui
+                     password: wazuh-wui
+                     run_as: false
+
 
 
   #. Access the Wazuh web interface with your credentials.


### PR DESCRIPTION
## Description

This PR fixes indentation and adds highlighting. This PR closes #5978. 
 
![image](https://user-images.githubusercontent.com/61882981/226949029-84673142-db28-42b3-8c95-664842e44f6f.png)

## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
