### PR TITLE
Added `-p|--port` option to Wazuh dashboard documention

### DIFF
--- a/source/installation-guide/wazuh-dashboard/installation-assistant.rst
+++ b/source/installation-guide/wazuh-dashboard/installation-assistant.rst
@@ -27,8 +27,8 @@ Wazuh dashboard installation
 
       # bash wazuh-install.sh --wazuh-dashboard dashboard
 
-   The default Wazuh web user interface port is 443, used by the Wazuh dashboard. You can specify this port by using the optional parameter ``-p|--port <port_number>``. Some recommended ports are 8443, 8444, 8080, 8888, and 9000.
-   
+   The default Wazuh web user interface port is 443, used by the Wazuh dashboard. You can change this port using the optional parameter ``-p|--port <port_number>``. Some recommended ports are 8443, 8444, 8080, 8888, and 9000.
+
    Once the assistant finishes the installation, the output shows the access credentials and a message that confirms that the installation was successful.
 
    .. code-block:: none

--- a/source/installation-guide/wazuh-dashboard/installation-assistant.rst
+++ b/source/installation-guide/wazuh-dashboard/installation-assistant.rst
@@ -28,6 +28,7 @@ Wazuh dashboard installation
       # bash wazuh-install.sh --wazuh-dashboard dashboard
 
    The default Wazuh web user interface port is 443, used by the Wazuh dashboard. You can specify this port by using the optional parameter ``-p|--port <port_number>``. Some recommended ports are 8443, 8444, 8080, 8888, and 9000.
+   
    Once the assistant finishes the installation, the output shows the access credentials and a message that confirms that the installation was successful.
 
    .. code-block:: none

--- a/source/installation-guide/wazuh-dashboard/installation-assistant.rst
+++ b/source/installation-guide/wazuh-dashboard/installation-assistant.rst
@@ -22,7 +22,7 @@ Wazuh dashboard installation
    .. note::
       
       Make sure that a copy of the ``wazuh-install-files.tar`` file, created during the initial configuration step, is placed in your working directory.
-      
+
    .. code-block:: console
 
       # bash wazuh-install.sh --wazuh-dashboard dashboard

--- a/source/installation-guide/wazuh-dashboard/installation-assistant.rst
+++ b/source/installation-guide/wazuh-dashboard/installation-assistant.rst
@@ -22,15 +22,12 @@ Wazuh dashboard installation
    .. note::
       
       Make sure that a copy of the ``wazuh-install-files.tar`` file, created during the initial configuration step, is placed in your working directory.
-
-   .. note::
-      
-      You can specify the Wazuh web interface port by using the optional parameter ``-p|--port <port_number>``.
       
    .. code-block:: console
 
       # bash wazuh-install.sh --wazuh-dashboard dashboard
 
+   The default Wazuh web user interface port is 443, used by the Wazuh dashboard. You can specify this port by using the optional parameter ``-p|--port <port_number>``. Some recommended ports are 8443, 8444, 8080, 8888, and 9000.
    Once the assistant finishes the installation, the output shows the access credentials and a message that confirms that the installation was successful.
 
    .. code-block:: none

--- a/source/installation-guide/wazuh-dashboard/installation-assistant.rst
+++ b/source/installation-guide/wazuh-dashboard/installation-assistant.rst
@@ -23,6 +23,10 @@ Wazuh dashboard installation
       
       Make sure that a copy of the ``wazuh-install-files.tar`` file, created during the initial configuration step, is placed in your working directory.
 
+   .. note::
+      
+      You can specify the Wazuh web interface port by using the optional parameter ``-p|--port <port_number>``.
+      
    .. code-block:: console
 
       # bash wazuh-install.sh --wazuh-dashboard dashboard


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
<!--
Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->

|Parent issue|
|---|
|https://github.com/wazuh/wazuh/issues/18164|

The aim of this PR is to modify the Wazuh dashboard installation using the Installation Assistant in order to add a new optional parameter, `-p|--port` to specify the Wazuh web interface port.
A new note has been added to the documentation to inform about this new option.

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
