### PR TITLE
Updated indentation for syscall-child decoder

### DIFF
--- a/source/user-manual/ruleset/ruleset-xml-syntax/decoders.rst
+++ b/source/user-manual/ruleset/ruleset-xml-syntax/decoders.rst
@@ -503,12 +503,12 @@ Example:
     <prematch>^$header</prematch>
   </decoder>
 
-    <decoder name="syscall-child">
-      <parent>syscall</parent>
-      <prematch offset="$offset">^: $type </prematch>
-      <regex offset="after_prematch">(\S+)</regex>
-      <order>syscall</order>
-    </decoder>
+  <decoder name="syscall-child">
+    <parent>syscall</parent>
+    <prematch offset="$offset">^: $type </prematch>
+    <regex offset="after_prematch">(\S+)</regex>
+    <order>syscall</order>
+  </decoder>
 
 .. _type:
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
<!--
Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->
## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
