### PR TITLE
Add download content to installation

### DIFF
--- a/source/deployment-options/wazuh-from-sources/wazuh-server/index.rst
+++ b/source/deployment-options/wazuh-from-sources/wazuh-server/index.rst
@@ -110,6 +110,17 @@ Installing the Wazuh manager
         # cd wazuh-|WAZUH_CURRENT_FROM_SOURCES|
         # ./install.sh
 
+    In addition to the basic installation, you can set the ``DOWNLOAD_CONTENT_AND_DECOMPRESS=y`` variable during the installation to download vulnerability detection content.
+
+    .. code-block:: console
+
+        # DOWNLOAD_CONTENT_AND_DECOMPRESS=y ./install.sh
+
+    .. note::
+        Wazuh adds vulnerability information to the CTI repository and keeps the vulnerability repository updated. However, for the initial run, the :doc:`vulnerability detection </user-manual/capabilities/vulnerability-detection/index>` content needs to be downloaded and processed, which can be time-consuming.
+
+        Therefore, we offer the option to download a pre-prepared initial database to bypass this data processing step.
+
     If you have previously compiled for another platform, you must clean the build using the Makefile  in ``src``:
 
     .. code-block:: console


### PR DESCRIPTION
## Description
There's a new option for installing the manager, `DOWNLOAD_CONTENT_AND_DECOMPRESS`. 

On the initial run of the manager, the vulnerability detection content must be downloaded and processed, which can be time-consuming. Due to this, it is now possible to download a database of the daily updated content, thereby avoiding processing on the initial run. This file is stored in S3.

Note: It's only for the installation, afterward the CTI will be used.

## Checks
### Docs building
- [ ] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.


## Update
![image](https://github.com/wazuh/wazuh-documentation/assets/13617613/661e1806-9afc-409c-864f-cd7b2d1b3d54)
