### PR TITLE
Fix AWS name references

### DIFF
--- a/source/getting-started/use-cases/posture-management.rst
+++ b/source/getting-started/use-cases/posture-management.rst
@@ -37,8 +37,9 @@ The image below shows an example log received from a monitored GCP instance on t
    :align: center
    :width: 80%
 
-Amazon Web Service
-------------------
+Amazon Web Services
+-------------------
+
 Wazuh provides CSPM to your AWS workloads by monitoring the AWS services and instances. Monitoring your AWS services includes collecting and analyzing log data about your AWS infrastructure using the :doc:`Wazuh module for AWS </cloud-security/amazon/services/index>`.
 
 You can enable the Amazon AWS module via your Wazuh dashboard to view logs related to AWS services.

--- a/source/user-manual/agents/labels.rst
+++ b/source/user-manual/agents/labels.rst
@@ -31,7 +31,7 @@ Use case
 
 Below is a case where the use of labels could prove helpful.
 
-Let's imagine we have a large environment deployed in Amazon Web Services (AWS) and monitored by Wazuh. In this situation, we want the manager to have the following information about each agent when an alert is triggered:
+In a large environment deployed in Amazon Web Services (AWS), you might want to have the following information about each agent when an alert is triggered:
 
 - AWS instance-id.
 - AWS Security group.

--- a/source/user-manual/agents/labels.rst
+++ b/source/user-manual/agents/labels.rst
@@ -31,8 +31,7 @@ Use case
 
 Below is a case where the use of labels could prove helpful.
 
-Let's imagine we have a large environment deployed in Amazon Web Service (AWS) and monitored by Wazuh. In this situation, we want the manager to have the following information about
-each agent when an alert is triggered:
+Let's imagine we have a large environment deployed in Amazon Web Services (AWS) and monitored by Wazuh. In this situation, we want the manager to have the following information about each agent when an alert is triggered:
 
 - AWS instance-id.
 - AWS Security group.


### PR DESCRIPTION
## Description
This PR fixes `Amazon Web Services` name references.

## Checks
### Docs building
- [X] Compiles without warnings.
### Code formatting and web optimization
- [X] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
