### PR TITLE
Clarify 'group' option in 'email_alerts'

### DIFF
--- a/source/user-manual/reference/ossec-conf/email-alerts.rst
+++ b/source/user-manual/reference/ossec-conf/email-alerts.rst
@@ -76,9 +76,9 @@ This option sets specific rule groups that alerts must belong to for email notif
 
 .. note::
 
-	To avoid partial matches, add a comma at the end of the group string. For example, ``<rules_group>group_a,|group_b,|group_c,</rules_group>``. Not ending the group string with a comma implies that it's a substring open for partial matches.  For example, the group string ``authentication`` matches rule groups ``authentication``, ``authentication_success``, and ``authentication_failure`` while the group string ``authentication,`` matches only rule group ``authentication``.
+   To avoid partial matches, add a comma at the end of the group string. For example, ``<rules_group>group_a,|group_b,|group_c,</rules_group>``. Not ending the group string with a comma implies that it's a substring open for partial matches.  For example, the group string ``authentication`` matches rule groups ``authentication``, ``authentication_success``, and ``authentication_failure`` while the group string ``authentication,`` matches only rule group ``authentication``.
 
-	Also, check that the rule group in your rule definitions ends with a comma as well. For example, ``<group>group_b,</group>``. This is usually the case in the Wazuh default ruleset.
+   Also, check that the rule group in your rule definitions ends with a comma as well. For example, ``<group>group_b,</group>``. This is usually the case in the Wazuh default ruleset.
 
 
 event_location

--- a/source/user-manual/reference/ossec-conf/email-alerts.rst
+++ b/source/user-manual/reference/ossec-conf/email-alerts.rst
@@ -66,7 +66,7 @@ This is the minimum alert severity level for which emails will be sent.
 group
 ^^^^^^^^
 
-This option sets the specific rule groups that alerts must belong to for email notification.
+This option sets specific rule groups that alerts must belong to for email notification.
 
 +--------------------+---------------------------------------------------------------------------------------------+
 | **Default value**  | n/a                                                                                         |
@@ -76,9 +76,9 @@ This option sets the specific rule groups that alerts must belong to for email n
 
 .. note::
 
-	To avoid partial matches, add a comma at the end of the group string. For example, ``<rules_group>group_a,|group_b,|group_c,</rules_group>`` Also, check that the rule group in your rule definitions ends with a comma as well. This is usually the case in the Wazuh default ruleset. For example, ``<group>group_b,</group>``.
+	To avoid partial matches, add a comma at the end of the group string. For example, ``<rules_group>group_a,|group_b,|group_c,</rules_group>``. Not ending the group string with a comma implies that it's a substring open for partial matches.  For example, the group string ``authentication`` matches rule groups ``authentication``, ``authentication_success``, and ``authentication_failure`` while the group string ``authentication,`` matches only rule group ``authentication``.
 
-	Not ending the group string with a comma implies that the group string is a substring open for partial matches.  For example, the group string ``authentication`` matches rule groups ``authentication``, ``authentication_success``, and ``authentication_failure`` while the group string ``authentication,`` matches only rule group ``authentication``.
+	Also, check that the rule group in your rule definitions ends with a comma as well. For example, ``<group>group_b,</group>``. This is usually the case in the Wazuh default ruleset.
 
 
 event_location

--- a/source/user-manual/reference/ossec-conf/email-alerts.rst
+++ b/source/user-manual/reference/ossec-conf/email-alerts.rst
@@ -66,16 +66,19 @@ This is the minimum alert severity level for which emails will be sent.
 group
 ^^^^^^^^
 
-This limits the sending of emails to only when rules are tripped that belongs to one of the listed groups.
+This option sets the specific rule groups that alerts must belong to for email notification.
 
 +--------------------+---------------------------------------------------------------------------------------------+
 | **Default value**  | n/a                                                                                         |
 +--------------------+---------------------------------------------------------------------------------------------+
-| **Allowed values** | Any rule group is allowed. Multiple groups should be separated with a pipe character (“|”). |
+| **Allowed values** | Any group string. For multiple groups, separate the strings with a pipe character ``|``.    |
 +--------------------+---------------------------------------------------------------------------------------------+
 
 .. note::
-	Observe that all groups must be finished with a comma.
+
+	To avoid partial matches, add a comma at the end of the group string. For example, ``<rules_group>group_a,|group_b,|group_c,</rules_group>`` Also, check that the rule group in your rule definitions ends with a comma as well. This is usually the case in the Wazuh default ruleset. For example, ``<group>group_b,</group>``.
+
+	Not ending the group string with a comma implies that the group string is a substring open for partial matches.  For example, the group string ``authentication`` matches rule groups ``authentication``, ``authentication_success``, and ``authentication_failure`` while the group string ``authentication,`` matches only rule group ``authentication``.
 
 
 event_location


### PR DESCRIPTION
## Description
This PR clarifies using <group> option in <email_alerts> in <ossec_config> for multiple groups and matching conditions. It closes #5961 

## Checks
- [X] Compiles without warnings.
- [X] Uses present tense, active voice, and semi-formal registry.
- [X] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [X] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
