### PR TITLE
Change docker version to `6.0.0`

### DIFF
--- a/source/proof-of-concept-guide/monitoring-docker.rst
+++ b/source/proof-of-concept-guide/monitoring-docker.rst
@@ -41,7 +41,7 @@ Perform the following steps to install Docker on the Ubuntu endpoint and configu
    .. code-block:: console
 
       $ curl -sSL https://get.docker.com/ | sh
-      $ sudo pip3 install docker==4.2.0 urllib3==1.26.18
+      $ sudo pip3 install docker==6.0.0 urllib3==1.26.18
 
 #. Edit the Wazuh agent configuration file ``/var/ossec/etc/ossec.conf`` and add this block to enable the ``docker-listener`` module:
 

--- a/source/user-manual/capabilities/container-security/monitoring-docker.rst
+++ b/source/user-manual/capabilities/container-security/monitoring-docker.rst
@@ -37,11 +37,11 @@ Docker library for Python
 
    The Wazuh manager includes all dependencies installed. These steps are only necessary when configuring the integration in a Wazuh agent.
 
-`Python Docker library <https://pypi.org/project/docker/>`_ is the official Python library for the Docker Engine API. The Wazuh docker integration requires ``docker 4.2.0``.
+`Python Docker library <https://pypi.org/project/docker/>`_ is the official Python library for the Docker Engine API. The Wazuh docker integration requires ``docker 6.0.0``.
 
 .. code-block:: console
 
-   # pip3 install docker==4.2.0 urllib3==1.26.18
+   # pip3 install docker==6.0.0 urllib3==1.26.18
 
 Configure the Wazuh agent
 ^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description

This PR closes https://github.com/wazuh/wazuh/issues/20617. The Docker version in the documentation has been updated to `6.0.0`, which is the one currently being used.

REF : https://github.com/wazuh/wazuh/blob/6f672d01053d274eab8f6d5622e995f6a588f6f8/framework/requirements.txt#L26


## Checks
### Docs building
- [ ] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
