### PR TITLE
Update the instructions on how to change user passwords on a Wazuh Docker deployment 

### DIFF
--- a/source/deployment-options/docker/wazuh-container.rst
+++ b/source/deployment-options/docker/wazuh-container.rst
@@ -291,17 +291,16 @@ Perform the following steps from your ``single-node`` directory. If you have a m
    .. code-block:: console
   
       export INSTALLATION_DIR=/usr/share/wazuh-indexer
-      export OPENSEARCH_PATH_CONF=${INSTALLATION_DIR}/config
-      CACERT=$OPENSEARCH_PATH_CONF/certs/root-ca.pem
-      KEY=$OPENSEARCH_PATH_CONF/certs/admin-key.pem
-      CERT=$OPENSEARCH_PATH_CONF/certs/admin.pem
+      CACERT=$INSTALLATION_DIR/certs/root-ca.pem
+      KEY=$INSTALLATION_DIR/certs/admin-key.pem
+      CERT=$INSTALLATION_DIR/certs/admin.pem
       export JAVA_HOME=/usr/share/wazuh-indexer/jdk
 
 #. Run the ``securityadmin.sh`` script to apply all changes:
 
    .. code-block:: console
 
-      # bash /usr/share/wazuh-indexer/plugins/opensearch-security/tools/securityadmin.sh -cd /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/ -nhnv -cacert  $CACERT -cert $CERT -key $KEY -p 9300 -icl
+      # bash /usr/share/wazuh-indexer/plugins/opensearch-security/tools/securityadmin.sh -cd /usr/share/wazuh-indexer/opensearch-security/ -nhnv -cacert  $CACERT -cert $CERT -key $KEY -p 9200 -icl
 
 #. Exit the Wazuh indexer container and login with the new credentials on the Wazuh dashboard.
 


### PR DESCRIPTION
## Description

This PR updates the instructions on how to [change user passwords](https://documentation.wazuh.com/current/deployment-options/docker/wazuh-container.html#change-the-password-of-an-existing-user) on a Wazuh v4.4.0 Docker deployment. This PR solves the problem reported in #6001.  

Changes include: 
-  [Step 8] Removing all references to the `OPENSEARCH_PATH_CONF` variable and replacing it with `INSTALLATION_DIR`  in the `CACERT`, `KEY` and `CERT` variables.
-  [Step 9] Changing the port to `9200` and changing the configuration directory  from `/usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig/` to `/usr/share/wazuh-indexer/opensearch-security/`. 
 
## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
