### PR TITLE
Merge v4.4.5 into 4.4

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -43,7 +43,7 @@ is_latest_release = True
 # The full version, including alpha/beta/rc tags
 # Important: use a valid branch (4.0) or, preferably, tag name (v4.0.0)
 release = '4.4.5'
-api_tag = '4.4.5'
+api_tag = 'v4.4.5'
 apiURL = 'https://raw.githubusercontent.com/wazuh/wazuh/'+api_tag+'/api/api/spec/spec.yaml'
 
 # -- General configuration ------------------------------------------------


### PR DESCRIPTION
## Description

This PR merges v4.4.5 into 4.4. Related issue: https://github.com/wazuh/wazuh-documentation/issues/6228

## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
