### PR TITLE
Move Wazuh archives documents to Wazuh server administration section

### DIFF
--- a/source/_static/js/redirects.js
+++ b/source/_static/js/redirects.js
@@ -95,6 +95,8 @@ redirectSameRelease['4.4'] = {
     '/compliance/nist/active-response.html',
   '/nist/threat-intelligence.html':
     '/compliance/nist/threat-intelligence.html',
+  '/user-manual/capabilities/wazuh-archives.html':
+    '/user-manual/manager/wazuh-archives.html',
 };
 
 /* Redirections from 4.3 to 4.4  */
@@ -412,6 +414,7 @@ newUrls['4.4'] = [
   '/user-manual/agents/antiflooding.html',
   '/user-manual/agents/labels.html',
   '/user-manual/manager/fluent-forwarder.html',
+  '/user-manual/manager/wazuh-archives.html',
   '/user-manual/capabilities/container-security/index.html',
   '/user-manual/capabilities/container-security/monitoring-docker.html',
   '/user-manual/capabilities/container-security/use-cases.html',
@@ -439,7 +442,6 @@ newUrls['4.4'] = [
   '/user-manual/capabilities/system-calls-monitoring/use-cases/monitoring-file-and-directory-access.html',
   '/user-manual/capabilities/system-calls-monitoring/use-cases/monitoring-commands-run-as-root.html',
   '/user-manual/capabilities/system-calls-monitoring/use-cases/privilege-abuse.html',
-  '/user-manual/capabilities/wazuh-archives.html',
   '/user-manual/capabilities/agentless-monitoring/connection.html',
   '/user-manual/capabilities/agentless-monitoring/visualization.html',
   '/user-manual/capabilities/agentless-monitoring/use-cases.html',  
@@ -481,6 +483,7 @@ removedUrls['4.4'] = [
   '/user-manual/capabilities/auditing-whodata/who-windows-policies.html',  
   '/user-manual/capabilities/syscollector.html',  
   '/user-manual/capabilities/agentless-monitoring/agentless-faq.html',
+  '/user-manual/capabilities/wazuh-archives.html',
   '/container-security/index.html',
   '/container-security/docker-monitor/index.html',
   '/container-security/docker-monitor/dependencies.html',

--- a/source/user-manual/capabilities/index.rst
+++ b/source/user-manual/capabilities/index.rst
@@ -35,4 +35,3 @@ In this section you will find:
    agentless-monitoring/index        
    osquery
    policy-monitoring/index
-   wazuh-archives

--- a/source/user-manual/manager/index.rst
+++ b/source/user-manual/manager/index.rst
@@ -12,16 +12,16 @@ The Wazuh manager is the system that analyzes the data received from all registe
 
 .. topic:: Contents
 
-    .. toctree::
-        :maxdepth: 2
+   .. toctree::
+      :maxdepth: 2
 
-        remote-service
-        alert-threshold
-        manual-integration
-        manual-syslog-output
-        manual-database-output
-        automatic-reports
-        manual-email-report/index
-        manual-backup-restore
-        fluent-forwarder
-
+      remote-service
+      alert-threshold
+      manual-integration
+      manual-syslog-output
+      manual-database-output
+      automatic-reports
+      manual-email-report/index
+      manual-backup-restore
+      fluent-forwarder
+      wazuh-archives

--- a/source/user-manual/manager/wazuh-archives.rst
+++ b/source/user-manual/manager/wazuh-archives.rst
@@ -3,8 +3,6 @@
 .. meta::
   :description: Wazuh archives store all events received by the Wazuh server, whether or not they trip a rule.  Learn how to enable them, how to visualize them in the dashboard, and explore a use case in this section of the documentation.
 
-:orphan:
-
 Wazuh archives
 ==============
 


### PR DESCRIPTION
## Description
This PR moves [Wazuh archives](https://documentation.wazuh.com/current/user-manual/capabilities/wazuh-archives.html) from the [capabilities](https://documentation.wazuh.com/current/user-manual/capabilities/index.html) section to the [Wazuh server administration](https://documentation.wazuh.com/current/user-manual/manager/index.html) section.

## Checks
- [X] Compiles without warnings.
- [X] Uses present tense, active voice, and semi-formal registry.
- [X] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [X] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
