### PR TITLE
Fix Keystore execution order

### DIFF
--- a/source/deployment-options/offline-installation.rst
+++ b/source/deployment-options/offline-installation.rst
@@ -221,18 +221,18 @@ Installing the Wazuh manager
 
    .. code-block:: console
 
-       # /var/ossec/bin/wazuh-keystore -f indexer -k username -v <INDEXER_USERNAME>
-       # /var/ossec/bin/wazuh-keystore -f indexer -k password -v <INDEXER_PASSWORD>   
+      # /var/ossec/bin/wazuh-keystore -f indexer -k username -v <INDEXER_USERNAME>
+      # /var/ossec/bin/wazuh-keystore -f indexer -k password -v <INDEXER_PASSWORD>   
 
    .. note:: The default offline-installation credentials are ``admin``:``admin``
 
-#.  Enable and start the Wazuh manager service.
+#. Enable and start the Wazuh manager service.
 
-    .. include:: /_templates/installations/wazuh/common/enable_wazuh_manager_service.rst
+   .. include:: /_templates/installations/wazuh/common/enable_wazuh_manager_service.rst
 
-#.  Run the following command to verify that the Wazuh manager status is active.
+#. Run the following command to verify that the Wazuh manager status is active.
 
-    .. include:: /_templates/installations/wazuh/common/check_wazuh_manager.rst
+   .. include:: /_templates/installations/wazuh/common/check_wazuh_manager.rst
 
 Installing Filebeat
 ~~~~~~~~~~~~~~~~~~~

--- a/source/deployment-options/offline-installation.rst
+++ b/source/deployment-options/offline-installation.rst
@@ -217,14 +217,6 @@ Installing the Wazuh manager
 
                 # dpkg -i ./wazuh-offline/wazuh-packages/wazuh-manager*.deb
 
-#.  Enable and start the Wazuh manager service.
-
-    .. include:: /_templates/installations/wazuh/common/enable_wazuh_manager_service.rst
-
-#.  Run the following command to verify that the Wazuh manager status is active.
-
-    .. include:: /_templates/installations/wazuh/common/check_wazuh_manager.rst
-
 #. Save the Wazuh indexer username and password into the Wazuh manager keystore using the wazuh-keystore tool: 
 
    .. code-block:: console
@@ -233,6 +225,14 @@ Installing the Wazuh manager
        # /var/ossec/bin/wazuh-keystore -f indexer -k password -v <INDEXER_PASSWORD>   
 
    .. note:: The default offline-installation credentials are ``admin``:``admin``
+
+#.  Enable and start the Wazuh manager service.
+
+    .. include:: /_templates/installations/wazuh/common/enable_wazuh_manager_service.rst
+
+#.  Run the following command to verify that the Wazuh manager status is active.
+
+    .. include:: /_templates/installations/wazuh/common/check_wazuh_manager.rst
 
 Installing Filebeat
 ~~~~~~~~~~~~~~~~~~~

--- a/source/installation-guide/wazuh-server/step-by-step.rst
+++ b/source/installation-guide/wazuh-server/step-by-step.rst
@@ -68,6 +68,15 @@ Installing the Wazuh manager
 
               # apt-get -y install wazuh-manager|WAZUH_MANAGER_DEB_PKG_INSTALL|
 
+  #. Save the Wazuh indexer username and password into the Wazuh manager keystore using the wazuh-keystore tool: 
+
+      .. code-block:: console
+
+        # /var/ossec/bin/wazuh-keystore -f indexer -k username -v <INDEXER_USERNAME>
+        # /var/ossec/bin/wazuh-keystore -f indexer -k password -v <INDEXER_PASSWORD>   
+
+      .. note:: The default step-by-step installation credentials are ``admin``:``admin``
+
   #. Enable and start the Wazuh manager service.
 
       .. include:: /_templates/installations/wazuh/common/enable_wazuh_manager_service.rst
@@ -76,15 +85,6 @@ Installing the Wazuh manager
   #. Run the following command to verify the Wazuh manager status.
 
       .. include:: /_templates/installations/wazuh/common/check_wazuh_manager.rst
-
-  #. Save the Wazuh indexer username and password into the Wazuh manager keystore using the wazuh-keystore tool: 
-
-    .. code-block:: console
-
-       # /var/ossec/bin/wazuh-keystore -f indexer -k username -v <INDEXER_USERNAME>
-       # /var/ossec/bin/wazuh-keystore -f indexer -k password -v <INDEXER_PASSWORD>   
-
-    .. note:: The default step-by-step installation credentials are ``admin``:``admin``
 
 .. _wazuh_server_multi_node_filebeat:
 

--- a/source/installation-guide/wazuh-server/step-by-step.rst
+++ b/source/installation-guide/wazuh-server/step-by-step.rst
@@ -70,21 +70,20 @@ Installing the Wazuh manager
 
   #. Save the Wazuh indexer username and password into the Wazuh manager keystore using the wazuh-keystore tool: 
 
-      .. code-block:: console
+     .. code-block:: console
 
         # /var/ossec/bin/wazuh-keystore -f indexer -k username -v <INDEXER_USERNAME>
         # /var/ossec/bin/wazuh-keystore -f indexer -k password -v <INDEXER_PASSWORD>   
 
-      .. note:: The default step-by-step installation credentials are ``admin``:``admin``
+     .. note:: The default step-by-step installation credentials are ``admin``:``admin``
 
   #. Enable and start the Wazuh manager service.
 
-      .. include:: /_templates/installations/wazuh/common/enable_wazuh_manager_service.rst
-
+     .. include:: /_templates/installations/wazuh/common/enable_wazuh_manager_service.rst
 
   #. Run the following command to verify the Wazuh manager status.
 
-      .. include:: /_templates/installations/wazuh/common/check_wazuh_manager.rst
+     .. include:: /_templates/installations/wazuh/common/check_wazuh_manager.rst
 
 .. _wazuh_server_multi_node_filebeat:
 


### PR DESCRIPTION
|Related issue|
|---|
|Closes #7070|
## Description
This PR aims to fix the execution order in the Wazuh manager installation, related to the `keystore` commands


## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
