### PR TITLE
Bump version to 4.4.2

### DIFF
--- a/source/_templates/installations/basic/elastic/common/install_wazuh_kibana_plugin.rst
+++ b/source/_templates/installations/basic/elastic/common/install_wazuh_kibana_plugin.rst
@@ -8,7 +8,7 @@
 
       .. code-block:: console
 
-        # sudo -u kibana /usr/share/kibana/bin/kibana-plugin install https://packages.wazuh.com/4.x/ui/kibana/wazuh_kibana-4.4.1_7.17.9-1.zip
+        # sudo -u kibana /usr/share/kibana/bin/kibana-plugin install https://packages.wazuh.com/4.x/ui/kibana/wazuh_kibana-4.4.2_7.17.9-1.zip
 
 
 
@@ -17,7 +17,7 @@
 
       .. code-block:: console
 
-        # sudo -u kibana /usr/share/kibana/bin/kibana-plugin install file:///path/wazuh_kibana-4.4.1_7.17.9-1.zip
+        # sudo -u kibana /usr/share/kibana/bin/kibana-plugin install file:///path/wazuh_kibana-4.4.2_7.17.9-1.zip
 
 
 

--- a/source/_templates/installations/basic/wazuh/common/check_wazuh_cluster.rst
+++ b/source/_templates/installations/basic/wazuh/common/check_wazuh_cluster.rst
@@ -12,9 +12,9 @@ An example output of the command looks as follows:
     :class: output
     
       NAME         TYPE    VERSION  ADDRESS
-      master-node  master  4.4.1   10.0.0.3
-      worker-node1 worker  4.4.1   10.0.0.4
-      worker-node2 worker  4.4.1   10.0.0.5
+      master-node  master  4.4.2   10.0.0.3
+      worker-node1 worker  4.4.2   10.0.0.4
+      worker-node2 worker  4.4.2   10.0.0.5
 
 Note that ``10.0.0.3``, ``10.0.0.4``, ``10.0.0.5`` are example IPs.
 

--- a/source/_templates/installations/wazuh/solaris/install_wazuh_agent_s10_intel.rst
+++ b/source/_templates/installations/wazuh/solaris/install_wazuh_agent_s10_intel.rst
@@ -1,11 +1,11 @@
 .. Copyright (C) 2015, Wazuh, Inc.
 
-#. Download the `Wazuh agent for Solaris 10 i386 <https://packages.wazuh.com/4.x/solaris/i386/10/wazuh-agent_v4.4.1-sol10-i386.pkg>`_ package. 
+#. Download the `Wazuh agent for Solaris 10 i386 <https://packages.wazuh.com/4.x/solaris/i386/10/wazuh-agent_v4.4.2-sol10-i386.pkg>`_ package. 
 
 #. Install the Wazuh agent.
 
    .. code-block:: console
 
-     # pkgadd -d wazuh-agent_v4.4.1-sol10-i386.pkg
+     # pkgadd -d wazuh-agent_v4.4.2-sol10-i386.pkg
 
 .. End of include file

--- a/source/_templates/installations/wazuh/solaris/install_wazuh_agent_s10_sparc.rst
+++ b/source/_templates/installations/wazuh/solaris/install_wazuh_agent_s10_sparc.rst
@@ -1,11 +1,11 @@
 .. Copyright (C) 2015, Wazuh, Inc.
 
-#. Download the `Wazuh agent for Solaris 10 SPARC <https://packages.wazuh.com/4.x/solaris/sparc/10/wazuh-agent_v4.4.1-sol10-sparc.pkg>`_ package. 
+#. Download the `Wazuh agent for Solaris 10 SPARC <https://packages.wazuh.com/4.x/solaris/sparc/10/wazuh-agent_v4.4.2-sol10-sparc.pkg>`_ package. 
 
 #. Install the Wazuh agent.
 
    .. code-block:: console
    
-     # pkgadd -d wazuh-agent_v4.4.1-sol10-sparc.pkg
+     # pkgadd -d wazuh-agent_v4.4.2-sol10-sparc.pkg
 
 .. End of include file

--- a/source/_templates/installations/wazuh/solaris/install_wazuh_agent_s11_intel.rst
+++ b/source/_templates/installations/wazuh/solaris/install_wazuh_agent_s11_intel.rst
@@ -1,17 +1,17 @@
 .. Copyright (C) 2015, Wazuh, Inc.
 
-#. Download the `Wazuh agent for Solaris 11 i386 <https://packages.wazuh.com/4.x/solaris/i386/11/wazuh-agent_v4.4.1-sol11-i386.p5p>`_. 
+#. Download the `Wazuh agent for Solaris 11 i386 <https://packages.wazuh.com/4.x/solaris/i386/11/wazuh-agent_v4.4.2-sol11-i386.p5p>`_. 
 
 #. Install the Wazuh agent.
 
    .. code-block:: console
    
-     # pkg install -g wazuh-agent_v4.4.1-sol11-i386.p5p wazuh-agent
+     # pkg install -g wazuh-agent_v4.4.2-sol11-i386.p5p wazuh-agent
    
 If the Solaris 11 zone where you want to install the package has child zones, create a repository to install the Wazuh agent:
 
 .. code-block:: console
 
-  # pkg set-publisher -g wazuh-agent_v4.4.1-sol11-i386.p5p wazuh && pkg install --accept wazuh-agent && pkg unset-publisher wazuh
+  # pkg set-publisher -g wazuh-agent_v4.4.2-sol11-i386.p5p wazuh && pkg install --accept wazuh-agent && pkg unset-publisher wazuh
 
 .. End of include file

--- a/source/_templates/installations/wazuh/solaris/install_wazuh_agent_s11_sparc.rst
+++ b/source/_templates/installations/wazuh/solaris/install_wazuh_agent_s11_sparc.rst
@@ -1,17 +1,17 @@
 .. Copyright (C) 2015, Wazuh, Inc.
 
-#. Download the `Wazuh agent for Solaris 11 SPARC <https://packages.wazuh.com/4.x/solaris/sparc/11/wazuh-agent_v4.4.1-sol11-sparc.p5p>`_. 
+#. Download the `Wazuh agent for Solaris 11 SPARC <https://packages.wazuh.com/4.x/solaris/sparc/11/wazuh-agent_v4.4.2-sol11-sparc.p5p>`_. 
 
 #. Install the Wazuh agent.
    
    .. code-block:: console
    
-     # pkg install -g wazuh-agent_v4.4.1-sol11-sparc.p5p wazuh-agent
+     # pkg install -g wazuh-agent_v4.4.2-sol11-sparc.p5p wazuh-agent
    
 If the Solaris 11 zone where you want to install the package has child zones, create a repository to install the Wazuh agent:
 
 .. code-block:: console
 
-  # pkg set-publisher -g wazuh-agent_v4.4.1-sol11-sparc.p5p wazuh && pkg install --accept wazuh-agent && pkg unset-publisher wazuh
+  # pkg set-publisher -g wazuh-agent_v4.4.2-sol11-sparc.p5p wazuh && pkg install --accept wazuh-agent && pkg unset-publisher wazuh
 
 .. End of include file

--- a/source/conf.py
+++ b/source/conf.py
@@ -42,8 +42,8 @@ is_latest_release = True
 
 # The full version, including alpha/beta/rc tags
 # Important: use a valid branch (4.0) or, preferably, tag name (v4.0.0)
-release = '4.4.1'
-api_tag = 'v4.4.1'
+release = '4.4.2'
+api_tag = 'v4.4.2'
 apiURL = 'https://raw.githubusercontent.com/wazuh/wazuh/'+api_tag+'/api/api/spec/spec.yaml'
 
 # -- General configuration ------------------------------------------------

--- a/source/deployment-options/deploying-with-puppet/wazuh-puppet-module/index.rst
+++ b/source/deployment-options/deploying-with-puppet/wazuh-puppet-module/index.rst
@@ -27,7 +27,7 @@ Download and install the Wazuh module from Puppet Forge:
     Notice: Downloading from https://forgeapi.puppet.com ...
     Notice: Installing -- do not interrupt ...
     /etc/puppetlabs/code/environments/production/modules
-    └─┬ wazuh-wazuh (v4.4.1)
+    └─┬ wazuh-wazuh (v4.4.2)
       ├── puppet-nodejs (v7.0.1)
       ├── puppet-selinux (v3.4.1)
       ├── puppetlabs-apt (v7.7.1)

--- a/source/deployment-options/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-agent-class.rst
+++ b/source/deployment-options/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-agent-class.rst
@@ -907,7 +907,7 @@ $agent_package_name
 $agent_package_version
   Define package version
 
-  `Default 4.4.1-1`
+  `Default 4.4.2-1`
 
   `Type String`
 

--- a/source/deployment-options/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-manager-class.rst
+++ b/source/deployment-options/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-manager-class.rst
@@ -1327,7 +1327,7 @@ Misc Variables
 $server_package_version
   Modified client.pp and server.pp to accept package versions as a parameter.
 
-  `Default 4.4.1-1`
+  `Default 4.4.2-1`
 
   `Type String`
 


### PR DESCRIPTION
## Description
This issue aims to bump the documentation version to 4.4.2.

## Checks
- [ ] Compiles without warnings.
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
