### PR TITLE
Whodata 3.1+ & Alpine Linux support

### DIFF
--- a/source/user-manual/capabilities/file-integrity/advanced-settings.rst
+++ b/source/user-manual/capabilities/file-integrity/advanced-settings.rst
@@ -49,6 +49,7 @@ For Alpine Linux systems:
       # apk add audit=3.1.1-r0
       # rc-update add auditd default
       # cp /usr/sbin/audisp-af_unix /sbin/audisp-af_unix
+      # rc-service auditd restart
 
 
 .. note::

--- a/source/user-manual/capabilities/file-integrity/advanced-settings.rst
+++ b/source/user-manual/capabilities/file-integrity/advanced-settings.rst
@@ -55,7 +55,7 @@ For Alpine Linux systems:
 
       `Audit 3.1.1 changelog <https://people.redhat.com/sgrubb/audit/ChangeLog>`_. indicates that the audispd af_unix plugin was moved to a standalone program. For whodata to successfully connect to the Audit daemon, it is necessary to install this plugin.
 
-      In Red Hat based systems, use the following command to install the audspd af_unix plugin:
+      In Red Hat based systems, use the following command to install the audispd af_unix plugin:
 
          .. code-block:: console
 

--- a/source/user-manual/capabilities/file-integrity/advanced-settings.rst
+++ b/source/user-manual/capabilities/file-integrity/advanced-settings.rst
@@ -61,7 +61,7 @@ For Alpine Linux systems:
 
             # yum install audispd-plugins
 
-      For Debian based systems, use the following command to install the audspd af_unix plugin:
+      For Debian based systems, use the following command to install the audispd af_unix plugin:
 
          .. code-block:: console
 

--- a/source/user-manual/capabilities/file-integrity/advanced-settings.rst
+++ b/source/user-manual/capabilities/file-integrity/advanced-settings.rst
@@ -42,6 +42,37 @@ For Debian based systems, use the following command:
 
       # apt-get install auditd
 
+For Alpine Linux systems:
+
+   .. code-block:: console
+
+      # apk add audit=3.1.1-r0
+      # rc-update add auditd default
+      # cp /usr/sbin/audisp-af_unix /sbin/audisp-af_unix
+
+
+.. note::
+
+      `Audit 3.1.1 changelog <https://people.redhat.com/sgrubb/audit/ChangeLog>`_. indicates that the audispd af_unix plugin was moved to a standalone program. For whodata to successfully connect to the Audit daemon, it is necessary to install this plugin.
+
+      In Red Hat based systems, use the following command to install the audspd af_unix plugin:
+
+         .. code-block:: console
+
+            # yum install audispd-plugins
+
+      For Debian based systems, use the following command to install the audspd af_unix plugin:
+
+         .. code-block:: console
+
+            # apt-get install audispd-plugins
+
+      In any case, you should restart the Auditd daemon.
+
+         .. code-block:: console
+
+            # service auditd restart
+
 Perform the following steps to enable who-data monitoring. In this example, you configure who-data monitoring for ``/etc`` directory.
 
 #. Edit the Wazuh agent ``/var/ossec/etc/ossec.conf`` configuration file and add the configuration below:

--- a/source/user-manual/capabilities/file-integrity/advanced-settings.rst
+++ b/source/user-manual/capabilities/file-integrity/advanced-settings.rst
@@ -30,49 +30,42 @@ Configuration
 
 You need to install the audit daemon if you don’t have it already installed on your endpoint.
 
-In Red Hat based systems, auditd is usually installed by default. If not, install it using the following command:
+.. tabs::
 
-   .. code-block:: console
+   .. group-tab:: Red Hat-based
 
-      # yum install audit
+      .. code-block:: console
 
-For Debian based systems, use the following command:
+         # yum install audit
+      
+      For Audit 3.1.1 and later, install the audispd af_unix plugin and restart the Audit service.
 
-   .. code-block:: console
+      .. code-block:: console
 
-      # apt-get install auditd
+         # yum install audispd-plugins
+         # systemctl restart auditd
 
-For Alpine Linux systems:
+   .. group-tab:: Debian-based
 
-   .. code-block:: console
+      .. code-block:: console
 
-      # apk add audit=3.1.1-r0
-      # rc-update add auditd default
-      # cp /usr/sbin/audisp-af_unix /sbin/audisp-af_unix
-      # rc-service auditd restart
+         # apt-get install auditd
 
+      For Audit 3.1.1 and later, install the audispd af_unix plugin and restart the Audit service.
 
-.. note::
+      .. code-block:: console
 
-      `Audit 3.1.1 changelog <https://people.redhat.com/sgrubb/audit/ChangeLog>`_. indicates that the audispd af_unix plugin was moved to a standalone program. For whodata to successfully connect to the Audit daemon, it is necessary to install this plugin.
+         # apt-get install audispd-plugins
+         # systemctl restart auditd
 
-      In Red Hat based systems, use the following command to install the audispd af_unix plugin:
+   .. group-tab:: Alpine Linux
 
-         .. code-block:: console
+      .. code-block:: console
 
-            # yum install audispd-plugins
-
-      For Debian based systems, use the following command to install the audispd af_unix plugin:
-
-         .. code-block:: console
-
-            # apt-get install audispd-plugins
-
-      In any case, you should restart the Auditd daemon.
-
-         .. code-block:: console
-
-            # service auditd restart
+         # apk add audit=3.1.1-r0
+         # rc-update add auditd default
+         # cp /usr/sbin/audisp-af_unix /sbin/audisp-af_unix
+         # rc-service auditd restart
 
 Perform the following steps to enable who-data monitoring. In this example, you configure who-data monitoring for ``/etc`` directory.
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
<!--
Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->
Closes [19585](https://github.com/wazuh/wazuh/issues/19585), [6833](https://github.com/wazuh/wazuh-documentation/issues/6833), and [19412](https://github.com/wazuh/wazuh/issues/19412)

It has been added the procedure to allow Whodata to work on Alpine Linux (tested on 3.18.4 and 3.18.5) as well as a note to fix Whodata on newer Linux versions, where Auditd 3.1.1 or higher versions are used.

![image](https://github.com/wazuh/wazuh-documentation/assets/69121070/9ab2b49b-2621-4f69-b1ba-54edca8573b8)

## Checks
### Docs building
- [X] Compiles without warnings.
### Code formatting and web optimization
- [X] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [X] Uses present tense, active voice, and semi-formal registry.
- [X] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
