### PR TITLE
Changed the wazuh-ansible branch to the latest tag

### DIFF
--- a/source/deployment-options/deploying-with-ansible/guide/install-ansible.rst
+++ b/source/deployment-options/deploying-with-ansible/guide/install-ansible.rst
@@ -1,8 +1,8 @@
 .. Copyright (C) 2015, Wazuh, Inc.
 
 .. meta::
-   :description: Learn how to install the Ansible server in this section of the Wazuh documentation. Check out this step-by-step guide. 
-   
+   :description: Learn how to install the Ansible server in this section of the Wazuh documentation. Check out this step-by-step guide.
+
 Install Ansible
 ===============
 
@@ -15,7 +15,7 @@ In the example we will follow in this guide, we have the following infrastructur
 -  Wazuh agent
 
 .. note::
-  
+
    OpenSSH Compatibility: Ansible version 1.3 and later uses native OpenSSH for remote communication.
 
 .. contents::
@@ -115,11 +115,11 @@ Our Ansible server will need to connect to the other endpoints. Let’s see how 
          # ssh-keygen
 
    #. Check the permissions of the generated keys.
-    
+
       .. code-block:: console
 
          # ls -la ~/.ssh
-            
+
       ``id_rsa`` must have restrictive permissions (600 or “- r w - - - - - - -“).
 
       .. code-block:: none
@@ -132,17 +132,17 @@ Our Ansible server will need to connect to the other endpoints. Let’s see how 
          -rw-r--r--. 1 root root  175 Mar 18 10:14 known_hosts
 
       In addition, the ``/root/.ssh/`` directory must have its permissions set to ``700 (d r w x - - - - - -)``. The permissions can be set using the command below:
-        
+
       .. code-block:: console
 
          # chmod 700 ~/.ssh/
-                
+
 #. Now, proceed to copy the public key of the Ansible server to the  ~/.ssh/authorized_keys file in the $HOME directory of the remote system (the Wazuh server in this example).
 
    #. On the remote system, install openssh-server if it is not installed.
 
       .. tabs::
-          
+
          .. group-tab:: CentOS/RHEL/Fedora
 
             .. code-block:: console
@@ -247,7 +247,7 @@ Testing the Ansible connection to remote endpoints
 #. Add endpoints for management by Ansible.
 
    This is done by including the hostname or IP Address in ``/etc/ansible/hosts`` on our Ansible server. In this case, we intend to use the Ansible playbooks to deploy the Wazuh indexer, dashboard, and manager on one server (all-in-one deployment). The IP address of the server is ``192.168.33.31`` and the user is ``centos``.
-   
+
    We proceed to add the following entry to the ``/etc/ansible/hosts`` file:
 
    .. code-block:: none
@@ -292,7 +292,7 @@ On the Ansible server, the following commands are run:
 .. code-block:: console
 
    # cd /etc/ansible/roles/
-   # sudo git clone --branch |WAZUH_CURRENT_MINOR_ANSIBLE| https://github.com/wazuh/wazuh-ansible.git
+   # sudo git clone --branch v|WAZUH_CURRENT_ANSIBLE| https://github.com/wazuh/wazuh-ansible.git
    # ls
 
 .. code-block:: none

--- a/source/deployment-options/deploying-with-ansible/roles/index.rst
+++ b/source/deployment-options/deploying-with-ansible/roles/index.rst
@@ -11,7 +11,7 @@ You can use our preconfigured roles to deploy the Wazuh indexer and dashboard co
 .. code-block:: console
 
    # cd /etc/ansible/roles
-   # git clone --branch v|WAZUH_CURRENT_MINOR_ANSIBLE| https://github.com/wazuh/wazuh-ansible.git
+   # git clone --branch v|WAZUH_CURRENT_ANSIBLE| https://github.com/wazuh/wazuh-ansible.git
 
 Below we briefly explain how to use these roles. Please check out the `Ansible Playbook Documentation <http://docs.ansible.com/ansible/playbooks.html>`_ for more information on Ansible roles.
 


### PR DESCRIPTION

## Description

This PR fixes the wazuh-ansible repository references to use the latest available tag.

![image](https://user-images.githubusercontent.com/14913942/229861295-1506f862-4f94-4f9b-88ea-d0538747a2a4.png)
![image](https://user-images.githubusercontent.com/14913942/229861365-bc6a428a-a7b2-4929-9522-01bb886addb3.png)


## Checks
- [x] Compiles without warnings.
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
