### PR TITLE
Fix Wazuh indexer backup folder reference

### DIFF
--- a/source/user-manual/files-backup/wazuh-central-components.rst
+++ b/source/user-manual/files-backup/wazuh-central-components.rst
@@ -107,7 +107,7 @@ Backing up the Wazuh indexer and dashboard
       /etc/wazuh-indexer/opensearch.keystore \
       /etc/wazuh-indexer/opensearch-observability/ \
       /etc/wazuh-indexer/opensearch-reports-scheduler/ \
-      /usr/share/wazuh-indexer/plugins/opensearch-security/tools/config.yml \
+      /etc/wazuh-indexer/opensearch-security/ \
       /usr/lib/sysctl.d/wazuh-indexer.conf $bkp_folder
 
 #. Back up the Wazuh dashboard certificates and configuration files.

--- a/source/user-manual/files-backup/wazuh-central-components.rst
+++ b/source/user-manual/files-backup/wazuh-central-components.rst
@@ -107,7 +107,7 @@ Backing up the Wazuh indexer and dashboard
       /etc/wazuh-indexer/opensearch.keystore \
       /etc/wazuh-indexer/opensearch-observability/ \
       /etc/wazuh-indexer/opensearch-reports-scheduler/ \
-      /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig \
+      /usr/share/wazuh-indexer/plugins/opensearch-security/tools/config.yml \
       /usr/lib/sysctl.d/wazuh-indexer.conf $bkp_folder
 
 #. Back up the Wazuh dashboard certificates and configuration files.


### PR DESCRIPTION
## Description

Wazuh **4.3** deployments includes the following files.
```
# ls /usr/share/wazuh-indexer/plugins/opensearch-security/securityconfig
action_groups.yml  audit.yml  config.yml  internal_users.yml  nodes_dn.yml  opensearch.yml.example  roles_mapping.yml  roles.yml  tenants.yml  whitelist.yml

```

However, since version **4.4**, these configuration files [have been moved](https://github.com/wazuh/wazuh-packages/blob/89256cd17ff38b1f26b539b944f3dcd7b649b850/.github/actions/upgrade-indexer/common.sh#L3).

```
# ls /usr/share/wazuh-indexer/plugins/opensearch-security/*/
audit_config_migrater.sh  config.yml  hash.sh  securityadmin.sh  SECURITY_ADMIN_TESTS.md  wazuh-certs-tool.sh  wazuh-passwords-tool.sh

# ls /etc/wazuh-indexer/opensearch-security/
action_groups.yml  allowlist.yml  audit.yml  config.yml  internal_users.yml  nodes_dn.yml  opensearch.yml.example  roles_mapping.yml  roles.yml  tenants.yml  whitelist.yml

```

This PR replaces the backup reference of the `securityconfig/` folder.

## Checks
- [X] Compiles without warnings.
- [X] Uses present tense, active voice, and semi-formal registry.
- [X] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [X] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).