### PR TITLE
Add Pub/Sub configuration warning

### DIFF
--- a/source/cloud-security/gcp/posture-management.rst
+++ b/source/cloud-security/gcp/posture-management.rst
@@ -102,6 +102,10 @@ Configure the Wazuh server to receive logs from GCP by performing the following 
 
    Run the commands with root permission.
 
+.. warning::
+
+   The Wazuh GCP module does not support multiple Pub/Sub sections in the same :ref:`Wazuh configuration file<reference_ossec_conf>`. To configure more than one service, deploying multiple agents is required.
+
 #. Create a ``credentials.json`` file in the ``/var/ossec/wodles/gcloud/`` directory:
 
    .. code-block:: console

--- a/source/cloud-security/gcp/posture-management.rst
+++ b/source/cloud-security/gcp/posture-management.rst
@@ -102,10 +102,6 @@ Configure the Wazuh server to receive logs from GCP by performing the following 
 
    Run the commands with root permission.
 
-.. warning::
-
-   The Wazuh GCP module does not support multiple Pub/Sub sections in the same :ref:`Wazuh configuration file<reference_ossec_conf>`. To configure more than one service, deploying multiple agents is required.
-
 #. Create a ``credentials.json`` file in the ``/var/ossec/wodles/gcloud/`` directory:
 
    .. code-block:: console
@@ -134,6 +130,10 @@ Configure the Wazuh server to receive logs from GCP by performing the following 
 
    -  ``<PROJECT_ID>`` is the ID of the `GCP project`_ created above.
    -  ``<SUBSCRIPTION_NAME>`` is the `subscription ID`_ of your GCP Pub/Sub.
+
+   .. note::
+   
+      The Wazuh GCP module supports only one ``gcp-pubsub`` section per :ref:`Wazuh configuration file <reference_ossec_conf>`. To configure more than one service, you need to deploy multiple agents.
 
 #. Create a rule file ``gcp_posture.xml`` in the ``/var/ossec/etc/rules/`` directory and add the following custom rules to detect GCP posture findings:
 

--- a/source/cloud-security/gcp/prerequisites/pubsub.rst
+++ b/source/cloud-security/gcp/prerequisites/pubsub.rst
@@ -14,10 +14,6 @@ We use it to get security events from the Google Cloud instances without creatin
 
 In this section, we see how to create a topic, a subscription, and a sink to fully configure Google Cloud Pub/Sub to work with Wazuh.
 
-.. warning::
-
-   The Wazuh GCP module does not support multiple Pub/Sub sections in the same configuration. To configure more than one service, deploying multiple agents is required.
-
 Create a topic
 --------------
 

--- a/source/cloud-security/gcp/prerequisites/pubsub.rst
+++ b/source/cloud-security/gcp/prerequisites/pubsub.rst
@@ -14,6 +14,10 @@ We use it to get security events from the Google Cloud instances without creatin
 
 In this section, we see how to create a topic, a subscription, and a sink to fully configure Google Cloud Pub/Sub to work with Wazuh.
 
+.. warning::
+
+   The Wazuh GCP module does not support multiple Pub/Sub sections in the same configuration. To configure more than one service, deploying multiple agents is required.
+
 Create a topic
 --------------
 

--- a/source/user-manual/reference/ossec-conf/gcp-pubsub.rst
+++ b/source/user-manual/reference/ossec-conf/gcp-pubsub.rst
@@ -13,7 +13,11 @@ gcp-pubsub
 		<gcp-pubsub>
 		</gcp-pubsub>
 
-   This configuration section is used to configure the Google Cloud Pub/Sub module.
+This configuration section is used to configure the Google Cloud Pub/Sub module.
+
+.. warning::
+
+   Only one ``gcp-pubsub`` section is supported in the same configuration. To configure more than one service, deploying multiple agents is required.
 
 .. topic:: Main options:
 

--- a/source/user-manual/reference/ossec-conf/gcp-pubsub.rst
+++ b/source/user-manual/reference/ossec-conf/gcp-pubsub.rst
@@ -17,7 +17,7 @@ This configuration section is used to configure the Google Cloud Pub/Sub module.
 
 .. warning::
 
-   Only one ``gcp-pubsub`` section is supported in the same configuration. To configure more than one service, deploying multiple agents is required.
+   Only one ``gcp-pubsub`` section is supported in the same :ref:`Wazuh configuration file<reference_ossec_conf>`. To configure more than one service, deploying multiple agents is required.
 
 .. topic:: Main options:
 

--- a/source/user-manual/reference/ossec-conf/gcp-pubsub.rst
+++ b/source/user-manual/reference/ossec-conf/gcp-pubsub.rst
@@ -15,9 +15,9 @@ gcp-pubsub
 
 This configuration section is used to configure the Google Cloud Pub/Sub module.
 
-.. warning::
+.. note::
 
-   Only one ``gcp-pubsub`` section is supported in the same :ref:`Wazuh configuration file<reference_ossec_conf>`. To configure more than one service, deploying multiple agents is required.
+   The Wazuh GCP module supports only one ``gcp-pubsub`` section per :ref:`Wazuh configuration file <reference_ossec_conf>`. To configure more than one service, you need to deploy multiple agents.
 
 .. topic:: Main options:
 


### PR DESCRIPTION
## Description

Adds a warning message mentioning that multiple `gcp-pubsub` sections are not supported in the same configuration to the files related to the service.

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.