### PR TITLE
Fix in GCP configuration examples

### DIFF
--- a/source/cloud-security/gcp/prerequisites/credentials.rst
+++ b/source/cloud-security/gcp/prerequisites/credentials.rst
@@ -70,16 +70,12 @@ Regardless of the service, the authentication file is always specified in the ``
         <interval>1m</interval>
         <project_id>wazuh-dev-123456</project_id>
         <subscription_name>wazuh-subscription</subscription_name>
-
         <credentials_file>/var/ossec/wodles/gcloud/credentials.json</credentials_file>
     </gcp-pubsub>
 
     <gcp-bucket>
         <run_on_start>yes</run_on_start>
         <interval>1m</interval>
-        <project_id>wazuh-dev-123456</project_id>
-        <subscription_name>wazuh-subscription</subscription_name>
-
         <credentials_file>/var/ossec/wodles/gcloud/credentials.json</credentials_file>
     </gcp-bucket>
 

--- a/source/cloud-security/gcp/prerequisites/credentials.rst
+++ b/source/cloud-security/gcp/prerequisites/credentials.rst
@@ -76,7 +76,15 @@ Regardless of the service, the authentication file is always specified in the ``
     <gcp-bucket>
         <run_on_start>yes</run_on_start>
         <interval>1m</interval>
-        <credentials_file>/var/ossec/wodles/gcloud/credentials.json</credentials_file>
+        <bucket type="access_logs">
+            <name>wazuh-test-bucket</name>
+            <credentials_file>/var/ossec/wodles/gcloud/credentials.json</credentials_file>
+            <only_logs_after>2021-JUN-01</only_logs_after>
+            <path>access_logs/</path>
+            <remove_from_bucket>no</remove_from_bucket>
+        </bucket>
+    </gcp-bucket>
+        
     </gcp-bucket>
 
 

--- a/source/cloud-security/gcp/prerequisites/credentials.rst
+++ b/source/cloud-security/gcp/prerequisites/credentials.rst
@@ -84,9 +84,6 @@ Regardless of the service, the authentication file is always specified in the ``
             <remove_from_bucket>no</remove_from_bucket>
         </bucket>
     </gcp-bucket>
-        
-    </gcp-bucket>
-
-
+    
 
 Check the :doc:`gcp-pubsub </user-manual/reference/ossec-conf/gcp-pubsub>` and :doc:`gcp-bucket </user-manual/reference/ossec-conf/gcp-bucket>` sections from the ossec.conf reference page for more information about the ``<credentials_file>`` and other available parameters.

--- a/source/cloud-security/gcp/prerequisites/credentials.rst
+++ b/source/cloud-security/gcp/prerequisites/credentials.rst
@@ -63,7 +63,7 @@ As explained before, the GCP integration requires a credentials file in JSON for
 Regardless of the service, the authentication file is always specified in the ``ossec.conf`` configuration file using the ``<credentials_file>`` tag. Take a look at the following example:
 
 .. code-block:: xml
-   :emphasize-lines: 7, 16
+   :emphasize-lines: 6, 14
 
     <gcp-pubsub>
         <pull_on_start>yes</pull_on_start>
@@ -84,6 +84,6 @@ Regardless of the service, the authentication file is always specified in the ``
             <remove_from_bucket>no</remove_from_bucket>
         </bucket>
     </gcp-bucket>
-    
+
 
 Check the :doc:`gcp-pubsub </user-manual/reference/ossec-conf/gcp-pubsub>` and :doc:`gcp-bucket </user-manual/reference/ossec-conf/gcp-bucket>` sections from the ossec.conf reference page for more information about the ``<credentials_file>`` and other available parameters.

--- a/source/user-manual/reference/ossec-conf/gcp-bucket.rst
+++ b/source/user-manual/reference/ossec-conf/gcp-bucket.rst
@@ -223,7 +223,11 @@ Linux configuration:
     <gcp-bucket>
         <run_on_start>yes</run_on_start>
         <interval>1m</interval>
-        <project_id>wazuh-dev</project_id>
-        <subscription_name>wazuhdns</subscription_name>
-        <credentials_file>wodles/gcp-bucket/credentials.json</credentials_file>
+        <bucket type="access_logs">
+            <name>wazuh-test-bucket</name>
+            <credentials_file>/var/ossec/wodles/gcloud/credentials.json</credentials_file>
+            <only_logs_after>2021-JUN-01</only_logs_after>
+            <path>access_logs/</path>
+            <remove_from_bucket>no</remove_from_bucket>
+        </bucket>
     </gcp-bucket>


### PR DESCRIPTION
## Description

A correction was made to the GCP configuration example. Blank spaces were removed, and the <project_id> and <subscription_name> fields within the <gcp-bucket> section were deleted as they are specific to pubsub, as mentioned in issue number #6482 . Additionally, the remaining <gcp-bucket> fields were added.

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
