### PR TITLE
Fix typo in example config

### DIFF
--- a/source/user-manual/reference/ossec-conf/ms-graph-module.rst
+++ b/source/user-manual/reference/ossec-conf/ms-graph-module.rst
@@ -279,7 +279,7 @@ Example of configuration
           <client_id>your_client_id</client_id>
           <tenant_id>your_tenant_id</tenant_id>
           <secret_value>your_secret_value</secret_value>
-          <api_auth>global</api_auth>
+          <api_type>global</api_type>
         </api_auth>
         <resource>
           <name>security</name>


### PR DESCRIPTION
## Description
Fixes a typo in the example config.
With <api_auth> inside of <api_auth> in the config wazuh-manager doesn't start.