### PR TITLE
Deprecate vulnerability endpoints

### DIFF
--- a/source/user-manual/api/rbac/reference.rst
+++ b/source/user-manual/api/rbac/reference.rst
@@ -672,13 +672,11 @@ Vulnerability
 ^^^^^^^^^^^^^^^
 vulnerability:read
 ~~~~~~~~~~~~~~~~~~
-- :api-ref:`GET /vulnerability/{agent_id} <operation/api.controllers.vulnerability_controller.get_vulnerability_agent>` (`agent:id`_, `agent:group`_)
-- :api-ref:`GET /vulnerability/{agent_id}/last_scan <operation/api.controllers.vulnerability_controller.get_last_scan_agent>` (`agent:id`_, `agent:group`_)
-- :api-ref:`GET /vulnerability/{agent_id}/summary/{field} <operation/api.controllers.vulnerability_controller.get_vulnerabilities_field_summary>` (`agent:id`_, `agent:group`_)
+.. deprecated:: 4.8.0
 
 vulnerability:run
 ~~~~~~~~~~~~~~~~~~
-- :api-ref:`PUT /vulnerability <operation/api.controllers.vulnerability_controller.run_vulnerability_scan>` (`*:*`_)
+.. deprecated:: 4.8.0
 
 .. _api_rbac_reference_default_policies:
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/20115 |

## Description

Marks `/vulnerability` endpoints RBAC resources as deprecated.

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
