### PR TITLE
Add discard_regex parameter to Services

### DIFF
--- a/source/user-manual/reference/ossec-conf/wodle-s3.rst
+++ b/source/user-manual/reference/ossec-conf/wodle-s3.rst
@@ -368,7 +368,7 @@ Name of AWS organization. Only works with CloudTrail buckets.
 discard_regex
 ^^^^^^^^^^^^^
 
-A regex value to determine if an event should be discarded. It requires a `field` attribute used to specify the field of the event where the regex should be applied.
+A regex value to determine if an event should be discarded. It requires a mandatory `field` attribute used to specify the field of the event where the regex should be applied.
 
 +--------------------+----------------------------------------+
 | **Default value**  | N/A                                    |
@@ -461,6 +461,8 @@ The available types are: ``cloudwatchlogs``, and ``inspector``.
 | :ref:`service_secret_key`              | Any alphanumerical key                                      | Optional                                      |
 +----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
 | :ref:`service_aws_profile`             | Valid profile name                                          | Optional                                      |
++----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
+| :ref:`service_discard_regex`           | A regex value to determine if an event should be discarded  | Optional                                      |
 +----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
 | :ref:`service_iam_role_arn`            | Valid role ARN                                              | Optional                                      |
 +----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
@@ -557,6 +559,43 @@ A valid profile name from a Shared Credential File or AWS Config File with the p
 +--------------------+--------------------+
 | **Allowed values** | Valid profile name |
 +--------------------+--------------------+
+
+.. _service_discard_regex:
+
+discard_regex
+^^^^^^^^^^^^^
+
+A regex value to determine if an event should be discarded. 
+For ``inspector``, requires a mandatory `field` attribute used to specify the field of the event where the regex should be applied.
+In the case of ``cloudwatchlogs``, the `field` attribute can be ommited since the logs can be plain text or JSON format.
+
++--------------------+----------------------------------------+
+| **Default value**  | N/A                                    |
++--------------------+----------------------------------------+
+| **Allowed values** | Any regex or sregex expression         |
++--------------------+----------------------------------------+
+
+Attributes:
+
++-----------+------------------------------------------------------------------------------------------------------+
+| **field** | The event's field on which the regex should be applied to determine if the event should be skipped   |
+|           +------------------+-----------------------------------------------------------------------------------+
+|           | Default value    | N/A                                                                               |
+|           +------------------+-----------------------------------------------------------------------------------+
+|           | Allowed values   | A str containing the full field name path                                         |
++-----------+------------------+-----------------------------------------------------------------------------------+
+
+Usage examples:
+
+.. code-block:: console
+
+    <discard_regex field="data.configurationItemStatus">REJECT</discard_regex>
+    
+- Only available for ``cloudwatchlogs``:
+
+.. code-block:: console
+
+    <discard_regex>.*Log:.*</discard_regex>
 
 .. _service_iam_role_arn:
 

--- a/source/user-manual/reference/ossec-conf/wodle-s3.rst
+++ b/source/user-manual/reference/ossec-conf/wodle-s3.rst
@@ -568,7 +568,7 @@ discard_regex
 A regular expression to determine if an event must be discarded.
 
 -  For ``inspector``, it requires a mandatory ``field`` attribute. The regex is applied to the event field specified with this attribute.
--  For ``cloudwatchlogs``, the ``field`` attribute is optional. You can ommit it, for example, when monitoring Cloudwatch logs in JSON format and plain text.
+-  For ``cloudwatchlogs``, the ``field`` attribute is optional. You can omit it, for example, when monitoring Cloudwatch logs in JSON format and plain text.
 
 +--------------------+----------------------------------------+
 | **Default value**  | N/A                                    |

--- a/source/user-manual/reference/ossec-conf/wodle-s3.rst
+++ b/source/user-manual/reference/ossec-conf/wodle-s3.rst
@@ -178,7 +178,7 @@ The available types are:  ``cloudtrail``, ``guardduty``, ``vpcflow``, ``config``
 +----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
 | :ref:`bucket_aws_organization_id`      | Name of AWS organization                                    | Optional (only works with CloudTrail buckets) |
 +----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
-| :ref:`bucket_discard_regex`            | A regex value to determine if an event should be discarded  | Optional                                      |
+| :ref:`bucket_discard_regex`            | A regex to determine if an event must be discarded          | Optional                                      |
 +----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
 | :ref:`bucket_remove_from_bucket`       | A value to determine if each log file is deleted once it    | Optional                                      |
 |                                        | has been collected by the module                            |                                               |
@@ -368,7 +368,7 @@ Name of AWS organization. Only works with CloudTrail buckets.
 discard_regex
 ^^^^^^^^^^^^^
 
-A regex value to determine if an event should be discarded. It requires a mandatory `field` attribute used to specify the field of the event where the regex should be applied.
+A regular expression to determine if an event must be discarded. It requires a mandatory ``field`` attribute. The regex is applied to the event field specified with this attribute.
 
 +--------------------+----------------------------------------+
 | **Default value**  | N/A                                    |
@@ -379,7 +379,7 @@ A regex value to determine if an event should be discarded. It requires a mandat
 Attributes:
 
 +-----------+------------------------------------------------------------------------------------------------------+
-| **field** | The event's field on which the regex should be applied to determine if the event should be skipped   |
+| **field** | The event field where to apply the regex.                                                            |
 |           +------------------+-----------------------------------------------------------------------------------+
 |           | Default value    | N/A                                                                               |
 |           +------------------+-----------------------------------------------------------------------------------+
@@ -462,7 +462,7 @@ The available types are: ``cloudwatchlogs``, and ``inspector``.
 +----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
 | :ref:`service_aws_profile`             | Valid profile name                                          | Optional                                      |
 +----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
-| :ref:`service_discard_regex`           | A regex value to determine if an event should be discarded  | Optional                                      |
+| :ref:`service_discard_regex`           | A regex to determine if an event must be discarded          | Optional                                      |
 +----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
 | :ref:`service_iam_role_arn`            | Valid role ARN                                              | Optional                                      |
 +----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
@@ -565,9 +565,10 @@ A valid profile name from a Shared Credential File or AWS Config File with the p
 discard_regex
 ^^^^^^^^^^^^^
 
-A regex value to determine if an event should be discarded. 
-For ``inspector``, requires a mandatory `field` attribute used to specify the field of the event where the regex should be applied.
-In the case of ``cloudwatchlogs``, the `field` attribute can be ommited since the logs can be plain text or JSON format.
+A regular expression to determine if an event must be discarded.
+
+-  For ``inspector``, it requires a mandatory ``field`` attribute. The regex is applied to the event field specified with this attribute.
+-  For ``cloudwatchlogs``, the ``field`` attribute is optional. You can ommit it, for example, when monitoring Cloudwatch logs in JSON format and plain text.
 
 +--------------------+----------------------------------------+
 | **Default value**  | N/A                                    |
@@ -578,20 +579,20 @@ In the case of ``cloudwatchlogs``, the `field` attribute can be ommited since th
 Attributes:
 
 +-----------+------------------------------------------------------------------------------------------------------+
-| **field** | The event's field on which the regex should be applied to determine if the event should be skipped   |
+| **field** | The event field where to apply the regex                                                             |
 |           +------------------+-----------------------------------------------------------------------------------+
 |           | Default value    | N/A                                                                               |
 |           +------------------+-----------------------------------------------------------------------------------+
 |           | Allowed values   | A str containing the full field name path                                         |
 +-----------+------------------+-----------------------------------------------------------------------------------+
 
-Usage examples:
+Usage example:
 
 .. code-block:: console
 
     <discard_regex field="data.configurationItemStatus">REJECT</discard_regex>
-    
-- Only available for ``cloudwatchlogs``:
+
+Usage example only for ``cloudwatchlogs``:
 
 .. code-block:: console
 


### PR DESCRIPTION
## Description
This PR is part of https://github.com/wazuh/wazuh/issues/17388. It adds the `discard_regex` parameter to the Services section of the AWS module reference.

## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
