### PR TITLE
Add path parameter usage example to Azure Storage

### DIFF
--- a/source/cloud-security/azure/activity-services/prerequisites/considerations.rst
+++ b/source/cloud-security/azure/activity-services/prerequisites/considerations.rst
@@ -86,12 +86,14 @@ It is possible to add more than one ``request`` block at the same time in the sa
                 <blobs>.json</blobs>
                 <content_type>json_inline</content_type>
                 <time_offset>24h</time_offset>
+                <path>info-logs</path>
             </container>
 
             <container name="insights-operational-logs">
                 <blobs>.txt</blobs>
                 <content_type>json_inline</content_type>
                 <time_offset>24h</time_offset>
+                <path>info-logs</path>
             </container>
 
         </storage>

--- a/source/cloud-security/azure/activity-services/services/storage.rst
+++ b/source/cloud-security/azure/activity-services/services/storage.rst
@@ -94,6 +94,7 @@ Applying the following configuration, the integration will be executed every day
                     <blobs>.json</blobs>
                     <content_type>json_inline</content_type>
                     <time_offset>24h</time_offset>
+                    <path>info-logs</path>
                 </container>
 
         </storage>

--- a/source/user-manual/reference/ossec-conf/wodle-azure-logs.rst
+++ b/source/user-manual/reference/ossec-conf/wodle-azure-logs.rst
@@ -761,7 +761,7 @@ This option sets the time delay in which we will perform the query. For example,
 storage\\container\\path
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Defines, for the container, a path to search into. If it isn't present, the module retrieves all the blobs at the root level.
+Defines, for the container, a path to search for logs. If it isn't present, the module retrieves all the blobs starting from the root level.
 
 +--------------------+----------------------------------------------------------------------------------------------------------------------------+
 | **Default value**  | N/A                                                                                                                        |
@@ -789,6 +789,7 @@ Example of storage configuration
                 <blobs>.json</blobs>
                 <content_type>json_inline</content_type>
                 <time_offset>24h</time_offset>
+                <path>info-logs</path>
             </container>
 
 	    <container name="audit-logs"/>
@@ -848,6 +849,7 @@ Example of all integration
                 <blobs>.json</blobs>
                 <content_type>json_inline</content_type>
                 <time_offset>24h</time_offset>
+                <path>info-logs</path>
             </container>
 
 	    <container name="audit-logs"/>


### PR DESCRIPTION
## Description

Closes #6523. Modifies the `path` parameter description in the Azure module reference and adds some usages in the described configuration examples.

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
