### PR TITLE
Set the default value of allow_higher_versions to no

### DIFF
--- a/source/user-manual/reference/ossec-conf/auth.rst
+++ b/source/user-manual/reference/ossec-conf/auth.rst
@@ -269,7 +269,7 @@ key_request
 The key request settings are configured inside this tag. Read more about this feature at :doc:`agent key request <../../agents/key-request>`.
 
 .. code-block:: xml
-    
+
     <key_request>
       <enabled>yes</enabled>
       <exec_path>/usr/bin/python /home/script.py</exec_path>
@@ -349,11 +349,11 @@ agents
 **allow_higher_versions**
 
 .. versionadded:: 4.6.0
-  
+
 Accept agents with a later version than the current manager.
 
 +--------------------+------------------+
-| **Default value**  | yes              |
+| **Default value**  | no               |
 +--------------------+------------------+
 | **Allowed values** | yes, no          |
 +--------------------+------------------+

--- a/source/user-manual/reference/ossec-conf/remote.rst
+++ b/source/user-manual/reference/ossec-conf/remote.rst
@@ -1,8 +1,8 @@
 .. Copyright (C) 2015, Wazuh, Inc.
 
 .. meta::
-  :description: Check out how to configure the manager to listen for events from the agents and an example of configuration in this section of the Wazuh documentation. 
-  
+  :description: Check out how to configure the manager to listen for events from the agents and an example of configuration in this section of the Wazuh documentation.
+
 .. _reference_ossec_remote:
 
 remote
@@ -171,11 +171,11 @@ agents
 **allow_higher_versions**
 
 .. versionadded:: 4.6.0
-  
+
 Accept agents with a later version than the current manager.
 
 +--------------------+------------------+
-| **Default value**  | yes              |
+| **Default value**  | no               |
 +--------------------+------------------+
 | **Allowed values** | yes, no          |
 +--------------------+------------------+
@@ -205,6 +205,6 @@ Example of configuration
       <rids_closing_time>5m</rids_closing_time>
       <connection_overtake_time>600</connection_overtake_time>
       <agents>
-        <allow_higher_versions>yes</allow_higher_versions>
-      </agents>  
+        <allow_higher_versions>no</allow_higher_versions>
+      </agents>
     </remote>


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
<!--
Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->

This PR is related to:

- https://github.com/wazuh/wazuh/issues/20366

We're switching the default value of option `<allow_higher_versions>` from `yes` to `no`. This PR aims to reflect such change in the reference.

## Checks
### Docs building
- [ ] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
