### PR TITLE
Set release date and adapt api_tag

### DIFF
--- a/source/_variables/settings.py
+++ b/source/_variables/settings.py
@@ -22,6 +22,6 @@ is_latest_release = True
 # Important: use a valid branch (4.0) or, preferably, tag name (v4.0.0)
 
 release = '4.7.1'
-api_tag = '4.7.1'
+api_tag = 'v4.7.1'
 
 apiURL = 'https://raw.githubusercontent.com/wazuh/wazuh/'+api_tag+'/api/api/spec/spec.yaml'

--- a/source/release-notes/index-4x.rst
+++ b/source/release-notes/index-4x.rst
@@ -11,7 +11,7 @@ This section summarizes the most important features of each Wazuh 4.x release.
 =============================================  ====================
 Wazuh version                                  Release date
 =============================================  ====================
-:doc:`4.7.1 </release-notes/release-4-7-1>`    TBD
+:doc:`4.7.1 </release-notes/release-4-7-1>`    19 December 2023
 :doc:`4.7.0 </release-notes/release-4-7-0>`    27 November 2023
 :doc:`4.6.0 </release-notes/release-4-6-0>`    31 October 2023
 :doc:`4.5.4 </release-notes/release-4-5-4>`    23 October 2023

--- a/source/release-notes/index-4x.rst
+++ b/source/release-notes/index-4x.rst
@@ -11,7 +11,7 @@ This section summarizes the most important features of each Wazuh 4.x release.
 =============================================  ====================
 Wazuh version                                  Release date
 =============================================  ====================
-:doc:`4.7.1 </release-notes/release-4-7-1>`    19 December 2023
+:doc:`4.7.1 </release-notes/release-4-7-1>`    20 December 2023
 :doc:`4.7.0 </release-notes/release-4-7-0>`    27 November 2023
 :doc:`4.6.0 </release-notes/release-4-6-0>`    31 October 2023
 :doc:`4.5.4 </release-notes/release-4-5-4>`    23 October 2023

--- a/source/release-notes/index.rst
+++ b/source/release-notes/index.rst
@@ -11,7 +11,7 @@ This section summarizes the most important features of each Wazuh release.
 ==============================================   ====================
 Wazuh version                                    Release date
 ==============================================   ====================
-:doc:`4.7.1 </release-notes/release-4-7-1>`      TBD
+:doc:`4.7.1 </release-notes/release-4-7-1>`      19 December 2023
 :doc:`4.7.0 </release-notes/release-4-7-0>`      27 November 2023
 :doc:`4.6.0 </release-notes/release-4-6-0>`      31 October 2023
 :doc:`4.5.4 </release-notes/release-4-5-4>`      23 October 2023

--- a/source/release-notes/index.rst
+++ b/source/release-notes/index.rst
@@ -11,7 +11,7 @@ This section summarizes the most important features of each Wazuh release.
 ==============================================   ====================
 Wazuh version                                    Release date
 ==============================================   ====================
-:doc:`4.7.1 </release-notes/release-4-7-1>`      19 December 2023
+:doc:`4.7.1 </release-notes/release-4-7-1>`      20 December 2023
 :doc:`4.7.0 </release-notes/release-4-7-0>`      27 November 2023
 :doc:`4.6.0 </release-notes/release-4-6-0>`      31 October 2023
 :doc:`4.5.4 </release-notes/release-4-5-4>`      23 October 2023

--- a/source/release-notes/release-4-7-1.rst
+++ b/source/release-notes/release-4-7-1.rst
@@ -3,8 +3,8 @@
 .. meta::
   :description: Wazuh 4.7.1 has been released. Check out our release notes to discover the changes and additions of this release.
 
-4.7.1 Release notes - TBD
-=========================
+4.7.1 Release notes - 19 December 2023
+======================================
 
 This section lists the changes in version 4.7.1. Every update of the Wazuh solution is cumulative and includes all enhancements and fixes from previous releases.
 

--- a/source/release-notes/release-4-7-1.rst
+++ b/source/release-notes/release-4-7-1.rst
@@ -3,7 +3,7 @@
 .. meta::
   :description: Wazuh 4.7.1 has been released. Check out our release notes to discover the changes and additions of this release.
 
-4.7.1 Release notes - 19 December 2023
+4.7.1 Release notes - 20 December 2023
 ======================================
 
 This section lists the changes in version 4.7.1. Every update of the Wazuh solution is cumulative and includes all enhancements and fixes from previous releases.


### PR DESCRIPTION
## Description
This PR (1) sets the release date in release notes documents and (2) changes `api_tag` value from `4.7.1` to `vX.Y.Z`.

## Checks
### Docs building
- [X] Compiles without warnings.
### Code formatting and web optimization
- [X] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [X] Uses present tense, active voice, and semi-formal registry.
- [X] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
