### PR TITLE
Upgrade guide grammar review

### DIFF
--- a/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-elastic-stack.rst
+++ b/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-elastic-stack.rst
@@ -8,7 +8,7 @@
 Wazuh and Elastic Stack basic license
 =====================================
 
-This section guides through the upgrade process of the Wazuh server, Elasticsearch, and Kibana for the *Elastic Stack basic license* distribution. 
+This section guides you through the upgrade process of the Wazuh server, Elasticsearch, and Kibana for the *Elastic Stack basic license* distribution. 
 
 .. note::
    

--- a/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-open-distro.rst
+++ b/source/upgrade-guide/elasticsearch-kibana-filebeat/upgrading-open-distro.rst
@@ -8,7 +8,7 @@
 Wazuh and Open Distro for Elasticsearch
 =======================================
 
-This section guides through the upgrade process of the Wazuh server, Elasticsearch, and Kibana for the *Open Distro for Elasticsearch* distribution. 
+This section guides you through the upgrade process of the Wazuh server, Elasticsearch, and Kibana for the *Open Distro for Elasticsearch* distribution. 
 
 .. note:: You need root user privileges to run all the commands described below.
 
@@ -165,7 +165,7 @@ Preparations
 Upgrade
 ^^^^^^^
 
-This guide explains how to perform a rolling upgrade, which allows you to shut down one node at a time for minimal disruption of service.The cluster remains available throughout the process.
+This guide explains how to perform a rolling upgrade, which allows you to shut down one node at a time for minimal disruption of service. The cluster remains available throughout the process.
 
 The IP address ``127.0.0.1`` is used in the commands below. If Elasticsearch is bound to a specific IP address, replace ``127.0.0.1`` with your Elasticsearch IP address. If using ``http``, the option ``-k`` must be omitted, and if not using user/password authentication, ``-u`` must be omitted.
 

--- a/source/upgrade-guide/index.rst
+++ b/source/upgrade-guide/index.rst
@@ -17,9 +17,9 @@ Select an option below according to your Wazuh installation and follow the instr
 
 The Wazuh central components section includes instructions to upgrade the Wazuh server, the Wazuh indexer, and the Wazuh dashboard. This is the default Wazuh installation starting with Wazuh v4.3.0. 
 
-The Wazuh and Open Distro for Elasticsearch section describes the upgrade process for the Wazuh manager, Filebeat-OSS, Open Distro for Elasticsearch and Kibana. This was the default Wazuh installation from Wazuh v4.0.0 to 4.2.7. 
+The Wazuh and Open Distro for Elasticsearch section describes the upgrade process for the Wazuh manager, Filebeat-OSS, Open Distro for Elasticsearch, and Kibana. This was the default Wazuh installation from Wazuh v4.0.0 to 4.2.7. 
 
-The Wazuh and Elastic Stack basic license section includes instructions to upgrade the Wazuh manager, Filebeat, Elasticsearch and Kibana. The latest supported Elastic Stack basic license version is |ELASTICSEARCH_ELK_LATEST|. 
+The Wazuh and Elastic Stack basic license section includes instructions to upgrade the Wazuh manager, Filebeat, Elasticsearch, and Kibana. The latest supported Elastic Stack basic license version is |ELASTICSEARCH_ELK_LATEST|. 
 
 .. raw:: html
 

--- a/source/upgrade-guide/legacy/index.rst
+++ b/source/upgrade-guide/legacy/index.rst
@@ -1,14 +1,14 @@
 .. Copyright (C) 2015, Wazuh, Inc.
 
 .. meta::
-    :description: This section guides through the process of upgrading the Wazuh server and the Wazuh agent installations from a version prior to 3.0.
+    :description: This section guides you through the process of upgrading the Wazuh server and the Wazuh agent installations from a version prior to 3.0.
     
 .. _upgrading_wazuh_legacy:
 
 Upgrading from a legacy version
 ===============================
 
-This section guides through the process of upgrading the Wazuh server and the Wazuh agent installations from a version prior to 3.0.
+This section guides you through the process of upgrading the Wazuh server and the Wazuh agent installations from a version prior to 3.0.
 
 It also explains how to upgrade the Elastic Stack components from a version previous to 7.0.
 

--- a/source/upgrade-guide/legacy/upgrading-agent/from-1.x-to-2.x.rst
+++ b/source/upgrade-guide/legacy/upgrading-agent/from-1.x-to-2.x.rst
@@ -33,7 +33,7 @@ Follow these steps to update the Wazuh agent 1.x to the Wazuh agent 2.x:
 
   .. group-tab:: Windows
 
-    On Windows systems the Wazuh agent upgrade can be done by deleting the previous version and installing the Wazuh agent 2.x from scratch. As the Wazuh agent's ``ossec.conf`` configuration file will be overwritten, it is recommended to backup the old configuration file and import previous settings where needed.
+    On Windows systems, the Wazuh agent upgrade can be done by deleting the previous version and installing the Wazuh agent 2.x from scratch. As the Wazuh agent's ``ossec.conf`` configuration file will be overwritten, it is recommended to backup the old configuration file and import previous settings where needed.
 
     More information about the process can be found in the :ref:`Wazuh agent installation on Windows <wazuh_agent_package_windows>` section.
 

--- a/source/upgrade-guide/legacy/upgrading-agent/from-2.x-to-3.x.rst
+++ b/source/upgrade-guide/legacy/upgrading-agent/from-2.x-to-3.x.rst
@@ -13,7 +13,7 @@ The following steps show how to upgrade the Wazuh agent from 2.x to 3.x.
 Upgrading the Wazuh agent
 -------------------------
 
-To upgrade the Wazuh agent choose the appropriate tab for the desired operating system:
+To upgrade the Wazuh agent, choose the appropriate tab for the desired operating system:
 
     .. tabs::
 

--- a/source/upgrade-guide/legacy/upgrading-agent/index.rst
+++ b/source/upgrade-guide/legacy/upgrading-agent/index.rst
@@ -8,7 +8,7 @@
 Upgrading the Wazuh agent
 =========================
 
-This section guides through the process of upgrading the Wazuh agent installations from versions prior to 3.0.
+This section guides you through the process of upgrading the Wazuh agent installations from versions prior to 3.0.
 
 .. topic:: Contents
 

--- a/source/upgrade-guide/legacy/upgrading-elastic-stack/from-6.8-to-7.x.rst
+++ b/source/upgrade-guide/legacy/upgrading-elastic-stack/from-6.8-to-7.x.rst
@@ -8,7 +8,7 @@
 Upgrading Elastic Stack from 6.8 to 7.x
 =======================================
 
-This section guides through the upgrade process of Elastic Stack components, including Elasticsearch, Filebeat, and Kibana for the Elastic distribution.
+This section guides you through the upgrade process of Elastic Stack components, including Elasticsearch, Filebeat, and Kibana for the Elastic distribution.
 
 Coming new in Elastic 7.x, there is an architecture change introduced in the Wazuh installation. Logstash is no longer required, and Filebeat will send the events directly to Elasticsearch. In addition, Elasticsearch 7.x has Java embedded, so unless the user decides to use Logstash, Java is no longer required.
 
@@ -165,7 +165,7 @@ Field migration: From @timestamp to timestamp
 
 In the previous Elasticsearch versions, the Elastic documents were indexed using the ``@timestamp`` field as the reference field for time-based indices. Starting in Elastic 7.x, this field has become a reserved field and is no longer manipulable. The Wazuh time-based indices use the ``timestamp`` field instead.
 
-Due to this change, the previous alerts will not be visible in the Wazuh indices, and an update must be performed to all previous indices in order to complete the upgrade.
+Due to this change, the previous alerts will not be visible in the Wazuh indices, and an update must be performed on all previous indices in order to complete the upgrade.
 
 Run the request below for each Wazuh index created before the Elastic 7.x upgrade. It will add the ``timestamp`` field for all the index documents.
 

--- a/source/upgrade-guide/legacy/upgrading-elastic-stack/from-6.x-to-6.8.rst
+++ b/source/upgrade-guide/legacy/upgrading-elastic-stack/from-6.x-to-6.8.rst
@@ -8,7 +8,7 @@
 Upgrading Elastic Stack from 6.x to 6.8
 =======================================
 
-This section guides through the upgrade process of the Elastic Stack components, including Elasticsearch, Logstash, Filebeat, and Kibana for the Elastic distribution.
+This section guides you through the upgrade process of the Elastic Stack components, including Elasticsearch, Logstash, Filebeat, and Kibana for the Elastic distribution.
 
 Preparing the Elastic Stack
 ---------------------------

--- a/source/upgrade-guide/legacy/upgrading-elastic-stack/index.rst
+++ b/source/upgrade-guide/legacy/upgrading-elastic-stack/index.rst
@@ -8,7 +8,7 @@
 Upgrading Elastic Stack
 =======================
 
-This section guides through the process of upgrading the Elastic Stack components from versions prior to 7.0.
+This section guides you through the process of upgrading the Elastic Stack components from versions prior to 7.0.
 
 .. note::
 

--- a/source/upgrade-guide/legacy/upgrading-wazuh-server/from-2.x-to-3.x.rst
+++ b/source/upgrade-guide/legacy/upgrading-wazuh-server/from-2.x-to-3.x.rst
@@ -79,7 +79,7 @@ To upgrade the Wazuh server, choose the appropriate tab for the desired package 
 
   The installation of the updated packages will automatically ``restart the services`` for the Wazuh manager and the Wazuh API. The Wazuh manager configuration file will be ``unmodified``, so the user will need to manually add the settings for the new capabilities. More information can be found in the :doc:`User manual </user-manual/index>`.
 
-  After the upgrade, the old alerts will not be visualized in Kibana due to a change in the Wazuh alerts’ template. In order to access the old alerts and visualize them along with the new ones, the indices need to be reindexed to apply the new mapping. The process is described in the :ref:`Restore the Wazuh alerts from Wazuh 2.x <restore_alerts_2.x_3.x>` section.
+  After the upgrade, the old alerts will not be visualized in Kibana due to a change in the Wazuh alerts template. In order to access the old alerts and visualize them along with the new ones, the indices need to be reindexed to apply the new mapping. The process is described in the :ref:`Restore the Wazuh alerts from Wazuh 2.x <restore_alerts_2.x_3.x>` section.
 
 Disable the Wazuh repository
 ----------------------------

--- a/source/upgrade-guide/legacy/upgrading-wazuh-server/index.rst
+++ b/source/upgrade-guide/legacy/upgrading-wazuh-server/index.rst
@@ -8,7 +8,7 @@
 Upgrading the Wazuh server
 ==========================
 
-This section guides through the process of upgrading the Wazuh server installations from versions prior to 3.0.
+This section guides you through the process of upgrading the Wazuh server installations from versions prior to 3.0.
 
 .. topic:: Contents
 

--- a/source/upgrade-guide/legacy/upgrading-wazuh-server/restore-alerts-from-2.x-to-3.x.rst
+++ b/source/upgrade-guide/legacy/upgrading-wazuh-server/restore-alerts-from-2.x-to-3.x.rst
@@ -8,7 +8,7 @@
 Restore the Wazuh alerts from Wazuh 2.x
 =======================================
 
-After upgrading Wazuh from 2.x to 3.x, the old alerts will not be lost. However, they cannot be visualized in Kibana due to a change in the Wazuh alerts' template. In order to access the old alerts and visualize them along with the new ones, the indices need to be reindexed to apply the new mapping.
+After upgrading Wazuh from 2.x to 3.x, the old alerts will not be lost. However, they cannot be visualized in Kibana due to a change in the Wazuh alerts template. In order to access the old alerts and visualize them along with the new ones, the indices need to be reindexed to apply the new mapping.
 
 To do so, download the `restore_alerts.sh <https://github.com/wazuh/wazuh/blob/3.13/extensions/elasticsearch/restore_alerts/restore_alerts.sh>`_ script and the Logstash configuration file called `restore_alerts.conf <https://github.com/wazuh/wazuh/blob/3.13/extensions/elasticsearch/restore_alerts/restore_alerts.conf>`_:
 

--- a/source/upgrade-guide/upgrading-central-components.rst
+++ b/source/upgrade-guide/upgrading-central-components.rst
@@ -6,7 +6,7 @@
 Wazuh central components
 ========================
 
-This section guides through the upgrade process of the Wazuh indexer, the Wazuh server, and the Wazuh dashboard. To migrate from Open Distro for Elasticsearch 1.13 to the Wazuh indexer and dashboard components, read the corresponding :doc:`/migration-guide/wazuh-indexer` and :doc:`/migration-guide/wazuh-dashboard` sections.
+This section guides you through the upgrade process of the Wazuh indexer, the Wazuh server, and the Wazuh dashboard. To migrate from Open Distro for Elasticsearch 1.13 to the Wazuh indexer and dashboard components, read the corresponding :doc:`/migration-guide/wazuh-indexer` and :doc:`/migration-guide/wazuh-dashboard` sections.
 
 .. note:: You need root user privileges to run all the commands described below.
 

--- a/source/upgrade-guide/wazuh-agent/aix.rst
+++ b/source/upgrade-guide/wazuh-agent/aix.rst
@@ -4,8 +4,8 @@
   :description: Check out how to upgrade the Wazuh agent to the latest available version remotely, using the agent_upgrade tool or the Wazuh API, or locally.
 
 
-Ugrading Wazuh agents on AIX systems
-====================================
+Upgrading Wazuh agents on AIX systems
+=====================================
 
 Follow the steps to upgrade the Wazuh agent on AIX systems.  
   

--- a/source/upgrade-guide/wazuh-agent/linux.rst
+++ b/source/upgrade-guide/wazuh-agent/linux.rst
@@ -4,8 +4,8 @@
   :description: Check out how to upgrade the Wazuh agent to the latest available version remotely, using the agent_upgrade tool or the Wazuh API, or locally.
 
 
-Ugrading Wazuh agents on Linux systems
-======================================
+Upgrading Wazuh agents on Linux systems
+=======================================
 
 Select your package manager and follow the instructions to upgrade the Wazuh agent locally. If you want to perform a remote upgrade, check the :doc:`Remote agent upgrade </user-manual/agents/remote-upgrading/upgrading-agent>` section to learn more. 
 

--- a/source/upgrade-guide/wazuh-agent/macos.rst
+++ b/source/upgrade-guide/wazuh-agent/macos.rst
@@ -4,8 +4,8 @@
   :description: Check out how to upgrade the Wazuh agent to the latest available version remotely, using the agent_upgrade tool or the Wazuh API, or locally.
 
 
-Ugrading Wazuh agents on macOS systems
-======================================
+Upgrading Wazuh agents on macOS systems
+=======================================
 
 Follow these steps to upgrade Wazuh agents locally on macOS systems. If you want to perform a remote upgrade, check the :doc:`Remote agent upgrade </user-manual/agents/remote-upgrading/upgrading-agent>` section to learn more. 
 

--- a/source/upgrade-guide/wazuh-agent/solaris.rst
+++ b/source/upgrade-guide/wazuh-agent/solaris.rst
@@ -4,8 +4,8 @@
   :description: Check out how to upgrade the Wazuh agent to the latest available version remotely, using the agent_upgrade tool or the Wazuh API, or locally.
 
 
-Ugrading Wazuh agents on Solaris systems
-========================================
+Upgrading Wazuh agents on Solaris systems
+=========================================
 
 Select your Solaris version and follow the steps to upgrade the Wazuh agent. 
 


### PR DESCRIPTION
## Description
This issue aims to make a grammar review of the `Upgrade guide`:

## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
