### PR TITLE
Clarifying use of centralized configuration options

### DIFF
--- a/source/user-manual/reference/centralized-configuration.rst
+++ b/source/user-manual/reference/centralized-configuration.rst
@@ -120,26 +120,52 @@ Options
 +-------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | **name**    | Allows assignment of the block to one particular agent.                                                                                                           |
 +             +-------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+
-|             | Allowed values                                        | Any agent name                                                                                            |
+|             | Allowed values                                        | Any regular expression that matches the agent name .                                                      |
 +-------------+-------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+
 | **os**      | Allows assignment of the block to an operating system.                                                                                                            |
 +             +-------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+
-|             | Allowed values                                        | Any OS family                                                                                             |
+|             | Allowed values                                        | Any regular expression that matches the agent OS information.                                             |
 +-------------+-------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+
 | **profile** | Allows assignment of a profile name to a block. Any agent configured to use the defined :ref:`profile <reference_ossec_client_config_profile>` may use the block. |
 +             +-------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+
-|             | Allowed values                                        | Any defined profile                                                                                       |
+|             | Allowed values                                        | Any regular expression that matches the defined profile.                                                  |
 +-------------+-------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+
 
-Examples
+.. topic:: Example
 
 	.. code-block:: xml
 
-		<agent_config name=”agent01”>
+		<agent_config name=”^agent01”>
 		...
-		<agent_config os="Linux">
+		<agent_config os="^Linux">
 		...
-		<agent_config profile="UnixHost">
+		<agent_config profile="^UnixHost">
+
+Get the agent name and operating system.
+
+    .. code-block:: console
+
+        agent_control -i <AGENT_ID>
+
+    Where ``<AGENT_ID>`` corresponds to the agent ID of the endpoint.
+
+    .. code-block:: none
+        :class: output
+
+        Wazuh agent_control. Agent information:
+        Agent ID:   001
+        Agent Name: agent01
+        IP address: any
+        Status:     Active
+
+        Operating system:    Linux |centos9 |5.14.0-366.el9.x86_64 |#1 SMP PREEMPT_DYNAMIC Thu Sep 14 23:37:14 UTC 2023 |x86_64
+        Client version:      Wazuh v4.5.2
+        Configuration hash:  ab73af41699f13fdd81903b5f23d8d00
+        Shared file hash:    4a8724b20dee0124ff9656783c490c4e
+        Last keep alive:     1696963366
+
+        Syscheck last started at:  Tue Oct 10 12:37:43 2023
+        Syscheck last ended at:    Tue Oct 10 12:37:46 2023
 
 Centralized configuration process
 ---------------------------------

--- a/source/user-manual/reference/centralized-configuration.rst
+++ b/source/user-manual/reference/centralized-configuration.rst
@@ -118,30 +118,30 @@ Options
 -------
 
 +-------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| **name**    | Allows assignment of the block to one particular agent.                                                                                                           |
+| **name**    | Assigns the block to agents with specific names.                                                                                                                  |
 +             +-------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+
-|             | Allowed values                                        | Any regular expression that matches the agent name .                                                      |
+|             | Allowed values                                        | Any regular expression that matches the agent name.                                                       |
 +-------------+-------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+
-| **os**      | Allows assignment of the block to an operating system.                                                                                                            |
+| **os**      | Assigns the block to agents on specific operating systems.                                                                                                        |
 +             +-------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+
 |             | Allowed values                                        | Any regular expression that matches the agent OS information.                                             |
 +-------------+-------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+
-| **profile** | Allows assignment of a profile name to a block. Any agent configured to use the defined :ref:`profile <reference_ossec_client_config_profile>` may use the block. |
+| **profile** | Assigns the block to agents with specific profiles as defined in :ref:`client configuration <reference_ossec_client_config_profile>`.                             |
 +             +-------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+
-|             | Allowed values                                        | Any regular expression that matches the defined profile.                                                  |
+|             | Allowed values                                        | Any regular expression that matches the agent profile.                                                    |
 +-------------+-------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+
 
 .. topic:: Example
 
 	.. code-block:: xml
 
-		<agent_config name=”^agent01”>
+		<agent_config name=”^agent01|^agent02”>
 		...
 		<agent_config os="^Linux">
 		...
 		<agent_config profile="^UnixHost">
 
-Get the agent name and operating system.
+   To get the agent name and operating system information, you can run the ``agent_control`` utility.
 
     .. code-block:: console
 


### PR DESCRIPTION
# Issue 

#6558 

## Description

This PR improves the description in the options section. 

<details><summary> Compilation </summary> 

![2023-10-10_15-52](https://github.com/wazuh/wazuh-documentation/assets/13010397/deeb50f8-53af-405b-a4e7-8c5b23868a16)

</details>

<details><summary> Result </summary> 

![2023-10-10_16-07](https://github.com/wazuh/wazuh-documentation/assets/13010397/09cab16f-76f1-4b1f-99dd-cc9aa2cd3ff2)
![2023-10-10_16-07_1](https://github.com/wazuh/wazuh-documentation/assets/13010397/133ca5b6-950d-4c11-b45a-65c0f6714e3d)

</details>

## Checks
### Docs building
- [x] Compiles without warnings.

