### PR TITLE
Changed Windows agent support in Ansible deployment

### DIFF
--- a/source/deployment-options/deploying-with-ansible/guide/install-ansible.rst
+++ b/source/deployment-options/deploying-with-ansible/guide/install-ansible.rst
@@ -35,9 +35,9 @@ The following minimum requirements should be met to use Ansible on Windows endpo
 -  At least .NET version 4.0 should be installed on the Windows endpoint.
 -  A WinRM listener should be created and activated.
 
-Before deploying on your Windows endpoints, you must set Ansible to use port `5986` . Edit the `/etc/ansible/hosts` file and add a configuration block for the Windows agents. For example:
+Before deploying on your Windows endpoints, you must set Ansible to use port ``5986`` . Edit the ``/etc/ansible/hosts`` file and add a configuration block for the Windows agents. For example:
 
-.. code-block:: none
+.. code-block:: ini
 
    [windows_agents]
    agent1 ansible_host=192.168.1.101 ansible_port=5986
@@ -45,9 +45,10 @@ Before deploying on your Windows endpoints, you must set Ansible to use port `59
    agent3 ansible_host=192.168.1.103 ansible_port=5986
 
 Where:
--  `windows_agents` is a host group name for the Windows agents.
--  `agent1`, `agent2`, and `agent3` are names for each host.
--  `192.168.1.101–103` are the respective Windows host IP addresses.
+
+-  ``windows_agents`` is a host group name for the Windows agents.
+-  ``agent1``, ``agent2``, and ``agent3`` are names for each host.
+-  ``192.168.1.101``–``103`` are the respective Windows host IP addresses.
 
 Make sure to replace these values with your Windows agents actual data. Add and remove lines accordingly.
 

--- a/source/deployment-options/deploying-with-ansible/guide/install-ansible.rst
+++ b/source/deployment-options/deploying-with-ansible/guide/install-ansible.rst
@@ -35,12 +35,21 @@ The following minimum requirements should be met to use Ansible on Windows endpo
 -  At least .NET version 4.0 should be installed on the Windows endpoint.
 -  A WinRM listener should be created and activated.
 
-Before deploying on your Windows endpoints, you must set Ansible to use port `5986`. Edit the `/etc/ansible/hosts` file and add the following lines.
+Before deploying on your Windows endpoints, you must set Ansible to use port `5986` . Edit the `/etc/ansible/hosts` file and add a configuration block for the Windows agents. For example:
 
 .. code-block:: none
 
-   [<windows_hostname>]
-   <ip_address> ansible_ssh_port=5986
+   [windows_agents]
+   agent1 ansible_host=192.168.1.101 ansible_port=5986
+   agent2 ansible_host=192.168.1.102 ansible_port=5986
+   agent3 ansible_host=192.168.1.103 ansible_port=5986
+
+Where:
+-  `windows_agents` is a host group name for the Windows agents.
+-  `agent1`, `agent2`, and `agent3` are names for each host.
+-  `192.168.1.101–103` are the respective Windows host IP addresses.
+
+Make sure to replace these values with your Windows agents actual data. Add and remove lines accordingly.
 
 Installation on CentOS/RHEL/Fedora
 ----------------------------------

--- a/source/deployment-options/deploying-with-ansible/guide/install-ansible.rst
+++ b/source/deployment-options/deploying-with-ansible/guide/install-ansible.rst
@@ -34,6 +34,7 @@ The following minimum requirements should be met to use Ansible on Windows endpo
 -  PowerShell 3.0 or newer.
 -  At least .NET version 4.0 should be installed on the Windows endpoint.
 -  A WinRM listener should be created and activated.
+-  The port 5986 specified in the `ansible_ssh_port` variable in the hosts file. 
 
 Installation on CentOS/RHEL/Fedora
 ----------------------------------

--- a/source/deployment-options/deploying-with-ansible/guide/install-ansible.rst
+++ b/source/deployment-options/deploying-with-ansible/guide/install-ansible.rst
@@ -34,7 +34,13 @@ The following minimum requirements should be met to use Ansible on Windows endpo
 -  PowerShell 3.0 or newer.
 -  At least .NET version 4.0 should be installed on the Windows endpoint.
 -  A WinRM listener should be created and activated.
--  The port 5986 specified in the `ansible_ssh_port` variable in the hosts file. 
+
+Before deploying on your Windows endpoints, you must set Ansible to use port `5986`. Edit the `/etc/ansible/hosts` file and add the following lines.
+
+.. code-block:: none
+
+   [<windows_hostname>]
+   <ip_address> ansible_ssh_port=5986
 
 Installation on CentOS/RHEL/Fedora
 ----------------------------------

--- a/source/deployment-options/deploying-with-ansible/guide/install-wazuh-agent.rst
+++ b/source/deployment-options/deploying-with-ansible/guide/install-wazuh-agent.rst
@@ -17,7 +17,6 @@ We can install the Wazuh agent on endpoints using the roles and playbooks availa
 
 	- 	SSH key-pairing should already be configured between the ansible deployment server and the endpoints.
 	- 	Add the endpoints where the agent will be deployed in the Ansible hosts file under the ``[wazuh-agents]`` hosts group.
-	- 	This playbook does not support deploying Wazuh agents to Windows and macOS endpoints.
 
 1 - Accessing the wazuh-ansible directory
 -----------------------------------------


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description

Related issue: https://github.com/wazuh/wazuh-documentation/issues/6532

The aim of this PR is to change the Ansible documentation in order to specify the support for Windows and macOS endpoints due to: https://github.com/wazuh/wazuh-ansible/issues/768
<!--
Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->
## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
