### PR TITLE
Update Debian OVAL URL for offline update

### DIFF
--- a/source/user-manual/capabilities/vulnerability-detection/offline-update.rst
+++ b/source/user-manual/capabilities/vulnerability-detection/offline-update.rst
@@ -62,7 +62,7 @@ Currently, the module fetches the Debian vulnerabilities from two different sour
 -  JSON feed with global information about the affected packages for each distribution.
 
 .. note::
-   
+
    Both sources are necessary for the proper functioning of the scanner. Below are the steps to configure each source for the offline update.
 
 Debian OVAL feed
@@ -70,13 +70,13 @@ Debian OVAL feed
 
 To perform an offline update of Debian OVAL feeds, you must download the appropriate files.
 
-+------------+-------------------------------------------------------------------------------------------------------+
-| OS         | Files                                                                                                 |
-+============+=======================================================================================================+
-| Bullseye   | `oval-definitions-bullseye.xml <https://www.debian.org/security/oval/oval-definitions-bullseye.xml>`_ |
-+------------+-------------------------------------------------------------------------------------------------------+
-| Buster     | `oval-definitions-buster.xml <https://www.debian.org/security/oval/oval-definitions-buster.xml>`_     |
-+------------+-------------------------------------------------------------------------------------------------------+
++------------+---------------------------------------------------------------------------------------------------------------+
+| OS         | Files                                                                                                         |
++============+===============================================================================================================+
+| Bullseye   | `oval-definitions-bullseye.xml.bz2 <https://www.debian.org/security/oval/oval-definitions-bullseye.xml.bz2>`_ |
++------------+---------------------------------------------------------------------------------------------------------------+
+| Buster     | `oval-definitions-buster.xml.bz2 <https://www.debian.org/security/oval/oval-definitions-buster.xml.bz2>`_     |
++------------+---------------------------------------------------------------------------------------------------------------+
 
 To update the vulnerability feed from a user-defined repository, use a configuration similar to the following.
 
@@ -84,8 +84,8 @@ To update the vulnerability feed from a user-defined repository, use a configura
 
    <provider name="debian">
       <enabled>yes</enabled>
-      <os url="http://local_repo/oval-definitions-bullseye.xml">bullseye</os>
-      <os url="http://local_repo/oval-definitions-buster.xml">buster</os>
+      <os url="http://local_repo/oval-definitions-bullseye.xml.bz2">bullseye</os>
+      <os url="http://local_repo/oval-definitions-buster.xml.bz2">buster</os>
       <update_interval>1h</update_interval>
    </provider>
 
@@ -95,8 +95,8 @@ To use a local feed file, add the ``path`` attribute accompanying the ``os`` opt
 
    <provider name="debian">
       <enabled>yes</enabled>
-      <os path="/local_path/oval-definitions-bullseye.xml">bullseye</os>
-      <os path="/local_path/oval-definitions-buster.xml">buster</os>
+      <os path="/local_path/oval-definitions-bullseye.xml.bz2">bullseye</os>
+      <os path="/local_path/oval-definitions-buster.xml.bz2">buster</os>
       <update_interval>1h</update_interval>
    </provider>
 
@@ -430,8 +430,8 @@ Sample Configuration
        <!-- Debian OS vulnerabilities -->
        <provider name="debian">
            <enabled>yes</enabled>
-           <os path="/local_path/oval-definitions-bullseye.xml">bullseye</os>
-           <os path="/local_path/oval-definitions-buster.xml">buster</os>
+           <os path="/local_path/oval-definitions-bullseye.xml.bz2">bullseye</os>
+           <os path="/local_path/oval-definitions-buster.xml.bz2">buster</os>
            <path>/local_path/security_tracker_local.json</path>
            <update_interval>1h</update_interval>
        </provider>


### PR DESCRIPTION
## Description

This PR updates the Debian OVALs URL for the offline update, due to the change applied in the following issue:
- wazuh/wazuh#18765

## Checks
- [x] It compiles without warnings.
- [x] Spelling and grammar. 
- [x] Used impersonal speech. 
- [x] Used uppercase only on nouns. 


