### PR TITLE
Remove apt-transport-https from APT install instructions

### DIFF
--- a/source/_templates/installations/common/deb/add-repository.rst
+++ b/source/_templates/installations/common/deb/add-repository.rst
@@ -4,7 +4,7 @@
 
     .. code-block:: console
 
-      # apt-get install gnupg apt-transport-https
+      # apt-get install gnupg
 
 #. Install the GPG key.
 


### PR DESCRIPTION
as APT natively supports HTTPS since v1.5 from 2017. apt-transport-https has remained a transitional dummy package for apt itself: https://packages.debian.org/apt-transport-https

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
<!--
Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->
## Checks
### Docs building
- [ ] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
