### PR TITLE
Update Single Sign-on documentation 

### DIFF
--- a/source/deployment-options/offline-installation.rst
+++ b/source/deployment-options/offline-installation.rst
@@ -612,7 +612,7 @@ Select your deployment type and follow the instructions to change the default pa
                   url: https://localhost
                   port: 55000
                   username: wazuh-wui
-                  password: <wazuh-wui-password>
+                  password: "<wazuh-wui-password>"
                   run_as: false
 
       #. Restart the Wazuh dashboard to apply the changes.

--- a/source/installation-guide/wazuh-dashboard/step-by-step.rst
+++ b/source/installation-guide/wazuh-dashboard/step-by-step.rst
@@ -221,7 +221,7 @@ Select your deployment type and follow the instructions to change the default pa
                   url: https://localhost
                   port: 55000
                   username: wazuh-wui
-                  password: <wazuh-wui-password>
+                  password: "<wazuh-wui-password>"
                   run_as: false
 
       #. Restart the Wazuh dashboard to apply the changes.

--- a/source/user-manual/user-administration/password-management.rst
+++ b/source/user-manual/user-administration/password-management.rst
@@ -239,7 +239,7 @@ Follow the instructions below to change the passwords for all the Wazuh indexer 
             url: https://localhost
             port: 55000
             username: wazuh-wui
-            password: <wazuh-wui-password>
+            password: "<wazuh-wui-password>"
             run_as: false
 
 #. Restart the Wazuh dashboard to apply the changes.

--- a/source/user-manual/user-administration/single-sign-on/azure-active-directory.rst
+++ b/source/user-manual/user-administration/single-sign-on/azure-active-directory.rst
@@ -284,20 +284,6 @@ Wazuh dashboard configuration
       opensearch_security.auth.type: "saml"
       server.xsrf.allowlist: ["/_opendistro/_security/saml/acs", "/_opendistro/_security/saml/logout", "/_opendistro/_security/saml/acs/idpinitiated"]
 
-   .. note::
-      :class: not-long
-
-      *For versions 4.3.9 and earlier*, also replace ``path: `/auth/logout``` with ``path: `/logout``` in ``/usr/share/wazuh-dashboard/plugins/securityDashboards/server/auth/types/saml/routes.js``. We recommend that you back up these files before you carry out the configuration.
-
-      .. code-block:: console
-         :emphasize-lines: 3
-
-         ...
-            this.router.get({
-               path: `/logout`,
-               validate: false
-         ...
-
 #. Ensure that ``run_as`` is set to false in the ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` configuration file.
 
    .. code-block:: yaml

--- a/source/user-manual/user-administration/single-sign-on/azure-active-directory.rst
+++ b/source/user-manual/user-administration/single-sign-on/azure-active-directory.rst
@@ -298,6 +298,19 @@ Wazuh dashboard configuration
                validate: false
          ...
 
+#. Ensure that ``run_as`` is set to false in the ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` configuration file.
+
+   .. code-block:: yaml
+      :emphasize-lines: 7
+
+      hosts:
+        - default:
+            url: https://localhost
+            port: 55000
+            username: wazuh-wui
+            password: <wazuh-wui-password>
+            run_as: false
+
 #. Restart the Wazuh dashboard service.
 
    .. include:: /_templates/common/restart_dashboard.rst

--- a/source/user-manual/user-administration/single-sign-on/azure-active-directory.rst
+++ b/source/user-manual/user-administration/single-sign-on/azure-active-directory.rst
@@ -294,7 +294,7 @@ Wazuh dashboard configuration
             url: https://localhost
             port: 55000
             username: wazuh-wui
-            password: <wazuh-wui-password>
+            password: "<wazuh-wui-password>"
             run_as: false
 
 #. Restart the Wazuh dashboard service.

--- a/source/user-manual/user-administration/single-sign-on/google.rst
+++ b/source/user-manual/user-administration/single-sign-on/google.rst
@@ -261,7 +261,7 @@ Wazuh dashboard configuration
             url: https://localhost
             port: 55000
             username: wazuh-wui
-            password: <wazuh-wui-password>
+            password: "<wazuh-wui-password>"
             run_as: false
 
 #. Restart the Wazuh dashboard service using this command:

--- a/source/user-manual/user-administration/single-sign-on/google.rst
+++ b/source/user-manual/user-administration/single-sign-on/google.rst
@@ -265,6 +265,19 @@ Wazuh dashboard configuration
                validate: false
          ...
 
+#. Ensure that ``run_as`` is set to false in the ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` configuration file.
+
+   .. code-block:: yaml
+      :emphasize-lines: 7
+
+      hosts:
+        - default:
+            url: https://localhost
+            port: 55000
+            username: wazuh-wui
+            password: <wazuh-wui-password>
+            run_as: false
+
 #. Restart the Wazuh dashboard service using this command:
 
    .. include:: /_templates/common/restart_dashboard.rst

--- a/source/user-manual/user-administration/single-sign-on/google.rst
+++ b/source/user-manual/user-administration/single-sign-on/google.rst
@@ -251,20 +251,6 @@ Wazuh dashboard configuration
       opensearch_security.auth.type: "saml"
       server.xsrf.allowlist: ["/_opendistro/_security/saml/acs", "/_opendistro/_security/saml/logout", "/_opendistro/_security/saml/acs/idpinitiated"]
 
-   .. note::
-      :class: not-long
-
-      *For versions 4.3.9 and earlier*, also replace ``path: `/auth/logout``` with ``path: `/logout``` in ``/usr/share/wazuh-dashboard/plugins/securityDashboards/server/auth/types/saml/routes.js``. We recommend that you back up these files before you carry out the configuration.
-
-      .. code-block:: console
-         :emphasize-lines: 3
-
-         ...
-            this.router.get({
-               path: `/logout`,
-               validate: false
-         ...
-
 #. Ensure that ``run_as`` is set to false in the ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` configuration file.
 
    .. code-block:: yaml

--- a/source/user-manual/user-administration/single-sign-on/jumpcloud.rst
+++ b/source/user-manual/user-administration/single-sign-on/jumpcloud.rst
@@ -266,6 +266,19 @@ Wazuh dashboard configuration
                validate: false
          ...
 
+#. Ensure that ``run_as`` is set to false in the ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` configuration file.
+
+   .. code-block:: yaml
+      :emphasize-lines: 7
+
+      hosts:
+        - default:
+            url: https://localhost
+            port: 55000
+            username: wazuh-wui
+            password: <wazuh-wui-password>
+            run_as: false
+
 #. Restart the Wazuh dashboard service.
 
    .. include:: /_templates/common/restart_dashboard.rst

--- a/source/user-manual/user-administration/single-sign-on/jumpcloud.rst
+++ b/source/user-manual/user-administration/single-sign-on/jumpcloud.rst
@@ -252,20 +252,6 @@ Wazuh dashboard configuration
       opensearch_security.auth.type: "saml"
       server.xsrf.allowlist: ["/_opendistro/_security/saml/acs", "/_opendistro/_security/saml/logout", "/_opendistro/_security/saml/acs/idpinitiated"]
 
-   .. note::
-      :class: not-long
-
-      *For versions 4.3.9 and earlier*, also replace ``path: `/auth/logout``` with ``path: `/logout``` in ``/usr/share/wazuh-dashboard/plugins/securityDashboards/server/auth/types/saml/routes.js``. We recommend that you back up these files before you carry out the configuration.
-
-      .. code-block:: console
-         :emphasize-lines: 3
-
-         ...
-            this.router.get({
-               path: `/logout`,
-               validate: false
-         ...
-
 #. Ensure that ``run_as`` is set to false in the ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` configuration file.
 
    .. code-block:: yaml

--- a/source/user-manual/user-administration/single-sign-on/jumpcloud.rst
+++ b/source/user-manual/user-administration/single-sign-on/jumpcloud.rst
@@ -262,7 +262,7 @@ Wazuh dashboard configuration
             url: https://localhost
             port: 55000
             username: wazuh-wui
-            password: <wazuh-wui-password>
+            password: "<wazuh-wui-password>"
             run_as: false
 
 #. Restart the Wazuh dashboard service.

--- a/source/user-manual/user-administration/single-sign-on/keycloak.rst
+++ b/source/user-manual/user-administration/single-sign-on/keycloak.rst
@@ -369,7 +369,7 @@ Wazuh dashboard configuration
             url: https://localhost
             port: 55000
             username: wazuh-wui
-            password: <wazuh-wui-password>
+            password: "<wazuh-wui-password>"
             run_as: false
 
 #. Restart the Wazuh dashboard service using this command:

--- a/source/user-manual/user-administration/single-sign-on/keycloak.rst
+++ b/source/user-manual/user-administration/single-sign-on/keycloak.rst
@@ -373,6 +373,19 @@ Wazuh dashboard configuration
                validate: false
          ...
 
+#. Ensure that ``run_as`` is set to false in the ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` configuration file.
+
+   .. code-block:: yaml
+      :emphasize-lines: 7
+
+      hosts:
+        - default:
+            url: https://localhost
+            port: 55000
+            username: wazuh-wui
+            password: <wazuh-wui-password>
+            run_as: false
+
 #. Restart the Wazuh dashboard service using this command:
 
    .. include:: /_templates/common/restart_dashboard.rst

--- a/source/user-manual/user-administration/single-sign-on/keycloak.rst
+++ b/source/user-manual/user-administration/single-sign-on/keycloak.rst
@@ -359,20 +359,6 @@ Wazuh dashboard configuration
       opensearch_security.auth.type: "saml"
       server.xsrf.allowlist: ["/_opendistro/_security/saml/acs", "/_opendistro/_security/saml/logout", "/_opendistro/_security/saml/acs/idpinitiated"]
 
-   .. note::
-      :class: not-long
-
-      *For versions 4.3.9 and earlier*, also replace ``path: `/auth/logout``` with ``path: `/logout``` in ``/usr/share/wazuh-dashboard/plugins/securityDashboards/server/auth/types/saml/routes.js``. We recommend that you back up these files before you carry out the configuration.
-
-      .. code-block:: console
-         :emphasize-lines: 3
-
-         ...
-            this.router.get({
-               path: `/logout`,
-               validate: false
-         ...
-
 #. Ensure that ``run_as`` is set to false in the ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` configuration file.
 
    .. code-block:: yaml

--- a/source/user-manual/user-administration/single-sign-on/okta.rst
+++ b/source/user-manual/user-administration/single-sign-on/okta.rst
@@ -285,20 +285,6 @@ Wazuh dashboard configuration
       opensearch_security.auth.type: "saml"
       server.xsrf.allowlist: ["/_opendistro/_security/saml/acs", "/_opendistro/_security/saml/logout", "/_opendistro/_security/saml/acs/idpinitiated"]
 
-   .. note::
-      :class: not-long
-
-      *For versions 4.3.9 and earlier*, also replace ``path: `/auth/logout``` with ``path: `/logout``` in ``/usr/share/wazuh-dashboard/plugins/securityDashboards/server/auth/types/saml/routes.js``. We recommend that you back up these files before you carry out the configuration.
-
-      .. code-block:: console
-         :emphasize-lines: 3
-
-         ...
-            this.router.get({
-               path: `/logout`,
-               validate: false
-         ...
-
 #. Ensure that ``run_as`` is set to false in the ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` configuration file.
 
    .. code-block:: yaml

--- a/source/user-manual/user-administration/single-sign-on/okta.rst
+++ b/source/user-manual/user-administration/single-sign-on/okta.rst
@@ -299,6 +299,20 @@ Wazuh dashboard configuration
                validate: false
          ...
 
+#. Ensure that ``run_as`` is set to false in the ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` configuration file.
+
+   .. code-block:: yaml
+      :emphasize-lines: 7
+
+      hosts:
+        - default:
+            url: https://localhost
+            port: 55000
+            username: wazuh-wui
+            password: <wazuh-wui-password>
+            run_as: false
+
+
 #. Restart the Wazuh dashboard service.
 
    .. include:: /_templates/common/restart_dashboard.rst

--- a/source/user-manual/user-administration/single-sign-on/okta.rst
+++ b/source/user-manual/user-administration/single-sign-on/okta.rst
@@ -295,7 +295,7 @@ Wazuh dashboard configuration
             url: https://localhost
             port: 55000
             username: wazuh-wui
-            password: <wazuh-wui-password>
+            password: "<wazuh-wui-password>"
             run_as: false
 
 

--- a/source/user-manual/user-administration/single-sign-on/onelogin.rst
+++ b/source/user-manual/user-administration/single-sign-on/onelogin.rst
@@ -295,7 +295,7 @@ Wazuh dashboard configuration
             url: https://localhost
             port: 55000
             username: wazuh-wui
-            password: <wazuh-wui-password>
+            password: "<wazuh-wui-password>"
             run_as: false
 
 #. Restart the Wazuh dashboard service.

--- a/source/user-manual/user-administration/single-sign-on/onelogin.rst
+++ b/source/user-manual/user-administration/single-sign-on/onelogin.rst
@@ -285,20 +285,6 @@ Wazuh dashboard configuration
       opensearch_security.auth.type: "saml"
       server.xsrf.allowlist: ["/_opendistro/_security/saml/acs", "/_opendistro/_security/saml/logout", "/_opendistro/_security/saml/acs/idpinitiated"]
 
-   .. note::
-      :class: not-long
-
-      *For versions 4.3.9 and earlier*, also replace ``path: `/auth/logout``` with ``path: `/logout``` in ``/usr/share/wazuh-dashboard/plugins/securityDashboards/server/auth/types/saml/routes.js``. We recommend that you back up these files before you carry out the configuration.
-
-      .. code-block:: console
-         :emphasize-lines: 3
-
-         ...
-            this.router.get({
-               path: `/logout`,
-               validate: false
-         ...
-
 #. Ensure that ``run_as`` is set to false in the ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` configuration file.
 
    .. code-block:: yaml

--- a/source/user-manual/user-administration/single-sign-on/onelogin.rst
+++ b/source/user-manual/user-administration/single-sign-on/onelogin.rst
@@ -299,6 +299,19 @@ Wazuh dashboard configuration
                validate: false
          ...
 
+#. Ensure that ``run_as`` is set to false in the ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` configuration file.
+
+   .. code-block:: yaml
+      :emphasize-lines: 7
+
+      hosts:
+        - default:
+            url: https://localhost
+            port: 55000
+            username: wazuh-wui
+            password: <wazuh-wui-password>
+            run_as: false
+
 #. Restart the Wazuh dashboard service.
 
    .. include:: /_templates/common/restart_dashboard.rst

--- a/source/user-manual/user-administration/single-sign-on/pingone.rst
+++ b/source/user-manual/user-administration/single-sign-on/pingone.rst
@@ -263,7 +263,7 @@ Wazuh dashboard configuration
             url: https://localhost
             port: 55000
             username: wazuh-wui
-            password: <wazuh-wui-password>
+            password: "<wazuh-wui-password>"
             run_as: false
 
 #. Restart the Wazuh dashboard service.

--- a/source/user-manual/user-administration/single-sign-on/pingone.rst
+++ b/source/user-manual/user-administration/single-sign-on/pingone.rst
@@ -267,6 +267,19 @@ Wazuh dashboard configuration
                validate: false
          ...
 
+#. Ensure that ``run_as`` is set to false in the ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` configuration file.
+
+   .. code-block:: yaml
+      :emphasize-lines: 7
+
+      hosts:
+        - default:
+            url: https://localhost
+            port: 55000
+            username: wazuh-wui
+            password: <wazuh-wui-password>
+            run_as: false
+
 #. Restart the Wazuh dashboard service.
 
    .. include:: /_templates/common/restart_dashboard.rst

--- a/source/user-manual/user-administration/single-sign-on/pingone.rst
+++ b/source/user-manual/user-administration/single-sign-on/pingone.rst
@@ -253,20 +253,6 @@ Wazuh dashboard configuration
       opensearch_security.auth.type: "saml"
       server.xsrf.allowlist: ["/_opendistro/_security/saml/acs", "/_opendistro/_security/saml/logout", "/_opendistro/_security/saml/acs/idpinitiated"]
 
-   .. note::
-      :class: not-long
-
-      *For versions 4.3.9 and earlier*, also replace ``path: `/auth/logout``` with ``path: `/logout``` in ``/usr/share/wazuh-dashboard/plugins/securityDashboards/server/auth/types/saml/routes.js``. We recommend that you back up these files before you carry out the configuration.
-
-      .. code-block:: console
-         :emphasize-lines: 3
-
-         ...
-            this.router.get({
-               path: `/logout`,
-               validate: false
-         ...
-
 #. Ensure that ``run_as`` is set to false in the ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` configuration file.
 
    .. code-block:: yaml


### PR DESCRIPTION
## Description

This PR clarifies that `run_as` must be set as false in the `/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml` configuration file and closes #6175. It also removes a note that does not apply to versions 4.4.x. 

## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
