### PR TITLE
Remove deprecated plain text auth references for wodles

### DIFF
--- a/source/cloud-security/amazon/services/prerequisites/considerations.rst
+++ b/source/cloud-security/amazon/services/prerequisites/considerations.rst
@@ -231,7 +231,6 @@ The `service_endpoint` and `sts_endpoint` tags can be used to specify the VPC en
     </bucket>
 
     <bucket type="cloudtrail">
-      <aws_profile>default</aws_profile>
       <name>wazuh-cloudtrail-2</name>
       <aws_profile>default</aws_profile>
       <iam_role_arn>arn:aws:iam::xxxxxxxxxxx:role/wazuh-role</iam_role_arn>

--- a/source/cloud-security/amazon/services/prerequisites/considerations.rst
+++ b/source/cloud-security/amazon/services/prerequisites/considerations.rst
@@ -36,7 +36,7 @@ Reparse
 -------
 
 .. warning::
-  
+
    Using the ``reparse`` option will fetch and process all the logs from the starting date until the present. This process may generate duplicate alerts.
 
 To fetch and process older logs, you need to manually run the module using the ``--reparse`` option.
@@ -231,6 +231,7 @@ The `service_endpoint` and `sts_endpoint` tags can be used to specify the VPC en
     </bucket>
 
     <bucket type="cloudtrail">
+      <aws_profile>default</aws_profile>
       <name>wazuh-cloudtrail-2</name>
       <aws_profile>default</aws_profile>
       <iam_role_arn>arn:aws:iam::xxxxxxxxxxx:role/wazuh-role</iam_role_arn>

--- a/source/cloud-security/amazon/services/prerequisites/credentials.rst
+++ b/source/cloud-security/amazon/services/prerequisites/credentials.rst
@@ -16,7 +16,6 @@ There are multiple ways to configure the AWS credentials:
 - `IAM Roles`_
 - `IAM roles for EC2 instances`_
 - `Environment variables`_
-- `Insert the credentials into the configuration`_
 
 Create an IAM User
 ------------------
@@ -182,20 +181,3 @@ If you're using a single AWS account for all your buckets this could be the most
 
 * ``AWS_ACCESS_KEY_ID``
 * ``AWS_SECRET_ACCESS_KEY``
-
-Insert the credentials into the configuration
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. deprecated:: 4.4.0
-
-Another available option to set up credentials is writing them right into the Wazuh configuration file (``/var/ossec/etc/ossec.conf``), inside of the ``<bucket>`` block on the module configuration.
-
-This is an example configuration:
-
-.. code-block:: xml
-
-  <bucket type="cloudtrail">
-    <name>my-bucket</name>
-    <access_key>insert_access_key</access_key>
-    <secret_key>insert_secret_key</secret_key>
-  </bucket>

--- a/source/cloud-security/azure/activity-services/prerequisites/credentials.rst
+++ b/source/cloud-security/azure/activity-services/prerequisites/credentials.rst
@@ -35,14 +35,8 @@ Getting access credentials for Storage
     :align: center
     :width: 100%
 
-
-Authentication options
-----------------------
-
-There are two different ways to set up the Azure authentication:
-
 Using an authentication file
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+----------------------------
 
 It is possible to store the credentials in a file for authentication as long as the file content follows the `field = value` format explained below.
 
@@ -112,71 +106,5 @@ Regardless of the service or activity to be monitored, the authentication file i
 
 
 Check the :doc:`azure-logs wodle </user-manual/reference/ossec-conf/wodle-azure-logs>` section from the ossec.conf reference page for more information about the ``<auth_path>`` and other available parameters.
-
-
-Inserting the credentials into the configuration
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. deprecated:: 4.4.0
-
-Another authentication option is to set up credentials by storing them directly into the Wazuh configuration file ``/var/ossec/etc/ossec.conf``, inside of the ``<graph>``, ``<log_analytics>`` and ``<storage>`` blocks on the module configuration.
-
-The tags to use are different depending on the type of service or activity to be monitored:
-
-.. rubric:: Microsoft Graph and Log Analytics
-   :class: h5
-
-.. code-block:: none
-   :emphasize-lines: 6, 7, 18, 19
-
-   <wodle name="azure-logs">
-     <disabled>no</disabled>
-     <run_on_start>yes</run_on_start>
-
-     <log_analytics>
-         <application_id>8b7...c14</application_id>
-         <application_key>w22...91x</application_key>
-
-         <tenantdomain>wazuh.onmicrosoft.com</tenantdomain>
-         <request>
-             <query>AzureActivity</query>
-             <workspace>d6b...efa</workspace>
-             <time_offset>1d</time_offset>
-         </request>
-     </log_analytics>
-
-     <graph>
-         <application_id>8b7...c14</application_id>
-         <application_key>w22...91x</application_key>
-
-         <tenantdomain>wazuh.onmicrosoft.com</tenantdomain>
-         <request>
-             <query>auditLogs/directoryAudits</query>
-             <time_offset>1d</time_offset>
-         </request>
-     </graph>
-   </wodle>
-
-.. rubric:: Storage
-   :class: h5
-
-.. code-block:: none
-   :emphasize-lines: 6, 7
-
-   <wodle name="azure-logs">
-     <disabled>no</disabled>
-     <run_on_start>yes</run_on_start>
-
-     <storage>
-         <account_name>exampleaccountname</account_name>
-         <account_key>w22...91x</account_key>
-
-         <container name="insights-operational-logs">
-             <blobs>.json</blobs>
-             <content_type>json_inline</content_type>
-             <time_offset>24h</time_offset>
-         </container>
-     </storage>
-   </wodle>
 
 Take a look at the :doc:`azure-logs wodle </user-manual/reference/ossec-conf/wodle-azure-logs>` entry from the ``ossec.conf`` reference page for more information about the parameters.

--- a/source/cloud-security/azure/activity-services/prerequisites/credentials.rst
+++ b/source/cloud-security/azure/activity-services/prerequisites/credentials.rst
@@ -35,10 +35,11 @@ Getting access credentials for Storage
     :align: center
     :width: 100%
 
-Using an authentication file
-----------------------------
 
-It is possible to store the credentials in a file for authentication as long as the file content follows the `field = value` format explained below.
+Authentication
+--------------
+
+To authenticate, store the credentials in a file whose content follows the `field = value` format explained below.
 
 The fields expected to be present in the credentials file will change depending on the type of service or activity to be monitored.
 

--- a/source/user-manual/reference/ossec-conf/wodle-azure-logs.rst
+++ b/source/user-manual/reference/ossec-conf/wodle-azure-logs.rst
@@ -29,8 +29,6 @@ Options
 - `time`_
 - `timeout`_
 - `log_analytics`_
-- `log_analytics\\application_id`_
-- `log_analytics\\application_key`_
 - `log_analytics\\auth_path`_
 - `log_analytics\\tenantdomain`_
 - `log_analytics\\request`_
@@ -39,8 +37,6 @@ Options
 - `log_analytics\\request\\workspace`_
 - `log_analytics\\request\\timeout`_
 - `log_analytics\\request\\time_offset`_
-- `graph\\application_id`_
-- `graph\\application_key`_
 - `graph\\auth_path`_
 - `graph\\tenantdomain`_
 - `graph\\request`_
@@ -48,8 +44,6 @@ Options
 - `graph\\request\\query`_
 - `graph\\request\\timeout`_
 - `graph\\request\\time_offset`_
-- `storage\\account_name`_
-- `storage\\account_key`_
 - `storage\\auth_path`_
 - `storage\\tag`_
 - `storage\\container`_
@@ -76,10 +70,6 @@ Options
 +----------------------------------------+----------------------------------------------+
 | `log_analytics`_                       | N/A                                          |
 +----------------------------------------+----------------------------------------------+
-| `log_analytics\\application_id`_       | Any string                                   |
-+----------------------------------------+----------------------------------------------+
-| `log_analytics\\application_key`_      | Any string                                   |
-+----------------------------------------+----------------------------------------------+
 | `log_analytics\\auth_path`_            | File path                                    |
 +----------------------------------------+----------------------------------------------+
 | `log_analytics\\tenantdomain`_         | Any string                                   |
@@ -98,10 +88,6 @@ Options
 +----------------------------------------+----------------------------------------------+
 | `graph`_                               | N/A                                          |
 +----------------------------------------+----------------------------------------------+
-| `graph\\application_id`_               | Any string                                   |
-+----------------------------------------+----------------------------------------------+
-| `graph\\application_key`_              | Any string                                   |
-+----------------------------------------+----------------------------------------------+
 | `graph\\auth_path`_                    | File path                                    |
 +----------------------------------------+----------------------------------------------+
 | `graph\\tenantdomain`_                 | Any string                                   |
@@ -117,10 +103,6 @@ Options
 | `graph\\request\\time_offset`_         | A positive number + suffix                   |
 +----------------------------------------+----------------------------------------------+
 | `storage`_                             | N/A                                          |
-+----------------------------------------+----------------------------------------------+
-| `storage\\account_name`_               | Any string                                   |
-+----------------------------------------+----------------------------------------------+
-| `storage\\account_key`_                | Any string                                   |
 +----------------------------------------+----------------------------------------------+
 | `storage\\auth_path`_                  | File path                                    |
 +----------------------------------------+----------------------------------------------+
@@ -248,8 +230,6 @@ Defines the use of the Azure Log Analytics REST API to get the desired logs.
 
 This block configures the integration with Azure Log Analytics REST API.
 
-- `log_analytics\\application_id`_
-- `log_analytics\\application_key`_
 - `log_analytics\\auth_path`_
 - `log_analytics\\tenantdomain`_
 - `log_analytics\\request`_
@@ -257,10 +237,6 @@ This block configures the integration with Azure Log Analytics REST API.
 +----------------------------------------+----------------------------------------------+
 | Options                                | Allowed values                               |
 +========================================+==============================================+
-| `log_analytics\\application_id`_       | Any string                                   |
-+----------------------------------------+----------------------------------------------+
-| `log_analytics\\application_key`_      | Any string                                   |
-+----------------------------------------+----------------------------------------------+
 | `log_analytics\\auth_path`_            | File path                                    |
 +----------------------------------------+----------------------------------------------+
 | `log_analytics\\tenantdomain`_         | Any string                                   |
@@ -268,32 +244,10 @@ This block configures the integration with Azure Log Analytics REST API.
 | `log_analytics\\request`_              | N/A                                          |
 +----------------------------------------+----------------------------------------------+
 
-log_analytics\\application_id
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Identifier of the application that we will use for the authentication and to be able to use the Azure Log Analytics API. It must be used next to the ``application_key`` option obligatorily. Incompatible with ``auth_path`` option.
-
-+--------------------+--------------------+
-| **Default value**  | N/A                |
-+--------------------+--------------------+
-| **Allowed values** | Any string         |
-+--------------------+--------------------+
-
-log_analytics\\application_key
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Key to the application we will use for authentication and to be able to use the Azure Log Analytics API. It must be used next to the ``application_id`` option obligatorily. Incompatible with ``auth_path`` option.
-
-+--------------------+--------------------+
-| **Default value**  | N/A                |
-+--------------------+--------------------+
-| **Allowed values** | Any string         |
-+--------------------+--------------------+
-
 log_analytics\\auth_path
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Path of the file that contains the application identifier and the application key for authentication in order to use the Azure Log Analytics API. Incompatible with ``application_id`` and ``application_key`` options.
+Path of the file that contains the application identifier and the application key for authentication in order to use the Azure Log Analytics API.
 
 +--------------------+--------------------+
 | **Default value**  | N/A                |
@@ -440,8 +394,6 @@ graph
 
 This block configures the integration with Azure Active Directory Graph REST API.
 
-- `graph\\application_id`_
-- `graph\\application_key`_
 - `graph\\auth_path`_
 - `graph\\tenantdomain`_
 - `graph\\request`_
@@ -449,10 +401,6 @@ This block configures the integration with Azure Active Directory Graph REST API
 +----------------------------------+----------------------------------------------+
 | Options                          | Allowed values                               |
 +==================================+==============================================+
-| `graph\\application_id`_         | Any string                                   |
-+----------------------------------+----------------------------------------------+
-| `graph\\application_key`_        | Any string                                   |
-+----------------------------------+----------------------------------------------+
 | `graph\\auth_path`_              | File path                                    |
 +----------------------------------+----------------------------------------------+
 | `graph\\tenantdomain`_           | Any string                                   |
@@ -460,32 +408,10 @@ This block configures the integration with Azure Active Directory Graph REST API
 | `graph\\request`_                | N/A                                          |
 +----------------------------------+----------------------------------------------+
 
-graph\\application_id
-^^^^^^^^^^^^^^^^^^^^^
-
-Identifier of the application that we will use for the authentication and to be able to use the Azure Active Directory Graph API. It must be used next to the ``application_key`` option obligatorily. Incompatible with ``auth_path`` option.
-
-+--------------------+--------------------+
-| **Default value**  | N/A                |
-+--------------------+--------------------+
-| **Allowed values** | Any string         |
-+--------------------+--------------------+
-
-graph\\application_key
-^^^^^^^^^^^^^^^^^^^^^^
-
-Key to the application we will use for authentication and to be able to use the Azure Active Directory Graph API. It must be used next to the ``application_id`` option obligatorily. Incompatible with ``auth_path`` option.
-
-+--------------------+--------------------+
-| **Default value**  | N/A                |
-+--------------------+--------------------+
-| **Allowed values** | Any string         |
-+--------------------+--------------------+
-
 graph\\auth_path
 ^^^^^^^^^^^^^^^^
 
-Path of the file that contains the application identifier and the application key for authentication in order to use the Azure Active Directory Graph API. Incompatible with the ``application_id`` and ``application_key`` options. Check the :doc:`credentials </cloud-security/azure/activity-services/prerequisites/credentials>` reference for more information about this topic.
+Path of the file that contains the application identifier and the application key for authentication in order to use the AAD Graph API.
 
 +--------------------+--------------------+
 | **Default value**  | N/A                |
@@ -603,8 +529,6 @@ storage
 
 This block configures the integration with Azure Storage.
 
-- `storage\\account_name`_
-- `storage\\account_key`_
 - `storage\\auth_path`_
 - `storage\\tag`_
 - `storage\\container`_
@@ -612,10 +536,6 @@ This block configures the integration with Azure Storage.
 +----------------------------------+----------------------------------------------+
 | Options                          | Allowed values                               |
 +==================================+==============================================+
-| `storage\\account_name`_         | Any string                                   |
-+----------------------------------+----------------------------------------------+
-| `storage\\account_key`_          | Any string                                   |
-+----------------------------------+----------------------------------------------+
 | `storage\\auth_path`_            | File path                                    |
 +----------------------------------+----------------------------------------------+
 | `storage\\tag`_                  | Any string                                   |
@@ -623,32 +543,10 @@ This block configures the integration with Azure Storage.
 | `storage\\container`_            | N/A                                          |
 +----------------------------------+----------------------------------------------+
 
-storage\\account_name
-^^^^^^^^^^^^^^^^^^^^^
-
-Identifier of the account name that we will use for the authentication- It must be used next to the ``account_key`` option obligatorily. Incompatible with ``auth_path`` option.
-
-+--------------------+--------------------+
-| **Default value**  | N/A                |
-+--------------------+--------------------+
-| **Allowed values** | Any string         |
-+--------------------+--------------------+
-
-storage\\account_key
-^^^^^^^^^^^^^^^^^^^^
-
-Identifier of the account key that we will use for the authentication- It must be used next to the ``account_name`` option obligatorily. Incompatible with ``auth_path`` option.
-
-+--------------------+--------------------+
-| **Default value**  | N/A                |
-+--------------------+--------------------+
-| **Allowed values** | Any string         |
-+--------------------+--------------------+
-
 storage\\auth_path
 ^^^^^^^^^^^^^^^^^^
 
-Path of the file that contains the account name and the account key for authentication. Incompatible with ``account_name`` and ``account_key`` options.
+Path of the file that contains the account name and the account key for authentication.
 
 +--------------------+--------------------+
 | **Default value**  | N/A                |

--- a/source/user-manual/reference/ossec-conf/wodle-azure-logs.rst
+++ b/source/user-manual/reference/ossec-conf/wodle-azure-logs.rst
@@ -247,7 +247,7 @@ This block configures the integration with Azure Log Analytics REST API.
 log_analytics\\auth_path
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Path of the file that contains the application identifier and the application key for authentication in order to use the Azure Log Analytics API.
+File path containing the application identifier and key for authentication. This is necessary to use the Azure Log Analytics API.
 
 +--------------------+--------------------+
 | **Default value**  | N/A                |
@@ -411,7 +411,7 @@ This block configures the integration with Azure Active Directory Graph REST API
 graph\\auth_path
 ^^^^^^^^^^^^^^^^
 
-Path of the file that contains the application identifier and the application key for authentication in order to use the AAD Graph API.
+File path containing the application identifier and key for authentication. This is necessary to use the AAD Graph API.
 
 +--------------------+--------------------+
 | **Default value**  | N/A                |
@@ -546,7 +546,7 @@ This block configures the integration with Azure Storage.
 storage\\auth_path
 ^^^^^^^^^^^^^^^^^^
 
-Path of the file that contains the account name and the account key for authentication.
+File path containing the account name and key for authentication.
 
 +--------------------+--------------------+
 | **Default value**  | N/A                |

--- a/source/user-manual/reference/ossec-conf/wodle-s3.rst
+++ b/source/user-manual/reference/ossec-conf/wodle-s3.rst
@@ -157,10 +157,6 @@ The available types are:  ``cloudtrail``, ``guardduty``, ``vpcflow``, ``config``
 +----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
 | :ref:`bucket_account_alias`            | Any string                                                  | Optional                                      |
 +----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
-| :ref:`bucket_access_key`               | Alphanumerical key                                          | Optional                                      |
-+----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
-| :ref:`bucket_secret_key`               | Alphanumerical key                                          | Optional                                      |
-+----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
 | :ref:`bucket_aws_profile`              | Any string                                                  | Optional                                      |
 +----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
 | :ref:`bucket_iam_role_arn`             | IAM role ARN                                                | Optional                                      |
@@ -227,37 +223,6 @@ A user-friendly name for the AWS account.
 +--------------------+-----------------------------+
 | **Allowed values** | Any string                  |
 +--------------------+-----------------------------+
-
-.. _bucket_access_key:
-
-access_key
-^^^^^^^^^^
-
-.. deprecated:: 4.4.0
-
-The access key ID for the IAM user with the permission to read logs from the bucket.
-
-+--------------------+--------------------------+
-| **Default value**  | N/A                      |
-+--------------------+--------------------------+
-| **Allowed values** | Any alphanumerical key   |
-+--------------------+--------------------------+
-
-.. _bucket_secret_key:
-
-
-secret_key
-^^^^^^^^^^
-
-.. deprecated:: 4.4.0
-
-The secret key created for the IAM user with the permission to read logs from the bucket.
-
-+--------------------+--------------------------+
-| **Default value**  | N/A                      |
-+--------------------+--------------------------+
-| **Allowed values** | Any alphanumerical key   |
-+--------------------+--------------------------+
 
 .. _bucket_aws_profile:
 
@@ -505,10 +470,6 @@ The available types are: ``cloudwatchlogs``, and ``inspector``.
 +----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
 | :ref:`service_aws_log_groups`          | Comma-separated list of valid log group names               | Mandatory for CloudWatch Logs                 |
 +----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
-| :ref:`service_access_key`              | Any alphanumerical key                                      | Optional                                      |
-+----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
-| :ref:`service_secret_key`              | Any alphanumerical key                                      | Optional                                      |
-+----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
 | :ref:`service_aws_profile`             | Valid profile name                                          | Optional                                      |
 +----------------------------------------+-------------------------------------------------------------+-----------------------------------------------+
 | :ref:`service_discard_regex`           | A regex to determine if an event must be discarded          | Optional                                      |
@@ -555,19 +516,6 @@ A user-friendly name for the AWS account.
 | **Allowed values** | Any string                  |
 +--------------------+-----------------------------+
 
-.. _service_access_key:
-
-access_key
-^^^^^^^^^^
-
-The access key ID for the IAM user with the permission to access the service.
-
-+--------------------+--------------------------+
-| **Default value**  | N/A                      |
-+--------------------+--------------------------+
-| **Allowed values** | Any alphanumerical key   |
-+--------------------+--------------------------+
-
 .. _service_aws_log_groups:
 
 aws_log_groups
@@ -580,19 +528,6 @@ A comma-separated list of log group names from where the logs should be extracte
 +--------------------+------------------------------------------------+
 | **Allowed values** | Comma-separated list of valid log group names  |
 +--------------------+------------------------------------------------+
-
-.. _service_secret_key:
-
-secret_key
-^^^^^^^^^^
-
-The secret key created for the IAM user with the permission to access the service.
-
-+--------------------+--------------------------+
-| **Default value**  | N/A                      |
-+--------------------+--------------------------+
-| **Allowed values** | Any alphanumerical key   |
-+--------------------+--------------------------+
 
 .. _service_aws_profile:
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
<!--
Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->

This PR removes the plain text authentication references for AWS and Azure wodles configurations.

## Checks
### Docs building
- [x] Compiles without warnings.

### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
