### PR TITLE
Modify Azure Storage container name and remove path

### DIFF
--- a/source/cloud-security/azure/activity-services/services/storage.rst
+++ b/source/cloud-security/azure/activity-services/services/storage.rst
@@ -75,7 +75,7 @@ Proceed to configure the ``azure-logs`` module in the local configuration (``oss
     :align: center
     :width: 80%
 
-Applying the following configuration, the integration will be executed every day using a credentials file for authentication. The contents of the ``insights-operational-logs`` will be processed, downloading every blob available with ``.json`` extension from the last ``24 hours``. The content for these blobs is expected to be in ``json_inline`` format.
+Applying the following configuration, the integration will be executed every day using a credentials file for authentication. The ``insights-logs-auditlogs`` container content will be processed, downloading every blob available with the ``.json`` extension from the last ``24 hours``. The content for these blobs is expected to be in ``json_inline`` format.
 
 .. code-block:: xml
 
@@ -90,11 +90,10 @@ Applying the following configuration, the integration will be executed every day
                 <auth_path>/home/manager/Azure/storage_auth.txt</auth_path>
                 <tag>azure-activity</tag>
 
-                <container name="insights-operational-logs">
+                <container name="insights-logs-auditlogs">
                     <blobs>.json</blobs>
                     <content_type>json_inline</content_type>
                     <time_offset>24h</time_offset>
-                    <path>info-logs</path>
                 </container>
 
         </storage>
@@ -105,7 +104,7 @@ Check the :doc:`Azure module </user-manual/reference/ossec-conf/wodle-azure-logs
 Wazuh rules
 ^^^^^^^^^^^
 
-Thanks to the following rules, already included in Wazuh ruleset by default, it it possible to monitor the infrastructure activity and get the related alerts:
+Thanks to the following rules, already included in the default Wazuh ruleset, it is possible to monitor the infrastructure activity and obtain related alerts:
 
 .. code-block:: xml
 


### PR DESCRIPTION
## Description
<!--
Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->
Closes #6563. Removes the use of the `container/path` option and changes the `container name` in the Azure Storage use case to keep consistency with the values shown in the images. This option is not mandatory, so the user can learn about it in the [Azure module](https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/wodle-azure-logs.html) reference.

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
