### PR TITLE
Add support for 4.8.1 release notes

### DIFF
--- a/source/_static/js/redirects.js
+++ b/source/_static/js/redirects.js
@@ -68,6 +68,7 @@ removedUrls['x.y'] = [
 
 newUrls['4.8'] = [
   '/release-notes/release-4-8-0.html',
+  '/release-notes/release-4-8-1.html',
 ];
 
 /* Pages no longer available in 4.8 */

--- a/source/release-notes/index-4x.rst
+++ b/source/release-notes/index-4x.rst
@@ -11,6 +11,7 @@ This section summarizes the most important features of each Wazuh 4.x release.
 =============================================  ====================
 Wazuh version                                  Release date
 =============================================  ====================
+:doc:`4.8.1 </release-notes/release-4-8-1>`    TBD
 :doc:`4.8.0 </release-notes/release-4-8-0>`    TBD
 :doc:`4.7.2 </release-notes/release-4-7-2>`    10 January 2024
 :doc:`4.7.1 </release-notes/release-4-7-1>`    20 December 2023
@@ -64,6 +65,7 @@ Wazuh version                                  Release date
 
    .. toctree::
 
+      4.8.1 Release notes <release-4-8-1>
       4.8.0 Release notes <release-4-8-0>
       4.7.2 Release notes <release-4-7-2>
       4.7.1 Release notes <release-4-7-1>

--- a/source/release-notes/index.rst
+++ b/source/release-notes/index.rst
@@ -11,6 +11,7 @@ This section summarizes the most important features of each Wazuh release.
 ==============================================   ====================
 Wazuh version                                    Release date
 ==============================================   ====================
+:doc:`4.8.1 </release-notes/release-4-8-1>`      TBD
 :doc:`4.8.0 </release-notes/release-4-8-0>`      TBD
 :doc:`4.7.2 </release-notes/release-4-7-2>`      10 January 2024
 :doc:`4.7.1 </release-notes/release-4-7-1>`      20 December 2023

--- a/source/release-notes/release-4-8-1.rst
+++ b/source/release-notes/release-4-8-1.rst
@@ -1,0 +1,28 @@
+.. Copyright (C) 2015, Wazuh, Inc.
+
+.. meta::
+  :description: Wazuh 4.8.1 has been released. Check out our release notes to discover the changes and additions of this release.
+
+4.8.1 Release notes - TBD
+=========================
+
+This section lists the changes in version 4.8.1. Every update of the Wazuh solution is cumulative and includes all enhancements and fixes from previous releases.
+
+What's new
+----------
+
+This release includes new features or enhancements as the following:
+
+Resolved issues
+---------------
+
+This release resolves known issues as the following: 
+
+Changelogs
+----------
+
+More details about these changes are provided in the changelog of each component:
+
+- `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/v4.8.1/CHANGELOG.md>`__
+- `wazuh/wazuh-dashboard <https://github.com/wazuh/wazuh-dashboard-plugins/blob/v4.8.1-2.10.0/CHANGELOG.md>`__
+- `wazuh/wazuh-packages <https://github.com/wazuh/wazuh-packages/releases/tag/v4.8.1>`__


### PR DESCRIPTION
## Description
This PR adds an empty of notes 4.8.1 release notes page.

## Checks
### Docs building
- [X] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [X] Uses present tense, active voice, and semi-formal registry.
- [X] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.