### PR TITLE
[4.5] macOS deployment variables - remove outdated information 

### DIFF
--- a/source/installation-guide/wazuh-agent/wazuh-agent-package-macos.rst
+++ b/source/installation-guide/wazuh-agent/wazuh-agent-package-macos.rst
@@ -26,13 +26,6 @@ The agent runs on the endpoint you want to monitor and communicates with the Waz
     
                   # echo "WAZUH_MANAGER='10.0.0.2'" > /tmp/wazuh_envs && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /
     
-                .. note:: For version 4.4.2 and earlier, run the following command instead. Replace ``<WAZUH.VERSION-REV>`` with your package version, such as ``4.4.2-1``.
-                   :class: not-long
-
-                   .. code-block:: console
-    
-                      # launchctl setenv WAZUH_MANAGER "10.0.0.2" && installer -pkg wazuh-agent-<WAZUH.VERSION-REV>.pkg -target /
-
                 For additional deployment options such as agent name, agent group, and registration password, see the :doc:`Deployment variables for macOS </user-manual/deployment-variables/deployment-variables-macos>` section.
                 
                 .. note:: Alternatively, if you want to install an agent without registering it, omit the deployment variables. To learn more about the different registration methods, see the :doc:`Wazuh agent enrollment </user-manual/agent-enrollment/index>` section.

--- a/source/user-manual/deployment-variables/deployment-variables-macos.rst
+++ b/source/user-manual/deployment-variables/deployment-variables-macos.rst
@@ -45,94 +45,48 @@ Below you can find a table describing the variables used by Wazuh installers, an
 |   ENROLLMENT_DELAY               |  Assigns the time that agentd should wait after a successful registration. See :ref:`delay_after_enrollment <enrollment_delay_after_enrollment>`.                                                    |
 +----------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
-.. tabs::
-
-   .. group-tab:: Examples
+Examples:
     
-      -  Registration with password:
+-  Registration with password:
 
-         .. code-block:: console
-         
-            # echo "WAZUH_MANAGER='10.0.0.2' && WAZUH_REGISTRATION_PASSWORD='TopSecret' && \
-            WAZUH_AGENT_NAME='macos-agent'" > /tmp/wazuh_envs && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /
+   .. code-block:: console
 
-      -  Registration with password and assigning a group:
+      # echo "WAZUH_MANAGER='10.0.0.2' && WAZUH_REGISTRATION_PASSWORD='TopSecret' && \
+      WAZUH_AGENT_NAME='macos-agent'" > /tmp/wazuh_envs && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /
 
-         .. code-block:: console
-         
-            # echo "WAZUH_MANAGER='10.0.0.2' && WAZUH_REGISTRATION_SERVER='10.0.0.2' && WAZUH_REGISTRATION_PASSWORD='TopSecret' && \
-            WAZUH_AGENT_GROUP='my-group'" > /tmp/wazuh_envs && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /            
+-  Registration with password and assigning a group:
 
-      -  Registration with relative path to CA. It will be searched at your Wazuh installation folder:
+   .. code-block:: console
 
-         .. code-block:: console
-         
-            # echo "WAZUH_MANAGER='10.0.0.2' && WAZUH_REGISTRATION_SERVER='10.0.0.2' && WAZUH_AGENT_NAME='macos-agent' && \
-            WAZUH_REGISTRATION_CA='rootCA.pem'" > /tmp/wazuh_envs && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /
+      # echo "WAZUH_MANAGER='10.0.0.2' && WAZUH_REGISTRATION_SERVER='10.0.0.2' && WAZUH_REGISTRATION_PASSWORD='TopSecret' && \
+      WAZUH_AGENT_GROUP='my-group'" > /tmp/wazuh_envs && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /
 
-      -  Registration with protocol:
+-  Registration with relative path to CA. It will be searched at your Wazuh installation folder:
 
-         .. code-block:: console
-      
-            # echo "WAZUH_MANAGER='10.0.0.2' && WAZUH_REGISTRATION_SERVER='10.0.0.2' && WAZUH_AGENT_NAME='macos-agent' && \
-            WAZUH_PROTOCOL='udp'" > /tmp/wazuh_envs && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /
+   .. code-block:: console
 
-      -  Registration and adding multiple address:
+      # echo "WAZUH_MANAGER='10.0.0.2' && WAZUH_REGISTRATION_SERVER='10.0.0.2' && WAZUH_AGENT_NAME='macos-agent' && \
+      WAZUH_REGISTRATION_CA='rootCA.pem'" > /tmp/wazuh_envs && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /
 
-         .. code-block:: console
-      
-            # echo "WAZUH_MANAGER='10.0.0.2,10.0.0.3' && WAZUH_REGISTRATION_SERVER='10.0.0.2' && \
-            WAZUH_AGENT_NAME='macos-agent'" > /tmp/wazuh_envs && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /
+-  Registration with protocol:
 
-      -  Absolute paths to CA, certificate or key that contain spaces can be written as shown below:
+   .. code-block:: console
 
-         .. code-block:: console
-      
-            # echo "WAZUH_MANAGER='10.0.0.2' && WAZUH_REGISTRATION_SERVER='10.0.0.2' && WAZUH_REGISTRATION_KEY='/var/ossec/etc/sslagent.key' && \
-            WAZUH_REGISTRATION_CERTIFICATE='/var/ossec/etc/sslagent.cert'" > /tmp/wazuh_envs && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /
+      # echo "WAZUH_MANAGER='10.0.0.2' && WAZUH_REGISTRATION_SERVER='10.0.0.2' && WAZUH_AGENT_NAME='macos-agent' && \
+      WAZUH_PROTOCOL='udp'" > /tmp/wazuh_envs && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /
 
-   .. group-tab:: Examples (for 4.4.2 and earlier)
+-  Registration and adding multiple address:
 
-      -  Registration with password:
+   .. code-block:: console
 
-         .. code-block:: console
-         
-            # launchctl setenv WAZUH_MANAGER "10.0.0.2" WAZUH_REGISTRATION_PASSWORD "TopSecret" \
-            WAZUH_AGENT_NAME "macos-agent" && installer -pkg wazuh-agent-4.4.2-1.pkg -target /
+      # echo "WAZUH_MANAGER='10.0.0.2,10.0.0.3' && WAZUH_REGISTRATION_SERVER='10.0.0.2' && \
+      WAZUH_AGENT_NAME='macos-agent'" > /tmp/wazuh_envs && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /
 
-      -  Registration with password and assigning a group:
+-  Absolute paths to CA, certificate or key that contain spaces can be written as shown below:
 
-         .. code-block:: console
-         
-            # launchctl setenv WAZUH_MANAGER "10.0.0.2" WAZUH_REGISTRATION_SERVER "10.0.0.2" WAZUH_REGISTRATION_PASSWORD "TopSecret" \
-            WAZUH_AGENT_GROUP "my-group" && installer -pkg wazuh-agent-4.4.2-1.pkg -target /
+   .. code-block:: console
 
-      -  Registration with relative path to CA. It will be searched at your Wazuh installation folder:
-
-         .. code-block:: console
-         
-            # launchctl setenv WAZUH_MANAGER "10.0.0.2" WAZUH_REGISTRATION_SERVER "10.0.0.2" WAZUH_AGENT_NAME "macos-agent" \
-            WAZUH_REGISTRATION_CA "rootCA.pem" && installer -pkg wazuh-agent-4.4.2-1.pkg -target /
-
-      -  Registration with protocol:
-
-         .. code-block:: console
-      
-            # launchctl setenv WAZUH_MANAGER "10.0.0.2" WAZUH_REGISTRATION_SERVER "10.0.0.2" WAZUH_AGENT_NAME "macos-agent" \
-            WAZUH_PROTOCOL "udp" && installer -pkg wazuh-agent-4.4.2-1.pkg -target /
-
-      -  Registration and adding multiple address:
-
-         .. code-block:: console
-      
-            # launchctl setenv WAZUH_MANAGER "10.0.0.2,10.0.0.3" WAZUH_REGISTRATION_SERVER "10.0.0.2" \
-            WAZUH_AGENT_NAME "macos-agent" && installer -pkg wazuh-agent-4.4.2-1.pkg -target /
-
-      -  Absolute paths to CA, certificate or key that contain spaces can be written as shown below:
-
-         .. code-block:: console
-      
-            # launchctl setenv WAZUH_MANAGER "10.0.0.2" WAZUH_REGISTRATION_SERVER "10.0.0.2" WAZUH_REGISTRATION_KEY "/var/ossec/etc/sslagent.key" \
-            WAZUH_REGISTRATION_CERTIFICATE "/var/ossec/etc/sslagent.cert" && installer -pkg wazuh-agent-4.4.2-1.pkg -target /
+      # echo "WAZUH_MANAGER='10.0.0.2' && WAZUH_REGISTRATION_SERVER='10.0.0.2' && WAZUH_REGISTRATION_KEY='/var/ossec/etc/sslagent.key' && \
+      WAZUH_REGISTRATION_CERTIFICATE='/var/ossec/etc/sslagent.cert'" > /tmp/wazuh_envs && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.pkg -target /
 
 .. note:: It’s necessary to use both KEY and PEM options to verify agents' identities with the registration server. See the :ref:`Registration Service with host verification - Agent verification with host validation <enrollment_additional_security>` section.


### PR DESCRIPTION

## Description

This pull request updates the macOS deployment variables information by removing an outdated note as well as some examples that do not correspond to version 4.5.x. It closes #6286.  

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
