### PR TITLE
Fix snapd package name in documentation

### DIFF
--- a/source/user-manual/wazuh-dashboard/configuring-third-party-certs/ssl.rst
+++ b/source/user-manual/wazuh-dashboard/configuring-third-party-certs/ssl.rst
@@ -42,7 +42,7 @@ Install certbot
          .. code-block:: console
 
             # apt-get update
-            # apt-get install snap
+            # apt-get install snapd
 
 #. Confirm installed snap is the latest:
 


### PR DESCRIPTION
fix snapd package name

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
The current documentation lists `apt-get install snap` as the command to install snap, but the package name is `snapd`. 
## Checks
### Docs building
- [ ] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
