### PR TITLE
[4.3] Update Single Sign-on documentation

### DIFF
--- a/source/deployment-options/offline-installation.rst
+++ b/source/deployment-options/offline-installation.rst
@@ -598,7 +598,7 @@ Select your deployment type and follow the instructions to change the default pa
                   url: https://localhost
                   port: 55000
                   username: wazuh-wui
-                  password: <wazuh-wui-password>
+                  password: "<wazuh-wui-password>"
                   run_as: false
 
       #. Restart the Wazuh dashboard to apply the changes.

--- a/source/installation-guide/wazuh-dashboard/step-by-step.rst
+++ b/source/installation-guide/wazuh-dashboard/step-by-step.rst
@@ -221,7 +221,7 @@ Select your deployment type and follow the instructions to change the default pa
                   url: https://localhost
                   port: 55000
                   username: wazuh-wui
-                  password: <wazuh-wui-password>
+                  password: "<wazuh-wui-password>"
                   run_as: false
 
       #. Restart the Wazuh dashboard to apply the changes.

--- a/source/user-manual/user-administration/password-management.rst
+++ b/source/user-manual/user-administration/password-management.rst
@@ -239,7 +239,7 @@ Follow the instructions below to change the passwords for all the Wazuh indexer 
             url: https://localhost
             port: 55000
             username: wazuh-wui
-            password: <wazuh-wui-password>
+            password: "<wazuh-wui-password>"
             run_as: false
 
 #. Restart the Wazuh dashboard to apply the changes.

--- a/source/user-manual/user-administration/single-sign-on/azure-active-directory.rst
+++ b/source/user-manual/user-administration/single-sign-on/azure-active-directory.rst
@@ -300,6 +300,19 @@ Wazuh dashboard configuration
                validate: false
          ...
 
+#. Ensure that ``run_as`` is set to false in the ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` configuration file.
+
+   .. code-block:: yaml
+      :emphasize-lines: 7
+
+      hosts:
+        - default:
+            url: https://localhost
+            port: 55000
+            username: wazuh-wui
+            password: "<wazuh-wui-password>"
+            run_as: false
+
 #. Restart the Wazuh dashboard service.
 
    .. include:: /_templates/common/restart_dashboard.rst

--- a/source/user-manual/user-administration/single-sign-on/google.rst
+++ b/source/user-manual/user-administration/single-sign-on/google.rst
@@ -264,6 +264,19 @@ Wazuh dashboard configuration
                validate: false
          ...
 
+#. Ensure that ``run_as`` is set to false in the ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` configuration file.
+
+   .. code-block:: yaml
+      :emphasize-lines: 7
+
+      hosts:
+        - default:
+            url: https://localhost
+            port: 55000
+            username: wazuh-wui
+            password: "<wazuh-wui-password>"
+            run_as: false
+
 #. Restart the Wazuh dashboard service using this command:
 
    .. include:: /_templates/common/restart_dashboard.rst

--- a/source/user-manual/user-administration/single-sign-on/jumpcloud.rst
+++ b/source/user-manual/user-administration/single-sign-on/jumpcloud.rst
@@ -263,6 +263,19 @@ Wazuh dashboard configuration
                validate: false
          ...
 
+#. Ensure that ``run_as`` is set to false in the ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` configuration file.
+
+   .. code-block:: yaml
+      :emphasize-lines: 7
+
+      hosts:
+        - default:
+            url: https://localhost
+            port: 55000
+            username: wazuh-wui
+            password: "<wazuh-wui-password>"
+            run_as: false
+
 #. Restart the Wazuh dashboard service.
 
    .. include:: /_templates/common/restart_dashboard.rst

--- a/source/user-manual/user-administration/single-sign-on/keycloak.rst
+++ b/source/user-manual/user-administration/single-sign-on/keycloak.rst
@@ -378,6 +378,19 @@ Wazuh dashboard configuration
                validate: false
          ...
 
+#. Ensure that ``run_as`` is set to false in the ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` configuration file.
+
+   .. code-block:: yaml
+      :emphasize-lines: 7
+
+      hosts:
+        - default:
+            url: https://localhost
+            port: 55000
+            username: wazuh-wui
+            password: "<wazuh-wui-password>"
+            run_as: false
+
 #. Restart the Wazuh dashboard service using this command:
 
    .. include:: /_templates/common/restart_dashboard.rst

--- a/source/user-manual/user-administration/single-sign-on/okta.rst
+++ b/source/user-manual/user-administration/single-sign-on/okta.rst
@@ -298,6 +298,19 @@ Wazuh dashboard configuration
                validate: false
          ...
 
+#. Ensure that ``run_as`` is set to false in the ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` configuration file.
+
+   .. code-block:: yaml
+      :emphasize-lines: 7
+
+      hosts:
+        - default:
+            url: https://localhost
+            port: 55000
+            username: wazuh-wui
+            password: "<wazuh-wui-password>"
+            run_as: false
+
 #. Restart the Wazuh dashboard service.
 
    .. include:: /_templates/common/restart_dashboard.rst

--- a/source/user-manual/user-administration/single-sign-on/onelogin.rst
+++ b/source/user-manual/user-administration/single-sign-on/onelogin.rst
@@ -298,6 +298,19 @@ Wazuh dashboard configuration
                validate: false
          ...
 
+#. Ensure that ``run_as`` is set to false in the ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` configuration file.
+
+   .. code-block:: yaml
+      :emphasize-lines: 7
+
+      hosts:
+        - default:
+            url: https://localhost
+            port: 55000
+            username: wazuh-wui
+            password: "<wazuh-wui-password>"
+            run_as: false
+
 #. Restart the Wazuh dashboard service.
 
    .. include:: /_templates/common/restart_dashboard.rst

--- a/source/user-manual/user-administration/single-sign-on/pingone.rst
+++ b/source/user-manual/user-administration/single-sign-on/pingone.rst
@@ -269,6 +269,19 @@ Wazuh dashboard configuration
                validate: false
          ...
 
+#. Ensure that ``run_as`` is set to false in the ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` configuration file.
+
+   .. code-block:: yaml
+      :emphasize-lines: 7
+
+      hosts:
+        - default:
+            url: https://localhost
+            port: 55000
+            username: wazuh-wui
+            password: "<wazuh-wui-password>"
+            run_as: false
+
 #. Restart the Wazuh dashboard service.
 
    .. include:: /_templates/common/restart_dashboard.rst


### PR DESCRIPTION
## Description

This PR clarifies that `run_as` must be set as false in the `/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml` configuration file. Related issue: https://github.com/wazuh/wazuh-documentation/issues/6175. 

## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
