### PR TITLE
Add fix to unsupported system using debian vulnerabilities feed

### DIFF
--- a/source/user-manual/capabilities/vulnerability-detection/allow-os.rst
+++ b/source/user-manual/capabilities/vulnerability-detection/allow-os.rst
@@ -75,17 +75,26 @@ Configuring Vulnerability Detector to include unsupported systems
 
 Use the format ``OS_name-OS_major`` with the ``allow`` attribute to include the operating system. Add a list of systems separated by commas to include more than one operating system.
 
-For example, if you want to scan Kali Linux 2022 using the Debian vulnerability feed and scan PopOS 18 and Linux Mint 19 using the Ubuntu 18 (Bionic) feed, use:
+For example, if you want to scan PopOS 18 and Linux Mint 19 using the Ubuntu 18 (Bionic) feed, use:
 
 .. code-block:: xml
 
    <provider name="canonical">
        <enabled>yes</enabled>
-       <os allow="Kali GNU/Linux-2022">debian</os>
        <os allow="Linux Mint-19,Pop!_OS-18">bionic</os>
        <update_interval>1h</update_interval>
    </provider>
    
+To scan Kali Linux 2023 using the Debian 10 (Buster) vulnerability feed, use:
+
+.. code-block:: xml
+
+   <provider name="debian">
+       <enabled>yes</enabled>
+       <os allow="Kali GNU/Linux-2023">buster</os>
+       <update_interval>1h</update_interval>
+   </provider>
+
 You can also scan other operating systems using the Redhat vulnerability feed. Alternatively, you can use a substring of the operating system extracted from the agent in the second step. For this reason, you see ``Oracle Linux`` instead of ``Oracle Linux Server``.
 
 .. code-block:: xml


### PR DESCRIPTION
## Description
This PR fixes the example of how to use debian 10 vulnerabilities feed on a Kali Linux system

## Checks
### Docs building
- [X] Compiles without warnings.
### Code formatting and web optimization
- [X] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
