### PR TITLE
Add considerations for max_size API options

### DIFF
--- a/source/user-manual/api/configuration.rst
+++ b/source/user-manual/api/configuration.rst
@@ -256,7 +256,7 @@ max_size
 |            |                                               |               | Rotation occurs after adding a new entry to the API log, triggering the selected method.                                   |
 |            |                                               |               | For instance, the time-based rotation will rotate after a new entry is added past midnight. Not at midnight automatically. |
 +------------+-----------------------------------------------+---------------+----------------------------------------------------------------------------------------------------------------------------+
-| size       | Any positive number followed by a valid unit. | 1M            | Set a file size to trigger log rotation. This value must be equal to or greater than 1M.                                      |
+| size       | Any positive number followed by a valid unit. | 1M            | Set a file size to trigger log rotation. This value must be equal to or greater than 1M.                                   |
 |            | K/k for kilobytes, M/m for megabytes.         |               |                                                                                                                            |
 +------------+-----------------------------------------------+---------------+----------------------------------------------------------------------------------------------------------------------------+
 

--- a/source/user-manual/api/configuration.rst
+++ b/source/user-manual/api/configuration.rst
@@ -256,7 +256,7 @@ max_size
 |            |                                               |               | Rotation occurs after adding a new entry to the API log, triggering the selected method.                                   |
 |            |                                               |               | For instance, the time-based rotation will rotate after a new entry is added past midnight. Not at midnight automatically. |
 +------------+-----------------------------------------------+---------------+----------------------------------------------------------------------------------------------------------------------------+
-| size       | Any positive number followed by a valid unit. | 1M            | Set a file size to trigger log rotation. This value must be equal or greater than 1M.                                      |
+| size       | Any positive number followed by a valid unit. | 1M            | Set a file size to trigger log rotation. This value must be equal to or greater than 1M.                                      |
 |            | K/k for kilobytes, M/m for megabytes.         |               |                                                                                                                            |
 +------------+-----------------------------------------------+---------------+----------------------------------------------------------------------------------------------------------------------------+
 

--- a/source/user-manual/api/configuration.rst
+++ b/source/user-manual/api/configuration.rst
@@ -252,11 +252,10 @@ max_size
 +------------+-----------------------------------------------+---------------+----------------------------------------------------------------------------------------------------------------------------+
 | Sub-fields | Allowed values                                | Default value | Description                                                                                                                |
 +============+===============================================+===============+============================================================================================================================+
-| enabled    | yes, true, no, false                          | false         | Enable or disable log file rotation based on file size. This option will disable log file rotation based on time.          |
-|            |                                               |               | Rotation occurs after adding a new entry to the API log, triggering the selected method.                                   |
-|            |                                               |               | For instance, the time-based rotation will rotate after a new entry is added past midnight. Not at midnight automatically. |
+| enabled    | yes, true, no, false                          | false         | Toggle between time-based and size-based Wazuh API log rotation.                                                           |
+|            |                                               |               | Enabling this option disables time-based rotation, enabling rotation based on file size instead.                           |
 +------------+-----------------------------------------------+---------------+----------------------------------------------------------------------------------------------------------------------------+
-| size       | Any positive number followed by a valid unit. | 1M            | Set a file size to trigger log rotation. This value must be equal to or greater than 1M.                                   |
+| size       | Any positive number followed by a valid unit. | 1M            | Set the maximum file size to not trigger size-based log rotation. Lower than 1 M values are considered as 1 M.             |
 |            | K/k for kilobytes, M/m for megabytes.         |               |                                                                                                                            |
 +------------+-----------------------------------------------+---------------+----------------------------------------------------------------------------------------------------------------------------+
 

--- a/source/user-manual/api/configuration.rst
+++ b/source/user-manual/api/configuration.rst
@@ -220,8 +220,8 @@ https
 +--------------+------------------------------------+----------------------------------+-------------------------------------------------------------------------------------------------+
 | ca           | Any text string                    | ca.crt                           | Name of the certificate of the Certificate Authority (CA). Stored in ``api/configuration/ssl``. |
 +--------------+------------------------------------+----------------------------------+-------------------------------------------------------------------------------------------------+
-| ssl_protocol | TLS, TLSv1, TLSv1.1, TLSv1.2, auto | .. versionadded:: 4.8.0          |                                                                                                 | 
-|              |                                    |                                  |                                                                                                 |   
+| ssl_protocol | TLS, TLSv1, TLSv1.1, TLSv1.2, auto | .. versionadded:: 4.8.0          |                                                                                                 |
+|              |                                    |                                  |                                                                                                 |
 |              |                                    | auto                             | SSL protocol to allow. Its value is not case sensitive.                                         |
 +--------------+------------------------------------+----------------------------------+-------------------------------------------------------------------------------------------------+
 | ssl_ciphers  | Any text string                    | None                             | SSL ciphers to allow. Its value is not case sensitive.                                          |
@@ -249,14 +249,16 @@ max_size
 
 .. versionadded:: 4.6.0
 
-+------------+-----------------------------------------------+---------------+-------------------------------------------------------------------------------------------------------------------+
-| Sub-fields | Allowed values                                | Default value | Description                                                                                                       |
-+============+===============================================+===============+===================================================================================================================+
-| enabled    | yes, true, no, false                          | false         | Enable or disable log file rotation based on file size. This option will disable log file rotation based on time. |
-+------------+-----------------------------------------------+---------------+-------------------------------------------------------------------------------------------------------------------+
-| size       | Any positive number followed by a valid unit. | 1M            | Set a file size to trigger log rotation.                                                                          |
-|            | K/k for kilobytes, M/m for megabytes.         |               |                                                                                                                   |
-+------------+-----------------------------------------------+---------------+-------------------------------------------------------------------------------------------------------------------+
++------------+-----------------------------------------------+---------------+----------------------------------------------------------------------------------------------------------------------------+
+| Sub-fields | Allowed values                                | Default value | Description                                                                                                                |
++============+===============================================+===============+============================================================================================================================+
+| enabled    | yes, true, no, false                          | false         | Enable or disable log file rotation based on file size. This option will disable log file rotation based on time.          |
+|            |                                               |               | Rotation occurs after adding a new entry to the API log, triggering the selected method.                                   |
+|            |                                               |               | For instance, the time-based rotation will rotate after a new entry is added past midnight. Not at midnight automatically. |
++------------+-----------------------------------------------+---------------+----------------------------------------------------------------------------------------------------------------------------+
+| size       | Any positive number followed by a valid unit. | 1M            | Set a file size to trigger log rotation. This value must be equal or greater than 1M.                                      |
+|            | K/k for kilobytes, M/m for megabytes.         |               |                                                                                                                            |
++------------+-----------------------------------------------+---------------+----------------------------------------------------------------------------------------------------------------------------+
 
 
 cors

--- a/source/user-manual/api/getting-started.rst
+++ b/source/user-manual/api/getting-started.rst
@@ -429,6 +429,8 @@ Here are some of the basic concepts related to making API requests and understan
 - All requests (except ``POST /security/user/authenticate`` and ``POST /security/user/authenticate/run_as``) accept the parameter ``pretty`` to convert the JSON response to a more human-readable format.
 - The Wazuh API log is stored on the manager at ``WAZUH_PATH/logs`` directory as ``api.log`` or ``api.json`` depending on the chosen log format (the verbosity level can be changed in the Wazuh API configuration file). The Wazuh API logs are rotated daily. Rotated logs are stored in ``WAZUH_PATH/logs/api/<year>/<month>`` and compressed using ``gzip``.
 - All Wazuh API requests will be aborted if no response is received after a certain amount of time. The parameter ``wait_for_complete`` can be used to disable this timeout. This is useful for calls that could take more time than expected, such as :api-ref:`PUT /agents/upgrade <operation/api.controllers.agent_controller.put_upgrade_agents>`.
+- The Wazuh API logs are rotated based on time by default. Rotation only occurs after adding a new entry to the log. For instance, time-based rotation triggers when a new entry is added on a different day, not necessarily every midnight.
+
 
 .. note:: The maximum API response time can be modified in the :ref:`API configuration <api_configuration_options>`.
 

--- a/source/user-manual/api/getting-started.rst
+++ b/source/user-manual/api/getting-started.rst
@@ -427,10 +427,9 @@ Here are some of the basic concepts related to making API requests and understan
 - Responses containing collections of data will return a maximum of 500 elements by default. The *offset* and *limit* parameters may be used to iterate through large collections. The *limit* parameter accepts up to 100000 items, although it is recommended not to exceed the default value (500 items). Doing so can lead to unexpected behaviors (timeouts, large responses, etc.). Use with caution.
 - All responses have an HTTP status code: 2xx (success), 4xx (client error), 5xx (server error), etc.
 - All requests (except ``POST /security/user/authenticate`` and ``POST /security/user/authenticate/run_as``) accept the parameter ``pretty`` to convert the JSON response to a more human-readable format.
-- The Wazuh API log is stored on the manager at ``WAZUH_PATH/logs`` directory as ``api.log`` or ``api.json`` depending on the chosen log format (the verbosity level can be changed in the Wazuh API configuration file). The Wazuh API logs are rotated daily. Rotated logs are stored in ``WAZUH_PATH/logs/api/<year>/<month>`` and compressed using ``gzip``.
+- The Wazuh API stores logs in the ``api.log`` or ``api.json`` files, depending on the chosen log format. These log files are located at ``WAZUH_PATH/logs/`` on the Wazuh server. You can change the verbosity level in the :ref:`Wazuh API configuration file <api_configuration_file>`.
+- The Wazuh API logs are rotated based on time by default. Rotation only occurs after adding a new entry to the log. For instance, time-based rotation triggers when a new entry is added on a different day, not necessarily every midnight. Rotated logs are stored in ``WAZUH_PATH/logs/api/<year>/<month>/`` and compressed using ``gzip``.
 - All Wazuh API requests will be aborted if no response is received after a certain amount of time. The parameter ``wait_for_complete`` can be used to disable this timeout. This is useful for calls that could take more time than expected, such as :api-ref:`PUT /agents/upgrade <operation/api.controllers.agent_controller.put_upgrade_agents>`.
-- The Wazuh API logs are rotated based on time by default. Rotation only occurs after adding a new entry to the log. For instance, time-based rotation triggers when a new entry is added on a different day, not necessarily every midnight.
-
 
 .. note:: The maximum API response time can be modified in the :ref:`API configuration <api_configuration_options>`.
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
<!--
Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->

This PR closes #7013. Adds extra considerations for `max_size` sub-fields in API configurations.

![image](https://github.com/wazuh/wazuh-documentation/assets/7127104/cef2d48c-e76f-4724-adac-38da23ab622b)

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
