### PR TITLE
Turn into note the paragraph about saved passwords in Quickstart guide

### DIFF
--- a/source/quickstart.rst
+++ b/source/quickstart.rst
@@ -98,12 +98,14 @@ Installing Wazuh
 
 When you access the Wazuh dashboard for the first time, the browser shows a warning message stating that the certificate was not issued by a trusted authority. This is expected and the user has the option to accept the certificate as an exception or, alternatively, configure the system to use a certificate from a trusted authority.
 
-You can find the passwords for all the Wazuh indexer and Wazuh API users in the ``wazuh-passwords.txt`` file inside ``wazuh-install-files.tar``. To print them, run the following command:
+.. note::
+   :class: not-long
+  
+   You can find the passwords for all the Wazuh indexer and Wazuh API users in the ``wazuh-passwords.txt`` file inside ``wazuh-install-files.tar``. To print them, run the following command:
 
-
-   .. code-block:: console
-   
-      $ sudo tar -O -xvf wazuh-install-files.tar wazuh-install-files/wazuh-passwords.txt
+      .. code-block:: console
+      
+         $ sudo tar -O -xvf wazuh-install-files.tar wazuh-install-files/wazuh-passwords.txt
 
 If you want to uninstall the Wazuh central components, run the Wazuh installation assistant using the option ``-u`` or ``–-uninstall``.
 


### PR DESCRIPTION
## Description
This PR highlights the paragraph about finding the passwords generated using the Quickstart guide. It turns it into a note.

![imagen](https://github.com/wazuh/wazuh-documentation/assets/47069802/93816b0a-8262-4d2e-beea-7cc7d6703ac3)

## Checks
- [X] Compiles without warnings.
- [X] Uses present tense, active voice, and semi-formal registry.
- [X] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [X] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).