### PR TITLE
Fix upgrade guide link - OVA and AMI

### DIFF
--- a/source/deployment-options/amazon-machine-images/amazon-machine-images.rst
+++ b/source/deployment-options/amazon-machine-images/amazon-machine-images.rst
@@ -142,4 +142,4 @@ Upgrading the Wazuh server
 
 The Wazuh server in the instance can be upgraded as a traditional installation.
 
-  - :ref:`Upgrading the Wazuh manager <upgrading_wazuh_server>`
+  - :doc:`Upgrading the Wazuh central components </upgrade-guide/upgrading-central-components>`

--- a/source/deployment-options/virtual-machine/virtual-machine.rst
+++ b/source/deployment-options/virtual-machine/virtual-machine.rst
@@ -119,4 +119,4 @@ Upgrading the VM
 
 The virtual machine can be upgraded as a traditional installation:
 
-  - :ref:`Upgrading the Wazuh manager <upgrading_wazuh_server>`
+  - :doc:`Upgrading the Wazuh central components </upgrade-guide/upgrading-central-components>`


### PR DESCRIPTION
## Description

This PR fixes the upgrade guide link in the OVA and AMI sections and closes #6094.

## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
