### PR TITLE
Fix broken link in the Onelogin SSO document

### DIFF
--- a/source/user-manual/user-administration/single-sign-on/administrator/onelogin.rst
+++ b/source/user-manual/user-administration/single-sign-on/administrator/onelogin.rst
@@ -11,7 +11,7 @@ OneLogin
 There are three stages in the single sign-on integration.
 
 #. `OneLogin Configuration`_
-#. `Wazuh indexer configuration_`
+#. `Wazuh indexer configuration`_
 #. `Wazuh dashboard configuration`_
    
 OneLogin Configuration


### PR DESCRIPTION

## Description

This PR fixes a broken link in the "Setup single sign-on with administrator role -  OneLogin" document. This PR closes #6441. 
 
## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
