### PR TITLE
Fix installation removal in macos from sources

### DIFF
--- a/source/deployment-options/wazuh-from-sources/wazuh-agent/index.rst
+++ b/source/deployment-options/wazuh-from-sources/wazuh-agent/index.rst
@@ -396,7 +396,7 @@ The Wazuh agent is a single and lightweight monitoring software. It is a multi-p
 
         .. code-block:: console
 
-            # rm -rf /Library/StartupItems/OSSEC
+            # rm -rf /Library/StartupItems/WAZUH
 
         Remove Wazuh user and group:
 


### PR DESCRIPTION

## Description
Fix a small error in the `Uninstall` section of the MacOS `Installing the Wazuh agent from sources` page, https://documentation.wazuh.com/current/deployment-options/wazuh-from-sources/wazuh-agent/index.html.

One of the steps of the installation is removing `/Library/StartupItems/Ossec`, which has been changed to `/Library/StartupItems/WAZUH`
