### PR TITLE
Update the TSC CC8.1 Use case: Monitoring packages installed on an Ubuntu endpoint

### DIFF
--- a/source/compliance/tsc/common-criteria/cc8.1.rst
+++ b/source/compliance/tsc/common-criteria/cc8.1.rst
@@ -29,10 +29,10 @@ To carry out this use case, set up a Wazuh server and an Ubuntu 22.04 endpoint w
 
 #. Filter for rule ID ``2902``.
 
-   .. thumbnail:: /images/compliance/tsc/common-criteria/ruleid-2902-filtering.gif
-      :title: Rule ID 2902 filtering
-      :alt: Rule ID 2902 filtering
-      :align: center
-      :width: 80%
+.. thumbnail:: /images/compliance/tsc/common-criteria/ruleid-2902-filtering.gif
+   :title: Rule ID 2902 filtering
+   :alt: Rule ID 2902 filtering
+   :align: center
+   :width: 80%
 
 Wazuh contributes to the CC8.1 requirement by maintaining an accurate and up-to-date record of the software installed on each monitored agent. This information is vital for understanding the overall system configuration, tracking licenses, and ensuring compliance. Wazuh also integrates with vulnerability assessment tools and databases to identify known vulnerabilities associated with specific software packages. By cross-referencing the package inventory with vulnerability information, Wazuh highlights potential security weaknesses. This information allows organizations to prioritize patching or mitigating vulnerable packages, reducing the risk of exploitation.

--- a/source/compliance/tsc/common-criteria/cc8.1.rst
+++ b/source/compliance/tsc/common-criteria/cc8.1.rst
@@ -25,6 +25,8 @@ To carry out this use case, set up a Wazuh server and an Ubuntu 22.04 endpoint w
 
 #. Select **Security events** from your Wazuh dashboard.
 
+#. Ensure the Ubuntu endpoint is selected. 
+
 #. Filter for rule ID ``2902``.
 
    .. thumbnail:: /images/compliance/tsc/common-criteria/ruleid-2902-filtering.gif


### PR DESCRIPTION
## Description

This PR adds a step in the TSC CC8.1 Use case: "Monitoring packages installed on an Ubuntu endpoint" asking the user to ensure the Ubuntu endpoint is selected. 

## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
