### PR TITLE
Task manager: clarify that the cleanup_time must be greater than or equal to the task_timeout parameter

### DIFF
--- a/source/user-manual/reference/ossec-conf/task-manager.rst
+++ b/source/user-manual/reference/ossec-conf/task-manager.rst
@@ -43,6 +43,7 @@ Maximum time that the task information will remain stored in the task database.
 | **Required**       | no                                                                                                                                 |
 +--------------------+------------------------------------------------------------------------------------------------------------------------------------+
 
+.. note:: The ``cleanup_time`` must be greater than or equal to the ``task_timeout`` parameter.
 
 task_timeout
 ^^^^^^^^^^^^


### PR DESCRIPTION
## Description

This PR clarifies that the `cleanup_time` must be greater than or equal to the `task_timeout` parameter. It closes #6253. 

## Checks
- [x] Compiles without warnings.
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
