### PR TITLE
Move OSQuery section to the Malware detection section

### DIFF
--- a/source/_static/js/redirects.js
+++ b/source/_static/js/redirects.js
@@ -79,6 +79,7 @@ newUrls['4.7'] = [
   '/cloud-service/getting-started/enroll-agents.html',
   '/cloud-service/your-environment/limits.html',
   '/cloud-service/your-environment/settings.html',
+  '/user-manual/capabilities/malware-detection/osquery.html',
 ];
 
 /* Pages no longer available in 4.7 */
@@ -90,6 +91,7 @@ removedUrls['4.7'] = [
   '/cloud-service/cold-storage/configuration.html',
   '/cloud-service/cold-storage/filename-format.html',
   '/cloud-service/getting-started/register-agents.html',
+  '/user-manual/capabilities/osquery.html',
 ];
 
 /* *** RELEASE 4.6 ****/

--- a/source/_variables/redirect_same_release.py
+++ b/source/_variables/redirect_same_release.py
@@ -14,6 +14,8 @@ redirectSameRelease = {
       '/cloud-service/archive-data/filename-format.html',
     '/cloud-service/getting-started/register-agents.html':
       '/cloud-service/getting-started/enroll-agents.html',
+    '/user-manual/capabilities/osquery.html':
+      '/user-manual/capabilities/malware-detection/osquery.html',
   },
   '4.6': {
     '/cloud-security/azure/activity-services/active-directory/index.html':

--- a/source/user-manual/capabilities/index.rst
+++ b/source/user-manual/capabilities/index.rst
@@ -33,5 +33,4 @@ In this section you will find:
    system-inventory/index
    system-calls-monitoring/index
    agentless-monitoring/index        
-   osquery
    policy-monitoring/index

--- a/source/user-manual/capabilities/malware-detection/index.rst
+++ b/source/user-manual/capabilities/malware-detection/index.rst
@@ -29,3 +29,4 @@ Wazuh :doc:`log collection capability <../log-data-collection/index>` allows you
       clam-av-logs-collection
       win-defender-logs-collection
       custom-rules-malware-ioc
+      osquery

--- a/source/user-manual/capabilities/malware-detection/osquery.rst
+++ b/source/user-manual/capabilities/malware-detection/osquery.rst
@@ -126,10 +126,10 @@ And the osquery module must be enabled for the agents where the osquery is runni
 
   <wodle name="osquery"/>
 
-To their ``/var/ossec/etc/ossec.conf`` file or through :doc:`centralized configuration <../reference/centralized-configuration>`
+To their ``/var/ossec/etc/ossec.conf`` file or through :doc:`centralized configuration </user-manual/reference/centralized-configuration>`
 
 .. note::
-  More options may be specified as shown in the  :doc:`osquery configuration reference <../reference/ossec-conf/wodle-osquery>`
+  More options may be specified as shown in the  :doc:`osquery configuration reference </user-manual/reference/ossec-conf/wodle-osquery>`
 
 As you can see in this sample configuration, ``system_info``, ``high_load_average`` and ``low_free_memory`` queries will be executed every hour.
 

--- a/source/user-manual/reference/daemons/wazuh-modulesd.rst
+++ b/source/user-manual/reference/daemons/wazuh-modulesd.rst
@@ -51,7 +51,7 @@ The wazuh-modulesd program manages the Wazuh modules described below.
 
 .. topic:: Osquery wodle
 
-  The Osquery wodle provides the user with an operating system instrumentation tool that makes low-level operating system analytics and monitoring both efficient and intuitive using SQL-based queries. For more information, read through the documentation for :doc:`osquery integration <../../capabilities/osquery>`.
+  The Osquery wodle provides the user with an operating system instrumentation tool that makes low-level operating system analytics and monitoring both efficient and intuitive using SQL-based queries. For more information, read through the documentation for :doc:`osquery integration </user-manual/capabilities/malware-detection/osquery>`.
 
 .. topic:: SCA module
 


### PR DESCRIPTION
## Description
This PR moves https://documentation.wazuh.com/4.7/user-manual/capabilities/osquery.html into https://documentation.wazuh.com/4.7/user-manual/capabilities/malware-detection/

## Checks
### Docs building
- [X] Compiles without warnings.
### Code formatting and web optimization
- [X] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [X] Uses present tense, active voice, and semi-formal registry.
- [X] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
