### PR TITLE
Remove the modification of number of shards from the offline installation

### DIFF
--- a/source/deployment-options/offline-installation.rst
+++ b/source/deployment-options/offline-installation.rst
@@ -255,21 +255,6 @@ Filebeat must be installed and configured on the same server as the Wazuh manage
         cp ./wazuh-offline/wazuh-files/wazuh-template.json /etc/filebeat/ &&\
         chmod go+r /etc/filebeat/wazuh-template.json
 
-#.  Edit ``/etc/filebeat/wazuh-template.json`` and change to ``"1"`` the value for ``"index.number_of_shards"`` for  a single-node installation. This value can be changed based on the user requirement when performing a distributed installation.
-
-    .. code-block:: none
-        :emphasize-lines: 5
-
-        {
-          ...
-          "settings": {
-            ...
-            "index.number_of_shards": "1",
-            ...
-          },
-          ...
-        }
-
 #. Edit the ``/etc/filebeat/filebeat.yml`` configuration file and replace the following value:
 
    .. include:: /_templates/installations/filebeat/opensearch/configure_filebeat.rst
@@ -339,27 +324,6 @@ Filebeat must be installed and configured on the same server as the Wazuh manage
             dial up... OK
           talk to server... OK
           version: 7.10.2
-
-    To check the number of shards that have been configured, you can run the following command. Note that this command uses localhost, set your Wazuh indexer address if necessary.
-
-    .. code-block:: console
-
-        # curl -k -u admin:admin "https://localhost:9200/_template/wazuh?pretty&filter_path=wazuh.settings.index.number_of_shards"
-
-    Expand the output to see an example response.
-
-    .. code-block:: none
-        :class: output collapsed
-
-        {
-          "wazuh" : {
-            "settings" : {
-              "index" : {
-                "number_of_shards" : "1"
-              }
-            }
-          }
-        }
 
 
 Your Wazuh server node is now successfully installed. Repeat the steps of this installation process stage for every Wazuh server node in your cluster, expand the **Wazuh cluster configuration for multi-node deployment** section below, and carry on then with configuring the Wazuh cluster. If you want a Wazuh server single-node cluster, everything is set and you can proceed directly with the Wazuh dashboard installation.


### PR DESCRIPTION

## Description

In #6946, it was requested to remove the step to tweak the number of shards in the `wazuh-template.json` for the offline installation. This PR removes such instructions.

We plan to add this back in the future as part of a major update of the `wazuh-indexer` documentation.

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
