### PR TITLE
Add differentiation between commands from different Python versions

### DIFF
--- a/source/cloud-security/amazon/services/prerequisites/dependencies.rst
+++ b/source/cloud-security/amazon/services/prerequisites/dependencies.rst
@@ -55,7 +55,7 @@ It is recommended to use a pip version greater than or equal to 19.3 to ease the
 
 .. tabs::
 
-   .. group-tab:: Python 3.7 - 3.10
+   .. group-tab:: Python 3.7–3.10
 
       .. code-block:: console
 
@@ -69,7 +69,9 @@ It is recommended to use a pip version greater than or equal to 19.3 to ease the
    
       .. note::
          
-         The ``--break-system-packages`` parameter is required to make the install on the default externally managed environment (more information on the `PEP 668 description <https://peps.python.org/pep-0668/>`_). To avoid it, the command can be executed inside a virtual environment but this would require a modification on the ``aws-s3`` script shebang to use the environment's interpreter. 
+         This command modifies the default externally managed Python environment. See the `PEP 668 <https://peps.python.org/pep-0668/>`__ description for more information.
+         
+         To prevent the modification, you can run ``pip3 install --upgrade pip`` within a virtual environment. You must update the ``aws-s3`` script shebang with your virtual environment interpreter, for example, ``#!/path/to/your/virtual/environment/bin/python3``.
 
 
 .. _boto-3:
@@ -83,7 +85,7 @@ To install the dependencies, execute the following command:
 
 .. tabs::
 
-   .. group-tab:: Python 3.7 - 3.10
+   .. group-tab:: Python 3.7–3.10
 
       .. code-block:: console
 
@@ -97,4 +99,4 @@ To install the dependencies, execute the following command:
 
       .. note::
          
-         In the case of using a virtual environment, the ``--break-system-packages`` parameter should be removed from the command.
+         If you're using a virtual environment, remove the ``--break-system-packages`` parameter from the command above.

--- a/source/cloud-security/amazon/services/prerequisites/dependencies.rst
+++ b/source/cloud-security/amazon/services/prerequisites/dependencies.rst
@@ -53,9 +53,24 @@ The required modules can be installed with Pip, the Python package manager. Most
 
 It is recommended to use a pip version greater than or equal to 19.3 to ease the installation of the required dependencies.
 
-.. code-block:: console
+.. tabs::
 
-  # pip3 install --upgrade pip
+   .. group-tab:: Python 3.7 - 3.10
+
+      .. code-block:: console
+
+         # pip3 install --upgrade pip
+
+   .. group-tab:: Python 3.11
+
+      .. code-block:: console
+
+         # pip3 install --upgrade pip --break-system-packages
+   
+      .. note::
+         
+         The ``--break-system-packages`` parameter is required to make the install on the default externally managed environment (more information on the `PEP 668 description <https://peps.python.org/pep-0668/>`_). To avoid it, the command can be executed inside a virtual environment but this would require a modification on the ``aws-s3`` script shebang to use the environment's interpreter. 
+
 
 .. _boto-3:
 
@@ -66,6 +81,20 @@ AWS pip dependencies
 
 To install the dependencies, execute the following command:
 
-.. code-block:: console
+.. tabs::
 
-  # pip3 install boto3==1.17.85 botocore==1.20.85 jmespath==0.9.5 python-dateutil==2.8.1 six==1.14.0 urllib3==1.26.5 s3transfer==0.4.2 pyarrow==8.0.0 numpy==1.21.6
+   .. group-tab:: Python 3.7 - 3.10
+
+      .. code-block:: console
+
+         # pip3 install boto3==1.17.85 botocore==1.20.85 jmespath==0.9.5 python-dateutil==2.8.1 six==1.14.0 urllib3==1.26.5 s3transfer==0.4.2 pyarrow==8.0.0 numpy==1.21.6
+   
+   .. group-tab:: Python 3.11
+
+      .. code-block:: console
+
+         # pip3 install --break-system-packages boto3==1.17.85 botocore==1.20.85 jmespath==0.9.5 python-dateutil==2.8.1 six==1.14.0 urllib3==1.26.5 s3transfer==0.4.2 pyarrow==8.0.0 numpy==1.21.6
+
+      .. note::
+         
+         In the case of using a virtual environment, the ``--break-system-packages`` parameter should be removed from the command.

--- a/source/cloud-security/azure/activity-services/prerequisites/dependencies.rst
+++ b/source/cloud-security/azure/activity-services/prerequisites/dependencies.rst
@@ -53,9 +53,23 @@ The required modules can be installed with Pip, the Python package manager. Most
 
 It is recommended to use a pip version greater than or equal to 19.3 to ease the installation of the required dependencies.
 
-.. code-block:: console
+.. tabs::
 
-  # pip3 install --upgrade pip
+   .. group-tab:: Python 3.7 - 3.10
+
+      .. code-block:: console
+
+         # pip3 install --upgrade pip
+
+   .. group-tab:: Python 3.11
+
+      .. code-block:: console
+
+         # pip3 install --upgrade pip --break-system-packages
+   
+      .. note::
+         
+         The ``--break-system-packages`` parameter is required to make the install on the default externally managed environment (more information on the `PEP 668 description <https://peps.python.org/pep-0668/>`_). To avoid it, the command can be executed inside a virtual environment but this would require a modification on the ``aws-s3`` script shebang to use the environment's interpreter. 
 
 Azure Storage Blobs client library for Python
 ---------------------------------------------
@@ -64,6 +78,20 @@ Azure Storage Blobs client library for Python
 
 To install the Azure Storage Blobs client library for Python, execute the following command:
 
-.. code-block:: console
+.. tabs::
 
-  # pip3 install azure-storage-blob==2.1.0 azure-storage-common==2.1.0 azure-common==1.1.25 cryptography==3.3.2 cffi==1.14.4 pycparser==2.20 six==1.14.0 python-dateutil==2.8.1 requests==2.25.1 certifi==2022.12.07 chardet==3.0.4 idna==2.9 urllib3==1.26.5 SQLAlchemy==1.3.11 pytz==2020.1
+   .. group-tab:: Python 3.7 - 3.10
+
+      .. code-block:: console
+
+         # pip3 install azure-storage-blob==2.1.0 azure-storage-common==2.1.0 azure-common==1.1.25 cryptography==3.3.2 cffi==1.14.4 pycparser==2.20 six==1.14.0 python-dateutil==2.8.1 requests==2.25.1 certifi==2022.12.07 chardet==3.0.4 idna==2.9 urllib3==1.26.5 SQLAlchemy==1.3.11 pytz==2020.1
+
+   .. group-tab:: Python 3.11
+
+      .. code-block:: console
+
+         # pip3 install --break-system-packages azure-storage-blob==2.1.0 azure-storage-common==2.1.0 azure-common==1.1.25 cryptography==3.3.2 cffi==1.14.4 pycparser==2.20 six==1.14.0 python-dateutil==2.8.1 requests==2.25.1 certifi==2022.12.07 chardet==3.0.4 idna==2.9 urllib3==1.26.5 SQLAlchemy==1.3.11 pytz==2020.1
+
+      .. note::
+         
+         In the case of using a virtual environment, the ``--break-system-packages`` parameter should be removed from the command.

--- a/source/cloud-security/azure/activity-services/prerequisites/dependencies.rst
+++ b/source/cloud-security/azure/activity-services/prerequisites/dependencies.rst
@@ -55,7 +55,7 @@ It is recommended to use a pip version greater than or equal to 19.3 to ease the
 
 .. tabs::
 
-   .. group-tab:: Python 3.7 - 3.10
+   .. group-tab:: Python 3.7–3.10
 
       .. code-block:: console
 
@@ -69,7 +69,9 @@ It is recommended to use a pip version greater than or equal to 19.3 to ease the
    
       .. note::
          
-         The ``--break-system-packages`` parameter is required to make the install on the default externally managed environment (more information on the `PEP 668 description <https://peps.python.org/pep-0668/>`_). To avoid it, the command can be executed inside a virtual environment but this would require a modification on the ``aws-s3`` script shebang to use the environment's interpreter. 
+         This command modifies the default externally managed Python environment. See the `PEP 668 <https://peps.python.org/pep-0668/>`__ description for more information.
+         
+         To prevent the modification, you can run ``pip3 install --upgrade pip`` within a virtual environment. You must update the ``azure-logs`` script shebang with your virtual environment interpreter, for example, ``#!/path/to/your/virtual/environment/bin/python3``. 
 
 Azure Storage Blobs client library for Python
 ---------------------------------------------
@@ -80,7 +82,7 @@ To install the Azure Storage Blobs client library for Python, execute the follow
 
 .. tabs::
 
-   .. group-tab:: Python 3.7 - 3.10
+   .. group-tab:: Python 3.7–3.10
 
       .. code-block:: console
 
@@ -94,4 +96,4 @@ To install the Azure Storage Blobs client library for Python, execute the follow
 
       .. note::
          
-         In the case of using a virtual environment, the ``--break-system-packages`` parameter should be removed from the command.
+         If you're using a virtual environment, remove the ``--break-system-packages`` parameter from the command above.

--- a/source/cloud-security/gcp/prerequisites/dependencies.rst
+++ b/source/cloud-security/gcp/prerequisites/dependencies.rst
@@ -53,9 +53,23 @@ The required modules can be installed with Pip, the Python package manager. Most
 
 It is recommended to use a pip version greater than or equal to 19.3 to ease the installation of the required dependencies.
 
-.. code-block:: console
+.. tabs::
 
-  # pip3 install --upgrade pip
+   .. group-tab:: Python 3.7 - 3.10
+
+      .. code-block:: console
+
+         # pip3 install --upgrade pip
+
+   .. group-tab:: Python 3.11
+
+      .. code-block:: console
+
+         # pip3 install --upgrade pip --break-system-packages
+   
+      .. note::
+         
+         The ``--break-system-packages`` parameter is required to make the install on the default externally managed environment (more information on the `PEP 668 description <https://peps.python.org/pep-0668/>`_). To avoid it, the command can be executed inside a virtual environment but this would require a modification on the ``aws-s3`` script shebang to use the environment's interpreter. 
 
 Google Cloud pip dependencies
 -----------------------------
@@ -64,6 +78,20 @@ Google Cloud pip dependencies
 
 To install the dependencies, execute the following command:
 
-  .. code-block:: console
+.. tabs::
 
-    # pip3 install cachetools==4.1.0 certifi==2022.12.07 cffi==1.14.4 chardet==3.0.4 charset-normalizer==2.0.4 google-api-core==1.30.0 google-auth==1.28.0 google-cloud-core==1.7.1 google-cloud-pubsub==2.7.1 google-cloud-storage==1.39.0 google-crc32c==1.1.2 google-resumable-media==1.3.1 googleapis-common-protos==1.51.0 grpc-google-iam-v1==0.12.3 grpcio==1.38.1 idna==2.9 libcst==0.3.20 mypy-extensions==0.4.3 packaging==20.9 proto-plus==1.19.0 protobuf==3.19.6 pyasn1-modules==0.2.8 pyasn1==0.4.8 pycparser==2.20 pyparsing==2.4.7 pytz==2020.1 PyYAML==5.4.1 requests==2.25.1 rsa==4.7.2 setuptools==59.6.0 six==1.14.0 typing-extensions==3.10.0.2 typing-inspect==0.7.1 urllib3==1.26.5
+   .. group-tab:: Python 3.7 - 3.10
+
+      .. code-block:: console
+
+         # pip3 install cachetools==4.1.0 certifi==2022.12.07 cffi==1.14.4 chardet==3.0.4 charset-normalizer==2.0.4 google-api-core==1.30.0 google-auth==1.28.0 google-cloud-core==1.7.1 google-cloud-pubsub==2.7.1 google-cloud-storage==1.39.0 google-crc32c==1.1.2 google-resumable-media==1.3.1 googleapis-common-protos==1.51.0 grpc-google-iam-v1==0.12.3 grpcio==1.38.1 idna==2.9 libcst==0.3.20 mypy-extensions==0.4.3 packaging==20.9 proto-plus==1.19.0 protobuf==3.19.6 pyasn1-modules==0.2.8 pyasn1==0.4.8 pycparser==2.20 pyparsing==2.4.7 pytz==2020.1 PyYAML==5.4.1 requests==2.25.1 rsa==4.7.2 setuptools==59.6.0 six==1.14.0 typing-extensions==3.10.0.2 typing-inspect==0.7.1 urllib3==1.26.5
+   
+   .. group-tab:: Python 3.11
+
+      .. code-block:: console
+
+         # pip3 install --break-system-packages cachetools==4.1.0 certifi==2022.12.07 cffi==1.14.4 chardet==3.0.4 charset-normalizer==2.0.4 google-api-core==1.30.0 google-auth==1.28.0 google-cloud-core==1.7.1 google-cloud-pubsub==2.7.1 google-cloud-storage==1.39.0 google-crc32c==1.1.2 google-resumable-media==1.3.1 googleapis-common-protos==1.51.0 grpc-google-iam-v1==0.12.3 grpcio==1.38.1 idna==2.9 libcst==0.3.20 mypy-extensions==0.4.3 packaging==20.9 proto-plus==1.19.0 protobuf==3.19.6 pyasn1-modules==0.2.8 pyasn1==0.4.8 pycparser==2.20 pyparsing==2.4.7 pytz==2020.1 PyYAML==5.4.1 requests==2.25.1 rsa==4.7.2 setuptools==59.6.0 six==1.14.0 typing-extensions==3.10.0.2 typing-inspect==0.7.1 urllib3==1.26.5
+
+      .. note::
+         
+         In the case of using a virtual environment, the ``--break-system-packages`` parameter should be removed from the command.

--- a/source/cloud-security/gcp/prerequisites/dependencies.rst
+++ b/source/cloud-security/gcp/prerequisites/dependencies.rst
@@ -55,7 +55,7 @@ It is recommended to use a pip version greater than or equal to 19.3 to ease the
 
 .. tabs::
 
-   .. group-tab:: Python 3.7 - 3.10
+   .. group-tab:: Python 3.7–3.10
 
       .. code-block:: console
 
@@ -69,7 +69,9 @@ It is recommended to use a pip version greater than or equal to 19.3 to ease the
    
       .. note::
          
-         The ``--break-system-packages`` parameter is required to make the install on the default externally managed environment (more information on the `PEP 668 description <https://peps.python.org/pep-0668/>`_). To avoid it, the command can be executed inside a virtual environment but this would require a modification on the ``aws-s3`` script shebang to use the environment's interpreter. 
+         This command modifies the default externally managed Python environment. See the `PEP 668 <https://peps.python.org/pep-0668/>`__ description for more information.
+         
+         To prevent the modification, you can run ``pip3 install --upgrade pip`` within a virtual environment. You must update the ``gcloud`` script shebang with your virtual environment interpreter, for example, ``#!/path/to/your/virtual/environment/bin/python3``.  
 
 Google Cloud pip dependencies
 -----------------------------
@@ -80,7 +82,7 @@ To install the dependencies, execute the following command:
 
 .. tabs::
 
-   .. group-tab:: Python 3.7 - 3.10
+   .. group-tab:: Python 3.7–3.10
 
       .. code-block:: console
 
@@ -94,4 +96,4 @@ To install the dependencies, execute the following command:
 
       .. note::
          
-         In the case of using a virtual environment, the ``--break-system-packages`` parameter should be removed from the command.
+         If you're using a virtual environment, remove the ``--break-system-packages`` parameter from the command above.


### PR DESCRIPTION
## Description
<!--
Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->
Closes https://github.com/wazuh/wazuh/issues/18958. Separates the commands necessary to install the AWS, GCP and Azure modules dependencies between Python versions 3.7 to 3.10 and Python 3.11

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
