### PR TITLE
Remove launchtl unload step from macOS uninstalling manual

### DIFF
--- a/source/installation-guide/uninstalling-wazuh/agent.rst
+++ b/source/installation-guide/uninstalling-wazuh/agent.rst
@@ -81,12 +81,6 @@ Follow these steps to uninstall the Wazuh agent from your macOS endpoint.
 
       # /bin/rm -r /Library/Ossec
 
-#. Stop and unload dispatcher.
-
-    .. code-block:: console
-
-      # /bin/launchctl unload /Library/LaunchDaemons/com.wazuh.agent.plist
-
 #. Remove ``launchdaemons`` and ``StartupItems``.
 
     .. code-block:: console


### PR DESCRIPTION
|Close the issue|
|---|
| https://github.com/wazuh/wazuh-documentation/issues/7109|

## Description

The macOS uninstalling manual page was modified given the `launchtl unload` command might throw an error if the service has not yet been loaded.

In this case, we choose to delete such a step. Given this, after removing the Wazuh agent, if the service is loaded, it will continue to be listed until the system is restarted or the service is manually unloaded.

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
