### PR TITLE
Fix missing slash character y settings

### DIFF
--- a/source/user-manual/capabilities/active-response/additional-information.rst
+++ b/source/user-manual/capabilities/active-response/additional-information.rst
@@ -21,7 +21,7 @@ To configure a white list for the endpoint(s), add the related IP address, netbl
        <jsonout_output>yes</jsonout_output>
        <email_notification>no</email_notification>
        <logall>yes</logall>
-       <white_list><WHITE_LISTED_IP><white_list>
+       <white_list><WHITE_LISTED_IP></white_list>
      </global>
    </ossec_config>
 


### PR DESCRIPTION
## Description
This adds a missing `/` in the configuration block in https://documentation.wazuh.com/current/user-manual/capabilities/active-response/additional-information.html#white-list

## Checks
### Docs building
- [X] Compiles without warnings.
### Code formatting and web optimization
- [X] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [X] Uses present tense, active voice, and semi-formal registry.
- [X] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
