### PR TITLE
Change OVA package version to 4.3.11

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -531,7 +531,7 @@ custom_replacements = {
     "|WAZUH_CURRENT_AMI|" : "4.3.10",
     "|WAZUH_CURRENT_MAJOR_OVA|" : "4.x",
     #"|WAZUH_CURRENT_MINOR_OVA|" :
-    "|WAZUH_CURRENT_OVA|" : "4.3.10", #release,
+    "|WAZUH_CURRENT_OVA|" : release,
     #"|WAZUH_CURRENT_MAJOR_DOCKER|" :
     "|WAZUH_CURRENT_MINOR_DOCKER|" : version,
     "|WAZUH_CURRENT_DOCKER|" : release,


### PR DESCRIPTION
## Description
This PR sets back the version of the OVA package to latest 4.3.11 release.

## Checks
- [X] Compiles without warnings.
- [X] Uses present tense, active voice, and semi-formal registry.
- [X] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [X] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
