### PR TITLE
Add external ID and remove profile from Security Lake reference

### DIFF
--- a/source/amazon/services/supported-services/security-lake.rst
+++ b/source/amazon/services/supported-services/security-lake.rst
@@ -103,7 +103,7 @@ Follow these steps to modify the Security Lake subscriber role. You have to asso
 #. In the **Summary** page, navigate to the **Trust relationships** tab to modify the Trusted entity policy.
 #. Modify the Trusted entity policy with the following updates:
 
-    #. In the stanza containing the ARN, attach the username from your target user account to the end of the ARN. This step connects a user to the role. It lets you configure the Security Lake service with the secret access key. See the following example Trust entity:
+    #. In the stanza containing the ARN, attach the username from your target user account to the end of the ARN. This step connects a user to the role. It lets you configure the Security Lake service with the secret access key. See the following example Trusted entity:
 
     .. code-block:: JSON
 

--- a/source/amazon/services/supported-services/security-lake.rst
+++ b/source/amazon/services/supported-services/security-lake.rst
@@ -103,7 +103,7 @@ Follow these steps to modify the Security Lake subscriber role. You have to asso
 #. In the **Summary** page, navigate to the **Trust relationships** tab to modify the Trusted entity policy.
 #. Modify the Trusted entity policy with the following updates:
 
-    #. In the stanza containing the ARN, attach the username from your target user account to the end of the ARN. This step connects a user to the role. It lets you configure the Security Lake service with the secret access key. See the following example Trusted entity:
+    #. In the stanza containing the ARN, attach the username from your target user account to the end of the ARN. This step connects a user to the role. It lets you configure the Security Lake service with the secret access key. See the following Trusted entity example:
 
     .. code-block:: JSON
 

--- a/source/user-manual/reference/ossec-conf/wodle-s3.rst
+++ b/source/user-manual/reference/ossec-conf/wodle-s3.rst
@@ -680,7 +680,8 @@ The currently available type is: ``security_lake``.
 | :ref:`subscriber_iam_role_arn`         | Valid role ARN                                              | Mandatory for Amazon Security Lake            |
 |                                        |                                                             | Subscription                                  |
 +----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
-| :ref:`subscriber_aws_profile`          | Valid profile name                                          | Optional                                      |
+| :ref:`subscriber_external_id`          | Valid external ID                                           | Mandatory for Amazon Security Lake            |
+|                                        |                                                             | Subscription                                  |
 +----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
 | :ref:`subscriber_iam_role_duration`    | Number of seconds between 900 and 3600                      | Optional (if set, it requires an iam_role_arn |
 |                                        |                                                             | to be provided)                               |
@@ -703,17 +704,17 @@ Name of the SQS from where notifications are pulled.
 | **Allowed values** | Any valid SQS name          |
 +--------------------+-----------------------------+
 
-.. _subscriber_aws_profile:
+.. _subscriber_external_id:
 
-aws_profile
+external_id
 ^^^^^^^^^^^
 
-A valid profile name from a Shared Credential File or AWS Config File with permission to access the service.
+External ID to use when assuming the role.
 
 +--------------------+--------------------+
 | **Default value**  | N/A                |
 +--------------------+--------------------+
-| **Allowed values** | Valid profile name |
+| **Allowed values** | Valid external ID  |
 +--------------------+--------------------+
 
 .. _subscriber_iam_role_arn:
@@ -829,6 +830,8 @@ Example of configuration
       </service>
       <subscriber type="security_lake">
         <sqs_name>sqs-security-lake-main-queue</sqs_name>
-        <aws_profile>user_profile</aws_profile>
-    </subscriber>
+        <external_id>wazuh-external-id-value</external_id>
+        <iam_role_arn>arn:aws:iam::010203040506:role/ASL-Role</iam_role_arn>
+      </subscriber>
   </wodle>
+  


### PR DESCRIPTION
## Description

This PR closes #6136. It modifies the AWS module reference page, specifically the `Subscribers` section, adding the `external_id` parameter and removing the `aws_profile` which is not part of the `Amazon Security Lake` page.

## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
