### PR TITLE
Fix 4.7.1 release notes

### DIFF
--- a/source/release-notes/release-4-7-1.rst
+++ b/source/release-notes/release-4-7-1.rst
@@ -13,8 +13,8 @@ What's new
 
 This release includes new features or enhancements as the following:
 
-Manager
-^^^^^^^
+Agent
+^^^^^
 
 - `#20616 <https://github.com/wazuh/wazuh/pull/20616>`__ Improved WPK upgrade scripts to ensure safe execution and backup generation.
 
@@ -49,7 +49,6 @@ Reference                                                         Description
 `#19993 <https://github.com/wazuh/wazuh/pull/19993>`__            Fixed an insecure request warning in the Shuffle integration.
 `#19888 <https://github.com/wazuh/wazuh/pull/19888>`__            Fixed a bug that corrupted cluster logs when rotated.
 `#20580 <https://github.com/wazuh/wazuh/pull/20580>`__            Fixed a bug causing the Canonical feed parser to fail in Vulnerability Detector.
-`#20545 <https://github.com/wazuh/wazuh/pull/20545>`__            Fixed a bug that allowed two simultaneous updates to occur through WPK.
 ==============================================================    =============
 
 Agent
@@ -63,6 +62,7 @@ Reference                                                         Description
 `#20169 <https://github.com/wazuh/wazuh/pull/20169>`__            Fixed a bug in the FIM decoder at ``wazuh-analysisd`` that ignored Windows Registry events from agents earlier than 4.6.0.
 `#20250 <https://github.com/wazuh/wazuh/pull/20250>`__            Fixed multiple bugs in the Syscollector decoder at ``wazuh-analysisd`` that did not sanitize the input data properly.
 `#20284 <https://github.com/wazuh/wazuh/pull/20284>`__            Added the ``pyarrow_hotfix`` dependency to fix the pyarrow ``CVE-2023-47248`` vulnerability in the AWS integration.
+`#20598 <https://github.com/wazuh/wazuh/pull/20598>`__            Fixed a bug that allowed two simultaneous updates to occur through WPK.
 ==============================================================    =============
 
 RESTful API


### PR DESCRIPTION
## Description
This PR moves two 4.7.1 release notes entries to the Agent sections.

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
