### PR TITLE
Update urllib3 library version

### DIFF
--- a/source/proof-of-concept-guide/monitoring-docker.rst
+++ b/source/proof-of-concept-guide/monitoring-docker.rst
@@ -41,7 +41,7 @@ Perform the following steps to install Docker on the Ubuntu endpoint and configu
    .. code-block:: console
 
       $ curl -sSL https://get.docker.com/ | sh
-      $ sudo pip3 install docker==4.2.0
+      $ sudo pip3 install docker==4.2.0 urllib3==1.26.18
 
 #. Edit the Wazuh agent configuration file ``/var/ossec/etc/ossec.conf`` and add this block to enable the ``docker-listener`` module:
 

--- a/source/user-manual/capabilities/container-security/monitoring-docker.rst
+++ b/source/user-manual/capabilities/container-security/monitoring-docker.rst
@@ -53,7 +53,7 @@ Install dependencies on the Docker server
 
    .. code-block:: console
 
-      # pip3 install docker==4.2.0
+      # pip3 install docker==4.2.0 urllib3==1.26.18
 
 Configure the Wazuh agent
 ^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Description

Adds the `urllib3==1.26.18` library to be compatible with the `docker` version used.

> Used 4.7.2 as the base branch because it's the version used in production and this needs to be fixed as soon as possible.

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
