### PR TITLE
Improving step-by-step guide for vulnerability detector

### DIFF
--- a/source/_templates/installations/manager/configure_indexer_connection.rst
+++ b/source/_templates/installations/manager/configure_indexer_connection.rst
@@ -1,6 +1,6 @@
 .. Copyright (C) 2015, Wazuh, Inc.
 
-By default, the host is set to localhost: ``<host>https://0.0.0.0:9200/host>``. Replace it with your Wazuh indexer address accordingly. You can use either IP addresses or hostnames.
+By default, the host is set to localhost: ``<host>https://0.0.0.0:9200/</host>``. Replace ``0.0.0.0`` with your Wazuh indexer node IP address or hostname.
 
 .. code-block:: xml
   :emphasize-lines: 4
@@ -8,7 +8,7 @@ By default, the host is set to localhost: ``<host>https://0.0.0.0:9200/host>``. 
   <indexer>
       <enabled>yes</enabled>
       <hosts>
-        <host>https://10.0.0.1:9200</host>
+        <host>https://0.0.0.0:9200</host>
       </hosts>
       <ssl>
         <certificate_authorities>

--- a/source/_templates/installations/manager/configure_indexer_connection.rst
+++ b/source/_templates/installations/manager/configure_indexer_connection.rst
@@ -1,12 +1,14 @@
 .. Copyright (C) 2015, Wazuh, Inc.
 
+By default, the host is set to localhost: ``<host>https://0.0.0.0:9200/host>``. Replace it with your Wazuh indexer address accordingly. You can use either IP addresses or hostnames.
+
 .. code-block:: xml
   :emphasize-lines: 4
 
   <indexer>
       <enabled>yes</enabled>
       <hosts>
-        <host>https://0.0.0.0:9200</host> <!-- Replace with your indexer URL -->
+        <host>https://10.0.0.1:9200</host>
       </hosts>
       <ssl>
         <certificate_authorities>

--- a/source/_templates/installations/manager/configure_indexer_connection.rst
+++ b/source/_templates/installations/manager/configure_indexer_connection.rst
@@ -1,6 +1,6 @@
 .. Copyright (C) 2015, Wazuh, Inc.
 
-By default, the host is set to localhost: ``<host>https://0.0.0.0:9200/</host>``. Replace ``0.0.0.0`` with your Wazuh indexer node IP address or hostname.
+By default, the host is set to localhost: ``<host>https://0.0.0.0:9200</host>``. Replace ``0.0.0.0`` with your Wazuh indexer node IP address or hostname.
 
 .. code-block:: xml
   :emphasize-lines: 4

--- a/source/_templates/installations/manager/configure_indexer_connection.rst
+++ b/source/_templates/installations/manager/configure_indexer_connection.rst
@@ -17,5 +17,13 @@
       </ssl>
   </indexer>
 
-.. End of include file
+If you have more than one Wazuh indexer node, add all the required ``<host>`` entries. The vulnerability detector module will report to the first available node found and will switch to the next one in case of error.
 
+.. code-block:: xml
+
+      <hosts>
+        <host>https://10.0.0.1:9200</host>
+        <host>https://10.0.0.2:9200</host>
+      </hosts>
+
+.. End of include file

--- a/source/_templates/installations/manager/configure_indexer_connection.rst
+++ b/source/_templates/installations/manager/configure_indexer_connection.rst
@@ -1,31 +1,33 @@
 .. Copyright (C) 2015, Wazuh, Inc.
 
-By default, the host is set to localhost: ``<host>https://0.0.0.0:9200</host>``. Replace ``0.0.0.0`` with your Wazuh indexer node IP address or hostname.
+By default, the indexer settings have one host configured. It's set to localhost as highlighted below. Replace ``0.0.0.0`` with your Wazuh indexer node IP address or hostname.
 
 .. code-block:: xml
-  :emphasize-lines: 4
+   :emphasize-lines: 4
 
-  <indexer>
-      <enabled>yes</enabled>
-      <hosts>
-        <host>https://0.0.0.0:9200</host>
-      </hosts>
-      <ssl>
-        <certificate_authorities>
-          <ca>/etc/filebeat/certs/root-ca.pem</ca>
-        </certificate_authorities>
-        <certificate>/etc/filebeat/certs/filebeat.pem</certificate>
-        <key>/etc/filebeat/certs/filebeat-key.pem</key>
-      </ssl>
-  </indexer>
+   <indexer>
+     <enabled>yes</enabled>
+     <hosts>
+       <host>https://0.0.0.0:9200</host>
+     </hosts>
+     <ssl>
+       <certificate_authorities>
+         <ca>/etc/filebeat/certs/root-ca.pem</ca>
+       </certificate_authorities>
+       <certificate>/etc/filebeat/certs/filebeat.pem</certificate>
+       <key>/etc/filebeat/certs/filebeat-key.pem</key>
+     </ssl>
+   </indexer>
 
-If you have more than one Wazuh indexer node, add all the required ``<host>`` entries. The vulnerability detector module will report to the first available node found and will switch to the next one in case of error.
+If you have a Wazuh indexer cluster, add a ``<host>`` entry for each one of your nodes. For example, in a two-nodes configuration:
 
 .. code-block:: xml
 
-      <hosts>
-        <host>https://10.0.0.1:9200</host>
-        <host>https://10.0.0.2:9200</host>
-      </hosts>
+   <hosts>
+     <host>https://10.0.0.1:9200</host>
+     <host>https://10.0.0.2:9200</host>
+   </hosts>
+
+Vulnerability detection prioritizes reporting to the first node in the list. It switches to the next node in case it's not available.
 
 .. End of include file

--- a/source/installation-guide/wazuh-server/step-by-step.rst
+++ b/source/installation-guide/wazuh-server/step-by-step.rst
@@ -70,8 +70,10 @@ Installing the Wazuh manager
 
 Configuring the Wazuh indexer connection
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  .. note::
-    You can skip this step if you are not going to use the vulnerability detection capability.
+
+.. note::
+
+   You can skip this step if you are not going to use the vulnerability detection capability.
 
 #. Save the Wazuh indexer username and password into the Wazuh manager keystore using the wazuh-keystore tool:
 

--- a/source/installation-guide/wazuh-server/step-by-step.rst
+++ b/source/installation-guide/wazuh-server/step-by-step.rst
@@ -68,28 +68,23 @@ Installing the Wazuh manager
 
             # apt-get -y install wazuh-manager|WAZUH_MANAGER_DEB_PKG_INSTALL|
 
-#. Save the Wazuh indexer username and password into the Wazuh manager keystore using the wazuh-keystore tool: 
+Configuring the Wazuh manager
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+#. Save the Wazuh indexer username and password into the Wazuh manager keystore using the wazuh-keystore tool:
 
    .. code-block:: console
 
       # /var/ossec/bin/wazuh-keystore -f indexer -k username -v <INDEXER_USERNAME>
-      # /var/ossec/bin/wazuh-keystore -f indexer -k password -v <INDEXER_PASSWORD>   
+      # /var/ossec/bin/wazuh-keystore -f indexer -k password -v <INDEXER_PASSWORD>
 
    .. note::
-      
+
       The default step-by-step installation credentials are ``admin``:``admin``
 
-#. Edit ``/var/ossec/etc/ossec.conf`` to configure the indexer connection. Set your host indexer URL. You can skip this step if you are not going to use the vulnerability detection capability.
+#. Edit ``/var/ossec/etc/ossec.conf`` to configure the indexer connection. You can skip this step if you are not going to use the vulnerability detection capability.
 
    .. include:: /_templates/installations/manager/configure_indexer_connection.rst
-
-#. Enable and start the Wazuh manager service.
-
-   .. include:: /_templates/installations/wazuh/common/enable_wazuh_manager_service.rst
-
-#. Run the following command to verify the Wazuh manager status.
-
-   .. include:: /_templates/installations/wazuh/common/check_wazuh_manager.rst
 
 .. _wazuh_server_multi_node_filebeat:
 
@@ -165,6 +160,16 @@ Deploying certificates
 
       .. include:: /_templates/installations/filebeat/opensearch/copy_certificates_filebeat_wazuh_cluster.rst
 
+Starting the Wazuh manager
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+#. Enable and start the Wazuh manager service.
+
+   .. include:: /_templates/installations/wazuh/common/enable_wazuh_manager_service.rst
+
+#. Run the following command to verify the Wazuh manager status.
+
+   .. include:: /_templates/installations/wazuh/common/check_wazuh_manager.rst
 
 Starting the Filebeat service
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/installation-guide/wazuh-server/step-by-step.rst
+++ b/source/installation-guide/wazuh-server/step-by-step.rst
@@ -68,8 +68,10 @@ Installing the Wazuh manager
 
             # apt-get -y install wazuh-manager|WAZUH_MANAGER_DEB_PKG_INSTALL|
 
-Configuring the Wazuh manager
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Configuring the Wazuh indexer connection
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  .. note::
+    You can skip this step if you are not going to use the vulnerability detection capability.
 
 #. Save the Wazuh indexer username and password into the Wazuh manager keystore using the wazuh-keystore tool:
 
@@ -82,7 +84,7 @@ Configuring the Wazuh manager
 
       The default step-by-step installation credentials are ``admin``:``admin``
 
-#. Edit ``/var/ossec/etc/ossec.conf`` to configure the indexer connection. You can skip this step if you are not going to use the vulnerability detection capability.
+#. Edit ``/var/ossec/etc/ossec.conf`` to configure the indexer connection.
 
    .. include:: /_templates/installations/manager/configure_indexer_connection.rst
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->

Closes #7124 , wazuh/wazuh/issues/22532
## Description
<!--
Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->

This PR improves the step-by-step guide for vulnerability detector and the its connection with the indexer nodes:
- More details were added for multi-node environments. Also, the same words and expressions than the Filebeat section were used to improve consistency 

![2024-03-28_01-09](https://github.com/wazuh/wazuh-documentation/assets/65046601/1120ef16-7c9d-4ea2-b309-c8d2e69d0823)

- The start of the manager was moved after the certificates deployment to avoid warning messages during the installation

![2024-03-28_01-15](https://github.com/wazuh/wazuh-documentation/assets/65046601/79204f1a-6605-4601-8935-b6c91baec19a)


## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
