### PR TITLE
Add mapping users example

### DIFF
--- a/source/user-manual/user-administration/rbac.rst
+++ b/source/user-manual/user-administration/rbac.rst
@@ -339,7 +339,7 @@ To map the user with Wazuh, follow these steps:
 #. Click **Create Role mapping** and complete the empty fields with the requested information.
    
       - **Role mapping name**: Assign a name to the role mapping.
-      - **Roles**: Select the role created previously and  the ``cluster_readonly`` role. This role assigns the user basic configuration reading permissions.
+      - **Roles**: Select the role created previously, for example ``Team_A_role``, and the ``cluster_readonly`` role. The latter assigns the user basic configuration reading permissions.
       - **Internal users**: Select the internal user created previously.
 
        .. thumbnail:: /images/manual/user-administration/rbac/create-new-role-mapping.png


### PR DESCRIPTION
## Description

Adds the role name showcased in one of the images above as an example in a step later to avoid overlooking the requirement. 

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
