### PR TITLE
Fix documented values for remoted.request_pool

### DIFF
--- a/source/user-manual/reference/internal-options.rst
+++ b/source/user-manual/reference/internal-options.rst
@@ -728,11 +728,11 @@ Remoted
 +                                   +---------------+--------------------------------------------------------------+
 |                                   | Allowed Value | Any integer between 1 and 64.                                |
 +-----------------------------------+---------------+--------------------------------------------------------------+
-|   **remoted.request_pool**        | Description   | Number of parallel threads to dispatch requests.             |
+|   **remoted.request_pool**        | Description   | Limit of parallel threads to dispatch requests.              |
 +                                   +---------------+--------------------------------------------------------------+
-|                                   | Default Value | 8                                                            |
+|                                   | Default Value | 1024                                                         |
 +                                   +---------------+--------------------------------------------------------------+
-|                                   | Allowed Value | Any integer between 1 and 64.                                |
+|                                   | Allowed Value | Any integer between 1 and 4096.                              |
 +-----------------------------------+---------------+--------------------------------------------------------------+
 |   **remoted.request_timeout**     | Description   | Time (in seconds) the remote request listener rejects a      |
 |                                   |               | new request.                                                 |


### PR DESCRIPTION
## Description
This PR changes the default and allowed values documented for the `internal.conf` option `remoted.request_pool`.

## Checks
### Docs building
- [X] Compiles without warnings.
### Code formatting and web optimization
- [X] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [X] Uses present tense, active voice, and semi-formal registry.
- [X] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
