### PR TITLE
Added note on Docker passwords change

### DIFF
--- a/source/deployment-options/docker/wazuh-container.rst
+++ b/source/deployment-options/docker/wazuh-container.rst
@@ -260,7 +260,7 @@ To improve security, you can change the default password of the Wazuh users. The
 Wazuh indexer users
 ~~~~~~~~~~~~~~~~~~~
 
- To change the password of the default ``admin`` and ``kibanaserver`` users, do the following.
+ To change the password of the default ``admin`` and ``kibanaserver`` users, do the following. They can only be changed one at a time. 
 
 .. warning::
 

--- a/source/deployment-options/docker/wazuh-container.rst
+++ b/source/deployment-options/docker/wazuh-container.rst
@@ -260,7 +260,7 @@ To improve security, you can change the default password of the Wazuh users. The
 Wazuh indexer users
 ~~~~~~~~~~~~~~~~~~~
 
- To change the password of the default ``admin`` and ``kibanaserver`` users, do the following. They can only be changed one at a time. 
+ To change the password of the default ``admin`` and ``kibanaserver`` users, do the following. You can only change one at a time. 
 
 .. warning::
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
<!--
Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->

Related: https://github.com/wazuh/wazuh-docker/issues/1015
This PR modifies the "Change the password of Wazuh users" section of the Wazuh Docker deployment. https://documentation-dev.wazuh.com/v4.5.3-rc1/deployment-options/docker/wazuh-container.html#change-the-password-of-wazuh-users

This process does not allow to change the two passwords at once, so a new note has been added to warn this.

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
