### PR TITLE
Update the path of active response scripts in Windows

### DIFF
--- a/source/user-manual/capabilities/active-response/default-active-response-scripts.rst
+++ b/source/user-manual/capabilities/active-response/default-active-response-scripts.rst
@@ -71,7 +71,7 @@ Click on the name of each active response to open its source code.
 Windows endpoints
 -----------------
 
-The table below lists out-of-the-box scripts for Windows endpoints, located in the Wazuh agent ``C:\Program Files\ossec-agent\active-response\bin`` directory. Click on the name of each script to see its source code.
+The table below lists out-of-the-box scripts for Windows endpoints, located in the Wazuh agent ``C:\Program Files (x86)\ossec-agent\active-response\bin`` directory. Click on the name of each script to see its source code.
 
 .. |netsh.exe| replace:: `netsh.exe <https://github.com/wazuh/wazuh/blob/|WAZUH_CURRENT_MINOR|/src/active-response/netsh.c>`__
 .. |restart-wazuh.exe| replace:: `restart-wazuh.exe <https://github.com/wazuh/wazuh/blob/|WAZUH_CURRENT_MINOR|/src/active-response/restart-wazuh.c>`__

--- a/source/user-manual/capabilities/active-response/how-to-configure.rst
+++ b/source/user-manual/capabilities/active-response/how-to-configure.rst
@@ -117,7 +117,7 @@ macOS
 Windows
 ~~~~~~~
 
-#. Add your custom active response script or executable to the ``C:\Program Files\ossec-agent\active-response\bin`` directory on Windows endpoints.
+#. Add your custom active response script or executable to the ``C:\Program Files (x86)\ossec-agent\active-response\bin`` directory on Windows endpoints.
 
 .. note::
 

--- a/source/user-manual/reference/ossec-conf/commands.rst
+++ b/source/user-manual/reference/ossec-conf/commands.rst
@@ -44,7 +44,7 @@ executable
 
 Names an executable file to run. It is not necessary to provide the path.
 
-These files are located in ``/var/ossec/active-response/bin`` directory in Linux based systems, or in ``C:\Program Files\ossec-agent\active-response\bin`` directory in Windows systems.
+These files are located in ``/var/ossec/active-response/bin`` directory in Linux based systems, or in ``C:\Program Files (x86)\ossec-agent\active-response\bin`` directory in Windows systems.
 
 +--------------------+---------------+
 | **Default value**  | n/a           |


### PR DESCRIPTION
## Description

This PR updates the path of active response scripts in Windows from `C:\Program Files\ossec-agent\active-response\bin` to `C:\Program Files (x86)\ossec-agent\active-response\bin`. 

## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
