### PR TITLE
Add note to system inventory configuration

### DIFF
--- a/source/user-manual/capabilities/system-inventory/configuration.rst
+++ b/source/user-manual/capabilities/system-inventory/configuration.rst
@@ -55,4 +55,4 @@ Where:
 
 .. note::
 
-   Restart the agent when you make any changes to the configuration file. This will ensure that the changes take effect.
+   Restart the agent when you make any changes to the configuration file. This ensures that the changes take effect.

--- a/source/user-manual/capabilities/system-inventory/configuration.rst
+++ b/source/user-manual/capabilities/system-inventory/configuration.rst
@@ -52,3 +52,7 @@ Where:
 - ``<ports all="no">`` enables or disables the port scan. The default value is ``yes``. You can configure two allowed values of ``yes`` and ``no``. This option also accepts an additional parameter ``all``, with which you can restrict the scan to only listening ports using ``<ports all="no">``. If you want Syscollector to scan all ports, then you change the value to ``yes``.
 - ``<processes>`` enables or disables the scanning for running processes on a monitored endpoint. The default value of ``yes``. The allowed values are ``yes`` and ``no``.
 - ``<max_eps>`` allows you to set the maximum event reporting throughput. The default value is 10, which signifies 10 events per second. The allowed value is an Integer number between 0 and 1000000.
+
+.. note::
+
+   Restart the agent when you make any changes to the configuration file. This will ensure that the changes take effect.


### PR DESCRIPTION
## Description
This PR adds a note at the end of the configuration page.

## Checks
- [X] Compiles without warnings.
- [X] Uses present tense, active voice, and semi-formal registry.
- [X] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [X] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
