### PR TITLE
Add `-i` option to command in offline installation documentation

### DIFF
--- a/source/deployment-options/offline-installation.rst
+++ b/source/deployment-options/offline-installation.rst
@@ -164,7 +164,7 @@ Installing the Wazuh indexer
 
     .. code-block:: console
 
-        # /usr/share/wazuh-indexer/bin/indexer-init.sh
+        # bash /usr/share/wazuh-indexer/bin/indexer-init.sh -i <WAZUH_INDEXER_IP_ADDRESS>
   
 #. Run the following command to check that the installation is successful. Note that this command uses localhost, set your Wazuh indexer address if necessary. 
 


### PR DESCRIPTION
## Description

This PR adds the `-i` option to the command in offline installation documentation to initialize the cluster.

Closes https://github.com/wazuh/wazuh-packages/issues/2770

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
