### PR TITLE
Adjust ossec issue

### DIFF
--- a/source/user-manual/reference/ossec-conf/global.rst
+++ b/source/user-manual/reference/ossec-conf/global.rst
@@ -90,7 +90,7 @@ This specifies the email recipient for alerts.
 | **Allowed values** | Any valid email address |
 +--------------------+-------------------------+
 
-This section will only allow for one email address, but the section can be repeated for each email address you would wish include.
+This section will only allow for one email address, but the section can be repeated for each email address you would wish to include.
 
 email_from
 ^^^^^^^^^^
@@ -131,7 +131,7 @@ This option defines what SMTP server to use to deliver alerts.
 helo_server
 ^^^^^^^^^^^
 
-This option defines how the ossec server will identify itself when sending mail.
+This option defines how the Wazuh server will identify itself when sending mail.
 
 +--------------------+-----------------------------------------------+
 | **Default value**  | notify.ossec.net                              |

--- a/source/user-manual/reference/ossec-conf/global.rst
+++ b/source/user-manual/reference/ossec-conf/global.rst
@@ -90,7 +90,7 @@ This specifies the email recipient for alerts.
 | **Allowed values** | Any valid email address |
 +--------------------+-------------------------+
 
-This section will only allow for one email address, but the section can be repeated for each email address you would wish to include.
+Note that this section only allows for one email address. In case you want to add more than one, repeat the section as many times as required.
 
 email_from
 ^^^^^^^^^^
@@ -131,7 +131,7 @@ This option defines what SMTP server to use to deliver alerts.
 helo_server
 ^^^^^^^^^^^
 
-This option defines how the Wazuh server will identify itself when sending mail.
+This option defines how the Wazuh server identifies itself when sending mail.
 
 +--------------------+-----------------------------------------------+
 | **Default value**  | notify.ossec.net                              |


### PR DESCRIPTION
## Description
This PR aims to adjust `ossec` issue

## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
