### PR TITLE
Update Elastic Stack version

### DIFF
--- a/source/_templates/installations/basic/elastic/common/install_wazuh_kibana_plugin.rst
+++ b/source/_templates/installations/basic/elastic/common/install_wazuh_kibana_plugin.rst
@@ -8,7 +8,7 @@
 
       .. code-block:: console
 
-        # sudo -u kibana /usr/share/kibana/bin/kibana-plugin install https://packages.wazuh.com/4.x/ui/kibana/wazuh_kibana-4.4.0_7.17.8-1.zip
+        # sudo -u kibana /usr/share/kibana/bin/kibana-plugin install https://packages.wazuh.com/4.x/ui/kibana/wazuh_kibana-4.4.0_7.17.9-1.zip
 
 
 
@@ -17,7 +17,7 @@
 
       .. code-block:: console
 
-        # sudo -u kibana /usr/share/kibana/bin/kibana-plugin install file:///path/wazuh_kibana-4.4.0_7.17.8-1.zip
+        # sudo -u kibana /usr/share/kibana/bin/kibana-plugin install file:///path/wazuh_kibana-4.4.0_7.17.9-1.zip
 
 
 

--- a/source/_templates/installations/basic/elastic/deb/install_elasticsearch.rst
+++ b/source/_templates/installations/basic/elastic/deb/install_elasticsearch.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # apt-get install elasticsearch=7.17.8
+  # apt-get install elasticsearch=7.17.9
 
 .. End of include file

--- a/source/_templates/installations/basic/elastic/deb/install_filebeat.rst
+++ b/source/_templates/installations/basic/elastic/deb/install_filebeat.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # apt-get install filebeat=7.17.8
+  # apt-get install filebeat=7.17.9
 
 .. End of include file

--- a/source/_templates/installations/basic/elastic/deb/install_kibana.rst
+++ b/source/_templates/installations/basic/elastic/deb/install_kibana.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # apt-get install kibana=7.17.8
+  # apt-get install kibana=7.17.9
 
 .. End of include file

--- a/source/_templates/installations/basic/elastic/yum/install_elasticsearch.rst
+++ b/source/_templates/installations/basic/elastic/yum/install_elasticsearch.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # yum install elasticsearch-7.17.8
+  # yum install elasticsearch-7.17.9
 
 .. End of include file

--- a/source/_templates/installations/basic/elastic/yum/install_filebeat.rst
+++ b/source/_templates/installations/basic/elastic/yum/install_filebeat.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # yum install filebeat-7.17.8
+  # yum install filebeat-7.17.9
 
 .. End of include file

--- a/source/_templates/installations/basic/elastic/yum/install_kibana.rst
+++ b/source/_templates/installations/basic/elastic/yum/install_kibana.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # yum install kibana-7.17.8
+  # yum install kibana-7.17.9
 
 .. End of include file

--- a/source/conf.py
+++ b/source/conf.py
@@ -625,7 +625,7 @@ custom_replacements = {
     # --- Open Distro for Elasticsearch
     "|OPEN_DISTRO_LATEST|" : "1.13.2",
     # --- Elasticsearch
-    "|ELASTICSEARCH_ELK_LATEST|" : "7.17.8", # Basic license
+    "|ELASTICSEARCH_ELK_LATEST|" : "7.17.9", # Basic license
     "|ELASTICSEARCH_LATEST|" : "7.10.2",
     # --- Other Elastic
     "|ELASTIC_6_LATEST|" : "6.8.8",

--- a/source/deployment-options/elastic-stack/all-in-one-deployment/index.rst
+++ b/source/deployment-options/elastic-stack/all-in-one-deployment/index.rst
@@ -57,14 +57,14 @@ Elasticsearch installation and configuration
 
          .. code-block:: console
 
-           # yum install elasticsearch-7.17.8
+           # yum install elasticsearch-7.17.9
 
 
       .. group-tab:: APT
 
          .. code-block:: console
 
-           # apt-get install elasticsearch=7.17.8
+           # apt-get install elasticsearch=7.17.9
 
 
 #. Download the configuration file ``/etc/elasticsearch/elasticsearch.yml`` as follows:
@@ -128,24 +128,24 @@ This command should have an output like this:
 
 .. code-block:: console
    :class: output
-
+   
    {
      "name" : "elasticsearch",
      "cluster_name" : "elasticsearch",
-     "cluster_uuid" : "9hNRUiNbSwy0p0KAhsswdA",
+     "cluster_uuid" : "CFw_rkxnR7avI7pBv9MvtQ",
      "version" : {
-       "number" : "7.17.8",
+       "number" : "7.17.9",
        "build_flavor" : "default",
        "build_type" : "rpm",
-       "build_hash" : "120eabe1c8a0cb2ae87cffc109a5b65d213e9df1",
-       "build_date" : "2022-12-02T17:33:09.727072865Z",
+       "build_hash" : "ef48222227ee6b9e70e502f0f0daa52435ee634d",
+       "build_date" : "2023-01-31T05:34:43.305517834Z",
        "build_snapshot" : false,
        "lucene_version" : "8.11.1",
        "minimum_wire_compatibility_version" : "6.8.0",
        "minimum_index_compatibility_version" : "6.0.0-beta1"
      },
      "tagline" : "You Know, for Search"
-   }   
+   }  
 
 .. _basic_all_in_one_wazuh:
 
@@ -283,7 +283,7 @@ To ensure that Filebeat has been successfully installed, run the following comma
 This command should have an output like this:
 
 .. code-block:: console
-  :class: output
+   :class: output
 
    elasticsearch: https://127.0.0.1:9200...
      parse url... OK
@@ -298,8 +298,7 @@ This command should have an output like this:
        TLS version: TLSv1.3
        dial up... OK
      talk to server... OK
-     version: 7.17.8     
-
+     version: 7.17.9
 
 Kibana installation and configuration
 -------------------------------------

--- a/source/deployment-options/elastic-stack/index.rst
+++ b/source/deployment-options/elastic-stack/index.rst
@@ -74,7 +74,7 @@ The following Elastic Stack versions are compatible with the Wazuh manager |WAZU
 +-------------------------+
 | 7.16.0–7.16.3           |
 +-------------------------+
-| 7.17.0–7.17.8           | 
+| 7.17.0–7.17.9           | 
 +-------------------------+
 
 .. _packages_list_elk:
@@ -113,6 +113,8 @@ The following table contains the Wazuh Kibana plugin files for each version of E
 
 .. |WAZUH_KIBANA_7.17.8| replace:: `wazuh_kibana-|WAZUH_CURRENT|_7.17.8.zip <https://packages.wazuh.com/|WAZUH_CURRENT_MAJOR|/ui/kibana/wazuh_kibana-|WAZUH_CURRENT|_7.17.8-1.zip>`__ (`sha512 <https://packages.wazuh.com/|WAZUH_CURRENT_MAJOR|/checksums/wazuh/|WAZUH_CURRENT|/wazuh_kibana-|WAZUH_CURRENT|_7.17.8-1.zip.sha512>`__)
 
+.. |WAZUH_KIBANA_7.17.9| replace:: `wazuh_kibana-|WAZUH_CURRENT|_7.17.9.zip <https://packages.wazuh.com/|WAZUH_CURRENT_MAJOR|/ui/kibana/wazuh_kibana-|WAZUH_CURRENT|_7.17.9-1.zip>`__ (`sha512 <https://packages.wazuh.com/|WAZUH_CURRENT_MAJOR|/checksums/wazuh/|WAZUH_CURRENT|/wazuh_kibana-|WAZUH_CURRENT|_7.17.9-1.zip.sha512>`__)
+
 +------------------+--------------------------+
 | Kibana Version   | Package                  |
 +==================+==========================+
@@ -144,7 +146,8 @@ The following table contains the Wazuh Kibana plugin files for each version of E
 +------------------+--------------------------+
 | 7.17.8           | |WAZUH_KIBANA_7.17.8|    |
 +------------------+--------------------------+
-
+| 7.17.9           | |WAZUH_KIBANA_7.17.9|    |
++------------------+--------------------------+
 
 For a full list of the available Wazuh Kibana plugin packages, check the `Wazuh Kibana plugin compatibility matrix <https://github.com/wazuh/wazuh-kibana-app/wiki/Compatibility>`__.  
 

--- a/source/release-notes/release-4-4-0.rst
+++ b/source/release-notes/release-4-4-0.rst
@@ -677,7 +677,7 @@ More details about these changes are provided in the changelog of each component
 - `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/v4.4.0/CHANGELOG.md>`_
 - `wazuh/wazuh-dashboard <https://github.com/wazuh/wazuh-kibana-app/blob/v4.4.0-2.4.1/CHANGELOG.md>`_
 - `wazuh/wazuh-kibana-app 7.10.2 <https://github.com/wazuh/wazuh-kibana-app/blob/v4.4.0-7.10.2/CHANGELOG.md>`_
-- `wazuh/wazuh-kibana-app 7.17.x <https://github.com/wazuh/wazuh-kibana-app/blob/v4.4.0-7.17.8/CHANGELOG.md>`_
+- `wazuh/wazuh-kibana-app 7.17.x <https://github.com/wazuh/wazuh-kibana-app/blob/v4.4.0-7.17.9/CHANGELOG.md>`_
 - `wazuh/wazuh-splunk <https://github.com/wazuh/wazuh-splunk/blob/v4.4.0-8.2/CHANGELOG.md>`_
 - `wazuh/wazuh-packages <https://github.com/wazuh/wazuh-packages/releases/tag/v4.4.0>`_
 

--- a/source/upgrade-guide/compatibility-matrix/index.rst
+++ b/source/upgrade-guide/compatibility-matrix/index.rst
@@ -38,7 +38,7 @@ The following Elastic Stack and Open Distro for Elasticsearch versions are compa
 +--------------------------+---------------------------+
 | 7.16.0–7.16.3            |                           |
 +--------------------------+---------------------------+
-| 7.17.0–7.17.8            |                           |
+| 7.17.0–7.17.9            |                           |
 +--------------------------+---------------------------+
 
 You can find more information on the `Wazuh Kibana plugin repository <https://github.com/wazuh/wazuh-kibana-app/wiki/Compatibility>`_.


### PR DESCRIPTION
## Description

This PR updates the latest supported ELK version from 7.17.8 to 7.17.9.

It updates the "Wazuh with Elastic Stack" installation guide, the packages list and the compatibility matrix. 

## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
