### PR TITLE
Add changes to align with backup restoring section

### DIFF
--- a/source/user-manual/files-backup/creating/wazuh-agent.rst
+++ b/source/user-manual/files-backup/creating/wazuh-agent.rst
@@ -93,6 +93,32 @@ Backing up a Wazuh agent
 
 #. Back up your custom files such as local SCA policies, active response scripts, and wodles.
 
+   .. tabs::
+
+      .. group-tab:: Linux
+
+         .. code-block:: console
+
+            # rsync -aREz /var/ossec/etc/<SCA_DIRECTORY>/<CUSTOM_SCA_FILE> $bkp_folder
+            # rsync -aREz /var/ossec/active-response/bin/<CUSTOM_ACTIVE_RESPONSE_SCRIPT> $bkp_folder
+            # rsync -aREz /var/ossec/wodles/<CUSTOM_WODLE_SCRIPT> $bkp_folder
+
+      .. group-tab:: Windows
+
+         .. code-block:: doscon
+
+            > xcopy "C:\Program Files (x86)\ossec-agent\<SCA_DIRECTORY>\<CUSTOM_SCA_FILE>" %bkp_folder% /H /I /K /S /X
+            > xcopy "C:\Program Files (x86)\ossec-agent\active-response\bin\<CUSTOM_ACTIVE_RESPONSE_SCRIPT>" %bkp_folder%\active-response\bin\ /H /I /K /S /X
+            > xcopy "C:\Program Files (x86)\ossec-agent\wodles\<CUSTOM_WODLE_SCRIPT>" %bkp_folder%\wodles\ /H /I /K /S /X
+
+      .. group-tab:: macOS
+
+         .. code-block:: console
+
+            # rsync -aREz /Library/Ossec/etc/<SCA_DIRECTORY>/<CUSTOM_SCA_FILE> $bkp_folder 
+            # rsync -aREz /Library/Ossec/active-response/bin/<CUSTOM_ACTIVE_RESPONSE_SCRIPT> $bkp_folder
+            # rsync -aREz /Library/Ossec/wodles/<CUSTOM_WODLE_SCRIPT> $bkp_folder
+
 Checking the backup
 -------------------
 

--- a/source/user-manual/files-backup/creating/wazuh-central-components.rst
+++ b/source/user-manual/files-backup/creating/wazuh-central-components.rst
@@ -49,13 +49,11 @@ Backing up the Wazuh server
       /var/ossec/etc/decoders/local_decoder.xml \
       /var/ossec/etc/shared/ \
       /var/ossec/logs/ \
-      /var/ossec/queue/agent-groups/ \
       /var/ossec/queue/agentless/ \
       /var/ossec/queue/agents-timestamp \
       /var/ossec/queue/fts/ \
       /var/ossec/queue/rids/ \
       /var/ossec/stats/ \
-      /var/ossec/var/db/agents/ \
       /var/ossec/var/multigroups/ $bkp_folder
 
 #. If present, back up certificates and additional configuration files.


### PR DESCRIPTION
## Description
This PR adds commands for custom files backing up and removes unnecessary backing up of some files to align with  [Wazuh restore backup documentation](https://documentation.wazuh.com/current/user-manual/files-backup/restoring/index.html#restoring-wazuh-from-backup).

## Checks
### Docs building
- [X] Compiles without warnings.
### Code formatting and web optimization
- [X] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [X] Uses present tense, active voice, and semi-formal registry.
- [X] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
