### PR TITLE
Replace repository file references using branch names with tags

### DIFF
--- a/source/_templates/installations/filebeat/opensearch/load_filebeat_template.rst
+++ b/source/_templates/installations/filebeat/opensearch/load_filebeat_template.rst
@@ -1,8 +1,0 @@
-.. Copyright (C) 2015, Wazuh, Inc.
-
-.. code-block:: console
-  
-  # curl -so /etc/filebeat/wazuh-template.json https://raw.githubusercontent.com/wazuh/wazuh/4.5/extensions/elasticsearch/7.x/wazuh-template.json
-  # chmod go+r /etc/filebeat/wazuh-template.json
-
-.. End of include file

--- a/source/deployment-options/elastic-stack/all-in-one-deployment/index.rst
+++ b/source/deployment-options/elastic-stack/all-in-one-deployment/index.rst
@@ -244,7 +244,7 @@ Filebeat installation and configuration
 
     .. code-block:: console
 
-      # curl -so /etc/filebeat/wazuh-template.json https://raw.githubusercontent.com/wazuh/wazuh/|WAZUH_CURRENT_MINOR|/extensions/elasticsearch/7.x/wazuh-template.json
+      # curl -so /etc/filebeat/wazuh-template.json https://raw.githubusercontent.com/wazuh/wazuh/v|WAZUH_CURRENT|/extensions/elasticsearch/7.x/wazuh-template.json
       # chmod go+r /etc/filebeat/wazuh-template.json
 
 #. Download the Wazuh module for Filebeat:

--- a/source/deployment-options/elastic-stack/distributed-deployment/wazuh-cluster/wazuh-multi-node-cluster.rst
+++ b/source/deployment-options/elastic-stack/distributed-deployment/wazuh-cluster/wazuh-multi-node-cluster.rst
@@ -177,7 +177,7 @@ Filebeat installation and configuration
 
     .. code-block:: console
 
-      # curl -so /etc/filebeat/wazuh-template.json https://raw.githubusercontent.com/wazuh/wazuh/|WAZUH_CURRENT_MINOR|/extensions/elasticsearch/7.x/wazuh-template.json
+      # curl -so /etc/filebeat/wazuh-template.json https://raw.githubusercontent.com/wazuh/wazuh/v|WAZUH_CURRENT|/extensions/elasticsearch/7.x/wazuh-template.json
       # chmod go+r /etc/filebeat/wazuh-template.json
 
 #. Download the Wazuh module for Filebeat:

--- a/source/deployment-options/elastic-stack/distributed-deployment/wazuh-cluster/wazuh-single-node-cluster.rst
+++ b/source/deployment-options/elastic-stack/distributed-deployment/wazuh-cluster/wazuh-single-node-cluster.rst
@@ -133,7 +133,7 @@ Filebeat installation and configuration
 
     .. code-block:: console
 
-      # curl -so /etc/filebeat/wazuh-template.json https://raw.githubusercontent.com/wazuh/wazuh/|WAZUH_CURRENT_MINOR|/extensions/elasticsearch/7.x/wazuh-template.json
+      # curl -so /etc/filebeat/wazuh-template.json https://raw.githubusercontent.com/wazuh/wazuh/v|WAZUH_CURRENT|/extensions/elasticsearch/7.x/wazuh-template.json
       # chmod go+r /etc/filebeat/wazuh-template.json
 
 #. Download the Wazuh module for Filebeat:

--- a/source/installation-guide/wazuh-server/step-by-step.rst
+++ b/source/installation-guide/wazuh-server/step-by-step.rst
@@ -132,8 +132,10 @@ Configuring Filebeat
 
   #. Download the alerts template for the Wazuh indexer.
 
-      .. include:: /_templates/installations/filebeat/opensearch/load_filebeat_template.rst
-
+      .. code-block:: console
+      
+         # curl -so /etc/filebeat/wazuh-template.json https://raw.githubusercontent.com/wazuh/wazuh/v|WAZUH_CURRENT|/extensions/elasticsearch/7.x/wazuh-template.json
+         # chmod go+r /etc/filebeat/wazuh-template.json
 
   #. Install the Wazuh module for Filebeat.
 

--- a/source/user-manual/capabilities/vulnerability-detection/offline-update.rst
+++ b/source/user-manual/capabilities/vulnerability-detection/offline-update.rst
@@ -195,7 +195,7 @@ Alternatively, the feeds can be loaded from a local path. To achieve this, use t
 Red Hat Security Data JSON feed
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To perform an offline update, you must make requests to Redhat's API to get the feed pages starting from a specified date. Wazuh provides an `update script <https://github.com/wazuh/wazuh/blob/4.3/tools/vulnerability-detector/rh-generator.sh>`__ that automates the process of downloading the feed and checking for API downtime. The script downloads all the CVE data since the year 1999 by default. We recommend you use the default starting year to maintain a more comprehensive vulnerability database.
+To perform an offline update, you must make requests to Redhat's API to get the feed pages starting from a specified date. Wazuh provides an `update script <https://github.com/wazuh/wazuh/blob/v|WAZUH_CURRENT|/tools/vulnerability-detector/rh-generator.sh>`__ that automates the process of downloading the feed and checking for API downtime. The script downloads all the CVE data since the year 1999 by default. We recommend you use the default starting year to maintain a more comprehensive vulnerability database.
 
 How to use the update script
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/user-manual/reference/tools/fim-migrate.rst
+++ b/source/user-manual/reference/tools/fim-migrate.rst
@@ -20,7 +20,7 @@ This tool is not included in the Wazuh installation, but you can download it fro
 
 .. code-block:: console
 
-    # curl -so fim_migrate https://raw.githubusercontent.com/wazuh/wazuh/3.8/tools/migration/fim_migrate.py
+    # curl -so fim_migrate https://raw.githubusercontent.com/wazuh/wazuh/v|WAZUH_CURRENT|/tools/migration/fim_migrate.py
 
 Add execution permission and run this tool on the manager instance as follows:
 


### PR DESCRIPTION
## Description
This PR changes references to files hosted in Wazuh Github repositories using branch names. It replaces them with references that use specific tags.

However, it doesn't update the following references.

- https://raw.githubusercontent.com/wazuh/wazuh/2.1/extensions/logstash/01-wazuh.conf
- https://raw.githubusercontent.com/wazuh/wazuh/2.1/extensions/elasticsearch/wazuh-elastic2-template.json
- https://github.com/wazuh/wazuh/blob/3.13/extensions/elasticsearch/restore_alerts/restore_alerts.conf

Nor the following reference:

- https://github.com/wazuh/wazuh-packages/raw/master/hp-ux/depothelper-2.10-hppa_32-11.31.depot

## Checks
### Docs building
- [X] Compiles without warnings.
### Code formatting and web optimization
- [X] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [X] Uses present tense, active voice, and semi-formal registry.
- [X] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
