### PR TITLE
Add documentation on new Office365 module parameter

### DIFF
--- a/source/office365/monitoring-office365-activity.rst
+++ b/source/office365/monitoring-office365-activity.rst
@@ -119,6 +119,7 @@ Proceed to configure the ``office365`` module in the Wazuh manager or in the Waz
             <tenant_id>your_tenant_id</tenant_id>
             <client_id>your_client_id</client_id>
             <client_secret>your_client_secret</client_secret>
+            <api_type>commercial</api_type>
         </api_auth>
         <subscriptions>
             <subscription>Audit.SharePoint</subscription>

--- a/source/user-manual/reference/ossec-conf/office365-module.rst
+++ b/source/user-manual/reference/ossec-conf/office365-module.rst
@@ -36,6 +36,7 @@ Options
 - `api_auth\\client_id`_
 - `api_auth\\client_secret_path`_
 - `api_auth\\client_secret`_
+- `api_auth\\api_type`_
 - `subscriptions`_
 - `subscriptions\\subscription`_
 
@@ -59,6 +60,8 @@ Options
 | `api_auth\\client_secret_path`_        | Any string                      |
 +----------------------------------------+---------------------------------+
 | `api_auth\\client_secret`_             | Any string                      |
++----------------------------------------+---------------------------------+
+| `api_auth\\api_type`_                  | commercial, gcc, gcc-high       |
 +----------------------------------------+---------------------------------+
 | `subscriptions`_                       | N/A                             |
 +----------------------------------------+---------------------------------+
@@ -124,6 +127,7 @@ This block configures the credential for the **authentication** with the Office3
 - `api_auth\\client_id`_
 - `api_auth\\client_secret_path`_
 - `api_auth\\client_secret`_
+- `api_auth\\api_type`_
 
 .. warning::
 
@@ -139,6 +143,8 @@ This block configures the credential for the **authentication** with the Office3
 | `api_auth\\client_secret_path`_        | Any string                                   |
 +----------------------------------------+----------------------------------------------+
 | `api_auth\\client_secret`_             | Any string                                   |
++----------------------------------------+----------------------------------------------+
+| `api_auth\\api_type`_                  | commercial, gcc, gcc-high                    |
 +----------------------------------------+----------------------------------------------+
 
 api_auth\\tenant_id
@@ -184,6 +190,17 @@ Client secret value of your application registered in Azure.
 +--------------------+--------------------+
 | **Allowed values** | Any string         |
 +--------------------+--------------------+
+
+api_auth\\api_type
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Type of Microsoft 365 subscription plan used by the tenant.
+
++--------------------+---------------------------+
+| **Default value**  | commercial                |
++--------------------+---------------------------+
+| **Allowed values** | commercial, gcc, gcc-high |
++--------------------+---------------------------+
 
 .. note::
 
@@ -233,6 +250,7 @@ Example of configuration
             <tenant_id>your_tenant_id</tenant_id>
             <client_id>your_client_id</client_id>
             <client_secret>your_client_secret</client_secret>
+            <api_type>commercial</api_type>
         </api_auth>
         <subscriptions>
             <subscription>Audit.AzureActiveDirectory</subscription>
@@ -254,11 +272,13 @@ Example of multiple tenants
             <tenant_id>your_tenant_id</tenant_id>
             <client_id>your_client_id</client_id>
             <client_secret>your_client_secret</client_secret>
+            <api_type>commercial</api_type>
         </api_auth>
         <api_auth>
             <tenant_id>your_tenant_id_2</tenant_id>
             <client_id>your_client_id_2</client_id>
             <client_secret>your_client_secret_2</client_secret>
+            <api_type>commercial</api_type>
         </api_auth>
         <subscriptions>
             <subscription>Audit.AzureActiveDirectory</subscription>


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
<!--
Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->
The recent changes made to Wazuh's Office365 module so that it can support government instances of Microsoft 365 (see https://github.com/wazuh/wazuh/pull/15010 for more detail) have resulted in the addition of a new parameter, `api_auth\api_type`. The documentation changes in this PR delineate the options & purpose of this new parameter, and update existing examples of how to configure the Office365 module with practical examples of the new parameter being specified within a configuration file.

Where possible these changes mirror the existing documentation for the Office365 module, but if any changes are necessary I am happy to make them.
## Checks
- [X] Compiles without warnings.
- [X] Uses present tense, active voice, and semi-formal registry.
- [X] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [X] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
