### PR TITLE
Add new <global> option <forward_to> to configuration reference

### DIFF
--- a/source/user-manual/reference/ossec-conf/global.rst
+++ b/source/user-manual/reference/ossec-conf/global.rst
@@ -480,8 +480,10 @@ Example:
 
   <agents_disconnection_alert_time>1h</agents_disconnection_alert_time>
 
+.. _reference_limits:
+
 limits
-------
+^^^^^^
 
 This block configures the limits section.
 
@@ -494,7 +496,7 @@ This block configures the limits section.
 +----------------------------+
 
 limits\\eps
-^^^^^^^^^^^
+"""""""""""
 
 This block configures the events per second limitation functionality.
 
@@ -521,7 +523,7 @@ Events per second limits example block:
     </limits>
 
 limits\\eps\\maximum
-^^^^^^^^^^^^^^^^^^^^
+""""""""""""""""""""
 
 Maximum number of events per second allowed to be processed by decoders.
 
@@ -532,7 +534,7 @@ Maximum number of events per second allowed to be processed by decoders.
 +--------------------+-----------------------------------------------------------------+
 
 limits\\eps\\timeframe
-^^^^^^^^^^^^^^^^^^^^^^
+""""""""""""""""""""""
 
 A positive number expressed in seconds that indicates the time period where the events per second processed are increased and restored.
 

--- a/source/user-manual/reference/ossec-conf/global.rst
+++ b/source/user-manual/reference/ossec-conf/global.rst
@@ -50,6 +50,7 @@ Options
 - `agents_disconnection_alert_time`_
 - `limits`_
 - `update_check`_
+- `forward_to`_
 
 alerts_log
 ^^^^^^^^^^
@@ -554,6 +555,24 @@ This setting toggles whether to query the external Wazuh Cyber Threat Intelligen
 | **Allowed values** | yes, no |
 +--------------------+---------+
 
+.. _reference_forward_to:
+
+forward_to
+^^^^^^^^^^
+
+Specifies the name of the socket where the output will be redirected. The socket must be defined previously.
+
++-------------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| **Default value**       | None                                                                                                                                     |
++-------------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| **Allowed values**      | Any defined socket under /var/ossec                                                                                                      |
++-------------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+
+Example:
+
+.. code-block:: xml
+
+  <forward_to>fluentd</forward_to>
 
 Configuration example
 ---------------------

--- a/source/user-manual/reference/ossec-conf/global.rst
+++ b/source/user-manual/reference/ossec-conf/global.rst
@@ -562,19 +562,25 @@ This setting toggles whether to query the external Wazuh Cyber Threat Intelligen
 forward_to
 ^^^^^^^^^^
 
-Specifies the name of the socket where the output will be redirected. The socket must be defined previously.
+Specifies the :ref:`name of the socket <reference_ossec_socket_name>` where the output will be redirected. The socket must be defined previously. 
 
 +-------------------------+------------------------------------------------------------------------------------------------------------------------------------------+
 | **Default value**       | None                                                                                                                                     |
 +-------------------------+------------------------------------------------------------------------------------------------------------------------------------------+
-| **Allowed values**      | Any defined socket under /var/ossec                                                                                                      |
+| **Allowed values**      | Any defined socket under ``/var/ossec``                                                                                                  |
 +-------------------------+------------------------------------------------------------------------------------------------------------------------------------------+
 
 Example:
 
 .. code-block:: xml
 
-  <forward_to>fluentd</forward_to>
+  <socket>  
+    <name>custom_socket</name>  
+    <location>/var/ossec/custom.sock</location>  
+    <mode>tcp</mode>  
+  </socket>  
+
+  <forward_to>custom_socket</forward_to>  
 
 Configuration example
 ---------------------

--- a/source/user-manual/reference/ossec-conf/socket.rst
+++ b/source/user-manual/reference/ossec-conf/socket.rst
@@ -25,6 +25,7 @@ Options
 - `mode`_
 - `prefix`_
 
+.. _reference_ossec_socket_name:
 
 name
 ^^^^^^^^^^


### PR DESCRIPTION
|Related issue|
|---|
|#6971|

## Description

As explained in the issue, it is necessary to add the new option created ( `<forward_to>` ) to the [`ossec.conf` global configuration reference](https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/global.html).

This option shall be introduced in the `<global>` block:

|Name|Default value|Description|
|---|---|---|
|`<forward_to>`|None|Any socket under /var/ossec to forward messages.|


## Example

```xml
<global>
    <jsonout_output>yes</jsonout_output>
    <alerts_log>yes</alerts_log>
    <logall>no</logall>
    <logall_json>no</logall_json>
    <email_notification>no</email_notification>
    <smtp_server>smtp.example.wazuh.com</smtp_server>
    <email_from>wazuh@example.wazuh.com</email_from>
    <email_to>recipient@example.wazuh.com</email_to>
    <email_maxperhour>12</email_maxperhour>
    <email_log_source>alerts.log</email_log_source>
    <agents_disconnection_time>10m</agents_disconnection_time>
    <forward_to>fluentd</forward_to> <!-- Name of the socket to forward the alert, must be the same of socket section  -->
  </global>

  <fluent-forward>
     <enabled>yes</enabled>
     <tag>debug.test</tag>
     <socket_path>var/run/fluent.sock</socket_path>  <!-- WARNING: Path must be realtive to /var/ossec  -->
     <address>localhost</address>
     <port>24224</port>
  </fluent-forward>

  <socket>
	<name>fluentd</name> <!-- Name of the socket to forward the alert -->
	<location>var/run/fluent.sock</location>  <!-- WARNING: Path must be realtive to /var/ossec  -->
	<mode>udp</mode>
  </socket>
```
## Extra fix
I also noticed that `limits` was formatted incorrectly, since it was in a higher hierarchy, along with `Options` and not within it. This can be seen in the index.
## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
