### PR TITLE
Move GCP use-cases under pubsub

### DIFF
--- a/source/cloud-security/gcp/supported-services/index.rst
+++ b/source/cloud-security/gcp/supported-services/index.rst
@@ -12,5 +12,4 @@ You can use the Wazuh module for Google Cloud Pub/Sub and the Wazuh module for G
    :maxdepth: 1
 
    pubsub
-   use-cases
    cloud-storage-buckets

--- a/source/cloud-security/gcp/supported-services/pubsub.rst
+++ b/source/cloud-security/gcp/supported-services/pubsub.rst
@@ -165,3 +165,9 @@ Once the configuration is complete, you can visualize the logs on the Google Clo
    :alt: Visualize logs in the Google Cloud module
    :align: center
    :width: 80%
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
+   use-cases


### PR DESCRIPTION
## Description
This PR nests `cloud-security/gcp/supported-services/use-cases` under `cloud-security/gcp/supported-services/pubsub` within the navigation side menu.

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
