### PR TITLE
Missing setting in logstash configuration in the Opensearch integration guide

### DIFF
--- a/source/integrations-guide/elastic-stack/index.rst
+++ b/source/integrations-guide/elastic-stack/index.rst
@@ -217,7 +217,7 @@ We use the `Logstash keystore <https://www.elastic.co/guide/en/logstash/current/
          
          For testing purposes, you can avoid SSL verification by replacing ``cacert => "</PATH/TO/LOCAL/ELASTICSEARCH>/root-ca.pem"`` with ``ssl_certificate_verification => false``.
 
-         If you are using composable index templates and the _index_template API, set the optional parameter `legacy_template => false <https://opensearch.org/docs/latest/tools/logstash/ship-to-opensearch/#optional-parameters>`__.
+         If you aren't using composable index templates and the _index_template API, remove the `legacy_template => false <https://opensearch.org/docs/latest/tools/logstash/ship-to-opensearch/#optional-parameters>`__ parameter.
 
 Running Logstash
 ^^^^^^^^^^^^^^^^

--- a/source/integrations-guide/elastic-stack/index.rst
+++ b/source/integrations-guide/elastic-stack/index.rst
@@ -217,7 +217,7 @@ We use the `Logstash keystore <https://www.elastic.co/guide/en/logstash/current/
          
          For testing purposes, you can avoid SSL verification by replacing ``cacert => "</PATH/TO/LOCAL/ELASTICSEARCH>/root-ca.pem"`` with ``ssl_certificate_verification => false``.
 
-         If you aren't using composable index templates and the _index_template API, remove the `legacy_template => false <https://opensearch.org/docs/latest/tools/logstash/ship-to-opensearch/#optional-parameters>`__ parameter.
+         If you are using composable index templates and the _index_template API, set the optional parameter `legacy_template => false <https://opensearch.org/docs/latest/tools/logstash/ship-to-opensearch/#optional-parameters>`__.
 
 Running Logstash
 ^^^^^^^^^^^^^^^^

--- a/source/integrations-guide/opensearch/index.rst
+++ b/source/integrations-guide/opensearch/index.rst
@@ -201,6 +201,7 @@ We use the  `Logstash keystore <https://www.elastic.co/guide/en/logstash/current
                template => "/etc/logstash/templates/wazuh.json"
                template_name => "wazuh"
                template_overwrite => true
+               legacy_template => false
              }
          }
 
@@ -215,7 +216,7 @@ We use the  `Logstash keystore <https://www.elastic.co/guide/en/logstash/current
          
          For testing purposes, you can avoid SSL verification by replacing ``cacert => "</PATH/TO/LOCAL/OPENSEARCH/CERTIFICATE>/root-ca.pem"`` with ``ssl_certificate_verification => false``.
 
-         If you are using composable index templates and the _index_template API, set the optional parameter `legacy_template => false <https://opensearch.org/docs/latest/tools/logstash/ship-to-opensearch/#optional-parameters>`__.
+         If you aren't using composable index templates and the _index_template API, remove the `legacy_template => false <https://opensearch.org/docs/latest/tools/logstash/ship-to-opensearch/#optional-parameters>`__ parameter.
 
 Running Logstash
 ^^^^^^^^^^^^^^^^
@@ -404,6 +405,7 @@ We use the `Logstash keystore <https://www.elastic.co/guide/en/logstash/current/
                template => "/etc/logstash/templates/wazuh.json"
                template_name => "wazuh"
                template_overwrite => true
+               legacy_template => false
              }
          }
 
@@ -416,7 +418,7 @@ We use the `Logstash keystore <https://www.elastic.co/guide/en/logstash/current/
          
          For testing purposes, you can avoid SSL verification by replacing ``cacert => "</PATH/TO/LOCAL/OPENSEARCH/CERTIFICATE>/root-ca.pem"`` with ``ssl_certificate_verification => false``.
 
-         If you are using composable index templates and the _index_template API, set the optional parameter `legacy_template => false <https://opensearch.org/docs/latest/tools/logstash/ship-to-opensearch/#optional-parameters>`__.
+         If you aren't using composable index templates and the _index_template API, remove the `legacy_template => false <https://opensearch.org/docs/latest/tools/logstash/ship-to-opensearch/#optional-parameters>`__ parameter.
 
 #. By default the ``/var/ossec/logs/alerts/alerts.json`` file is owned by the ``wazuh`` user with restrictive permissions. You must add the ``logstash`` user to the ``wazuh`` group so it can read the file when running Logstash as a service:
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description

In the following [guide](https://documentation-dev.wazuh.com/v4.8.0-alpha2/integrations-guide/opensearch/index.html#configuring-a-pipeline) on integrations, more specifically on the integration with Opensearch, you can see that the setting `legacy_template => false` is missing in the logstash configuration, which causes the error discussed in the following [issue](https://github.com/wazuh/wazuh-dashboard-plugins/issues/5878).
<!--

-->
## Evidence
<img width="1792" alt="image" src="https://github.com/wazuh/wazuh-documentation/assets/99441266/2c47a7a0-aa2f-4f63-9449-753495e558cd">

Updated note on legacy template:
<img width="1094" alt="image" src="https://github.com/wazuh/wazuh-documentation/assets/99441266/2bd9e76c-2e3d-41c9-9da7-831b88acc9c1">

<!--

Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->
## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
