### PR TITLE
Add wazuh::repo class in agent instalation

### DIFF
--- a/source/deployment-options/deploying-with-puppet/wazuh-puppet-module/index.rst
+++ b/source/deployment-options/deploying-with-puppet/wazuh-puppet-module/index.rst
@@ -330,6 +330,9 @@ Here is an example of a manifest ``wazuh-agent.pp`` (please replace  ``MANAGER_I
   .. code-block:: puppet
 
    node "puppet-agent.com" {
+     class { 'wazuh::repo':
+       stage => repo
+     }
      class { "wazuh::agent":
        wazuh_register_endpoint => "<MANAGER_IP>",
        wazuh_reporting_endpoint => "<MANAGER_IP>"

--- a/source/deployment-options/deploying-with-puppet/wazuh-puppet-module/index.rst
+++ b/source/deployment-options/deploying-with-puppet/wazuh-puppet-module/index.rst
@@ -331,7 +331,6 @@ Here is an example of a manifest ``wazuh-agent.pp`` (please replace  ``MANAGER_I
 
    node "puppet-agent.com" {
      class { 'wazuh::repo':
-       stage => repo
      }
      class { "wazuh::agent":
        wazuh_register_endpoint => "<MANAGER_IP>",


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
<!--
Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->
This PR adds the wazuh::repo deployment when the user install Wazuh agent with Puppet deployment.
Issue Related https://github.com/wazuh/wazuh-puppet/issues/900
## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
