### PR TITLE
Add modifications to the restoring from backup guide

### DIFF
--- a/source/user-manual/files-backup/restoring/wazuh-agent.rst
+++ b/source/user-manual/files-backup/restoring/wazuh-agent.rst
@@ -41,7 +41,7 @@ Preparing the data restoration
       # cd ~/wazuh_files_backup/<DATE_TIME>
 
 Restoring Wazuh agent files
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Perform the steps below to restore the Wazuh agent files on a Linux endpoint.
 
@@ -100,7 +100,7 @@ Preparing the data restoration
 #. Decompress the file using `7-Zip <https://www.7-zip.org/>`__ or any of your preferred tools.
 
 Restoring Wazuh agent files
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Perform the steps below to restore the Wazuh agent files on a Windows endpoint.
 
@@ -131,7 +131,7 @@ Perform the steps below to restore the Wazuh agent files on a Windows endpoint.
 
    .. code-block:: doscon
 
-      > xcopy <SCA_DIRECTORY>/<CUSTOM_SCA_FILE> “C:\Program Files (x86)\ossec-agent\<SCA_DIRECTORY>” /H /I /K /S /X /Y
+      > xcopy <SCA_DIRECTORY>\<CUSTOM_SCA_FILE> “C:\Program Files (x86)\ossec-agent\<SCA_DIRECTORY>” /H /I /K /S /X /Y
       > xcopy active-response\bin\<CUSTOM_ACTIVE_RESPONSE_SCRIPT> "C:\Program Files (x86)\ossec-agent\active-response\bin\" /H /I /K /S /X /Y
       > xcopy wodles\<CUSTOM_WODLE_SCRIPT> "C:\Program Files (x86)\ossec-agent\wodles\" /H /I /K /S /X /Y
 
@@ -170,7 +170,7 @@ Preparing the data restoration
       # cd wazuh_files_backup/<DATE_TIME>
 
 Restoring Wazuh agent files
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Perform the steps below to restore Wazuh agent files on a macOS endpoint.
 
@@ -193,6 +193,12 @@ Perform the steps below to restore Wazuh agent files on a macOS endpoint.
       # cp -R Library/Ossec/queue/rids/* /Library/Ossec/queue/rids/ 
 
 #. Restore custom files, such as local SCA policies, active response, and wodle scripts, if there are any.
+
+   .. code-block:: console
+
+      # sudo cp Library/Ossec/<SCA_DIRECTORY>/<CUSTOM_SCA_FILE> /Library/Ossec/<SCA_DIRECTORY>/
+      # sudo cp Library/Ossec/active-response/bin/<CUSTOM_ACTIVE_RESPONSE_SCRIPT> /Library/Ossec/active-response/bin/
+      # sudo cp Library/Ossec/wodles/<CUSTOM_WODLE_SCRIPT> /Library/Ossec/wodles/
 
 #. Start the Wazuh agent service:
 

--- a/source/user-manual/files-backup/restoring/wazuh-central-components.rst
+++ b/source/user-manual/files-backup/restoring/wazuh-central-components.rst
@@ -84,7 +84,7 @@ Restoring Wazuh server files
 
 Perform the following steps to restore the Wazuh server files on the new server.
 
-#. Stop the Wazuh server to prevent any modification to the Wazuh server files during the restoration process:
+#. Stop the Wazuh manager and Filebeat to prevent any modification to the Wazuh server files during the restore process:
 
    .. code-block:: console
 
@@ -392,6 +392,7 @@ Perform the following actions on your Wazuh server to decompress these logs and 
 
 
    .. code-block:: yaml
+      :emphasize-lines: 7
 
       module_version: 0.1
 
@@ -806,6 +807,7 @@ Perform the following actions on both master and worker nodes of your Wazuh serv
 #. Add the ``/tmp/recovery.json`` path to the Wazuh Filebeat module ``/usr/share/filebeat/module/wazuh/alerts/manifest.yml`` so that Filebeat sends the old alerts to the Wazuh indexer for indexing:
 
    .. code-block:: yaml
+      :emphasize-lines: 7
 
       module_version: 0.1
 


### PR DESCRIPTION
## Description
This PR adds changes to the /user-manual/files-backup/restoring/index.

## Checks
### Docs building
- [X] Compiles without warnings.
### Code formatting and web optimization
- [X] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [X] Uses present tense, active voice, and semi-formal registry.
- [X] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
