### PR TITLE
Add the extensions settings for the GitHub and Office 365 modules to Wazuh dashboard configuration

### DIFF
--- a/source/user-manual/wazuh-dashboard/config-file.rst
+++ b/source/user-manual/wazuh-dashboard/config-file.rst
@@ -284,13 +284,57 @@ Extensions
 
     These options are only applied for newly inserted APIs on the *Settings* tab, not for the existing ones.
 
-extensions.pci
-^^^^^^^^^^^^^^
+extensions.audit
+^^^^^^^^^^^^^^^^
 
-Enable or disable the PCI DSS tab on *Overview* and *Agents*.
+Enable or disable the Audit tab on *Overview* and *Agents*.
 
 +--------------------+------------+
 | **Default value**  | true       |
++--------------------+------------+
+| **Allowed values** | true,false |
++--------------------+------------+
+
+extensions.aws
+^^^^^^^^^^^^^^
+
+Enable or disable the Amazon (AWS) tab on *Overview* and *Agents*.
+
++--------------------+------------+
+| **Default value**  | false      |
++--------------------+------------+
+| **Allowed values** | true,false |
++--------------------+------------+
+
+extensions.ciscat
+^^^^^^^^^^^^^^^^^
+
+Enable or disable the CIS-CAT tab on *Overview* and *Agents*.
+
++--------------------+------------+
+| **Default value**  | false      |
++--------------------+------------+
+| **Allowed values** | true,false |
++--------------------+------------+
+
+extensions.docker
+^^^^^^^^^^^^^^^^^
+
+Enable or disable the Docker listener tab on *Overview* and *Agents*.
+
++--------------------+------------+
+| **Default value**  | false      |
++--------------------+------------+
+| **Allowed values** | true,false |
++--------------------+------------+
+
+extensions.gcp
+^^^^^^^^^^^^^^
+
+Enable or disable the GCP tab on *Overview* and *Agents*.
+
++--------------------+------------+
+| **Default value**  | false      |
 +--------------------+------------+
 | **Allowed values** | true,false |
 +--------------------+------------+
@@ -302,6 +346,17 @@ Enable or disable the GDPR tab on *Overview* and *Agents*.
 
 +--------------------+------------+
 | **Default value**  | true       |
++--------------------+------------+
+| **Allowed values** | true,false |
++--------------------+------------+
+
+extensions.github
+^^^^^^^^^^^^^^^^^
+
+Enable or disable the GitHub tab on *Overview* and *Agents*.
+
++--------------------+------------+
+| **Default value**  | false      |
 +--------------------+------------+
 | **Allowed values** | true,false |
 +--------------------+------------+
@@ -328,24 +383,13 @@ Enable or disable the NIST tab on *Overview* and *Agents*.
 | **Allowed values** | true,false |
 +--------------------+------------+
 
-extensions.tsc
-^^^^^^^^^^^^^^
+extensions.office
+^^^^^^^^^^^^^^^^^
 
-Enable or disable the TSC tab on *Overview* and *Agents*.
-
-+--------------------+------------+
-| **Default value**  | true       |
-+--------------------+------------+
-| **Allowed values** | true,false |
-+--------------------+------------+
-
-extensions.audit
-^^^^^^^^^^^^^^^^
-
-Enable or disable the Audit tab on *Overview* and *Agents*.
+Enable or disable the Office 365 tab on *Overview* and *Agents*.
 
 +--------------------+------------+
-| **Default value**  | true       |
+| **Default value**  | false      |
 +--------------------+------------+
 | **Allowed values** | true,false |
 +--------------------+------------+
@@ -354,50 +398,6 @@ extensions.oscap
 ^^^^^^^^^^^^^^^^
 
 Enable or disable the OSCAP tab on *Overview* and *Agents*.
-
-+--------------------+------------+
-| **Default value**  | false      |
-+--------------------+------------+
-| **Allowed values** | true,false |
-+--------------------+------------+
-
-extensions.ciscat
-^^^^^^^^^^^^^^^^^
-
-Enable or disable the CIS-CAT tab on *Overview* and *Agents*.
-
-+--------------------+------------+
-| **Default value**  | false      |
-+--------------------+------------+
-| **Allowed values** | true,false |
-+--------------------+------------+
-
-extensions.aws
-^^^^^^^^^^^^^^
-
-Enable or disable the Amazon (AWS) tab on *Overview* and *Agents*.
-
-+--------------------+------------+
-| **Default value**  | false      |
-+--------------------+------------+
-| **Allowed values** | true,false |
-+--------------------+------------+
-
-extensions.gcp
-^^^^^^^^^^^^^^
-
-Enable or disable the GCP tab on *Overview* and *Agents*.
-
-+--------------------+------------+
-| **Default value**  | false      |
-+--------------------+------------+
-| **Allowed values** | true,false |
-+--------------------+------------+
-
-extensions.virustotal
-^^^^^^^^^^^^^^^^^^^^^
-
-Enable or disable the VirusTotal tab on *Overview* and *Agents*.
 
 +--------------------+------------+
 | **Default value**  | false      |
@@ -416,10 +416,32 @@ Enable or disable the Osquery tab on *Overview* and *Agents*.
 | **Allowed values** | true,false |
 +--------------------+------------+
 
-extensions.docker
-^^^^^^^^^^^^^^^^^
+extensions.pci
+^^^^^^^^^^^^^^
 
-Enable or disable the Docker listener tab on *Overview* and *Agents*.
+Enable or disable the PCI DSS tab on *Overview* and *Agents*.
+
++--------------------+------------+
+| **Default value**  | true       |
++--------------------+------------+
+| **Allowed values** | true,false |
++--------------------+------------+
+
+extensions.tsc
+^^^^^^^^^^^^^^
+
+Enable or disable the TSC tab on *Overview* and *Agents*.
+
++--------------------+------------+
+| **Default value**  | true       |
++--------------------+------------+
+| **Allowed values** | true,false |
++--------------------+------------+
+
+extensions.virustotal
+^^^^^^^^^^^^^^^^^^^^^
+
+Enable or disable the VirusTotal tab on *Overview* and *Agents*.
 
 +--------------------+------------+
 | **Default value**  | false      |
@@ -743,19 +765,21 @@ This is an example of the wazuh.yml configuration:
 
     #Extensions
 
-    extensions.pci       : true
+    extensions.audit     : true
+    extensions.aws       : false
+    extensions.docker    : false
+    extensions.ciscat    : false
+    extensions.gcp       : false
     extensions.gdpr      : true
+    extensions.github    : false
     extensions.hipaa     : true
     extensions.nist      : true
-    extensions.tsc       : true
-    extensions.audit     : true
+    extensions.office    : false
     extensions.oscap     : false
-    extensions.ciscat    : false
-    extensions.aws       : false
-    extensions.gcp       : false
-    extensions.virustotal: false
     extensions.osquery   : false
-    extensions.docker    : false
+    extensions.pci       : true
+    extensions.tsc       : true
+    extensions.virustotal: false
 
     #Advanced index options
 

--- a/source/user-manual/wazuh-dashboard/config-file.rst
+++ b/source/user-manual/wazuh-dashboard/config-file.rst
@@ -767,8 +767,8 @@ This is an example of the wazuh.yml configuration:
 
     extensions.audit     : true
     extensions.aws       : false
-    extensions.docker    : false
     extensions.ciscat    : false
+    extensions.docker    : false
     extensions.gcp       : false
     extensions.gdpr      : true
     extensions.github    : false


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
<!--
Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->
This pull requests add the documentation about the extensions settings of GitHub and Office 365 modules to the Wazuh dashbaord configuration file

Changes:
- Add settings
  - `extensions.github`
  - `extensions.office`
- Add the `extensions.github` and `extensions.office` settings to the example configuration file
- Sort alphabetically the `extensions` in the documentation and example configuration file

Related to: https://github.com/wazuh/wazuh-kibana-app/pull/5376

## Checks
- [ ] Compiles without warnings.
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
