### PR TITLE
Add support for Kibana 7.17.13

### DIFF
--- a/source/_templates/installations/basic/elastic/deb/install_elasticsearch.rst
+++ b/source/_templates/installations/basic/elastic/deb/install_elasticsearch.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # apt-get install elasticsearch=7.17.12
+  # apt-get install elasticsearch=7.17.13
 
 .. End of include file

--- a/source/_templates/installations/basic/elastic/deb/install_filebeat.rst
+++ b/source/_templates/installations/basic/elastic/deb/install_filebeat.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # apt-get install filebeat=7.17.12
+  # apt-get install filebeat=7.17.13
 
 .. End of include file

--- a/source/_templates/installations/basic/elastic/deb/install_kibana.rst
+++ b/source/_templates/installations/basic/elastic/deb/install_kibana.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # apt-get install kibana=7.17.12
+  # apt-get install kibana=7.17.13
 
 .. End of include file

--- a/source/_templates/installations/basic/elastic/yum/install_elasticsearch.rst
+++ b/source/_templates/installations/basic/elastic/yum/install_elasticsearch.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # yum install elasticsearch-7.17.12
+  # yum install elasticsearch-7.17.13
 
 .. End of include file

--- a/source/_templates/installations/basic/elastic/yum/install_filebeat.rst
+++ b/source/_templates/installations/basic/elastic/yum/install_filebeat.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # yum install filebeat-7.17.12
+  # yum install filebeat-7.17.13
 
 .. End of include file

--- a/source/_templates/installations/basic/elastic/yum/install_kibana.rst
+++ b/source/_templates/installations/basic/elastic/yum/install_kibana.rst
@@ -2,6 +2,6 @@
 
 .. code-block:: console
 
-  # yum install kibana-7.17.12
+  # yum install kibana-7.17.13
 
 .. End of include file

--- a/source/_variables/replacements.py
+++ b/source/_variables/replacements.py
@@ -167,7 +167,7 @@ custom_replacements = {
     # --- Open Distro for Elasticsearch
     "|OPEN_DISTRO_LATEST|" : "1.13.2",
     # --- Elasticsearch
-    "|ELASTICSEARCH_ELK_LATEST|" : "7.17.12", # Basic license
+    "|ELASTICSEARCH_ELK_LATEST|" : "7.17.13", # Basic license
     "|ELASTICSEARCH_LATEST|" : "7.10.2",
     # --- Other Elastic
     "|ELASTIC_6_LATEST|" : "6.8.8",

--- a/source/deployment-options/elastic-stack/all-in-one-deployment/index.rst
+++ b/source/deployment-options/elastic-stack/all-in-one-deployment/index.rst
@@ -132,13 +132,13 @@ This command should have an output like this:
    {
      "name" : "elasticsearch",
      "cluster_name" : "elasticsearch",
-     "cluster_uuid" : "Usvij2iGRMOqVtk9YdFfvA",
+     "cluster_uuid" : "EFEejKSIT7SMp6-f5fDI3A",
      "version" : {
-       "number" : "7.17.12",
+       "number" : "7.17.13",
        "build_flavor" : "default",
        "build_type" : "rpm",
-       "build_hash" : "e3b0c3d3c5c130e1dc6d567d6baef1c73eeb2059",
-       "build_date" : "2023-07-20T05:33:33.690180787Z",
+       "build_hash" : "2b211dbb8bfdecaf7f5b44d356bdfe54b1050c13",
+       "build_date" : "2023-08-31T17:33:19.958690787Z",
        "build_snapshot" : false,
        "lucene_version" : "8.11.1",
        "minimum_wire_compatibility_version" : "6.8.0",
@@ -297,7 +297,7 @@ This command should have an output like this:
        TLS version: TLSv1.3
        dial up... OK
      talk to server... OK
-     version: 7.17.12
+     version: 7.17.13
 
 Kibana installation and configuration
 -------------------------------------

--- a/source/deployment-options/elastic-stack/index.rst
+++ b/source/deployment-options/elastic-stack/index.rst
@@ -77,7 +77,7 @@ The following Elastic Stack versions are compatible with the Wazuh manager |WAZU
 +-------------------------+
 | 7.16.0–7.16.3           |
 +-------------------------+
-| 7.17.0–7.17.12          |
+| 7.17.0–7.17.13          |
 +-------------------------+
 
 .. _packages_list_elk:
@@ -124,6 +124,8 @@ The following table contains the Wazuh Kibana plugin files for each version of E
 
 .. |WAZUH_KIBANA_7.17.12| replace:: `wazuh_kibana-|WAZUH_CURRENT|_7.17.12.zip <https://packages.wazuh.com/|WAZUH_CURRENT_MAJOR|/ui/kibana/wazuh_kibana-|WAZUH_CURRENT|_7.17.12-1.zip>`__ (`sha512 <https://packages.wazuh.com/|WAZUH_CURRENT_MAJOR|/checksums/wazuh/|WAZUH_CURRENT|/wazuh_kibana-|WAZUH_CURRENT|_7.17.12-1.zip.sha512>`__)
 
+.. |WAZUH_KIBANA_7.17.13| replace:: `wazuh_kibana-|WAZUH_CURRENT|_7.17.13.zip <https://packages.wazuh.com/|WAZUH_CURRENT_MAJOR|/ui/kibana/wazuh_kibana-|WAZUH_CURRENT|_7.17.13-1.zip>`__ (`sha512 <https://packages.wazuh.com/|WAZUH_CURRENT_MAJOR|/checksums/wazuh/|WAZUH_CURRENT|/wazuh_kibana-|WAZUH_CURRENT|_7.17.13-1.zip.sha512>`__)
+
 +------------------+--------------------------+
 | Kibana Version   | Package                  |
 +==================+==========================+
@@ -162,6 +164,8 @@ The following table contains the Wazuh Kibana plugin files for each version of E
 | 7.17.11          | |WAZUH_KIBANA_7.17.11|   |
 +------------------+--------------------------+
 | 7.17.12          | |WAZUH_KIBANA_7.17.12|   |
++------------------+--------------------------+
+| 7.17.13          | |WAZUH_KIBANA_7.17.13|   |
 +------------------+--------------------------+
 
 For a full list of the available Wazuh Kibana plugin packages, check the `Wazuh Kibana plugin compatibility matrix <https://github.com/wazuh/wazuh-kibana-app/wiki/Compatibility>`__.  

--- a/source/upgrade-guide/compatibility-matrix/index.rst
+++ b/source/upgrade-guide/compatibility-matrix/index.rst
@@ -38,7 +38,7 @@ The following Elastic Stack and Open Distro for Elasticsearch versions are compa
 +--------------------------+---------------------------+
 | 7.16.0–7.16.3            |                           |
 +--------------------------+---------------------------+
-| 7.17.0–7.17.12           |                           |
+| 7.17.0–7.17.13           |                           |
 +--------------------------+---------------------------+
 
 You can find more information on the `Wazuh Kibana plugin repository <https://github.com/wazuh/wazuh-kibana-app/wiki/Compatibility>`_.


### PR DESCRIPTION
This PR updates the installation and upgrade instructions to the latest supported version of Kibana, which is 7.17.13. It also updates the compatibility matrix and package list to reflect support for Kibana 7.17.13. It closes https://github.com/wazuh/wazuh-documentation/issues/6530

## Checks
### Docs building
- [ ] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
