### PR TITLE
Update macOS deployment steps

### DIFF
--- a/source/installation-guide/wazuh-agent/wazuh-agent-package-macos.rst
+++ b/source/installation-guide/wazuh-agent/wazuh-agent-package-macos.rst
@@ -24,7 +24,7 @@ The agent runs on the endpoint you want to monitor and communicates with the Waz
 
                 .. code-block:: console
     
-                  # echo "WAZUH_MANAGER='10.0.0.2'" > /tmp/wazuh_vars && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /
+                  # echo "WAZUH_MANAGER='10.0.0.2'" > /tmp/wazuh_envs && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /
     
                 .. note:: For version 4.4.2 and earlier, run the following command instead. Replace ``<WAZUH.VERSION-REV>`` with your package version, such as ``4.4.2-1``.
                    :class: not-long

--- a/source/installation-guide/wazuh-agent/wazuh-agent-package-macos.rst
+++ b/source/installation-guide/wazuh-agent/wazuh-agent-package-macos.rst
@@ -26,6 +26,13 @@ The agent runs on the endpoint you want to monitor and communicates with the Waz
     
                   # echo "WAZUH_MANAGER='10.0.0.2'" > /tmp/wazuh_vars && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /
     
+                .. note:: For version 4.4.2 and earlier, run the following command instead. Replace ``<WAZUH.VERSION-REV>`` with your package version, such as ``4.4.2-1``.
+                   :class: not-long
+
+                   .. code-block:: console
+    
+                      # launchctl setenv WAZUH_MANAGER "10.0.0.2" && installer -pkg wazuh-agent-<WAZUH.VERSION-REV>.pkg -target /
+
                 For additional deployment options such as agent name, agent group, and registration password, see the :doc:`Deployment variables for macOS </user-manual/deployment-variables/deployment-variables-macos>` section.
                 
                 .. note:: Alternatively, if you want to install an agent without registering it, omit the deployment variables. To learn more about the different registration methods, see the :doc:`Wazuh agent enrollment </user-manual/agent-enrollment/index>` section.
@@ -54,27 +61,6 @@ The agent runs on the endpoint you want to monitor and communicates with the Waz
                   # sudo /Library/Ossec/bin/wazuh-control start
  
             The installation process is now complete, and the Wazuh agent is successfully installed on your macOS endpoint. The next step is to register and configure the agent to communicate with the Wazuh server. To perform this action, see the :doc:`Wazuh agent enrollment </user-manual/agent-enrollment/index>` section.  
-
-          .. group-tab:: CLI (for 4.4.2 and earlier)
-    
-             #. To deploy the Wazuh agent on your endpoint, edit the ``WAZUH_MANAGER`` variable to contain your Wazuh manager IP address or hostname and run the following command. Replace ``<WAZUH.VERSION-REV>`` with your packages version ``4.4.2-1`` or earlier.
-
-                .. code-block:: console
-    
-                  # launchctl setenv WAZUH_MANAGER "10.0.0.2" && installer -pkg wazuh-agent-<WAZUH.VERSION-REV>.pkg -target /
-    
-                For additional deployment options such as agent name, agent group, and registration password, see the :doc:`Deployment variables for macOS </user-manual/deployment-variables/deployment-variables-macos>` section.
-                
-                .. note:: Alternatively, if you want to install an agent without registering it, omit the deployment variables. To learn more about the different registration methods, see the :doc:`Wazuh agent enrollment </user-manual/agent-enrollment/index>` section.
-
-             #. To complete the installation process, start the Wazuh agent.
-    
-                .. code-block:: console
-    
-                  # /Library/Ossec/bin/wazuh-control start
-
-
-            The installation process is now complete, and the Wazuh agent is successfully deployed and running on your macOS endpoint.
 
             
 By default, all agent files are stored in ``/Library/Ossec/`` after the installation.

--- a/source/installation-guide/wazuh-agent/wazuh-agent-package-macos.rst
+++ b/source/installation-guide/wazuh-agent/wazuh-agent-package-macos.rst
@@ -24,7 +24,7 @@ The agent runs on the endpoint you want to monitor and communicates with the Waz
 
                 .. code-block:: console
     
-                  # launchctl setenv WAZUH_MANAGER "10.0.0.2" && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /
+                  # echo "WAZUH_MANAGER='10.0.0.2'" > /tmp/wazuh_vars && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /
     
                 For additional deployment options such as agent name, agent group, and registration password, see the :doc:`Deployment variables for macOS </user-manual/deployment-variables/deployment-variables-macos>` section.
                 
@@ -55,6 +55,28 @@ The agent runs on the endpoint you want to monitor and communicates with the Waz
  
             The installation process is now complete, and the Wazuh agent is successfully installed on your macOS endpoint. The next step is to register and configure the agent to communicate with the Wazuh server. To perform this action, see the :doc:`Wazuh agent enrollment </user-manual/agent-enrollment/index>` section.  
 
+          .. group-tab:: CLI (for 4.4.2 and earlier)
+    
+             #. To deploy the Wazuh agent on your endpoint, edit the ``WAZUH_MANAGER`` variable to contain your Wazuh manager IP address or hostname and run the following command. Replace ``<WAZUH.VERSION-REV>`` with your packages version ``4.4.2-1`` or earlier.
+
+                .. code-block:: console
+    
+                  # launchctl setenv WAZUH_MANAGER "10.0.0.2" && installer -pkg wazuh-agent-<WAZUH.VERSION-REV>.pkg -target /
+    
+                For additional deployment options such as agent name, agent group, and registration password, see the :doc:`Deployment variables for macOS </user-manual/deployment-variables/deployment-variables-macos>` section.
+                
+                .. note:: Alternatively, if you want to install an agent without registering it, omit the deployment variables. To learn more about the different registration methods, see the :doc:`Wazuh agent enrollment </user-manual/agent-enrollment/index>` section.
+
+             #. To complete the installation process, start the Wazuh agent.
+    
+                .. code-block:: console
+    
+                  # /Library/Ossec/bin/wazuh-control start
+
+
+            The installation process is now complete, and the Wazuh agent is successfully deployed and running on your macOS endpoint.
+
+            
 By default, all agent files are stored in ``/Library/Ossec/`` after the installation.
     
 

--- a/source/installation-guide/wazuh-agent/wazuh-agent-package-macos.rst
+++ b/source/installation-guide/wazuh-agent/wazuh-agent-package-macos.rst
@@ -62,7 +62,6 @@ The agent runs on the endpoint you want to monitor and communicates with the Waz
  
             The installation process is now complete, and the Wazuh agent is successfully installed on your macOS endpoint. The next step is to register and configure the agent to communicate with the Wazuh server. To perform this action, see the :doc:`Wazuh agent enrollment </user-manual/agent-enrollment/index>` section.  
 
-            
 By default, all agent files are stored in ``/Library/Ossec/`` after the installation.
     
 

--- a/source/user-manual/deployment-variables/deployment-variables-macos.rst
+++ b/source/user-manual/deployment-variables/deployment-variables-macos.rst
@@ -54,42 +54,42 @@ Below you can find a table describing the variables used by Wazuh installers, an
          .. code-block:: console
          
             # echo "WAZUH_MANAGER='10.0.0.2' && WAZUH_REGISTRATION_PASSWORD='TopSecret' && \
-            WAZUH_AGENT_NAME='macos-agent'" > /tmp/wazuh_vars && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /
+            WAZUH_AGENT_NAME='macos-agent'" > /tmp/wazuh_envs && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /
 
       -  Registration with password and assigning a group:
 
          .. code-block:: console
          
             # echo "WAZUH_MANAGER='10.0.0.2' && WAZUH_REGISTRATION_SERVER='10.0.0.2' && WAZUH_REGISTRATION_PASSWORD='TopSecret' && \
-            WAZUH_AGENT_GROUP='my-group'" > /tmp/wazuh_vars && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /            
+            WAZUH_AGENT_GROUP='my-group'" > /tmp/wazuh_envs && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /            
 
       -  Registration with relative path to CA. It will be searched at your Wazuh installation folder:
 
          .. code-block:: console
          
             # echo "WAZUH_MANAGER='10.0.0.2' && WAZUH_REGISTRATION_SERVER='10.0.0.2' && WAZUH_AGENT_NAME='macos-agent' && \
-            WAZUH_REGISTRATION_CA='rootCA.pem'" && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /
+            WAZUH_REGISTRATION_CA='rootCA.pem'" > /tmp/wazuh_envs && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /
 
       -  Registration with protocol:
 
          .. code-block:: console
       
             # echo "WAZUH_MANAGER='10.0.0.2' && WAZUH_REGISTRATION_SERVER='10.0.0.2' && WAZUH_AGENT_NAME='macos-agent' && \
-            WAZUH_PROTOCOL='udp'" && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /
+            WAZUH_PROTOCOL='udp'" > /tmp/wazuh_envs && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /
 
       -  Registration and adding multiple address:
 
          .. code-block:: console
       
             # echo "WAZUH_MANAGER='10.0.0.2,10.0.0.3' && WAZUH_REGISTRATION_SERVER='10.0.0.2' && \
-            WAZUH_AGENT_NAME='macos-agent'" && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /
+            WAZUH_AGENT_NAME='macos-agent'" > /tmp/wazuh_envs && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /
 
       -  Absolute paths to CA, certificate or key that contain spaces can be written as shown below:
 
          .. code-block:: console
       
             # echo "WAZUH_MANAGER='10.0.0.2' && WAZUH_REGISTRATION_SERVER='10.0.0.2' && WAZUH_REGISTRATION_KEY='/var/ossec/etc/sslagent.key' && \
-            WAZUH_REGISTRATION_CERTIFICATE='/var/ossec/etc/sslagent.cert' && sudo installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /
+            WAZUH_REGISTRATION_CERTIFICATE='/var/ossec/etc/sslagent.cert'" > /tmp/wazuh_envs && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /
 
    .. group-tab:: Examples (for 4.4.2 and earlier)
 

--- a/source/user-manual/deployment-variables/deployment-variables-macos.rst
+++ b/source/user-manual/deployment-variables/deployment-variables-macos.rst
@@ -45,48 +45,94 @@ Below you can find a table describing the variables used by Wazuh installers, an
 |   ENROLLMENT_DELAY               |  Assigns the time that agentd should wait after a successful registration. See :ref:`delay_after_enrollment <enrollment_delay_after_enrollment>`.                                                    |
 +----------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
-Examples:
+.. tabs::
 
-* Registration with password:
+   .. group-tab:: Examples
+    
+      -  Registration with password:
 
-.. code-block:: console
+         .. code-block:: console
+         
+            # echo "WAZUH_MANAGER='10.0.0.2' && WAZUH_REGISTRATION_PASSWORD='TopSecret' && \
+            WAZUH_AGENT_NAME='macos-agent'" > /tmp/wazuh_vars && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /
 
-     # launchctl setenv WAZUH_MANAGER "10.0.0.2" WAZUH_REGISTRATION_PASSWORD "TopSecret" \
-          WAZUH_AGENT_NAME "macos-agent" && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /
+      -  Registration with password and assigning a group:
 
-* Registration with password and assigning a group:
+         .. code-block:: console
+         
+            # echo "WAZUH_MANAGER='10.0.0.2' && WAZUH_REGISTRATION_SERVER='10.0.0.2' && WAZUH_REGISTRATION_PASSWORD='TopSecret' && \
+            WAZUH_AGENT_GROUP='my-group'" > /tmp/wazuh_vars && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /            
 
-.. code-block:: console
+      -  Registration with relative path to CA. It will be searched at your Wazuh installation folder:
 
-     # launchctl setenv WAZUH_MANAGER "10.0.0.2" WAZUH_REGISTRATION_SERVER "10.0.0.2" WAZUH_REGISTRATION_PASSWORD "TopSecret" \
-          WAZUH_AGENT_GROUP "my-group" && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /
+         .. code-block:: console
+         
+            # echo "WAZUH_MANAGER='10.0.0.2' && WAZUH_REGISTRATION_SERVER='10.0.0.2' && WAZUH_AGENT_NAME='macos-agent' && \
+            WAZUH_REGISTRATION_CA='rootCA.pem'" && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /
 
-* Registration with relative path to CA. It will be searched at your Wazuh installation folder:
+      -  Registration with protocol:
 
-.. code-block:: console
+         .. code-block:: console
+      
+            # echo "WAZUH_MANAGER='10.0.0.2' && WAZUH_REGISTRATION_SERVER='10.0.0.2' && WAZUH_AGENT_NAME='macos-agent' && \
+            WAZUH_PROTOCOL='udp'" && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /
 
-     # launchctl setenv WAZUH_MANAGER "10.0.0.2" WAZUH_REGISTRATION_SERVER "10.0.0.2" WAZUH_AGENT_NAME "macos-agent" \
-          WAZUH_REGISTRATION_CA "rootCA.pem" && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /
+      -  Registration and adding multiple address:
 
-* Registration with protocol:
+         .. code-block:: console
+      
+            # echo "WAZUH_MANAGER='10.0.0.2,10.0.0.3' && WAZUH_REGISTRATION_SERVER='10.0.0.2' && \
+            WAZUH_AGENT_NAME='macos-agent'" && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /
 
-.. code-block:: console
+      -  Absolute paths to CA, certificate or key that contain spaces can be written as shown below:
 
-     # launchctl setenv WAZUH_MANAGER "10.0.0.2" WAZUH_REGISTRATION_SERVER "10.0.0.2" WAZUH_AGENT_NAME "macos-agent" \
-          WAZUH_PROTOCOL "udp" && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /
+         .. code-block:: console
+      
+            # echo "WAZUH_MANAGER='10.0.0.2' && WAZUH_REGISTRATION_SERVER='10.0.0.2' && WAZUH_REGISTRATION_KEY='/var/ossec/etc/sslagent.key' && \
+            WAZUH_REGISTRATION_CERTIFICATE='/var/ossec/etc/sslagent.cert' && sudo installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /
 
-* Registration and adding multiple address:
+   .. group-tab:: Examples (for 4.4.2 and earlier)
 
-.. code-block:: console
+      -  Registration with password:
 
-     # launchctl setenv WAZUH_MANAGER "10.0.0.2,10.0.0.3" WAZUH_REGISTRATION_SERVER "10.0.0.2" \
-          WAZUH_AGENT_NAME "macos-agent" && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /
+         .. code-block:: console
+         
+            # launchctl setenv WAZUH_MANAGER "10.0.0.2" WAZUH_REGISTRATION_PASSWORD "TopSecret" \
+            WAZUH_AGENT_NAME "macos-agent" && installer -pkg wazuh-agent-4.4.2-1.pkg -target /
 
-* Absolute paths to CA, certificate or key that contain spaces can be written as shown below:
+      -  Registration with password and assigning a group:
 
-.. code-block:: console
+         .. code-block:: console
+         
+            # launchctl setenv WAZUH_MANAGER "10.0.0.2" WAZUH_REGISTRATION_SERVER "10.0.0.2" WAZUH_REGISTRATION_PASSWORD "TopSecret" \
+            WAZUH_AGENT_GROUP "my-group" && installer -pkg wazuh-agent-4.4.2-1.pkg -target /
 
-     # launchctl setenv WAZUH_MANAGER "10.0.0.2" WAZUH_REGISTRATION_SERVER "10.0.0.2" WAZUH_REGISTRATION_KEY "/var/ossec/etc/sslagent.key" \
-          WAZUH_REGISTRATION_CERTIFICATE "/var/ossec/etc/sslagent.cert" && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /
+      -  Registration with relative path to CA. It will be searched at your Wazuh installation folder:
+
+         .. code-block:: console
+         
+            # launchctl setenv WAZUH_MANAGER "10.0.0.2" WAZUH_REGISTRATION_SERVER "10.0.0.2" WAZUH_AGENT_NAME "macos-agent" \
+            WAZUH_REGISTRATION_CA "rootCA.pem" && installer -pkg wazuh-agent-4.4.2-1.pkg -target /
+
+      -  Registration with protocol:
+
+         .. code-block:: console
+      
+            # launchctl setenv WAZUH_MANAGER "10.0.0.2" WAZUH_REGISTRATION_SERVER "10.0.0.2" WAZUH_AGENT_NAME "macos-agent" \
+            WAZUH_PROTOCOL "udp" && installer -pkg wazuh-agent-4.4.2-1.pkg -target /
+
+      -  Registration and adding multiple address:
+
+         .. code-block:: console
+      
+            # launchctl setenv WAZUH_MANAGER "10.0.0.2,10.0.0.3" WAZUH_REGISTRATION_SERVER "10.0.0.2" \
+            WAZUH_AGENT_NAME "macos-agent" && installer -pkg wazuh-agent-4.4.2-1.pkg -target /
+
+      -  Absolute paths to CA, certificate or key that contain spaces can be written as shown below:
+
+         .. code-block:: console
+      
+            # launchctl setenv WAZUH_MANAGER "10.0.0.2" WAZUH_REGISTRATION_SERVER "10.0.0.2" WAZUH_REGISTRATION_KEY "/var/ossec/etc/sslagent.key" \
+            WAZUH_REGISTRATION_CERTIFICATE "/var/ossec/etc/sslagent.cert" && installer -pkg wazuh-agent-4.4.2-1.pkg -target /
 
 .. note:: It’s necessary to use both KEY and PEM options to verify agents' identities with the registration server. See the :ref:`Registration Service with host verification - Agent verification with host validation <enrollment_additional_security>` section.


### PR DESCRIPTION
## Description
This PR closes #6123 It updates macOS deployment steps and variable examples following latest 4.4 patch.

## Checks
- [X] Compiles without warnings.
- [X] Uses present tense, active voice, and semi-formal registry.
- [X] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [X] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
