### PR TITLE
Fix malformed table

### DIFF
--- a/source/user-manual/reference/ossec-conf/syscheck.rst
+++ b/source/user-manual/reference/ossec-conf/syscheck.rst
@@ -380,7 +380,7 @@ max_eps
 Sets the maximum event reporting throughput. Events are messages that will produce an alert.
 
 +--------------------+---------------------------------------------------------+
-| **Default value**  | 50                                                     |
+| **Default value**  | 50                                                      |
 +--------------------+---------------------------------------------------------+
 | **Allowed values** | Integer number between 0 and 1000000. 0 means disabled. |
 +--------------------+---------------------------------------------------------+


### PR DESCRIPTION
## Description
This PR fixes a bug introduced in PR https://github.com/wazuh/wazuh-documentation/pull/6646 malforming a table. This lead to a 4.6 docs compilation warning and turned the table not renderable as shown in the image.

![imagen](https://github.com/wazuh/wazuh-documentation/assets/47069802/22b98195-2f60-4fd7-98b1-51893edfbd61)

## Checks
### Docs building
- [X] Compiles without warnings.
### Code formatting and web optimization
- [X] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [X] Uses present tense, active voice, and semi-formal registry.
- [X] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
