### PR TITLE
Bump cloud services python minimum version to 3.8

### DIFF
--- a/source/_variables/replacements.py
+++ b/source/_variables/replacements.py
@@ -39,7 +39,7 @@ custom_replacements = {
     "|WAZUH_CURRENT_MAJOR|" : "4.x",
     "|WAZUH_CURRENT_MINOR|" : version,
     "|WAZUH_CURRENT|" : release,
-    "|PYTHON_CLOUD_CONTAINERS_MIN|": "3.7",
+    "|PYTHON_CLOUD_CONTAINERS_MIN|": "3.8",
     "|PYTHON_CLOUD_CONTAINERS_MAX|": "3.11",
 
     # --- Revision numbers for Wazuh agent and manager packages versions

--- a/source/cloud-security/amazon/services/prerequisites/dependencies.rst
+++ b/source/cloud-security/amazon/services/prerequisites/dependencies.rst
@@ -56,12 +56,6 @@ It is recommended to use a pip version greater than or equal to 19.3 to ease the
 
 .. tabs::
 
-   .. group-tab:: Python 3.7
-
-      .. code-block:: console
-
-         # pip3 install --upgrade pip
-
    .. group-tab:: Python 3.8–3.10
 
       .. code-block:: console
@@ -91,12 +85,6 @@ AWS client library for Python
 To install the dependencies, execute the following command:
 
 .. tabs::
-
-   .. group-tab:: Python 3.7
-
-      .. code-block:: console
-
-         # pip3 install boto3==1.17.85 pyarrow==8.0.0 pyarrow_hotfix==0.5
 
    .. group-tab:: Python 3.8–3.10
 

--- a/source/cloud-security/azure/activity-services/prerequisites/dependencies.rst
+++ b/source/cloud-security/azure/activity-services/prerequisites/dependencies.rst
@@ -56,7 +56,7 @@ It is recommended to use a pip version greater than or equal to 19.3 to ease the
 
 .. tabs::
 
-   .. group-tab:: Python 3.7–3.10
+   .. group-tab:: Python 3.8–3.10
 
       .. code-block:: console
 
@@ -83,7 +83,7 @@ To install the dependencies, execute the following command:
 
 .. tabs::
 
-   .. group-tab:: Python 3.7–3.10
+   .. group-tab:: Python 3.8–3.10
 
       .. code-block:: console
 

--- a/source/cloud-security/gcp/prerequisites/dependencies.rst
+++ b/source/cloud-security/gcp/prerequisites/dependencies.rst
@@ -56,7 +56,7 @@ It is recommended to use a pip version greater than or equal to 19.3 to ease the
 
 .. tabs::
 
-   .. group-tab:: Python 3.7–3.10
+   .. group-tab:: Python 3.8–3.10
 
       .. code-block:: console
 
@@ -83,7 +83,7 @@ To install the dependencies, execute the following command:
 
 .. tabs::
 
-   .. group-tab:: Python 3.7–3.10
+   .. group-tab:: Python 3.8–3.10
 
       .. code-block:: console
 


### PR DESCRIPTION
## Description

Bumps the cloud services minimum supported version of Python to 3.8.

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
