### PR TITLE
[4.6.0] Add missing information to splunk integration

### DIFF
--- a/source/integrations-guide/splunk/index.rst
+++ b/source/integrations-guide/splunk/index.rst
@@ -171,7 +171,7 @@ Perform the following steps to configure the Logstash pipeline.
 
    .. note::
       
-      For testing purposes, you can avoid SSL verification by removing the line ``cacert => "/PATH/TO/LOCAL/SPLUNK/ca.pem"``.
+      For testing purposes, you can avoid SSL verification by removing the line ``cacert => "/PATH/TO/LOCAL/SPLUNK/ca.pem"`` and adding ``ssl_verification_mode => "none"``.
 
 Running Logstash
 ^^^^^^^^^^^^^^^^
@@ -325,7 +325,7 @@ To configure the Logstash pipeline do the following.
 
    .. note::
       
-      For testing purposes, you can avoid SSL verification by removing the ``cacert => "</PATH/TO/LOCAL/SPLUNK/CERTIFICATE>/ca.pem"`` line.
+      For testing purposes, you can avoid SSL verification by removing the line ``cacert => "</PATH/TO/LOCAL/SPLUNK/CERTIFICATE>/ca.pem"`` and adding ``ssl_verification_mode => "none"``.
 
 #. By default, the ``/var/ossec/logs/alerts/alerts.json`` file is owned by the ``wazuh`` user with restrictive permissions. You must add the ``logstash`` user to the ``wazuh`` group so it can read the file when running Logstash as a service:
 


### PR DESCRIPTION

## Description
This PR adds information that is missing in the notes of Splunk Integration refering to disable SSL Verification for testing purposes. Solves issue #6476
## Checks
### Docs building
- [ ] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
