### PR TITLE
Fix error in an active response configuration example

### DIFF
--- a/source/user-manual/capabilities/active-response/how-to-configure.rst
+++ b/source/user-manual/capabilities/active-response/how-to-configure.rst
@@ -63,7 +63,7 @@ Configuring the Wazuh server
                 <level>10</level>
                 <timeout>180</timeout>
               </active-response> 
-            <ossec_config>
+            </ossec_config>
 
       -  ``all``: Every Wazuh agent in the environment must run the script. Use this option with caution. Incorrect configuration can cause problems in your environment.
 


### PR DESCRIPTION
## Description

This PR fixes an active response configuration tag and closes #5985. 

## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
