### PR TITLE
Remove Wazuh_rules.pdf references

### DIFF
--- a/source/user-manual/ruleset/getting-started.rst
+++ b/source/user-manual/ruleset/getting-started.rst
@@ -72,9 +72,7 @@ In the Wazuh repository you will find:
 Resources
 ^^^^^^^^^
 
--  Visit our repository to view the rules in detail at `GitHub Wazuh <https://github.com/wazuh/wazuh/tree/v|WAZUH_CURRENT|/ruleset>`_
--  Find a complete description of the available rules at `Wazuh Ruleset Summary <http://www.wazuh.com/resources/Wazuh_Ruleset.pdf>`_
-
+Visit the `Wazuh GitHub repository <https://github.com/wazuh/wazuh/tree/v|WAZUH_CURRENT|/ruleset>`__ to view our ruleset in detail.
 
 Rule and Rootcheck example
 ^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Description
This PR updates the Resources subsection in /user-manual/ruleset/getting-started and removes the Wazuh_Ruleset.pdf reference.

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
