### PR TITLE
Update `agent_groups` CLI output when removing group

### DIFF
--- a/source/user-manual/reference/tools/agent-groups.rst
+++ b/source/user-manual/reference/tools/agent-groups.rst
@@ -148,8 +148,7 @@ Examples
     :class: output
 
     Do you want to remove the 'debian' group? [y/N]: y
-    All selected groups were removed
-    Affected agents: 007, 013
+    Group debian removed.
 
 * Add an agent to more than one group:
 


### PR DESCRIPTION
| Issue |
|--|
|https://github.com/wazuh/wazuh/issues/16483|

## Description
This PR updates the output of `agent_groups` CLI when a group is deleted (`-r -g <group_name>`) since it no longer returns a list of affected agents:
```
# /var/ossec/bin/agent_groups -r -g test_group3
Do you want to remove the 'test_group3' group? [y/N]: y
Group test_group3 removed.
```


## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
