### PR TITLE
Change python 3.11 pyarrow dependency version

### DIFF
--- a/source/cloud-security/amazon/services/prerequisites/dependencies.rst
+++ b/source/cloud-security/amazon/services/prerequisites/dependencies.rst
@@ -87,13 +87,13 @@ To install the dependencies, execute the following command:
 
       .. code-block:: console
 
-         # pip3 install boto3==1.17.85 botocore==1.20.85 jmespath==0.9.5 python-dateutil==2.8.1 six==1.14.0 urllib3==1.26.5 s3transfer==0.4.2 pyarrow==8.0.0 numpy==1.21.6
+         # pip3 install boto3==1.17.85 botocore==1.20.85 jmespath==0.9.5 python-dateutil==2.8.1 six==1.14.0 urllib3==1.26.5 s3transfer==0.4.2 pyarrow==8.0.0
    
    .. group-tab:: Python 3.11
 
       .. code-block:: console
 
-         # pip3 install --break-system-packages boto3==1.17.85 botocore==1.20.85 jmespath==0.9.5 python-dateutil==2.8.1 six==1.14.0 urllib3==1.26.5 s3transfer==0.4.2 pyarrow==8.0.0 numpy==1.21.6
+         # pip3 install --break-system-packages boto3==1.17.85 botocore==1.20.85 jmespath==0.9.5 python-dateutil==2.8.1 six==1.14.0 urllib3==1.26.5 s3transfer==0.4.2 pyarrow==13.0.0
 
       .. note::
          


### PR DESCRIPTION
## Description

Closes https://github.com/wazuh/wazuh-documentation/issues/6470.

Updates the pyarrow dependency version to `13.0.0` for the installation carried out in python 3.11 and removes `numpy` indirect dependency.

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
