### PR TITLE
Changes in the Dockerfile: updated sphinx-autobuild and the list of files to be ignored

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ FROM python:3.7-alpine
 
 COPY --chown=1000:1000 requirements.txt ./
 
-RUN python -m pip install --requirement requirements.txt && python -m pip install sphinx-autobuild==0.7.1
+RUN python -m pip install --requirement requirements.txt && python -m pip install sphinx-autobuild==2021.3.14
 
 EXPOSE 8000
 
-CMD ["sphinx-autobuild", "--host", "0.0.0.0", "--ignore","*.tmp","--port", "8000", "/home/python/docs", "/home/python/build/html"]
+CMD ["sphinx-autobuild", "--host", "0.0.0.0", "--ignore","*.tmp", "--ignore","**/*.min.*","--port", "8000", "/home/python/docs", "/home/python/build/html"]


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description

This PR updates the version of sphinx-autobuild used in the Dockerfile to avoid some errors, and the list of files that need to be ignored to avoid unnecessary rebuildings when no file has changed.

## Checks
- [x] Compiles without warnings.
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
