### PR TITLE
Replace 'automated response' references

### DIFF
--- a/source/compliance/gdpr/index.rst
+++ b/source/compliance/gdpr/index.rst
@@ -8,7 +8,7 @@ Using Wazuh for GDPR compliance
 
 The European Union's General Data Protection Regulation (GDPR) was created to reach an agreement on data privacy legislation across Europe. Its primary focus is protecting the data of European Union citizens. The regulation aims to improve user data privacy and reform how European Union organizations approach data privacy.
 
-Wazuh assists with GDPR compliance by performing log collection, file integrity monitoring, configuration assessment, intrusion detection, real-time alerting, and automated response to threats.
+Wazuh assists with GDPR compliance by performing log collection, file integrity monitoring, configuration assessment, intrusion detection, real-time alerting, and incident response.
 
 Wazuh includes default rules and decoders for detecting various attacks, system errors, security misconfigurations, and policy violations. By default, these rules are mapped to the associated GDPR requirements. It’s possible to map your custom rules to one or more GDPR requirements by adding the compliance identifier in the ``<group>`` tag of the rule. The syntax to map a rule to a GDPR requirement is ``gdpr_`` followed by the chapter, the article, and, if applicable, the section and paragraph to which the requirement belongs. For example, ``gdpr_II_5.1.f``. Refer to the :ref:`ruleset section <rules_group>` for more information.
 

--- a/source/compliance/nist/log-data-analysis.rst
+++ b/source/compliance/nist/log-data-analysis.rst
@@ -6,7 +6,7 @@
 Log data analysis
 =================
 
-The Wazuh log data analysis module collects and analyzes logs from various sources, such as applications, systems, network devices, and cloud workloads. This data helps in resource monitoring, threat detection, and automated response. 
+The Wazuh log data analysis module collects and analyzes logs from various sources, such as applications, systems, network devices, and cloud workloads. This data helps in resource monitoring, threat detection, and incident response. 
 
 The Wazuh :doc:`Log data analysis </user-manual/capabilities/log-data-collection/index>` module helps comply with the following NIST 800-53 controls:
 

--- a/source/user-manual/capabilities/active-response/additional-information.rst
+++ b/source/user-manual/capabilities/active-response/additional-information.rst
@@ -56,4 +56,4 @@ Restart the Wazuh agent to apply changes:
 
 The first time the active response triggers, it blocks the IP address for the specified period using the ``<timeout>`` configured on the Wazuh server side. Then, the second time for 10 minutes, the third time for 20 minutes, and the fourth time for 30 minutes using the ``<repeated offenders>`` on the agent side.
 
-Using the active response module, you can respond to several scenarios like restricting malicious activities and blocking attacks. Be aware that improperly configured automated responses can make an endpoint vulnerable, so you have to define your active responses carefully.
+Using the active response module, you can respond to several scenarios like restricting malicious activities and blocking attacks. Be aware that improperly configured responses can make an endpoint vulnerable, so you have to define your active responses carefully.


### PR DESCRIPTION
## Description
This PR replaces 'automated response' references.

## Checks
- [X] Compiles without warnings.
- [X] Uses present tense, active voice, and semi-formal registry.
- [X] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [X] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
