### PR TITLE
Removed reference for Wazuh indexer and dashboard mixed node from Readme file of production ready deployment with Ansible

### DIFF
--- a/source/deployment-options/deploying-with-ansible/guide/install-wazuh-cluster.rst
+++ b/source/deployment-options/deploying-with-ansible/guide/install-wazuh-cluster.rst
@@ -253,24 +253,11 @@ Let’s see below, the content of the YAML file ``/etc/ansible/roles/wazuh-ansib
    # Wazuh dashboard node
      - hosts: dashboard
        roles:
-         - role: "../roles/wazuh/wazuh-indexer"
          - role: "../roles/wazuh/wazuh-dashboard"
        become: yes
        become_user: root
        vars:
-         indexer_network_host: "{{ hostvars.dashboard.private_ip }}"
-         indexer_node_name: node-6
-         indexer_node_master: false
-         indexer_node_ingest: false
-         indexer_node_data: false
-         indexer_cluster_nodes:
-             - "{{ hostvars.wi1.private_ip }}"
-             - "{{ hostvars.wi2.private_ip }}"
-             - "{{ hostvars.wi3.private_ip }}"
-         indexer_discovery_nodes:
-             - "{{ hostvars.wi1.private_ip }}"
-             - "{{ hostvars.wi2.private_ip }}"
-             - "{{ hostvars.wi3.private_ip }}"
+         indexer_network_host: "{{ hostvars.wi1.private_ip }}"
          dashboard_node_name: node-6
          wazuh_api_credentials:
            - id: default
@@ -278,33 +265,6 @@ Let’s see below, the content of the YAML file ``/etc/ansible/roles/wazuh-ansib
              port: 55000
              username: custom-user
              password: SecretPassword1!
-         instances:
-           node1:
-             name: node-1
-             ip: "{{ hostvars.wi1.private_ip }}"   # When unzipping, the node will search for its node name folder to get the cert.
-             role: indexer
-           node2:
-             name: node-2
-             ip: "{{ hostvars.wi2.private_ip }}"
-             role: indexer
-           node3:
-             name: node-3
-             ip: "{{ hostvars.wi3.private_ip }}"
-             role: indexer
-           node4:
-             name: node-4
-             ip: "{{ hostvars.manager.private_ip }}"
-             role: wazuh
-             node_type: master
-           node5:
-             name: node-5
-             ip: "{{ hostvars.worker.private_ip }}"
-             role: wazuh
-             node_type: worker
-           node6:
-             name: node-6
-             ip: "{{ hostvars.dashboard.private_ip }}"
-             role: dashboard
          ansible_shell_allow_world_readable_temp: true
 
 Let’s take a closer look at the content.

--- a/source/deployment-options/deploying-with-ansible/guide/install-wazuh-cluster.rst
+++ b/source/deployment-options/deploying-with-ansible/guide/install-wazuh-cluster.rst
@@ -250,7 +250,7 @@ Let’s see below, the content of the YAML file ``/etc/ansible/roles/wazuh-ansib
                  - "{{ hostvars.wi2.private_ip }}"
                  - "{{ hostvars.wi3.private_ip }}"
 
-   # Indexer + dashboard node
+   # Wazuh dashboard node
      - hosts: dashboard
        roles:
          - role: "../roles/wazuh/wazuh-indexer"
@@ -320,7 +320,7 @@ More details on  default configuration variables can be found in the :doc:`varia
 2 - Preparing to run the playbook
 ---------------------------------
 
-The YAML file wazuh-production-ready.yml will provision a production-ready distributed Wazuh environment. We will add the public and private IP addresses of the endpoints where the various components of the cluster will be installed to the Ansible hosts file. For this guide, the architecture includes 2 Wazuh nodes, 3 Wazuh indexer nodes, and a mixed Wazuh dashboard node.
+The YAML file wazuh-production-ready.yml will provision a production-ready distributed Wazuh environment. We will add the public and private IP addresses of the endpoints where the various components of the cluster will be installed to the Ansible hosts file. For this guide, the architecture includes 2 Wazuh nodes, 3 Wazuh indexer nodes, and a Wazuh dashboard node.
 
 The contents of the host file is:
 


### PR DESCRIPTION
The messages that made reference to the use of a shared node for Wazuh dashboard in the Readme are corrected, it did not require changes in the playbooks because this was already something that was contemplated, in fact the example inventory indicates the configuration of a specific node for Wazuh dashboard

close https://github.com/wazuh/wazuh-ansible/issues/1086
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
<!--
Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->
## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
