### PR TITLE
Added documentation to include user .aws/config file as default config

### DIFF
--- a/source/amazon/services/prerequisites/considerations.rst
+++ b/source/amazon/services/prerequisites/considerations.rst
@@ -90,6 +90,53 @@ The following example of a ``~/.aws/config`` file sets retry parameters for the 
    retry_mode=standard
 
 
+Additional configuration
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Wazuh supports additional configuration found in the .aws/config file, the supported keys are the primary keys stated in the `boto3 configuration <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html>`_. Supported keys are:
+
+- region_name.
+- signature_version.
+- s3
+- proxies
+- proxies_config
+- retries
+
+The following example of a ``~/.aws/config`` file sets the supported configuration for the *dev* profile 
+
+.. code-block:: ini
+   
+   [dev]
+   region = us-east-1
+   output = json
+
+   dev.s3.max_concurrent_requests = 10
+   dev.s3.max_queue_size = 1000
+   dev.s3.multipart_threshold = 64MB
+   dev.s3.multipart_chunksize = 16MB
+   dev.s3.max_bandwidth = 50MB/s
+   dev.s3.use_accelerate_endpoint = true
+   dev.s3.addressing_style = virtual
+   
+   dev.proxy.host = proxy.example.com
+   dev.proxy.port = 8080
+   dev.proxy.username = your-proxy-username
+   dev.proxy.password = your-proxy-password
+   
+   dev.proxy.ca_bundle = /path/to/ca_bundle.pem
+   dev.proxy.client_cert = /path/to/client_cert.pem
+   dev.proxy.use_forwarding_for_https = true
+   
+   dev.signature_version = s3v4
+   max_attempts = 5
+   retry_mode = standard
+   
+
+.. note::
+   To configure multiple profile for the integration, declare each profile in the ``~/.aws/config`` file using the same pattern as before.
+   If no profile is declared in the module configuration, the *default* profile will be used. 
+
+  
 Configuring multiple services
 -----------------------------
 
@@ -222,3 +269,4 @@ The following is an example of a valid configuration.
     </service>
 
   </wodle>
+


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
<!--
Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->

AWS Module now supports using the _~/.aws/config_ file as the default configuration for the client.

Documentation has been updated to include how to configure user file to be sued as default configuration.

## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
