### PR TITLE
Update RBAC reference

### DIFF
--- a/source/user-manual/api/rbac/reference.rst
+++ b/source/user-manual/api/rbac/reference.rst
@@ -442,8 +442,7 @@ group:read
 - :api-ref:`GET /groups/{group_id}/agents <operation/api.controllers.agent_controller.get_agents_in_group>` (`group:id`_)
 - :api-ref:`GET /groups/{group_id}/configuration <operation/api.controllers.agent_controller.get_group_config>` (`group:id`_)
 - :api-ref:`GET /groups/{group_id}/files <operation/api.controllers.agent_controller.get_group_files>` (`group:id`_)
-- :api-ref:`GET /groups/{group_id}/files/{file_name}/json <operation/api.controllers.agent_controller.get_group_file_json>` (`group:id`_)
-- :api-ref:`GET /groups/{group_id}/files/{file_name}/xml <operation/api.controllers.agent_controller.get_group_file_xml>` (`group:id`_)
+- :api-ref:`GET /groups/{group_id}/files/{file_name} <operation/api.controllers.agent_controller.get_group_file>` (`group:id`_)
 - :api-ref:`GET /overview/agents <operation/api.controllers.overview_controller.get_overview_agents>` (`group:id`_)
 
 group:update_config


### PR DESCRIPTION
## Description

Closes https://github.com/wazuh/wazuh/issues/20851.

Updates the RBAC reference according to the changes introduced in https://github.com/wazuh/wazuh/pull/21653. No other reference to the endpoints was found in the documentation.

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
