### PR TITLE
Add suspicious binary download command

### DIFF
--- a/source/user-manual/capabilities/malware-detection/virus-total-integration.rst
+++ b/source/user-manual/capabilities/malware-detection/virus-total-integration.rst
@@ -97,7 +97,22 @@ For this use case, we show how to monitor the folder ``/media/user/software`` on
 
    .. include:: /_templates/common/restart_manager.rst
 
-After restarting, FIM applies the new configuration and monitors the folder you specify in near real time. When FIM detects a new file in the monitored directory, Wazuh generates the alert below:
+After restarting, FIM applies the new configuration and monitors the folder you specify in near real time.
+
+Test the configuration
+^^^^^^^^^^^^^^^^^^^^^^
+
+Now, you can download a malicious file on the endpoint in the monitored folder.
+
+.. warning::
+
+   Download the Eicar file here for testing purposes only. We recommend testing in a sandbox, not in a production environment.
+
+.. code-block:: console
+
+   $ sudo curl -Lo /media/user/software/suspicious-file.exe https://secure.eicar.org/eicar.com
+
+When FIM detects a new file in the monitored directory, Wazuh generates the alert below:
 
 .. code-block:: json
    :class: output


### PR DESCRIPTION
## Description
This PR updates the [User manual > Capabilities > Malware detection > VirusTotal integration](http://127.0.0.1:5500/build/html/user-manual/capabilities/malware-detection/virus-total-integration.html#use-case-scanning-a-file) section. It adds the eicar test file download command to test the Scanning a file use case .

## Checks
### Docs building
- [X] Compiles without warnings.
### Code formatting and web optimization
- [X] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [X] Uses present tense, active voice, and semi-formal registry.
- [X] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
