### PR TITLE
[3.6] Changed the redirect for the index page on previous releases

### DIFF
--- a/source/_themes/wazuh_doc_theme_v3/index.html
+++ b/source/_themes/wazuh_doc_theme_v3/index.html
@@ -55,7 +55,7 @@
     <title>Wazuh documentation</title>
     <link rel="canonical" href="https://documentation.wazuh.com/current/index.html">
   </head>
-  <body>
+  <body data-release="{{ version }}">
     {% set index_redirect_js = get_js_by_page(pagename+'-redirect')[0] %}
     <script src="{{ pathto( index_redirect_js, 1) }}"></script>
   </body>

--- a/source/_themes/wazuh_doc_theme_v3/src/js-source/index-redirect.js
+++ b/source/_themes/wazuh_doc_theme_v3/src/js-source/index-redirect.js
@@ -7,4 +7,5 @@ switch (document.location.protocol) {
   default:
     url = 'https://documentation.wazuh.com';
 }
-document.location = url + '/current/index.html';
+
+document.location = url + '/' + document.querySelector('body').getAttribute('data-release') + '/getting-started/index.html';

--- a/source/_themes/wazuh_doc_theme_v3/static/js/min/index-redirect.min.js
+++ b/source/_themes/wazuh_doc_theme_v3/static/js/min/index-redirect.min.js
@@ -1,2 +1,2 @@
-let url;switch(document.location.protocol){case"http":case"https":url=document.location.protocol+"//"+document.location.host;break;default:url="https://documentation.wazuh.com"}document.location=url+"/current/index.html";
+let url;switch(document.location.protocol){case"http":case"https":url=document.location.protocol+"//"+document.location.host;break;default:url="https://documentation.wazuh.com"}document.location=url+"/"+document.querySelector("body").getAttribute("data-release")+"/getting-started/index.html";
 //# sourceMappingURL=index-redirect.min.js.map


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description

This PR changes the redirect in the index page of past releases to point to the page "Getting started" instead of the index of the current release.

## Checks
- [x] Compiles without warnings.
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
