### PR TITLE
Puppet indentation fix

### DIFF
--- a/source/deployment-options/deploying-with-puppet/setup-puppet/setup-puppet-certificates.rst
+++ b/source/deployment-options/deploying-with-puppet/setup-puppet/setup-puppet-certificates.rst
@@ -10,36 +10,36 @@ Setting up Puppet certificates
 
 To generate and sign a certificate, follow the next steps:
 
-1. On the Puppet agent, run this command to generate an empty certificate:
+#. On the Puppet agent, run this command to generate an empty certificate:
 
-    .. code-block:: console
+   .. code-block:: console
 
-        # puppet agent -t
+      # puppet agent -t
 
-2. On the Puppet server side, list the current certificates that need approval:
+#. On the Puppet server side, list the current certificates that need approval:
 
-    .. code-block:: console
+   .. code-block:: console
 
-        # puppetserver ca list
+      # puppetserver ca list
 
-    It should output a list with your node hostname.
+   It should output a list with your node hostname.
 
-3. Approve the certificate, replacing ``pending-agent-node`` with your agent’s node name:
+#. Approve the certificate, replacing ``pending-agent-node`` with your agent’s node name:
 
-    .. code-block:: console
+   .. code-block:: console
 
-        # puppetserver ca sign --certname pending-agent-node
+      # puppetserver ca sign --certname pending-agent-node
 
-    All certificates can be approved with this:
+   All certificates can be approved with this:
 
-    .. code-block:: console
+   .. code-block:: console
 
-        # puppetserver ca sign --all
+      # puppetserver ca sign --all
 
-4. Back on the Puppet agent node, run in the puppet agent again:
+#. Back on the Puppet agent node, run in the puppet agent again:
 
-    .. code-block:: console
+   .. code-block:: console
 
-        # puppet agent -t
+      # puppet agent -t
 
 .. note:: Remember that private network DNS is a prerequisite for a successful certificate signing.

--- a/source/deployment-options/deploying-with-puppet/setup-puppet/setup-puppet-certificates.rst
+++ b/source/deployment-options/deploying-with-puppet/setup-puppet/setup-puppet-certificates.rst
@@ -14,13 +14,13 @@ To generate and sign a certificate, follow the next steps:
 
     .. code-block:: console
 
-       # puppet agent -t
+        # puppet agent -t
 
 2. On the Puppet server side, list the current certificates that need approval:
 
     .. code-block:: console
 
-       # puppetserver ca list
+        # puppetserver ca list
 
     It should output a list with your node hostname.
 
@@ -30,13 +30,11 @@ To generate and sign a certificate, follow the next steps:
 
         # puppetserver ca sign --certname pending-agent-node
 
-
-All certificates can be approved with this:
+    All certificates can be approved with this:
 
     .. code-block:: console
 
-         # puppetserver ca sign --all
-
+        # puppetserver ca sign --all
 
 4. Back on the Puppet agent node, run in the puppet agent again:
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
This PR closes #6352. It fixes indentation in the `setup-puppet-certificates.rst` file.
<!--
Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->
## Checks
### Docs building
- [ ] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
