### PR TITLE
Add MacOS 14 to SCA policies table

### DIFF
--- a/source/user-manual/capabilities/sec-config-assessment/available-sca-policies.rst
+++ b/source/user-manual/capabilities/sec-config-assessment/available-sca-policies.rst
@@ -103,6 +103,8 @@ The table below shows SCA policies pre-installed in Wazuh out-of-the-box. The Wa
     +-----------------------------+------------------------------------------------------------+-------------------------------+
     | cis_apple_macOS_13.x        |  CIS Checks for macOS 13.x                                 | macOS 13.x (Ventura)          |
     +-----------------------------+------------------------------------------------------------+-------------------------------+
+    | cis_apple_macOS_14.0        |  CIS Checks for macOS 14.0                                 | macOS 14.0 (Sonoma)           |
+    +-----------------------------+------------------------------------------------------------+-------------------------------+
     | web_vulnerabilities         |  System audit for web-related vulnerabilities              | N/A                           |
     +-----------------------------+------------------------------------------------------------+-------------------------------+
     | cis_apache_24               |  CIS Apache HTTP Server 2.4 Benchmark                      | Apache configuration files    |


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-documentation/issues/6887|

## Description
This PR adds missing SCA policies from the [available SCA policies table](https://documentation.wazuh.com/current/user-manual/capabilities/sec-config-assessment/available-sca-policies.html)

## Checks
### Docs building
- [X] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [X] Uses present tense, active voice, and semi-formal registry.
- [X] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
