### PR TITLE
Add redirections for syscollector

### DIFF
--- a/source/_static/js/redirects.js
+++ b/source/_static/js/redirects.js
@@ -160,7 +160,42 @@ redirections.push(
       '4.3': '/user-manual/capabilities/wazuh-logtest/logtest-faq.html',
       '4.4': '/user-manual/ruleset/testing.html',
     },
-);
+    {
+      'target': ['4.3=>4.4', '4.4=>4.3'],
+      '4.3': '/user-manual/capabilities/syscollector.html',
+      '4.4': '/user-manual/capabilities/system-inventory/index.html',
+    },
+    {
+      'target': ['4.3=>4.4', '4.4=>4.3'],
+      '4.3': '/user-manual/capabilities/syscollector.html#how-it-works',
+      '4.4': '/user-manual/capabilities/system-inventory/how-it-works.html',
+    },
+    {
+      'target': ['4.3=>4.4', '4.4=>4.3'],
+      '4.3': '/user-manual/capabilities/syscollector.html#available-scans',
+      '4.4': '/user-manual/capabilities/system-inventory/available-inventory-fields.html',
+    },
+    {
+      'target': ['4.3=>4.4', '4.4=>4.3'],
+      '4.3': '/user-manual/capabilities/syscollector.html#compatibility-matrix',
+      '4.4': '/user-manual/capabilities/system-inventory/compatibility-matrix.html',
+    },
+    {
+      'target': ['4.3=>4.4', '4.4=>4.3'],
+      '4.3': '/user-manual/capabilities/syscollector.html#using-syscollector-information-to-trigger-alerts',
+      '4.4': '/user-manual/capabilities/system-inventory/using-syscollector-information-to-trigger-alerts.html',
+    },
+    {
+      'target': ['4.3=>4.4', '4.4=>4.3'],
+      '4.3': '/user-manual/capabilities/syscollector.html#use-case-visualize-system-inventory-in-the-wazuh-app',
+      '4.4': '/user-manual/capabilities/system-inventory/viewing-system-inventory-data.html',
+    },
+    {
+      'target': ['4.4=>4.3'],
+      '4.3': '/user-manual/capabilities/syscollector.html#use-case-visualize-system-inventory-in-the-wazuh-app',
+      '4.4': '/user-manual/capabilities/system-inventory/configuration.html',
+    },
+  );
 
 /* Pages added in 4.4 */
 


### PR DESCRIPTION
## Description
This PR adds missing redirections for system inventory between 4.3 and 4.4 documents.

## Checks
- [X] Compiles without warnings.
- [X] Uses present tense, active voice, and semi-formal registry.
- [X] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [X] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).