### PR TITLE
Fixed command for manually requesting an agent key

### DIFF
--- a/source/user-manual/agent-enrollment/via-manager-API/requesting-the-key.rst
+++ b/source/user-manual/agent-enrollment/via-manager-API/requesting-the-key.rst
@@ -26,7 +26,7 @@ From Linux/Unix and macOS
 
    .. code-block:: console
 
-     # TOKEN=$(curl -u <user>:<password> -k -X POST "https://<MANAGER_IP>:55000/security/user/authenticate?raw=true")
+     # TOKEN=$(curl -u <user>:<password> -k "https://<MANAGER_IP>:55000/security/user/authenticate?raw=true")
 
    Run the command ``echo $TOKEN`` to confirm that the token was successfully generated. You should get an output like this:
 


### PR DESCRIPTION


<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
Fixed command for requesting an authentication key when enrolling a new agent using the manager API.
Using POST returned a 405 Error (method not allowed). The authentication request must be performed using a GET request.

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
