### PR TITLE
Remove deprecated plain text auth examples for AWS and Azure wodles

### DIFF
--- a/source/cloud-security/amazon/services/prerequisites/considerations.rst
+++ b/source/cloud-security/amazon/services/prerequisites/considerations.rst
@@ -2,7 +2,7 @@
 
 .. meta::
   :description: Learn about some considerations that must be taken into account when configuring the Wazuh module for AWS.
-  
+
 .. _amazon_considerations:
 
 Considerations for configuration
@@ -63,7 +63,7 @@ Users can customize two retry configurations.
 -  ``retry_mode``: legacy, standard, and adaptive.
 
    -  **Legacy** mode is the default retry mode. It sets the older version 1 for the retry handler. This includes:
-      
+
       -  Retry attempts for a limited number of errors/exceptions.
       -  A default value of 5 for maximum call attempts.
 
@@ -132,11 +132,10 @@ Below there is an example of different services configuration:
       <aws_profile>dev</aws_profile>
     </bucket>
 
-    <!-- CloudTrail, authentication with hardcoded keys (not recommended), without 'path' tag -->
+    <!-- CloudTrail, 'default' profile, without 'path' tag -->
     <bucket type="cloudtrail">
       <name>wazuh-cloudtrail</name>
-      <access_key>XXXXXXXXXX</access_key>
-      <secret_key>XXXXXXXXXX</secret_key>
+      <aws_profile>default</aws_profile>
     </bucket>
 
     <!-- CloudTrail, 'gov1' profile, and 'us-gov-east-1' GovCloud region -->
@@ -184,8 +183,7 @@ The `service_endpoint` and `sts_endpoint` tags can be used to specify the VPC en
 
     <bucket type="cloudtrail">
       <name>wazuh-cloudtrail-2</name>
-      <access_key>xxxxxx</access_key>
-      <secret_key>xxxxxx</secret_key>
+      <aws_profile>default</aws_profile>
       <iam_role_arn>arn:aws:iam::xxxxxxxxxxx:role/wazuh-role</iam_role_arn>
       <sts_endpoint>xxxxxx.sts.us-east-2.vpce.amazonaws.com</sts_endpoint>
       <service_endpoint>https://bucket.xxxxxx.s3.us-east-2.vpce.amazonaws.com</service_endpoint>

--- a/source/cloud-security/amazon/services/prerequisites/credentials.rst
+++ b/source/cloud-security/amazon/services/prerequisites/credentials.rst
@@ -2,7 +2,7 @@
 
 .. meta::
   :description: Learn about the different ways to configure your AWS credentials when monitoring AWS services with Wazuh.
-  
+
 .. _amazon_credentials:
 
 Configuring AWS credentials
@@ -156,8 +156,7 @@ Once your role is created, just paste it on the bucket configuration:
 
   <bucket type="cloudtrail">
     <name>my-bucket</name>
-    <access_key>xxxxxx</access_key>
-    <secret_key>xxxxxx</secret_key>
+    <aws_profile>default</aws_profile>
     <iam_role_arn>arn:aws:iam::xxxxxxxxxxx:role/wazuh-role</iam_role_arn>
  </bucket>
 

--- a/source/cloud-security/azure/activity-services/prerequisites/considerations.rst
+++ b/source/cloud-security/azure/activity-services/prerequisites/considerations.rst
@@ -1,7 +1,7 @@
 .. Copyright (C) 2015, Wazuh, Inc.
 
 .. meta::
-  :description: Learn considerations for configuring multiple services with the Wazuh Azure module in this section of the Wazuh documentation. 
+  :description: Learn considerations for configuring multiple services with the Wazuh Azure module in this section of the Wazuh documentation.
 
 .. _azure_considerations:
 
@@ -20,8 +20,7 @@ It is possible to add more than one ``request`` block at the same time in the sa
         <run_on_start>yes</run_on_start>
 
         <log_analytics>
-            <application_id>8b7...c14</application_id>
-            <application_key>w22...91x</application_key>
+            <auth_path>/var/ossec/wodles/credentials/log_analytics_credentials</auth_path>
             <tenantdomain>wazuh.onmicrosoft.com</tenantdomain>
 
             <request>
@@ -41,7 +40,7 @@ It is possible to add more than one ``request`` block at the same time in the sa
         </log_analytics>
 
         <graph>
-            <auth_path>/Azure/graph_auth.txt</auth_path>
+            <auth_path>/var/ossec/wodles/credentials/graph_credentials</auth_path>
             <tenantdomain>wazuh.onmicrosoft.com</tenantdomain>
 
             <request>
@@ -59,7 +58,7 @@ It is possible to add more than one ``request`` block at the same time in the sa
         </graph>
 
         <storage>
-            <auth_path>/home/manager/Azure/storage_auth.txt</auth_path>
+            <auth_path>/var/ossec/wodles/credentials/storage_credentials</auth_path>
             <tag>azure-activity</tag>
 
             <container name="insights-operational-logs">

--- a/source/user-manual/reference/ossec-conf/wodle-azure-logs.rst
+++ b/source/user-manual/reference/ossec-conf/wodle-azure-logs.rst
@@ -2,7 +2,7 @@
 
 .. meta::
   :description: Find out the configuration options of the azure-logs wodle. Learn more about it in this section of the Wazuh documentation.
-  
+
 .. _wodle_azure_logs:
 
 wodle name="azure-logs"
@@ -418,8 +418,7 @@ Example of log_analytics configuration
 
         <log_analytics>
 
-            <application_id>8b7...c14</application_id>
-            <application_key>w22...91x</application_key>
+            <auth_path>/var/ossec/wodles/credentials/log_analytics_credentials</auth_path>
             <tenantdomain>wazuh.onmicrosoft.com</tenantdomain>
 
             <request>
@@ -584,7 +583,7 @@ Example of graph configuration
 
 	    <graph>
 
-	        <auth_path>/Azure/graph_auth.txt</auth_path>
+            <auth_path>/var/ossec/wodles/credentials/graph_credentials</auth_path>
 	        <tenantdomain>wazuh.onmicrosoft.com</tenantdomain>
 
 	        <request>
@@ -766,7 +765,7 @@ Example of storage configuration
 
         <storage>
 
-            <auth_path>/home/manager/Azure/storage_auth.txt</auth_path>
+            <auth_path>/var/ossec/wodles/credentials/storage_credentials</auth_path>
             <tag>azure-activity</tag>
 
             <container name="insights-operational-logs">

--- a/source/user-manual/reference/ossec-conf/wodle-azure-logs.rst
+++ b/source/user-manual/reference/ossec-conf/wodle-azure-logs.rst
@@ -583,7 +583,7 @@ Example of graph configuration
 
 	    <graph>
 
-            <auth_path>/var/ossec/wodles/credentials/graph_credentials</auth_path>
+                <auth_path>/var/ossec/wodles/credentials/graph_credentials</auth_path>
 	        <tenantdomain>wazuh.onmicrosoft.com</tenantdomain>
 
 	        <request>
@@ -696,7 +696,7 @@ Specifies the name of the container. Enter ``*`` to access all account container
 storage\\container\\blobs
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Specifies the extension of the blobs like ``.json``. Enter "*" to access all the containers' blobs. 
+Specifies the extension of the blobs like ``.json``. Enter ``*`` to access all the containers blobs.
 
 .. note::
 
@@ -718,7 +718,7 @@ This parameter indicates the format of the blobs' content. The available values 
 - **json_inline**. Each line is a log in json format.
 
 The format of logs stored in Azure accounts is **inline JSON**.
-	
+
 .. note::
 
 	When the ``day`` option is set, the interval value must be a multiple of months. By default, the interval is set to a month.
@@ -795,8 +795,7 @@ Example of all integration
 
         <log_analytics>
 
-            <application_id>8b7...c14</application_id>
-            <application_key>w22...91x</application_key>
+            <auth_path>/var/ossec/wodles/credentials/log_analytics_credentials</auth_path>
             <tenantdomain>wazuh.onmicrosoft.com</tenantdomain>
 
             <request>
@@ -810,7 +809,7 @@ Example of all integration
 
         <graph>
 
-            <auth_path>/Azure/graph_auth.txt</auth_path>
+            <auth_path>/var/ossec/wodles/credentials/graph_credentials</auth_path>
             <tenantdomain>wazuh.onmicrosoft.com</tenantdomain>
 
             <request>
@@ -824,7 +823,7 @@ Example of all integration
 
         <storage>
 
-            <auth_path>/home/manager/Azure/storage_auth.txt</auth_path>
+            <auth_path>/var/ossec/wodles/credentials/storage_credentials</auth_path>
             <tag>azure-activity</tag>
 
             <container name="insights-operational-logs">

--- a/source/user-manual/reference/ossec-conf/wodle-s3.rst
+++ b/source/user-manual/reference/ossec-conf/wodle-s3.rst
@@ -815,8 +815,7 @@ Example of configuration
       <skip_on_error>no</skip_on_error>
       <bucket type="cloudtrail">
           <name>s3-dev-bucket</name>
-          <access_key>insert_access_key</access_key>
-          <secret_key>insert_secret_key</secret_key>
+          <aws_profile>default</aws_profile>
           <only_logs_after>2018-JUN-01</only_logs_after>
           <regions>us-east-1,us-west-1,eu-central-1</regions>
           <path>/dev1/</path>
@@ -827,8 +826,7 @@ Example of configuration
       </bucket>
       <bucket type="cloudtrail">
           <name>s3-dev-bucket</name>
-          <access_key>insert_access_key</access_key>
-          <secret_key>insert_secret_key</secret_key>
+          <aws_profile>default</aws_profile>
           <only_logs_after>2018-JUN-01</only_logs_after>
           <regions>us-east-1,us-west-1,eu-central-1</regions>
           <path>/dev2/</path>
@@ -854,8 +852,7 @@ Example of configuration
           <remove_from_bucket>yes<remove_from_bucket>
       </bucket>
       <service type="cloudwatchlogs">
-          <access_key>insert_access_key</access_key>
-          <secret_key>insert_secret_key</secret_key>
+          <aws_profile>default</aws_profile>
           <aws_log_groups>log_group1,log_group2</aws_log_groups>
           <only_logs_after>2018-JUN-01</only_logs_after>
           <regions>us-east-1,us-west-1,eu-central-1</regions>
@@ -867,4 +864,3 @@ Example of configuration
         <iam_role_arn>arn:aws:iam::010203040506:role/ASL-Role</iam_role_arn>
       </subscriber>
   </wodle>
-  


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
<!--
Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->
This PR closes #6363. Removes the plain text authentication examples for AWS and Azure wodles configurations.

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
