### PR TITLE
Add <allow_higher_versions> to 'remote' and 'auth' sections

### DIFF
--- a/source/user-manual/reference/ossec-conf/auth.rst
+++ b/source/user-manual/reference/ossec-conf/auth.rst
@@ -36,6 +36,7 @@ Options
 - `ssl_auto_negotiate`_
 - `ciphers`_
 - `key_request`_
+- `agents`_
 
 disabled
 ^^^^^^^^
@@ -284,18 +285,8 @@ The key request settings are configured inside this tag. Read more about this fe
 
 Configuration options of the ``key request`` feature.
 
-Options
--------
 
-- `enabled`_
-- `timeout`_
-- `exec_path`_
-- `socket`_
-- `threads`_
-- `queue_size`_
-
-enabled
-^^^^^^^
+**enabled**
 
 Enable the key request.
 
@@ -305,8 +296,7 @@ Enable the key request.
 | **Allowed values** | yes, no                     |
 +--------------------+-----------------------------+
 
-timeout
-^^^^^^^
+**timeout**
 
 Maximum time for waiting a response from the executable.
 
@@ -316,8 +306,7 @@ Maximum time for waiting a response from the executable.
 | **Allowed values** | A positive number in seconds |
 +--------------------+------------------------------+
 
-exec_path
-^^^^^^^^^
+**exec_path**
 
 Full path to the executable.
 
@@ -327,8 +316,7 @@ Full path to the executable.
 | **Allowed values** | A string indicating the full path |
 +--------------------+-----------------------------------+
 
-socket
-^^^^^^
+**socket**
 
 Full path to the Unix domain socket.
 
@@ -338,8 +326,7 @@ Full path to the Unix domain socket.
 | **Allowed values** | A string indicating the full path to a Unix domain socket |
 +--------------------+-----------------------------------------------------------+
 
-threads
-^^^^^^^
+**threads**
 
 Number of threads for dispatching the external keys requests.
 
@@ -349,8 +336,8 @@ Number of threads for dispatching the external keys requests.
 | **Allowed values** | A positive number indicating the number of threads [1..32] |
 +--------------------+------------------------------------------------------------+
 
-queue_size
-^^^^^^^^^^
+**queue_size**
+
 
 Indicates the maximum size of the queue for fetching external keys.
 
@@ -359,6 +346,26 @@ Indicates the maximum size of the queue for fetching external keys.
 +--------------------+------------------------------------------------------------+
 | **Allowed values** | A positive number indicating the queue size [1..220000]    |
 +--------------------+------------------------------------------------------------+
+
+agents
+^^^^^^
+
+**allow_higher_versions**
+
+.. versionadded:: 4.6.0
+  
+Accept agents with a later version than the current manager.
+
++--------------------+------------------+
+| **Default value**  | yes              |
++--------------------+------------------+
+| **Allowed values** | yes, no          |
++--------------------+------------------+
+
+.. note::
+
+   This option only works when **connection** is set to ``secure``.
+
 
 Default configuration
 ---------------------

--- a/source/user-manual/reference/ossec-conf/remote.rst
+++ b/source/user-manual/reference/ossec-conf/remote.rst
@@ -29,6 +29,7 @@ Options
 - `ipv6`_
 - `queue_size`_
 - `rids_closing_time`_
+- `agents`_
 
 connection
 ^^^^^^^^^^^
@@ -143,6 +144,25 @@ Sets the time to close the RIDS files for agents that don't report new events in
 | **Allowed values** | A positive number that should contain a suffix character indicating a time unit, such as, s (seconds), m (minutes), h (hours), d (days). |
 +--------------------+------------------------------------------------------------------------------------------------------------------------------------------+
 
+agents
+^^^^^^
+
+**allow_higher_versions**
+
+.. versionadded:: 4.6.0
+  
+Accept agents with a later version than the current manager.
+
++--------------------+------------------+
+| **Default value**  | yes              |
++--------------------+------------------+
+| **Allowed values** | yes, no          |
++--------------------+------------------+
+
+.. note::
+
+   This option only works when **connection** is set to ``secure``.
+
 
 Example of configuration
 ------------------------
@@ -163,4 +183,7 @@ Example of configuration
       <protocol>tcp,udp</protocol>
       <queue_size>16384</queue_size>
       <rids_closing_time>5m</rids_closing_time>
+      <agents>
+        <allow_higher_versions>yes</allow_higher_versions>
+      </agents>  
     </remote>


### PR DESCRIPTION

## Description

As requested in #6284 the documentation for the remote and auth configuration sections are updated with new `agents/allow_higher_versions` options.

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
