### PR TITLE
Change gcp-bucket example in ossec-conf

### DIFF
--- a/source/user-manual/reference/ossec-conf/gcp-bucket.rst
+++ b/source/user-manual/reference/ossec-conf/gcp-bucket.rst
@@ -220,10 +220,14 @@ Linux configuration:
 
 .. code-block:: xml
 
-    <gcp-bucket>
-        <run_on_start>yes</run_on_start>
-        <interval>1m</interval>
-        <project_id>wazuh-dev</project_id>
-        <subscription_name>wazuhdns</subscription_name>
-        <credentials_file>wodles/gcp-bucket/credentials.json</credentials_file>
-    </gcp-bucket>
+  <gcp-bucket> 
+     <run_on_start>yes</run_on_start> 
+     <interval>1m</interval> 
+     <bucket type="access_logs"> 
+         <name>wazuh-test-bucket</name> 
+         <credentials_file>credentials.json</credentials_file> 
+         <only_logs_after>2021-JUN-01</only_logs_after> 
+         <path>access_logs/</path> 
+         <remove_from_bucket>no</remove_from_bucket> 
+     </bucket> 
+  </gcp-bucket> 


### PR DESCRIPTION

## Description
The example of the `GCP bucket` in the `ossec-conf` has been changed as mentioned in #6427 

https://github.com/wazuh/wazuh-documentation/blob/cb641af940556903816a747a36331565b1a3fcfe/source/user-manual/reference/ossec-conf/gcp-bucket.rst?plain=1#L223-L229
## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
