### PR TITLE
Add warning about disabling `jsonout_output`

### DIFF
--- a/source/user-manual/reference/ossec-conf/global.rst
+++ b/source/user-manual/reference/ossec-conf/global.rst
@@ -294,6 +294,10 @@ jsonout_output
 
 This toggles the writing of JSON-formatted alerts to ``/var/ossec/logs/alerts/alerts.json`` which would include the same events that would be sent to alerts.log, only in JSON format.
 
+.. warning::
+
+   Disabling ``jsonout_output`` disrupts indexing of alerts. The Wazuh indexer relies on reading the alerts from the ``alerts.json`` file.
+
 +--------------------+---------+
 | **Default value**  | yes     |
 +--------------------+---------+


### PR DESCRIPTION
## Description
This PR adds a warning to prevent toggling off logging alerts in json format.

## Checks
### Docs building
- [X] Compiles without warnings.
### Code formatting and web optimization
- [X] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [X] Uses present tense, active voice, and semi-formal registry.
- [X] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
