### PR TITLE
Fix errors for clean compilation

### DIFF
--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -26,8 +26,8 @@ Go into the folder for the type of package to build
 
 .. code-block:: console
 
-	$ cd rpm # For RPM
-	$ cd db # For DEB
+   $ cd rpm # For RPM
+   $ cd db # For DEB
 
 Execute the ``build_package.sh`` script, with the different options you desire.
 
@@ -76,6 +76,6 @@ This will generate an Dashboard package in a given path instead of the default o
 
 .. code-block:: console
 
-	# ./build_package.sh -b no –dont-build-docker –app-url <APP-URL> 
+   # ./build_package.sh -b no –dont-build-docker –app-url <APP-URL> 
 
 This will generate a Dashboard package using an existing base and containers that are already present in the host with a custom wazuh plugin located in the given ``--app-url``

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -3,10 +3,8 @@
 .. meta::
   :description: Wazuh provides an automated way of building Wazuh Dashboard packages. Learn how to build your own Wazuh Dashboard packages in this section of our documentation.
 
-.. _create-dashboard:
-
 Wazuh Dashboard
-===
+===============
 
 Wazuh provides an automated way of building RPM and DEB Wazuh Dashboard packages. keep in mind that to build a package you must run this tool in a system of the wanted package type.
 
@@ -25,10 +23,11 @@ Download our wazuh-packages repository from GitHub and go to the dashboard direc
  $ cd wazuh-packages/stack/dashboard
 
 Go into the folder for the type of package to build
-.. code-block:: console
- $ cd rpm # For RPM
- $ cd db # For DEB
 
+.. code-block:: console
+
+	$ cd rpm # For RPM
+	$ cd db # For DEB
 
 Execute the ``build_package.sh`` script, with the different options you desire.
 
@@ -76,6 +75,7 @@ This will generate an Dashboard package using an existing base with revision ``t
 This will generate an Dashboard package in a given path instead of the default output path.
 
 .. code-block:: console
-  # ./build_package.sh -b no –dont-build-docker –app-url <APP-URL> 
+
+	# ./build_package.sh -b no –dont-build-docker –app-url <APP-URL> 
 
 This will generate a Dashboard package using an existing base and containers that are already present in the host with a custom wazuh plugin located in the given ``--app-url``

--- a/source/development/packaging/generate-indexer-package.rst
+++ b/source/development/packaging/generate-indexer-package.rst
@@ -3,10 +3,8 @@
 .. meta::
   :description: Wazuh provides an automated way of building Wazuh Indexer packages. Learn how to build your own Wazuh Indexer packages in this section of our documentation.
   
-.. _create-indexer:
-
 Wazuh Indexer
-===
+=============
 
 Wazuh provides an automated way of building RPM and DEB Wazuh Indexer packages. keep in mind that to build a package you must run this tool in a system of the wanted package type.
 
@@ -25,10 +23,11 @@ Download our wazuh-packages repository from GitHub and go to the indexer directo
  $ cd wazuh-packages/stack/indexer
 
 Go into the folder for the type of package to build
-.. code-block:: console
- $ cd rpm # For RPM
- $ cd db # For DEB
 
+.. code-block:: console
+
+   $ cd rpm # For RPM
+   $ cd db # For DEB
 
 Execute the ``build_package.sh`` script, with the different options you desire.
 


### PR DESCRIPTION
## Description
This PR fixes problems introduced with https://github.com/wazuh/wazuh-documentation/pull/6444 that lead to:

- Compilation errors
- Wrong table of contents display

## Checks
### Docs building
- [X] Compiles without warnings.
### Code formatting and web optimization
- [X] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [X] Uses present tense, active voice, and semi-formal registry.
- [X] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.