### PR TITLE
Add macOS13 entry to Available SCA scans table

### DIFF
--- a/source/user-manual/capabilities/sec-config-assessment/available-sca-policies.rst
+++ b/source/user-manual/capabilities/sec-config-assessment/available-sca-policies.rst
@@ -95,6 +95,8 @@ The table below shows SCA policies pre-installed in Wazuh out-of-the-box. The Wa
     +-----------------------------+------------------------------------------------------------+-------------------------------+
     | cis_apple_macOS_12.0        |  CIS Checks for macOS 12.x                                 | macOS 12.0 (Monterey)         |
     +-----------------------------+------------------------------------------------------------+-------------------------------+
+    | cis_apple_macOS_13.x        |  CIS Checks for macOS 13.x                                 | macOS 13.0 (Ventura)          |
+    +-----------------------------+------------------------------------------------------------+-------------------------------+
     | web_vulnerabilities         |  System audit for web-related vulnerabilities              | N/A                           |
     +-----------------------------+------------------------------------------------------------+-------------------------------+
     | cis_apache_24               |  CIS Apache HTTP Server 2.4 Benchmark                      | Apache configuration files    |

--- a/source/user-manual/capabilities/sec-config-assessment/available-sca-policies.rst
+++ b/source/user-manual/capabilities/sec-config-assessment/available-sca-policies.rst
@@ -95,7 +95,7 @@ The table below shows SCA policies pre-installed in Wazuh out-of-the-box. The Wa
     +-----------------------------+------------------------------------------------------------+-------------------------------+
     | cis_apple_macOS_12.0        |  CIS Checks for macOS 12.x                                 | macOS 12.0 (Monterey)         |
     +-----------------------------+------------------------------------------------------------+-------------------------------+
-    | cis_apple_macOS_13.x        |  CIS Checks for macOS 13.x                                 | macOS 13.0 (Ventura)          |
+    | cis_apple_macOS_13.x        |  CIS Checks for macOS 13.x                                 | macOS 13.x (Ventura)          |
     +-----------------------------+------------------------------------------------------------+-------------------------------+
     | web_vulnerabilities         |  System audit for web-related vulnerabilities              | N/A                           |
     +-----------------------------+------------------------------------------------------------+-------------------------------+


### PR DESCRIPTION
## Description
This PR addresses #6182. It addes An entry to  the available SCA scans table for macOS13 Ventura systems.

## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
