### PR TITLE
Update wazuh manager supported os for 4.8.0

### DIFF
--- a/source/deployment-options/deploying-with-ansible/guide/install-ansible.rst
+++ b/source/deployment-options/deploying-with-ansible/guide/install-ansible.rst
@@ -57,7 +57,7 @@ Installation on CentOS/RHEL/Fedora
 
 .. tabs::
 
-   .. tab:: CentOS/RHEL 6, 7, and Fedora
+   .. tab:: CentOS/RHEL 7, and Fedora
 
       #. Install the `EPEL <http://fedoraproject.org/wiki/EPEL>`__ repository:
 

--- a/source/deployment-options/wazuh-from-sources/wazuh-server/index.rst
+++ b/source/deployment-options/wazuh-from-sources/wazuh-server/index.rst
@@ -19,7 +19,7 @@ Installing dependencies
     
         .. tabs::
           
-            .. tab:: CentOS 6/7
+            .. tab:: CentOS 7
             
                 .. code-block:: console
                 


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh-documentation/issues/6764  |

## Description

Modifies the OS version where the Wazuh manager can be installed.
## Checks
### Docs building
- [ ] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
