### PR TITLE
Reduce the EPS limit default value for FIM

### DIFF
--- a/source/deployment-options/deploying-with-ansible/reference.rst
+++ b/source/deployment-options/deploying-with-ansible/reference.rst
@@ -398,7 +398,7 @@ Wazuh Manager
       skip_proc: 'yes'
       skip_sys: 'yes'
       process_priority: 10
-      max_eps: 100
+      max_eps: 50
       sync_enabled: 'yes'
       sync_interval: '5m'
       sync_max_interval: '1h'
@@ -1134,7 +1134,7 @@ Wazuh Agent
       skip_proc: 'yes'
       skip_sys: 'yes'
       process_priority: 10
-      max_eps: 100
+      max_eps: 50
       sync_enabled: 'yes'
       sync_interval: '5m'
       sync_max_interval: '1h'

--- a/source/deployment-options/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-manager-class.rst
+++ b/source/deployment-options/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-manager-class.rst
@@ -525,7 +525,7 @@ $ossec_syscheck_ignore_type_2
 $ossec_syscheck_max_eps
   Sets the maximum event reporting throughput. Events are messages that will produce an alert.
 
-  `Default 100`
+  `Default 50`
 
   `Type String`
 

--- a/source/user-manual/reference/ossec-conf/syscheck.rst
+++ b/source/user-manual/reference/ossec-conf/syscheck.rst
@@ -380,7 +380,7 @@ max_eps
 Sets the maximum event reporting throughput. Events are messages that will produce an alert.
 
 +--------------------+---------------------------------------------------------+
-| **Default value**  | 100                                                     |
+| **Default value**  | 50                                                     |
 +--------------------+---------------------------------------------------------+
 | **Allowed values** | Integer number between 0 and 1000000. 0 means disabled. |
 +--------------------+---------------------------------------------------------+
@@ -389,7 +389,7 @@ Example:
 
 .. code-block:: xml
 
- <max_eps>100</max_eps>
+ <max_eps>50</max_eps>
 
 
 .. _reference_ossec_syscheck_max_files_per_second:
@@ -1231,7 +1231,7 @@ Default syscheck configuration:
     <!-- Nice value for Syscheck process -->
     <process_priority>10</process_priority>
     <!-- Maximum output throughput -->
-    <max_eps>100</max_eps>
+    <max_eps>50</max_eps>
     <!-- Database synchronization settings -->
     <synchronization>
       <enabled>yes</enabled>
@@ -1277,7 +1277,7 @@ Default syscheck configuration:
     <!-- Nice value for Syscheck process -->
     <process_priority>10</process_priority>
     <!-- Maximum output throughput -->
-    <max_eps>100</max_eps>
+    <max_eps>50</max_eps>
     <!-- Database synchronization settings -->
     <synchronization>
       <enabled>yes</enabled>
@@ -1354,7 +1354,7 @@ Default syscheck configuration:
     <!-- Nice value for Syscheck module -->
     <process_priority>10</process_priority>
     <!-- Maximum output throughput -->
-    <max_eps>100</max_eps>
+    <max_eps>50</max_eps>
     <!-- Database synchronization settings -->
     <synchronization>
       <enabled>yes</enabled>
@@ -1402,7 +1402,7 @@ Default syscheck configuration:
     <!-- Nice value for Syscheck process -->
     <process_priority>10</process_priority>
     <!-- Maximum output throughput -->
-    <max_eps>100</max_eps>
+    <max_eps>50</max_eps>
     <!-- Database synchronization settings -->
     <synchronization>
       <enabled>yes</enabled>


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
From [this issue](https://github.com/wazuh/wazuh/issues/19752) and [this PR](https://github.com/wazuh/wazuh/pull/19758), were the default max_eps value was modified from 100 to 50, it is required to update documentation as well.

## Checks
### Docs building
- [ ] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
