### PR TITLE
Update using-password-authentication.rst

### DIFF
--- a/source/user-manual/agent-enrollment/security-options/using-password-authentication.rst
+++ b/source/user-manual/agent-enrollment/security-options/using-password-authentication.rst
@@ -183,6 +183,8 @@ The Wazuh agent installation directory depends on the architecture of the host.
       # echo “<CUSTOM_PASSWORD>” > "C:\Program Files (x86)\ossec-agent\authd.pass"
 
    Note that you have to replace ``<CUSTOM_PASSWORD>`` with the agents enrollment password created on the manager.
+   In some cases, if you create the ``authd.pass`` file through PowerShell, the encoding was in UTF-16LE format, remember to change the ``authd.pass`` encoding to UTF-8, which is 
+   the format the agent expects it to be.
 
 #. Add the Wazuh manager IP address or DNS name in the ``<client><server><address>`` section of ``C:\Program Files (x86)\ossec-agent\ossec.conf``:
 


### PR DESCRIPTION
Added a reminder, to ensure that the format of the authd.pass file on Windows is encoded in UTF-8, which is what wazuh expects it to be, if it is in another format it may cause password errors.

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
<!--
Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->
## Checks
### Docs building
- [ ] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
