### PR TITLE
Add note for Microsoft Graph multi-tenant not supported

### DIFF
--- a/source/cloud-security/ms-graph/monitoring-ms-graph-activity.rst
+++ b/source/cloud-security/ms-graph/monitoring-ms-graph-activity.rst
@@ -136,7 +136,7 @@ In this case, we will search for `alerts_v2` and `incidents` type events within 
         </resource>
     </ms-graph>
 
-.. note:: To learn more about the module options, see the :doc:`ms-graph </user-manual/reference/ossec-conf/ms-graph-module>` reference.
+.. note:: Multi-tenant is not supported. You can only configure one block of ``api_auth``. To learn more about the module options, see the :doc:`ms-graph </user-manual/reference/ossec-conf/ms-graph-module>` reference.
 
 Using the configuration mentioned above, we can examine a classic example of a security event: malicious spam emails.
 

--- a/source/user-manual/reference/ossec-conf/ms-graph-module.rst
+++ b/source/user-manual/reference/ossec-conf/ms-graph-module.rst
@@ -212,7 +212,7 @@ Type of Microsoft 365 subscription plan used by the tenant. `global` refers to e
 | **Allowed values** | global, gcc-high, dod  |
 +--------------------+------------------------+
 
-.. note:: At the moment, multi-tenant is not supported, so only one block of ``api_auth`` can be used in the entire configuration.
+.. note:: Multi-tenant is not supported. You can only configure one block of ``api_auth``.
 
 resource
 --------

--- a/source/user-manual/reference/ossec-conf/ms-graph-module.rst
+++ b/source/user-manual/reference/ossec-conf/ms-graph-module.rst
@@ -212,6 +212,8 @@ Type of Microsoft 365 subscription plan used by the tenant. `global` refers to e
 | **Allowed values** | global, gcc-high, dod  |
 +--------------------+------------------------+
 
+.. note:: At the moment, multi-tenant is not supported, so only one block of ``api_auth`` can be used in the entire configuration.
+
 resource
 --------
 

--- a/source/user-manual/reference/ossec-conf/ms-graph-module.rst
+++ b/source/user-manual/reference/ossec-conf/ms-graph-module.rst
@@ -156,6 +156,11 @@ This block configures the credentials used for authenticating with the Microsoft
 
 .. warning:: In the case of an invalid configuration, a warning message will be generated in the log file.
 
+.. note::
+  
+   Multi-tenant is not supported. You can only configure one block of ``api_auth``.
+
+
 +----------------------------------------+----------------------------------------------+
 | Options                                | Allowed values                               |
 +========================================+==============================================+
@@ -211,8 +216,6 @@ Type of Microsoft 365 subscription plan used by the tenant. `global` refers to e
 +--------------------+------------------------+
 | **Allowed values** | global, gcc-high, dod  |
 +--------------------+------------------------+
-
-.. note:: Multi-tenant is not supported. You can only configure one block of ``api_auth``.
 
 resource
 --------


### PR DESCRIPTION
## Description
As described in issue https://github.com/wazuh/wazuh-documentation/issues/6454, it was necessary to clarify that multi-tenant for Ms-Graph is not supported at the moment.

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Adds or updates meta descriptions accordingly.
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
