### PR TITLE
Updated Policy Path oscap-faq.rst

### DIFF
--- a/source/user-manual/capabilities/policy-monitoring/openscap/oscap-faq.rst
+++ b/source/user-manual/capabilities/policy-monitoring/openscap/oscap-faq.rst
@@ -41,4 +41,4 @@ Yes, by default, policies are evaluated when the wodle starts. You can change th
 Where are the policies?
 -----------------------
 
-Each agent must have its policies in ``/var/ossec/wodles/oscap/content``.
+Each agent must have its policies in ``/var/ossec/ruleset/sca``.


### PR DESCRIPTION
From Wazuh 4.0.0, OpenSCAP policies were removed from RPM and DEB packages, and the folder present policies in the agent installation will be removed. So, I updated it to the new default policy path.

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
<!--
Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->
## Checks
### Docs building
- [ ] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
