### PR TITLE
Fix Virustotal "How it works" documentation

### DIFF
--- a/source/user-manual/capabilities/malware-detection/virus-total-integration.rst
+++ b/source/user-manual/capabilities/malware-detection/virus-total-integration.rst
@@ -56,7 +56,7 @@ This integration uses the VirusTotal API to detect malicious content within the 
    -  Alert: No positives found.
    -  Alert: X engines detected this file. X is the number of antivirus engines.
 
-Wazuh logs the triggered alert in the ``/var/ossec/logs/integration.log`` file and stores it in the ``/var/ossec/logs/alerts.log`` file with all other alerts.
+Wazuh logs the triggered alert in the ``/var/ossec/logs/integrations.log`` file and stores it in the ``/var/ossec/logs/alerts/alerts.log`` file with all other alerts.
 
 Find examples of these alerts in the :ref:`VirusTotal integration alerts <virustotal-integration-alerts>` section below.
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description

Closes #6649.

This PR fixes two paths in the Virustotal documentation:
- `/var/ossec/logs/integration.log` --> `/var/ossec/logs/integrations.log`
- `/var/ossec/logs/alerts.log` --> `/var/ossec/logs/alerts/alerts.log`

### Images

#### Before
![image](https://github.com/wazuh/wazuh-documentation/assets/42682247/c8e8c56f-54a9-40b7-9971-49c7157358be)

#### After
![image](https://github.com/wazuh/wazuh-documentation/assets/42682247/f8f855c2-0358-40e0-8748-7cdfe97e74a2)

### Compilation with these changes

```bash
# make html
sphinx-build -b html -d build/doctrees   source build/html
Running Sphinx v7.0.1
loading translations [en-US]... not available for built-in messages
making output directory... done
building [mo]: targets for 0 po files that are out of date
writing output... 
building [html]: targets for 672 source files that are out of date
updating environment: [new config] 672 added, 0 changed, 0 removed
reading sources... [100%] user-manual/wazuh-dashboard/troubleshooting                                                                                                                        
Copying static files for wazuh-doc-images...[100%] img/loading.gif                                                                                                                           
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] user-manual/wazuh-dashboard/troubleshooting                                                                                                                         
generating indices... done
writing additional pages... not_found moved-content search done
copying images... [100%] images/kibana-app/features/settings/about.png                                                                                                                       
copying static files... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded.

The HTML pages are in build/html.

Build finished. The HTML pages are in build/html.
```

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
