### PR TITLE
Demote 4.5 branch to not the latest release

### DIFF
--- a/source/_variables/settings.py
+++ b/source/_variables/settings.py
@@ -16,7 +16,7 @@
 
 # The short X.Y version
 version = '4.5'
-is_latest_release = True
+is_latest_release = False
 
 # The full version, including alpha/beta/rc tags
 # Important: use a valid branch (4.0) or, preferably, tag name (v4.0.0)


### PR DESCRIPTION
## Description
This PR sets the `is_latest_release` variable to `False`.

## Checks
### Docs building
- [X] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
