### PR TITLE
Update add_repository.rst

### DIFF
--- a/source/_templates/installations/dashboard/apt/add_repository.rst
+++ b/source/_templates/installations/dashboard/apt/add_repository.rst
@@ -4,13 +4,13 @@
 
     .. code-block:: console
 
-      # curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | gpg --no-default-keyring --keyring gnupg-ring:/usr/share/keyrings/wazuh.gpg --import && chmod 644 /usr/share/keyrings/wazuh.gpg
+      # curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH -o /etc/apt/trusted.gpg.d/wazuh.asc && chmod 644 /etc/apt/trusted.gpg.d/wazuh.asc
 
 #. Add the repository.
 
     .. code-block:: console
 
-      # echo "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages.wazuh.com/4.x/apt/ stable main" | tee -a /etc/apt/sources.list.d/wazuh.list
+      # echo "deb https://packages.wazuh.com/4.x/apt/ stable main" | tee -a /etc/apt/sources.list.d/wazuh.list
 
 #. Update the package information.
 


### PR DESCRIPTION
Debian APT no longer permits the use of /etc/apt/trusted.gpg and does not encourage the use of /usr/share/keyrings. See DEPRECATION in apt-key(8)

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
<!--
Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->
Debian APT no longer permits the use of /etc/apt/trusted.gpg and does not encourage the use of /usr/share/keyrings.
See DEPRECATION in apt-key(8)
## Checks
- [ ] Compiles without warnings.
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
