### PR TITLE
Steps to enable who-data in Alpine Linux

### DIFF
--- a/source/development/packaging/generate-wpk-package.rst
+++ b/source/development/packaging/generate-wpk-package.rst
@@ -54,6 +54,9 @@ Execute the ``generate_wpk_package.sh`` script, with the different options you d
 
 To use this tool, the previously required :ref:`certificate <create-wpk-key>` and the key must be in the same directory.
 
+Alpine Linux WPK
+^^^^^^^^^^^^^^^^
+
 Linux WPK
 ^^^^^^^^^
 

--- a/source/development/packaging/generate-wpk-package.rst
+++ b/source/development/packaging/generate-wpk-package.rst
@@ -54,17 +54,6 @@ Execute the ``generate_wpk_package.sh`` script, with the different options you d
 
 To use this tool, the previously required :ref:`certificate <create-wpk-key>` and the key must be in the same directory.
 
-Alpine Linux WPK
-^^^^^^^^^^^^^^^^
-
-Example of Alpine Linux WPK package building.
-
-.. code-block:: console
-
-  # ./generate_alpine_linux_package_wpk.sh -b v|WAZUH_CURRENT| -a x86_64 -j 6 -d /tmp/wpk -k /tmp/keys 
-
-This script builds a Wazuh |WAZUH_CURRENT| Alpine Linux WPK package (name is derived from the source package) for x86_64 architecture and stores it in ``/var/local/wazuh/*.wpk``. This action is done using the previously generated keys that are saved in ``/tmp/keys``.
-
 Linux WPK
 ^^^^^^^^^
 

--- a/source/development/packaging/generate-wpk-package.rst
+++ b/source/development/packaging/generate-wpk-package.rst
@@ -57,6 +57,14 @@ To use this tool, the previously required :ref:`certificate <create-wpk-key>` an
 Alpine Linux WPK
 ^^^^^^^^^^^^^^^^
 
+Example of Alpine Linux WPK package building.
+
+.. code-block:: console
+
+  # ./generate_alpine_linux_package_wpk.sh -b v|WAZUH_CURRENT| -a x86_64 -j 6 -d /tmp/wpk -k /tmp/keys 
+
+This script builds a Wazuh |WAZUH_CURRENT| Alpine Linux WPK package (name is derived from the source package) for x86_64 architecture and stores it in ``/var/local/wazuh/*.wpk``. This action is done using the previously generated keys that are saved in ``/tmp/keys``.
+
 Linux WPK
 ^^^^^^^^^
 

--- a/source/user-manual/capabilities/file-integrity/advanced-settings.rst
+++ b/source/user-manual/capabilities/file-integrity/advanced-settings.rst
@@ -15,6 +15,25 @@ Who-data monitoring
 
 The who-data functionality allows the FIM module to obtain information about who made modifications to a monitored file. This information contains the user who made the changes to the monitored files and the program name or process used.
 
+.. _who-data-monitoring-alpine-linux:
+
+Who-data monitoring on Alpine Linux
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Before using
+~~~~~~~~~~~~
+
+Due to an incorrect installation of the Audit tool Who-data feature in Alpine Linux may not work properly. We have had this type of issue from version v3.1.1-r0 of Audit. To enable the use of Who-data until Audit makes the necessary adjustments, follow these steps.
+
+  .. code-block:: console
+
+    # cp /usr/sbin/audisp-af_unix  /sbin/audisp-af_unix
+
+    # rc-service auditd restart
+
+    # /var/ossec/bin/wazuh-control restart
+
+
 .. _who-data-monitoring-linux:
 
 Who-data monitoring on Linux


### PR DESCRIPTION

## Description
We have found an incorrect installation of the Audit tool that disables the use of Who-data. The solution to the problem is presented [here](https://github.com/wazuh/wazuh/issues/19412) and a change in documentation is necessary. 

## Checks
### Docs building
- [ ] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
