### PR TITLE
Remove word powerful

### DIFF
--- a/source/getting-started/components/wazuh-indexer.rst
+++ b/source/getting-started/components/wazuh-indexer.rst
@@ -113,4 +113,4 @@ Below is an extract of the query result, which is a part of the indexed alert do
 
 The Wazuh indexer is well suited for time-sensitive use cases like security analytics and infrastructure monitoring as it is a near real-time search platform. The latency from the time a document is indexed until it becomes searchable is very short, typically one second.
 
-In addition to its speed, scalability, and resiliency, the Wazuh indexer has several powerful built-in features that make storing and searching data even more efficient, such as data rollups, alerting, anomaly detection, and index lifecycle management.
+In addition to its speed, scalability, and resiliency, the Wazuh indexer has several built-in features that make storing and searching data even more efficient, such as data rollups, alerting, anomaly detection, and index lifecycle management.


### PR DESCRIPTION
## Description
This PR removes a the subjective word powerful in a `/getting-started/components/wazuh-indexer` sentence due to not complying with our technical writing style.

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.