### PR TITLE
connection_overtake_time setting added to remoted documentation.

### DIFF
--- a/source/user-manual/reference/ossec-conf/remote.rst
+++ b/source/user-manual/reference/ossec-conf/remote.rst
@@ -147,7 +147,7 @@ Sets the time to close the RIDS files for agents that don't report new events in
 connection_overtake_time
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Sets the time to consider a connection down with a TCP client when a collision happens.
+Sets the time to consider a connection down with a TCP client when a client key collision happens.
 
 +--------------------+------------------------------------------------------------------------------------------------------------------------------------------+
 | **Default value**  | 60                                                                                                                                       |
@@ -159,7 +159,7 @@ Sets the time to consider a connection down with a TCP client when a collision h
   The ``connection_overtake_time`` must be higher than ``notify_time`` from ``<client>`` configuration block. The value 0 disable this setting, so never a connection with a TCP client is considered down.
 
 .. note::
-  The ``connection_overtake_time`` do not apply to connections from UPD clients.
+  The ``connection_overtake_time`` do not apply to connections from UDP clients.
 
 Example of configuration
 ------------------------

--- a/source/user-manual/reference/ossec-conf/remote.rst
+++ b/source/user-manual/reference/ossec-conf/remote.rst
@@ -149,19 +149,21 @@ connection_overtake_time
 
 .. versionadded:: 4.5.2
 
-Sets the time to consider a connection down with a TCP client when a client key collision happens. The value 0 disable this setting, so never a connection with a TCP client is considered down in this situation.
-
-+--------------------+------------------------------------------------------------------------------------------------------------------------------------------+
-| **Default value**  | 60                                                                                                                                       |
-+--------------------+------------------------------------------------------------------------------------------------------------------------------------------+
-| **Allowed values** | A number between 0 and 3600 (seconds).                                                                                                   |
-+--------------------+------------------------------------------------------------------------------------------------------------------------------------------+
-
-.. note::
-  The ``connection_overtake_time`` do not apply to connections from UDP clients.
+Sets the time to wait before considering a TCP connection down. A value of 0 disables this assessment of connection activity.
 
 .. warning::
-  The ``connection_overtake_time`` should be higher than :ref:`notify-time <notify_time>` configured in the agents.
+
+   The ``connection_overtake_time`` must be higher than the agent :ref:`notify-time <notify_time>`.
+
++--------------------+-----------------------------------------------+
+| **Default value**  | 60                                            |
++--------------------+-----------------------------------------------+
+| **Allowed values** | A number between 0 and 3600 (seconds).        |
++--------------------+-----------------------------------------------+
+
+.. note::
+
+   ``connection_overtake_time`` doesn't apply to UDP connections.
 
 Example of configuration
 ------------------------

--- a/source/user-manual/reference/ossec-conf/remote.rst
+++ b/source/user-manual/reference/ossec-conf/remote.rst
@@ -29,6 +29,7 @@ Options
 - `ipv6`_
 - `queue_size`_
 - `rids_closing_time`_
+- `connection_overtake_time`_
 
 connection
 ^^^^^^^^^^^
@@ -143,6 +144,22 @@ Sets the time to close the RIDS files for agents that don't report new events in
 | **Allowed values** | A positive number that should contain a suffix character indicating a time unit, such as, s (seconds), m (minutes), h (hours), d (days). |
 +--------------------+------------------------------------------------------------------------------------------------------------------------------------------+
 
+connection_overtake_time
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Sets the time to consider a connection down with a TCP client when a collision happens.
+
++--------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| **Default value**  | 60                                                                                                                                       |
++--------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| **Allowed values** | A number between 0 and 3600 (seconds).                                                                                                   |
++--------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+
+.. note::
+  The ``connection_overtake_time`` must be higher than ``notify_time`` from ``<client>`` configuration block. The value 0 disable this setting, so never a connection with a TCP client is considered down.
+
+.. note::
+  The ``connection_overtake_time`` do not apply to connections from UPD clients.
 
 Example of configuration
 ------------------------

--- a/source/user-manual/reference/ossec-conf/remote.rst
+++ b/source/user-manual/reference/ossec-conf/remote.rst
@@ -149,7 +149,7 @@ connection_overtake_time
 
 .. versionadded:: 4.5.2
 
-Sets the time to wait before considering a TCP connection down. A value of 0 disables this assessment of connection activity.
+Sets the time to wait before considering a connection with a TCP client down when a new connection with the same key arrives. A value of 0 disables this assessment of connection activity.
 
 .. warning::
 
@@ -163,7 +163,7 @@ Sets the time to wait before considering a TCP connection down. A value of 0 dis
 
 .. note::
 
-   ``connection_overtake_time`` doesn't apply to UDP connections.
+   ``connection_overtake_time`` doesn't apply to connections with UDP clients.
 
 Example of configuration
 ------------------------

--- a/source/user-manual/reference/ossec-conf/remote.rst
+++ b/source/user-manual/reference/ossec-conf/remote.rst
@@ -147,7 +147,9 @@ Sets the time to close the RIDS files for agents that don't report new events in
 connection_overtake_time
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Sets the time to consider a connection down with a TCP client when a client key collision happens.
+.. versionadded:: 4.5.2
+
+Sets the time to consider a connection down with a TCP client when a client key collision happens. The value 0 disable this setting, so never a connection with a TCP client is considered down in this situation.
 
 +--------------------+------------------------------------------------------------------------------------------------------------------------------------------+
 | **Default value**  | 60                                                                                                                                       |
@@ -156,10 +158,10 @@ Sets the time to consider a connection down with a TCP client when a client key 
 +--------------------+------------------------------------------------------------------------------------------------------------------------------------------+
 
 .. note::
-  The ``connection_overtake_time`` must be higher than ``notify_time`` from ``<client>`` configuration block. The value 0 disable this setting, so never a connection with a TCP client is considered down.
-
-.. note::
   The ``connection_overtake_time`` do not apply to connections from UDP clients.
+
+.. warning::
+  The ``connection_overtake_time`` should be higher than :ref:`notify-time <notify_time>` configured in the agents.
 
 Example of configuration
 ------------------------
@@ -180,4 +182,5 @@ Example of configuration
       <protocol>tcp,udp</protocol>
       <queue_size>16384</queue_size>
       <rids_closing_time>5m</rids_closing_time>
+      <connection_overtake_time>600</connection_overtake_time>
     </remote>


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/wazuh/issues/17706 |

## Description

The main goal of this PR is to add the new setting ```connection_overtake_time``` with their respective description, default value and allowed values to the remote local configuration.

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
<!--
Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->
## Checks
### Docs building
- [x] Compiles without warnings.
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
