### PR TITLE
Add redirection for 4.6 certificates page

### DIFF
--- a/source/_static/js/redirects.js
+++ b/source/_static/js/redirects.js
@@ -317,7 +317,7 @@ redirections.push(
     '4.7': '/cloud-security/gcp/supported-services/pubsub.html#configuring-google-cloud-pub-sub',
   },
   {
-    'target': ['4.7=>4.6'],
+    'target': ['4.6=>4.7', '4.7=>4.6'],
     '4.6': '/user-manual/certificates.html',
     '4.7': '/user-manual/manager/certificates.html',
   },


### PR DESCRIPTION
## Description
This PR adds the 4.6 --> 4.7 redirection for the earlier `/user-manual/certificates` to the `/user-manual/wazuh-indexer/certificates`.

## Checks
### Docs building
- [X] Compiles without warnings.
### Code formatting and web optimization
- [X] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [X] Uses present tense, active voice, and semi-formal registry.
- [X] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.