### PR TITLE
Bump version to 4.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [v4.5.4]
+
+### Added
+
+- Support for Wazuh 4.5.4.
+
 ## [v4.5.3]
 ### Added
 

--- a/source/_variables/settings.py
+++ b/source/_variables/settings.py
@@ -20,7 +20,7 @@ is_latest_release = True
 
 # The full version, including alpha/beta/rc tags
 # Important: use a valid branch (4.0) or, preferably, tag name (v4.0.0)
-release = '4.5.3'
-api_tag = 'v4.5.3'
+release = '4.5.4'
+api_tag = '4.5.4'
 
 apiURL = 'https://raw.githubusercontent.com/wazuh/wazuh/'+api_tag+'/api/api/spec/spec.yaml'


### PR DESCRIPTION
## Description

This PR bumps the Wazuh version to 4.5.4. Related issue: https://github.com/wazuh/wazuh-documentation/issues/6638

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
