### PR TITLE
Fix cloud service docs redirections

### DIFF
--- a/source/_static/js/redirects.js
+++ b/source/_static/js/redirects.js
@@ -63,36 +63,6 @@ removedUrls['x.y'] = [
 
 /* *** RELEASE 4.7 ****/
 
-/* Redirections from 4.6 to 4.7  */
-
-redirections.push(
-    {
-      'target': ['4.6=>4.7', '4.7=>4.6'],
-      '4.6': '/cloud-service/cold-storage/index.html',
-      '4.7': '/cloud-service/archive-data/index.html',
-    },
-    {
-      'target': ['4.6=>4.7', '4.7=>4.6'],
-      '4.6': '/cloud-service/cold-storage/access.html',
-      '4.7': '/cloud-service/archive-data/access.html',
-    },
-    {
-      'target': ['4.6=>4.7', '4.7=>4.6'],
-      '4.6': '/cloud-service/cold-storage/configuration.html',
-      '4.7': '/cloud-service/archive-data/configuration.html',
-    },
-    {
-      'target': ['4.6=>4.7', '4.7=>4.6'],
-      '4.6': '/cloud-service/cold-storage/filename-format.html',
-      '4.7': '/cloud-service/archive-data/filename-format.html',
-    },
-    {
-      'target': ['4.6=>4.7', '4.7=>4.6'],
-      '4.6': '/cloud-service/getting-started/register-agents.html',
-      '4.7': '/cloud-service/getting-started/enroll-agents.html',
-    },
-);
-
 /* Pages added in 4.7 */
 
 newUrls['4.7'] = [

--- a/source/_variables/redirect_same_release.py
+++ b/source/_variables/redirect_same_release.py
@@ -3,6 +3,18 @@
 # Important: the redirect is relative to the old path
 
 redirectSameRelease = {
+  '4.7': {
+    '/cloud-service/cold-storage/index.html':
+      '/cloud-service/archive-data/index.html',
+    '/cloud-service/cold-storage/access.html':
+      '/cloud-service/archive-data/access.html',
+    '/cloud-service/cold-storage/configuration.html':
+      '/cloud-service/archive-data/configuration.html',
+    '/cloud-service/cold-storage/filename-format.html':
+      '/cloud-service/archive-data/filename-format.html',
+    '/cloud-service/getting-started/register-agents.html':
+      '/cloud-service/getting-started/enroll-agents.html',
+  },
   '4.6': {
     '/cloud-security/azure/activity-services/active-directory/index.html':
       '/cloud-security/azure/activity-services/entra/index.html',


### PR DESCRIPTION
## Description
This PR fixes redirections for the following Wazuh cloud service documents, since the old documents were already published with the `4.7` docs thus needing redirections within the same 4.7 release.
- https://documentation.wazuh.com/current/cloud-service/archive-data/index.html
- https://documentation.wazuh.com/current/cloud-service/archive-data/access.html
- https://documentation.wazuh.com/current/cloud-service/archive-data/configuration.html
- https://documentation.wazuh.com/current/cloud-service/archive-data/filename-format.html
- https://documentation.wazuh.com/current/cloud-service/getting-started/enroll-agents.html

## Checks
### Docs building
- [X] Compiles without warnings.
### Code formatting and web optimization
- [X] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [X] Uses present tense, active voice, and semi-formal registry.
- [X] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.