### PR TITLE
Missing setting in logstash configuration in the Opensearch integration guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Added Wazuh v4.8.0 release notes. ([#6550](https://github.com/wazuh/wazuh-documentation/pull/6550))
 - Added the ``update_check`` configuration option. ([#6673](https://github.com/wazuh/wazuh-documentation/pull/6673))
 - Added the Filebeat deployment into Wazuh manager worker nodes for distributed deployments with Puppet. ([#6872](https://github.com/wazuh/wazuh-documentation/pull/6872))
+- Add configuration to logstash in opensearch integration guide. ([#6981](https://github.com/wazuh/wazuh-documentation/pull/6981))
 
 ### Changed
 

--- a/source/integrations-guide/opensearch/index.rst
+++ b/source/integrations-guide/opensearch/index.rst
@@ -201,6 +201,7 @@ We use the  `Logstash keystore <https://www.elastic.co/guide/en/logstash/current
                template => "/etc/logstash/templates/wazuh.json"
                template_name => "wazuh"
                template_overwrite => true
+               legacy_template => false
              }
          }
 
@@ -404,6 +405,7 @@ We use the `Logstash keystore <https://www.elastic.co/guide/en/logstash/current/
                template => "/etc/logstash/templates/wazuh.json"
                template_name => "wazuh"
                template_overwrite => true
+               legacy_template => false
              }
          }
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description

In the following [guide](https://documentation-dev.wazuh.com/v4.8.0-alpha2/integrations-guide/opensearch/index.html#configuring-a-pipeline) on integrations, more specifically on the integration with Opensearch, you can see that the setting `legacy_template => false` is missing in the logstash configuration, which causes the error discussed in the following [issue](https://github.com/wazuh/wazuh-dashboard-plugins/issues/5878).
<!--

-->
## Evidence
<img width="1792" alt="image" src="https://github.com/wazuh/wazuh-documentation/assets/99441266/2c47a7a0-aa2f-4f63-9449-753495e558cd">
<!--

Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->
## Checks
### Docs building
- [ ] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
