### PR TITLE
[4.5.1] Add support for Kibana 7.17.10 and 7.17.11

### DIFF
--- a/source/_templates/installations/basic/elastic/deb/install_elasticsearch.rst
+++ b/source/_templates/installations/basic/elastic/deb/install_elasticsearch.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # apt-get install elasticsearch=7.17.9
+  # apt-get install elasticsearch=7.17.11
 
 .. End of include file

--- a/source/_templates/installations/basic/elastic/deb/install_filebeat.rst
+++ b/source/_templates/installations/basic/elastic/deb/install_filebeat.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # apt-get install filebeat=7.17.9
+  # apt-get install filebeat=7.17.11
 
 .. End of include file

--- a/source/_templates/installations/basic/elastic/deb/install_kibana.rst
+++ b/source/_templates/installations/basic/elastic/deb/install_kibana.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # apt-get install kibana=7.17.9
+  # apt-get install kibana=7.17.11
 
 .. End of include file

--- a/source/_templates/installations/basic/elastic/yum/install_elasticsearch.rst
+++ b/source/_templates/installations/basic/elastic/yum/install_elasticsearch.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # yum install elasticsearch-7.17.9
+  # yum install elasticsearch-7.17.11
 
 .. End of include file

--- a/source/_templates/installations/basic/elastic/yum/install_filebeat.rst
+++ b/source/_templates/installations/basic/elastic/yum/install_filebeat.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # yum install filebeat-7.17.9
+  # yum install filebeat-7.17.11
 
 .. End of include file

--- a/source/_templates/installations/basic/elastic/yum/install_kibana.rst
+++ b/source/_templates/installations/basic/elastic/yum/install_kibana.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # yum install kibana-7.17.9
+  # yum install kibana-7.17.11
 
 .. End of include file

--- a/source/deployment-options/elastic-stack/all-in-one-deployment/index.rst
+++ b/source/deployment-options/elastic-stack/all-in-one-deployment/index.rst
@@ -57,21 +57,21 @@ Elasticsearch installation and configuration
 
          .. code-block:: console
 
-           # yum install elasticsearch-7.17.9
+           # yum install elasticsearch-7.17.11
 
 
       .. group-tab:: APT
 
          .. code-block:: console
 
-           # apt-get install elasticsearch=7.17.9
+           # apt-get install elasticsearch=7.17.11
 
 
 #. Download the configuration file ``/etc/elasticsearch/elasticsearch.yml`` as follows:
 
    .. code-block:: console
 
-     # curl -so /etc/elasticsearch/elasticsearch.yml https://packages.wazuh.com/4.4/tpl/elastic-basic/elasticsearch_all_in_one.yml
+     # curl -so /etc/elasticsearch/elasticsearch.yml https://packages.wazuh.com/|WAZUH_CURRENT_MINOR|/tpl/elastic-basic/elasticsearch_all_in_one.yml
 
 
 Certificates creation and deployment
@@ -132,20 +132,21 @@ This command should have an output like this:
    {
      "name" : "elasticsearch",
      "cluster_name" : "elasticsearch",
-     "cluster_uuid" : "CFw_rkxnR7avI7pBv9MvtQ",
+     "cluster_uuid" : "VohZYVe1RKaT-lx7Lf6Jeg",
      "version" : {
-       "number" : "7.17.9",
+       "number" : "7.17.11",
        "build_flavor" : "default",
        "build_type" : "rpm",
-       "build_hash" : "ef48222227ee6b9e70e502f0f0daa52435ee634d",
-       "build_date" : "2023-01-31T05:34:43.305517834Z",
+       "build_hash" : "eeedb98c60326ea3d46caef960fb4c77958fb885",
+       "build_date" : "2023-06-23T05:33:12.261262042Z",
        "build_snapshot" : false,
        "lucene_version" : "8.11.1",
        "minimum_wire_compatibility_version" : "6.8.0",
        "minimum_index_compatibility_version" : "6.0.0-beta1"
      },
      "tagline" : "You Know, for Search"
-   }  
+   }
+
 
 .. _basic_all_in_one_wazuh:
 
@@ -296,7 +297,7 @@ This command should have an output like this:
        TLS version: TLSv1.3
        dial up... OK
      talk to server... OK
-     version: 7.17.9
+     version: 7.17.11
 
 Kibana installation and configuration
 -------------------------------------

--- a/source/deployment-options/elastic-stack/index.rst
+++ b/source/deployment-options/elastic-stack/index.rst
@@ -77,7 +77,7 @@ The following Elastic Stack versions are compatible with the Wazuh manager |WAZU
 +-------------------------+
 | 7.16.0–7.16.3           |
 +-------------------------+
-| 7.17.0–7.17.9           | 
+| 7.17.0–7.17.11          |
 +-------------------------+
 
 .. _packages_list_elk:
@@ -118,6 +118,10 @@ The following table contains the Wazuh Kibana plugin files for each version of E
 
 .. |WAZUH_KIBANA_7.17.9| replace:: `wazuh_kibana-|WAZUH_CURRENT|_7.17.9.zip <https://packages.wazuh.com/|WAZUH_CURRENT_MAJOR|/ui/kibana/wazuh_kibana-|WAZUH_CURRENT|_7.17.9-1.zip>`__ (`sha512 <https://packages.wazuh.com/|WAZUH_CURRENT_MAJOR|/checksums/wazuh/|WAZUH_CURRENT|/wazuh_kibana-|WAZUH_CURRENT|_7.17.9-1.zip.sha512>`__)
 
+.. |WAZUH_KIBANA_7.17.10| replace:: `wazuh_kibana-|WAZUH_CURRENT|_7.17.10.zip <https://packages.wazuh.com/|WAZUH_CURRENT_MAJOR|/ui/kibana/wazuh_kibana-|WAZUH_CURRENT|_7.17.10-1.zip>`__ (`sha512 <https://packages.wazuh.com/|WAZUH_CURRENT_MAJOR|/checksums/wazuh/|WAZUH_CURRENT|/wazuh_kibana-|WAZUH_CURRENT|_7.17.10-1.zip.sha512>`__)
+
+.. |WAZUH_KIBANA_7.17.11| replace:: `wazuh_kibana-|WAZUH_CURRENT|_7.17.11.zip <https://packages.wazuh.com/|WAZUH_CURRENT_MAJOR|/ui/kibana/wazuh_kibana-|WAZUH_CURRENT|_7.17.11-1.zip>`__ (`sha512 <https://packages.wazuh.com/|WAZUH_CURRENT_MAJOR|/checksums/wazuh/|WAZUH_CURRENT|/wazuh_kibana-|WAZUH_CURRENT|_7.17.11-1.zip.sha512>`__)
+
 +------------------+--------------------------+
 | Kibana Version   | Package                  |
 +==================+==========================+
@@ -150,6 +154,10 @@ The following table contains the Wazuh Kibana plugin files for each version of E
 | 7.17.8           | |WAZUH_KIBANA_7.17.8|    |
 +------------------+--------------------------+
 | 7.17.9           | |WAZUH_KIBANA_7.17.9|    |
++------------------+--------------------------+
+| 7.17.10          | |WAZUH_KIBANA_7.17.10|   |
++------------------+--------------------------+
+| 7.17.11          | |WAZUH_KIBANA_7.17.11|   |
 +------------------+--------------------------+
 
 For a full list of the available Wazuh Kibana plugin packages, check the `Wazuh Kibana plugin compatibility matrix <https://github.com/wazuh/wazuh-kibana-app/wiki/Compatibility>`__.  

--- a/source/upgrade-guide/compatibility-matrix/index.rst
+++ b/source/upgrade-guide/compatibility-matrix/index.rst
@@ -38,7 +38,7 @@ The following Elastic Stack and Open Distro for Elasticsearch versions are compa
 +--------------------------+---------------------------+
 | 7.16.0–7.16.3            |                           |
 +--------------------------+---------------------------+
-| 7.17.0–7.17.9            |                           |
+| 7.17.0–7.17.11           |                           |
 +--------------------------+---------------------------+
 
 You can find more information on the `Wazuh Kibana plugin repository <https://github.com/wazuh/wazuh-kibana-app/wiki/Compatibility>`_.


### PR DESCRIPTION
## Description

This PR updates the installation and upgrade instructions to the latest supported version of Kibana, which is 7.17.11. Additionally, it update the compatibility matrix and package list to reflect support for both Kibana 7.17.10 and 7.17.11.

## Checks
### Docs building
- [ ] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
