### PR TITLE
Add clarification in the upgrade guide regarding manually installed plugins 

### DIFF
--- a/source/upgrade-guide/upgrading-central-components.rst
+++ b/source/upgrade-guide/upgrading-central-components.rst
@@ -58,7 +58,7 @@ Upgrading the Wazuh indexer
 
 .. note:: 
 
-   Note that this upgrade process doesn't update plugins installed manually. This might cause the upgrade to fail.
+   Note that this upgrade process doesn't update plugins installed manually. Outdated plugins might cause the upgrade to fail.
 
    To ensure compatibility with the latest Wazuh indexer and Wazuh dashboard, please update manually installed plugins accordingly. For additional information, check the `distribution matrix <https://github.com/wazuh/wazuh-packages/tree/|WAZUH_CURRENT_MINOR|#distribution-version-matrix>`_.
 
@@ -205,7 +205,7 @@ Upgrading the Wazuh dashboard
 
 .. note:: 
 
-   Note that this upgrade process doesn't update plugins installed manually. This might cause the upgrade to fail.
+   Note that this upgrade process doesn't update plugins installed manually. Outdated plugins might cause the upgrade to fail.
 
    To ensure compatibility with the latest Wazuh indexer and Wazuh dashboard, please update manually installed plugins accordingly. For additional information, check the `distribution matrix <https://github.com/wazuh/wazuh-packages/tree/|WAZUH_CURRENT_MINOR|#distribution-version-matrix>`_.
 

--- a/source/upgrade-guide/upgrading-central-components.rst
+++ b/source/upgrade-guide/upgrading-central-components.rst
@@ -56,6 +56,12 @@ In the case Wazuh is installed in a multi-node cluster configuration, repeat the
 Upgrading the Wazuh indexer
 ---------------------------
 
+.. note:: 
+
+   Note that this upgrade process doesn't update plugins installed manually. This might cause the upgrade to fail.
+
+   To ensure compatibility with the latest Wazuh indexer and Wazuh dashboard, please update manually installed plugins accordingly. For additional information, check the `distribution matrix <https://github.com/wazuh/wazuh-packages/tree/|WAZUH_CURRENT_MINOR|#distribution-version-matrix>`_.
+
 In the case of having a Wazuh indexer cluster with multiple nodes, the cluster will remain available throughout the upgrading process. This rolling upgrade allows shutting down one Wazuh indexer node at a time for minimal disruption of service. Repeat these steps for every Wazuh indexer node.
 
 .. note::
@@ -196,6 +202,12 @@ When upgrading a multi-node Wazuh manager cluster, run the upgrade in every node
       
 Upgrading the Wazuh dashboard
 -----------------------------
+
+.. note:: 
+
+   Note that this upgrade process doesn't update plugins installed manually. This might cause the upgrade to fail.
+
+   To ensure compatibility with the latest Wazuh indexer and Wazuh dashboard, please update manually installed plugins accordingly. For additional information, check the `distribution matrix <https://github.com/wazuh/wazuh-packages/tree/|WAZUH_CURRENT_MINOR|#distribution-version-matrix>`_.
 
 #. Upgrade the Wazuh dashboard.
 


### PR DESCRIPTION

## Description

This PR adds notes to the upgrade guide regarding manually installed plugins. The notes warn that they need to be updated to be compatible with the new version of the Wazuh indexer and the Wazuh dashboard and include a link to the table with the corresponding versions. Related issue: https://github.com/wazuh/wazuh-kibana-app/issues/5380

## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
