### PR TITLE
Fix release note for macOS14 Sonoma support

### DIFF
--- a/source/release-notes/release-4-5-3.rst
+++ b/source/release-notes/release-4-5-3.rst
@@ -21,7 +21,7 @@ Manager
 Agent
 ^^^^^
 
--  `#19041 <https://github.com/wazuh/wazuh/pull/19041>`__ Updated the agent to report the name of macOS 14 (Sonoma).
+-  `#19205 <https://github.com/wazuh/wazuh/issues/19205>`__ Support for macOS 14 (Sonoma).
 
 RESTful API
 ^^^^^^^^^^^


### PR DESCRIPTION
## Description
This PR makes a change in 4.5.3 release notes to improve note on macOS14 support.

## Checks
### Docs building
- [X] Compiles without warnings.
### Code formatting and web optimization
- [X] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [X] Uses present tense, active voice, and semi-formal registry.
- [X] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
