### PR TITLE
Update placeholders formatting

### DIFF
--- a/source/_templates/cloud/amazon/bucket_policies.rst
+++ b/source/_templates/cloud/amazon/bucket_policies.rst
@@ -16,8 +16,8 @@
 		    "s3:ListBucket"
 		],
 		"Resource": [
-		    "arn:aws:s3:::<bucket-name>/*",
-		    "arn:aws:s3:::<bucket-name>"
+		    "arn:aws:s3:::<BUCKET_NAME>/*",
+		    "arn:aws:s3:::<BUCKET_NAME>"
 		]
 	    }
 	]
@@ -40,13 +40,13 @@
 		    "s3:DeleteObject"
 		],
 		"Resource": [
-		    "arn:aws:s3:::<bucket-name>/*",
-		    "arn:aws:s3:::<bucket-name>"
+		    "arn:aws:s3:::<BUCKET_NAME>/*",
+		    "arn:aws:s3:::<BUCKET_NAME>"
 		]
 	    }
 	]
     }
 
-.. note:: ``<bucket-name>`` is a placeholder. Replace it with the actual name of the bucket from which you want to retrieve logs.
+.. note:: ``<BUCKET_NAME>`` is a placeholder. Replace it with the actual name of the bucket from which you want to retrieve logs.
 
 .. End of include file

--- a/source/_templates/installations/dashboard/deploy_certificates.rst
+++ b/source/_templates/installations/dashboard/deploy_certificates.rst
@@ -1,10 +1,10 @@
 .. Copyright (C) 2015, Wazuh, Inc.
 
-#. Replace ``<dashboard-node-name>`` with your Wazuh dashboard node name, the same one used in ``config.yml`` to create the certificates, and move the certificates to their corresponding location. 
+#. Replace ``<DASHBOARD_NODE_NAME>`` with your Wazuh dashboard node name, the same one used in ``config.yml`` to create the certificates, and move the certificates to their corresponding location. 
 
     .. code-block:: console
 
-      # NODE_NAME=<dashboard-node-name>
+      # NODE_NAME=<DASHBOARD_NODE_NAME>
       
     .. code-block:: console  
     

--- a/source/_templates/installations/filebeat/opensearch/copy_certificates_filebeat_wazuh_cluster.rst
+++ b/source/_templates/installations/filebeat/opensearch/copy_certificates_filebeat_wazuh_cluster.rst
@@ -2,7 +2,7 @@
 
 .. code-block:: console
 
-  # NODE_NAME=<server-node-name>
+  # NODE_NAME=<SERVER_NODE_NAME>
 
 .. code-block:: console
   

--- a/source/cloud-security/amazon/services/prerequisites/considerations.rst
+++ b/source/cloud-security/amazon/services/prerequisites/considerations.rst
@@ -135,9 +135,9 @@ The following example of a ``~/.aws/config`` file sets the supported configurati
    signature_version = s3v4
 
 .. note::
-   All ``s3`` and ``proxy`` configuration sections must start with ``[profile <PROFILE-NAME>]``.
+   All ``s3`` and ``proxy`` configuration sections must start with ``[profile <PROFILE_NAME>]``.
 
-To configure multiple profiles for the integration, declare each profile section in ``~/.aws/config`` with ``[profile <PROFILE-NAME>]``. If you don't declare a profile section in this configuration file, Wazuh uses the ``default`` profile.
+To configure multiple profiles for the integration, declare each profile section in ``~/.aws/config`` with ``[profile <PROFILE_NAME>]``. If you don't declare a profile section in this configuration file, Wazuh uses the ``default`` profile.
 
 Configuring multiple services
 -----------------------------

--- a/source/cloud-security/gcp/supported-services/use-cases.rst
+++ b/source/cloud-security/gcp/supported-services/use-cases.rst
@@ -211,9 +211,9 @@ Visualizing the events on the Wazuh dashboard
 
 Once you configure the sink, apply the filter below on the Google Cloud module of the Wazuh dashboard to filter for DNS queries logs.
 
-Set the value of ``data.gcp.logName`` field to ``projects/<YOUR-PROJECT-ID>/logs/compute.googleapis.com%2Fdns_queries``.
+Set the value of ``data.gcp.logName`` field to ``projects/<YOUR_PROJECT_ID>/logs/compute.googleapis.com%2Fdns_queries``.
 
-Replace ``<YOUR-PROJECT-ID>`` with your project ID on Google Cloud.
+Replace ``<YOUR_PROJECT_ID>`` with your project ID on Google Cloud.
 
 .. thumbnail:: /images/cloud-security/gcp/filter-dns-query-logs.png
    :title: Filter DNS query logs
@@ -253,9 +253,9 @@ The :ref:`Export logs via sink <export_logs_via_sink>` section explains how to c
 .. code-block:: none
 
    resource.type="gce_subnetwork"
-   log_name="projects/<YOUR-PROJECT-ID>/logs/compute.googleapis.com%2Fvpc_flows"
+   log_name="projects/<YOUR_PROJECT_ID>/logs/compute.googleapis.com%2Fvpc_flows"
 
-Replace ``<YOUR-PROJECT-ID>`` with your project ID on Google Cloud.
+Replace ``<YOUR_PROJECT_ID>`` with your project ID on Google Cloud.
 
 .. thumbnail:: /images/cloud-security/gcp/gcp-create-logs-routing-sink-vpc-flow.png
    :title: Create logs routing sink
@@ -276,7 +276,7 @@ Visualizing the events on Wazuh dashboard
 
 Once you configure the sink, apply the filter below on the Google Cloud module of the Wazuh dashboard to filter for VPC Flow Logs.
 
-Set the value of ``data.gcp.logName`` field to ``projects/<YOUR-PROJECT-ID>/logs/compute.googleapis.com%2Fvpc_flows``. Replace ``<YOUR-PROJECT-ID>`` with your Google Cloud project ID.
+Set the value of ``data.gcp.logName`` field to ``projects/<YOUR_PROJECT_ID>/logs/compute.googleapis.com%2Fvpc_flows``. Replace ``<YOUR_PROJECT_ID>`` with your Google Cloud project ID.
 
 .. thumbnail:: /images/cloud-security/gcp/filter-vpc-flow-logs.png
    :title: Filter VPC flow logs
@@ -316,9 +316,9 @@ The :ref:`Export logs via sink <export_logs_via_sink>` section explains how to c
 .. code-block:: none
 
    (resource.type="gce_subnetwork"
-   log_name="projects/<YOUR-PROJECT-ID>/logs/compute.googleapis.com%2Ffirewall")
+   log_name="projects/<YOUR_PROJECT_ID>/logs/compute.googleapis.com%2Ffirewall")
 
-Replace ``<YOUR-PROJECT-ID>`` with your project ID on Google Cloud.
+Replace ``<YOUR_PROJECT_ID>`` with your project ID on Google Cloud.
 
 .. thumbnail:: /images/cloud-security/gcp/gpc-export-fw-rules.png
    :title: Export firewall rules
@@ -339,7 +339,7 @@ Visualizing the events on the Wazuh dashboard
 
 Once you configure the sink, apply the filter below on the Google Cloud module of the Wazuh dashboard to filter for Firewall Rules logs.
 
-Set the value of ``data.gcp.logName`` field to ``projects/<YOUR-PROJECT-ID>/logs/compute.googleapis.com%2Ffirewall``. Replace ``<YOUR-PROJECT-ID>`` with your own project ID on Google Cloud.
+Set the value of ``data.gcp.logName`` field to ``projects/<YOUR_PROJECT_ID>/logs/compute.googleapis.com%2Ffirewall``. Replace ``<YOUR_PROJECT_ID>`` with your own project ID on Google Cloud.
 
 .. thumbnail:: /images/cloud-security/gcp/filter-fw-logs.png
    :title: Filter firewall logs

--- a/source/cloud-security/office365/monitoring-office365-activity.rst
+++ b/source/cloud-security/office365/monitoring-office365-activity.rst
@@ -158,9 +158,9 @@ Below, we show how to use the Activity API to list available content and retriev
 
    .. code-block:: none
       
-      GET <contentUri>
+      GET <CONTENT_URI>
 
-   Replace the ``<contentUri>`` variable with the value of a content URI that is included in the list of available content.
+   Replace the ``<CONTENT_URI>`` variable with the value of a content URI that is included in the list of available content.
 
    The `Office 365 Management API documentation <https://docs.microsoft.com/en-us/office/office-365-management-api/office-365-management-activity-api-reference>`__ provides details on the available endpoints and response formats. You can refer to the documentation for more information.
 

--- a/source/deployment-options/deploying-with-puppet/wazuh-puppet-module/index.rst
+++ b/source/deployment-options/deploying-with-puppet/wazuh-puppet-module/index.rst
@@ -115,14 +115,14 @@ Install Wazuh agent via Puppet
 
 The agent is configured by installing the ``wazuh::agent`` class.
 
-Here is an example of a manifest ``wazuh-agent.pp`` (please replace  ``MANAGER_IP`` with your manager IP address).
+Here is an example of a manifest ``wazuh-agent.pp`` (please replace  ``<MANAGER_IP_ADDRESS>`` with your manager IP address).
 
   .. code-block:: puppet
 
    node "puppet-agent.com" {
      class { "wazuh::agent":
-       wazuh_register_endpoint => "<MANAGER_IP>",
-       wazuh_reporting_endpoint => "<MANAGER_IP>"
+       wazuh_register_endpoint => "<MANAGER_IP_ADDRESS>",
+       wazuh_reporting_endpoint => "<MANAGER_IP_ADDRESS>"
      }
    }
 

--- a/source/deployment-options/offline-installation.rst
+++ b/source/deployment-options/offline-installation.rst
@@ -293,11 +293,11 @@ Filebeat must be installed and configured on the same server as the Wazuh manage
 
         # tar -xzf ./wazuh-offline/wazuh-files/wazuh-filebeat-0.3.tar.gz -C /usr/share/filebeat/module
 
-#.  Replace ``<server-node-name>`` with your Wazuh server node certificate name, the same used in ``config.yml`` when creating the certificates. For example, ``wazuh-1``. Then, move the certificates to their corresponding location.
+#.  Replace ``<SERVER_NODE_NAME>`` with your Wazuh server node certificate name, the same used in ``config.yml`` when creating the certificates. For example, ``wazuh-1``. Then, move the certificates to their corresponding location.
 
      .. code-block:: console
 
-        # NODE_NAME=<server-node-name>
+        # NODE_NAME=<SERVER_NODE_NAME>
 
     .. code-block:: console
 
@@ -438,11 +438,11 @@ Installing the Wazuh dashboard
 
                 # dpkg -i ./wazuh-offline/wazuh-packages/wazuh-dashboard*.deb
 
-#.  Replace ``<dashboard-node-name>`` with your Wazuh dashboard node name, the same used in ``config.yml`` to create the certificates. For example, ``dashboard``. Then, move the certificates to their corresponding location.
+#.  Replace ``<DASHBOARD_NODE_NAME>`` with your Wazuh dashboard node name, the same used in ``config.yml`` to create the certificates. For example, ``dashboard``. Then, move the certificates to their corresponding location.
 
     .. code-block:: console
 
-        # NODE_NAME=<dashboard-node-name>
+        # NODE_NAME=<DASHBOARD_NODE_NAME>
 
     .. code-block:: console
 
@@ -595,11 +595,11 @@ Select your deployment type and follow the instructions to change the default pa
          .. note:: Remember to store these passwords securely.
 
 
-      #. On `all your Wazuh server nodes`, run the following command to update the `admin` password in the Filebeat keystore. Replace ``<admin-password>`` with the random password generated in the first step.
+      #. On `all your Wazuh server nodes`, run the following command to update the `admin` password in the Filebeat keystore. Replace ``<ADMIN_PASSWORD>`` with the random password generated in the first step.
 
          .. code-block:: console
 
-            # echo <admin-password> | filebeat keystore add password --stdin --force
+            # echo <ADMIN_PASSWORD> | filebeat keystore add password --stdin --force
 
       #. Restart Filebeat to apply the change.
 
@@ -607,11 +607,11 @@ Select your deployment type and follow the instructions to change the default pa
 
          .. note:: Repeat steps 3 and 4 on `every Wazuh server node`.
 
-      #. On your `Wazuh dashboard node`, run the following command to update the `kibanaserver` password in the Wazuh dashboard keystore. Replace ``<kibanaserver-password>`` with the random password generated in the first step.
+      #. On your `Wazuh dashboard node`, run the following command to update the `kibanaserver` password in the Wazuh dashboard keystore. Replace ``<KIBANASERVER_PASSWORD>`` with the random password generated in the first step.
 
          .. code-block:: console
 
-            # echo <kibanaserver-password> | /usr/share/wazuh-dashboard/bin/opensearch-dashboards-keystore --allow-root add -f --stdin opensearch.password
+            # echo <KIBANASERVER_PASSWORD> | /usr/share/wazuh-dashboard/bin/opensearch-dashboards-keystore --allow-root add -f --stdin opensearch.password
 
       #. Update the ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` configuration file with the new `wazuh-wui` password generated in the second step.
 

--- a/source/installation-guide/wazuh-dashboard/step-by-step.rst
+++ b/source/installation-guide/wazuh-dashboard/step-by-step.rst
@@ -191,11 +191,11 @@ Select your deployment type and follow the instructions to change the default pa
             INFO: The password for Wazuh API user wazuh is ivLOfmj7.jL6*7Ev?UJoFjrkGy9t6Je.
             INFO: The password for Wazuh API user wazuh-wui is fL+f?sFRPEv5pYRE559rqy9b6G4Z5pVi
 
-      #. On `all your Wazuh server nodes`, run the following command to update the `admin` password in the Filebeat keystore. Replace ``<admin-password>`` with the random password generated in the first step.
+      #. On `all your Wazuh server nodes`, run the following command to update the `admin` password in the Filebeat keystore. Replace ``<ADMIN_PASSWORD>`` with the random password generated in the first step.
       
          .. code-block:: console
 
-            # echo <admin-password> | filebeat keystore add password --stdin --force
+            # echo <ADMIN_PASSWORD> | filebeat keystore add password --stdin --force
 
       #. Restart Filebeat to apply the change.
 
@@ -203,11 +203,11 @@ Select your deployment type and follow the instructions to change the default pa
 
          .. note:: Repeat steps 3 and 4 on `every Wazuh server node`.
        
-      #. On your `Wazuh dashboard node`, run the following command to update the `kibanaserver` password in the Wazuh dashboard keystore. Replace ``<kibanaserver-password>`` with the random password generated in the first step.
+      #. On your `Wazuh dashboard node`, run the following command to update the `kibanaserver` password in the Wazuh dashboard keystore. Replace ``<KIBANASERVER_PASSWORD>`` with the random password generated in the first step.
 
          .. code-block:: console
 
-            # echo <kibanaserver-password> | /usr/share/wazuh-dashboard/bin/opensearch-dashboards-keystore --allow-root add -f --stdin opensearch.password
+            # echo <KIBANASERVER_PASSWORD> | /usr/share/wazuh-dashboard/bin/opensearch-dashboards-keystore --allow-root add -f --stdin opensearch.password
 
       #. Update the ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` configuration file with the new `wazuh-wui` password generated in the second step.
 

--- a/source/installation-guide/wazuh-server/step-by-step.rst
+++ b/source/installation-guide/wazuh-server/step-by-step.rst
@@ -149,7 +149,7 @@ Deploying certificates
   .. note::
     Make sure that a copy of the ``wazuh-certificates.tar`` file, created during the initial configuration step, is placed in your working directory.
 
-  #. Replace ``<server-node-name>`` with your Wazuh server node certificate name, the same one used in ``config.yml`` when creating the certificates. Then, move the certificates to their corresponding location.
+  #. Replace ``<SERVER_NODE_NAME>`` with your Wazuh server node certificate name, the same one used in ``config.yml`` when creating the certificates. Then, move the certificates to their corresponding location.
 
       .. include:: /_templates/installations/filebeat/opensearch/copy_certificates_filebeat_wazuh_cluster.rst
 

--- a/source/integrations-guide/elastic-stack/index.rst
+++ b/source/integrations-guide/elastic-stack/index.rst
@@ -52,10 +52,10 @@ Perform the following steps to install Logstash and the required plugin.
 
    .. code-block:: console
 
-      $ sudo chmod -R 755 </PATH/TO/LOCAL/WAZUH-INDEXER/CERTIFICATE>/root-ca.pem
+      $ sudo chmod -R 755 </PATH/TO/LOCAL/WAZUH_INDEXER/CERTIFICATE>/root-ca.pem
       $ sudo chmod -R 755 </PATH/TO/LOCAL/ELASTICSEARCH/CERTIFICATE>/root-ca.pem
 
-   Replace ``</PATH/TO/LOCAL/WAZUH-INDEXER/CERTIFICATE>/root-ca.pem`` and ``</PATH/TO/LOCAL/ELASTICSEARCH/CERTIFICATE>/root-ca.pem`` with your Wazuh indexer and Elasticsearch certificate local paths on the Logstash endpoint respectively.
+   Replace ``</PATH/TO/LOCAL/WAZUH_INDEXER/CERTIFICATE>/root-ca.pem`` and ``</PATH/TO/LOCAL/ELASTICSEARCH/CERTIFICATE>/root-ca.pem`` with your Wazuh indexer and Elasticsearch certificate local paths on the Logstash endpoint respectively.
 
 Configuring new indexes
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/integrations-guide/opensearch/index.rst
+++ b/source/integrations-guide/opensearch/index.rst
@@ -47,10 +47,10 @@ Perform the following steps to install Logstash and the required plugins. Ensure
 
    .. code-block:: console
 
-      $ sudo chmod -R 755 </PATH/TO/LOCAL/WAZUH-INDEXER/CERTIFICATE>/root-ca.pem
+      $ sudo chmod -R 755 </PATH/TO/LOCAL/WAZUH_INDEXER/CERTIFICATE>/root-ca.pem
       $ sudo chmod -R 755 </PATH/TO/LOCAL/OPENSEARCH/CERTIFICATE>/root-ca.pem
 
-   Replace ``</PATH/TO/LOCAL/WAZUH-INDEXER/CERTIFICATE>/root-ca.pem`` and ``</PATH/TO/LOCAL/OPENSEARCH/CERTIFICATE>/root-ca.pem`` with your Wazuh indexer and Opensearch certificate local path on the Logstash endpoint respectively.
+   Replace ``</PATH/TO/LOCAL/WAZUH_INDEXER/CERTIFICATE>/root-ca.pem`` and ``</PATH/TO/LOCAL/OPENSEARCH/CERTIFICATE>/root-ca.pem`` with your Wazuh indexer and Opensearch certificate local path on the Logstash endpoint respectively.
 
 Configuring new indexes
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -173,7 +173,7 @@ We use the  `Logstash keystore <https://www.elastic.co/guide/en/logstash/current
             password  =>  "${WAZUH_INDEXER_PASSWORD}"
             index =>  "wazuh-alerts-4.x-*"
             ssl => true
-            ca_file => "</PATH/TO/LOCAL/WAZUH-INDEXER/CERTIFICATE>/root-ca.pem"
+            ca_file => "</PATH/TO/LOCAL/WAZUH_INDEXER/CERTIFICATE>/root-ca.pem"
             query =>  '{
                 "query": {
                    "range": {
@@ -209,7 +209,7 @@ We use the  `Logstash keystore <https://www.elastic.co/guide/en/logstash/current
 
       -  ``<WAZUH_INDEXER_ADDRESS>`` is your Wazuh indexer address or addresses in case of cluster deployment.
       -  ``<OPENSEARCH_ADDRESS>`` is your OpenSearch address.
-      -  ``</PATH/TO/LOCAL/WAZUH-INDEXER/CERTIFICATE>/root-ca.pem`` is your Wazuh indexer certificate local path on the Wazuh server. For example,  you can use ``/etc/logstash/wazuh-indexer-certs/root-ca.pem`` which is the Wazuh indexer root certificate that was copied earlier.
+      -  ``</PATH/TO/LOCAL/WAZUH_INDEXER/CERTIFICATE>/root-ca.pem`` is your Wazuh indexer certificate local path on the Wazuh server. For example,  you can use ``/etc/logstash/wazuh-indexer-certs/root-ca.pem`` which is the Wazuh indexer root certificate that was copied earlier.
       -  ``</PATH/TO/LOCAL/OPENSEARCH/CERTIFICATE>/root-ca.pem`` is your OpenSearch certificate local path on the Wazuh server. For example, you can use ``/etc/logstash/opensearch-certs/root-ca.pem`` which is the OpenSearch certificate that was copied earlier.
 
       .. note::

--- a/source/integrations-guide/splunk/index.rst
+++ b/source/integrations-guide/splunk/index.rst
@@ -68,10 +68,10 @@ Perform the following steps on your Logstash server to set up your forwarder.
 
    .. code-block:: console
 
-      $ sudo chmod -R 755 </PATH/TO/LOCAL/WAZUH-INDEXER/CERTIFICATE>/root-ca.pem
+      $ sudo chmod -R 755 </PATH/TO/LOCAL/WAZUH_INDEXER/CERTIFICATE>/root-ca.pem
       $ sudo chmod -R 755 </PATH/TO/LOCAL/SPLUNK/CERTIFICATE>/ca.pem
 
-   Replace ``</PATH/TO/LOCAL/WAZUH-INDEXER/CERTIFICATE>/root-ca.pem`` and ``</PATH/TO/LOCAL/SPLUNK/CERTIFICATE>/ca.pem`` with your Wazuh indexer and Splunk certificate local paths on the Logstash endpoint respectively.
+   Replace ``</PATH/TO/LOCAL/WAZUH_INDEXER/CERTIFICATE>/root-ca.pem`` and ``</PATH/TO/LOCAL/SPLUNK/CERTIFICATE>/ca.pem`` with your Wazuh indexer and Splunk certificate local paths on the Logstash endpoint respectively.
 
 Configuring a pipeline
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -138,7 +138,7 @@ Perform the following steps to configure the Logstash pipeline.
          password  =>  "${WAZUH_INDEXER_PASSWORD}"
          index =>  "wazuh-alerts-4.x-*"
          ssl => true
-         ca_file => "</PATH/TO/LOCAL/WAZUH-INDEXER/CERTIFICATE>/root-ca.pem"
+         ca_file => "</PATH/TO/LOCAL/WAZUH_INDEXER/CERTIFICATE>/root-ca.pem"
          query =>  '{
              "query": {
                 "range": {
@@ -165,7 +165,7 @@ Perform the following steps to configure the Logstash pipeline.
 
    -  ``<WAZUH_INDEXER_ADDRESS>`` is your Wazuh indexer address or addresses in case of cluster deployment.
    -  ``<SPLUNK_URL>`` is your Splunk URL.
-   -  ``</PATH/TO/LOCAL/WAZUH-INDEXER/CERTIFICATE>/root-ca.pem`` is your Wazuh indexer certificate local path on the Logstash server. In our case we used ``/etc/logstash/wazuh-indexer-certs/root-ca.pem``.
+   -  ``</PATH/TO/LOCAL/WAZUH_INDEXER/CERTIFICATE>/root-ca.pem`` is your Wazuh indexer certificate local path on the Logstash server. In our case we used ``/etc/logstash/wazuh-indexer-certs/root-ca.pem``.
    -  ``</PATH/TO/LOCAL/SPLUNK/CERTIFICATE>/ca.pem`` is your Splunk certificate local path  on the Logstash server. In our case, we used ``/etc/logstash/splunk-certs/ca.pem``.
 
    .. note::

--- a/source/migration-guide/wazuh-indexer.rst
+++ b/source/migration-guide/wazuh-indexer.rst
@@ -12,11 +12,11 @@ Follow this guide to migrate from Open Distro for Elasticsearch 1.13 to the Wazu
 
 .. note:: You need root user privileges to run all the commands described below.
 
-#. Disable shard allocation to prevent Elasticsearch from replicating shards as you shut down nodes. Replace ``<elasticsearch_IP>`` with your Elasticsearch IP address or hostname, and ``<username>:<password>`` with your Elasticsearch username and password.  
+#. Disable shard allocation to prevent Elasticsearch from replicating shards as you shut down nodes. Replace ``<ELASTICSEARCH_IP_ADDRESS>`` with your Elasticsearch IP address or hostname, and ``<USERNAME>:<PASSWORD>`` with your Elasticsearch username and password.  
 
    .. code-block:: console
 
-     curl -X PUT "https://<elasticsearch_IP>:9200/_cluster/settings" -u <username>:<password> -k -H 'Content-Type: application/json' -d'
+     curl -X PUT "https://<ELASTICSEARCH_IP_ADDRESS>:9200/_cluster/settings" -u <USERNAME>:<PASSWORD> -k -H 'Content-Type: application/json' -d'
      {
        "persistent": {
          "cluster.routing.allocation.enable": "primaries"
@@ -28,7 +28,7 @@ Follow this guide to migrate from Open Distro for Elasticsearch 1.13 to the Wazu
 
    .. code-block:: console
 
-        curl -X POST "https://<elasticsearch_IP>:9200/_flush/synced" -u <username>:<password> -k
+        curl -X POST "https://<ELASTICSEARCH_IP_ADDRESS>:9200/_flush/synced" -u <USERNAME>:<PASSWORD> -k
 
 #. Stop Filebeat.
 
@@ -163,18 +163,18 @@ Follow this guide to migrate from Open Distro for Elasticsearch 1.13 to the Wazu
             talk to server... OK
             version: 7.10.2
 
-#. Monitor the health of the cluster as follows. Replace ``<Wazuh_indexer_IP>`` with your Wazuh indexer IP address or hostname, and ``<username>:<password>`` with your Elasticsearch username and password.  
+#. Monitor the health of the cluster as follows. Replace ``<WAZUH_INDEXER_IP_ADDRESS>`` with your Wazuh indexer IP address or hostname, and ``<USERNAME>:<PASSWORD>`` with your Elasticsearch username and password.  
 
 
    .. code-block:: console
 
-     curl -X GET "https://<Wazuh_indexer_IP>:9200/_cluster/health?pretty" -u <username>:<password> -k
+     curl -X GET "https://<WAZUH_INDEXER_IP_ADDRESS>:9200/_cluster/health?pretty" -u <USERNAME>:<PASSWORD> -k
 
 #. Re-enable shard allocation.
 
    .. code-block:: console
 
-      curl -X PUT "https://<Wazuh_indexer_IP>:9200/_cluster/settings" -u <username>:<password> -k -H 'Content-Type: application/json' -d'
+      curl -X PUT "https://<WAZUH_INDEXER_IP_ADDRESS>:9200/_cluster/settings" -u <USERNAME>:<PASSWORD> -k -H 'Content-Type: application/json' -d'
       {
         "persistent": {
           "cluster.routing.allocation.enable": null

--- a/source/proof-of-concept-guide/detect-web-attack-shellshock.rst
+++ b/source/proof-of-concept-guide/detect-web-attack-shellshock.rst
@@ -66,11 +66,11 @@ Perform the following steps to install an Apache web server and monitor its logs
 Attack emulation
 ----------------
 
-#. Replace ``<WEBSERVER_IP>`` with the Ubuntu IP address and execute the following command from the attacker endpoint:
+#. Replace ``<WEBSERVER_IP_ADDRESS>`` with the Ubuntu IP address and execute the following command from the attacker endpoint:
 
    .. code-block:: console
 
-      $ sudo curl -H "User-Agent: () { :; }; /bin/cat /etc/passwd" <WEBSERVER-IP>
+      $ sudo curl -H "User-Agent: () { :; }; /bin/cat /etc/passwd" <WEBSERVER_IP_ADDRESS>
 
 Visualize the alerts
 --------------------

--- a/source/upgrade-guide/upgrading-central-components.rst
+++ b/source/upgrade-guide/upgrading-central-components.rst
@@ -66,13 +66,13 @@ In the case of having a Wazuh indexer cluster with multiple nodes, the cluster w
 
 .. note::
 
-   -  Replace ``<WAZUH_INDEXER_IP>``, ``<username>``, and ``<password>`` before running the commands below.
+   -  Replace ``<WAZUH_INDEXER_IP_ADDRESS>``, ``<USERNAME>``, and ``<PASSWORD>`` before running the commands below.
 
 #. Disable shard allocation.
 
    .. code-block:: bash
 
-      curl -X PUT "https://<WAZUH_INDEXER_IP>:9200/_cluster/settings"  -u <username>:<password> -k -H 'Content-Type: application/json' -d'
+      curl -X PUT "https://<WAZUH_INDEXER_IP_ADDRESS>:9200/_cluster/settings"  -u <USERNAME>:<PASSWORD> -k -H 'Content-Type: application/json' -d'
       {
         "persistent": {
           "cluster.routing.allocation.enable": "primaries"
@@ -84,7 +84,7 @@ In the case of having a Wazuh indexer cluster with multiple nodes, the cluster w
 
    .. code-block:: console
 
-      # curl -X POST "https://<WAZUH_INDEXER_IP>:9200/_flush/synced" -u <username>:<password> -k
+      # curl -X POST "https://<WAZUH_INDEXER_IP_ADDRESS>:9200/_flush/synced" -u <USERNAME>:<PASSWORD> -k
 
 #. Shut down the Wazuh indexer in the node.
 
@@ -126,13 +126,13 @@ In the case of having a Wazuh indexer cluster with multiple nodes, the cluster w
 
    .. code-block:: console
 
-      # curl -k -u <username>:<password> https://<WAZUH_INDEXER_IP>:9200/_cat/nodes?v
+      # curl -k -u <USERNAME>:<PASSWORD> https://<WAZUH_INDEXER_IP_ADDRESS>:9200/_cat/nodes?v
 
 #. Re-enable shard allocation.
 
    .. code-block:: bash
 
-      curl -X PUT "https://<WAZUH_INDEXER_IP>:9200/_cluster/settings" -u <username>:<password> -k -H 'Content-Type: application/json' -d'
+      curl -X PUT "https://<WAZUH_INDEXER_IP_ADDRESS>:9200/_cluster/settings" -u <USERNAME>:<PASSWORD> -k -H 'Content-Type: application/json' -d'
       {
         "persistent": {
           "cluster.routing.allocation.enable": "all"
@@ -144,7 +144,7 @@ In the case of having a Wazuh indexer cluster with multiple nodes, the cluster w
 
    .. code-block:: console
 
-      # curl -k -u <username>:<password> https://<WAZUH_INDEXER_IP>:9200/_cat/nodes?v
+      # curl -k -u <USERNAME>:<PASSWORD> https://<WAZUH_INDEXER_IP_ADDRESS>:9200/_cat/nodes?v
 
 .. _upgrading_wazuh_server:
 

--- a/source/user-manual/agent/agent-enrollment/enrollment-methods/via-manager-API/requesting-the-key.rst
+++ b/source/user-manual/agent/agent-enrollment/enrollment-methods/via-manager-API/requesting-the-key.rst
@@ -35,11 +35,11 @@ From Linux/Unix and macOS
    
         eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3YXp1aCIsImF1ZCI6IldhenVoIEFQSSBSRVNUIiwibmJmIjoxNjQzMDExMjQ0LCJleHAiOjE2NDMwMTIxNDQsInN1YiI6IndhenVoIiwicnVuX2FzIjpmYWxzZSwicmJhY19yb2xlcyI6WzFdLCJyYmFjX21vZGUiOiJ3aGl0ZSJ9.Ad6zOZvx0BEV7K0J6s3pIXAXTWB-zdVfxaX2fotLfZMQkiYPMkwDaQHUFiOInsWJ_7KZV3y2BbhEs9-kBqlJAMvMAD0NDBPhEQ2qBd_iutZ7QWZECd6eYfIP83xGqH9iqS7uMI6fXOKr3w4aFV13Q6qsHSUQ1A-1LgDnnDGGaqF5ITYo
 
-#. Request the key and agent ID. Replace ``<agent_name>`` with the desired agent name.
+#. Request the key and agent ID. Replace ``<AGENT_NAME>`` with the desired agent name.
 
    .. code-block:: console
 
-     # curl -k -X POST -d '{"name":"<agent_name>"}' "https://<MANAGER_IP>:55000/agents?pretty=true" -H "Content-Type:application/json" -H "Authorization: Bearer $TOKEN" 
+     # curl -k -X POST -d '{"name":"<AGENT_NAME>"}' "https://<MANAGER_IP>:55000/agents?pretty=true" -H "Content-Type:application/json" -H "Authorization: Bearer $TOKEN" 
 
    The output with the key looks like this:
 
@@ -111,17 +111,17 @@ The following steps serve as a guide on how to send agent enrollment requests fr
 
 #. Create environment variables to hold the generated token and the agent variable.
 
-    - Replace ``<token_generated>`` with the token generated in step 2.
+    - Replace ``<TOKEN_GENERATED>`` with the token generated in step 2.
 
       .. code-block:: console
  
-        # $TOKEN = “<token_generated>”  
+        # $TOKEN = “<TOKEN_GENERATED>”  
 
-    - Replace ``<agent_name>`` with the desired agent name.
+    - Replace ``<AGENT_NAME>`` with the desired agent name.
 
       .. code-block:: console
 
-        # $AgentName = @{"name"="<agent_name>"} | ConvertTo-Json
+        # $AgentName = @{"name"="<AGENT_NAME>"} | ConvertTo-Json
    
    These environment variables will be used in subsequent requests made to the manager.
 

--- a/source/user-manual/agent/agent-enrollment/security-options/manager-identity-verification.rst
+++ b/source/user-manual/agent/agent-enrollment/security-options/manager-identity-verification.rst
@@ -54,7 +54,7 @@ Manager configuration
 
 #. Generate an SSL certificate on the Wazuh manager signed by the certificate authority. The steps to generate an SSL certificate for the manager are as follows:
 
-    #. Create a certificate request configuration file ``req.conf`` on the manager. Replace ``<manager_IP>`` with the hostname or the IP address of the Wazuh manager where the Wazuh agents are going to be enrolled. The contents of the file can be as follows:
+    #. Create a certificate request configuration file ``req.conf`` on the manager. Replace ``<MANAGER_IP_ADDRESS>`` with the hostname or the IP address of the Wazuh manager where the Wazuh agents are going to be enrolled. The contents of the file can be as follows:
 
          .. code-block:: xml
             :class: output
@@ -65,7 +65,7 @@ Manager configuration
                   prompt = no
                   [req_distinguished_name]
                   C = US
-                  CN = <manager_IP>
+                  CN = <MANAGER_IP_ADDRESS>
                   [req_ext]
                   subjectAltName = @alt_names
                   [alt_names]

--- a/source/user-manual/agent/agent-management/remove-agents/restful-api-remove.rst
+++ b/source/user-manual/agent/agent-management/remove-agents/restful-api-remove.rst
@@ -10,11 +10,11 @@ Remove agents using the Wazuh API
 
 This section includes examples of how to use the :api-ref:`DELETE /agents <operation/api.controllers.agent_controller.delete_agents>` request to either delete a list of agents or agents that have been disconnected for a given period of time. 
 
-The examples use :ref:`an authentication token <api_log_in>`. To get your token, replace ``<user>:<password>`` with your Wazuh API credentials and run the following command:
+The examples use :ref:`an authentication token <api_log_in>`. To get your token, replace ``<USER>:<PASSWORD>`` with your Wazuh API credentials and run the following command:
 
 .. code-block:: console
 
-   # TOKEN=$(curl -u <user>:<password> -k -X GET "https://localhost:55000/security/user/authenticate?raw=true")
+   # TOKEN=$(curl -u <USER>:<PASSWORD> -k -X GET "https://localhost:55000/security/user/authenticate?raw=true")
 
 Removing agents in a list
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/user-manual/api/getting-started.rst
+++ b/source/user-manual/api/getting-started.rst
@@ -41,13 +41,13 @@ Logging into the Wazuh API
 
 Wazuh API endpoints require authentication in order to be used. Therefore, all calls must include a JSON Web Token. JWT is an open standard (RFC 7519) that defines a compact and self-contained way for securely transmitting information between parties as a JSON object. Follow the steps below to log in using :api-ref:`POST /security/user/authenticate <operation/api.controllers.security_controller.login_user>` and obtain a token in order to run any endpoint:
 
-#. Use the cURL command to log in. The Wazuh API will provide a JWT token upon success. Replace <user> and <password> with yours. By default, the user is ``wazuh``, and the password is ``wazuh``. If ``SSL`` (HTTPS) is enabled in the API and it is using the default **self-signed certificates**, it will be necessary to add the parameter ``-k``. Use the ``raw`` option to get the token in a plain text format. Querying the login endpoint with ``raw=true`` is recommended when using cURL commands as tokens could be long and difficult to handle. Exporting the token to an environment variable will ease the use of API requests after login.
+#. Use the cURL command to log in. The Wazuh API will provide a JWT token upon success. Replace <USER> and <PASSWORD> with yours. By default, the user is ``wazuh``, and the password is ``wazuh``. If ``SSL`` (HTTPS) is enabled in the API and it is using the default **self-signed certificates**, it will be necessary to add the parameter ``-k``. Use the ``raw`` option to get the token in a plain text format. Querying the login endpoint with ``raw=true`` is recommended when using cURL commands as tokens could be long and difficult to handle. Exporting the token to an environment variable will ease the use of API requests after login.
 
     Export the token to an environment variable to use it in authorization header of future API requests:
 
     .. code-block:: console
 
-        # TOKEN=$(curl -u <user>:<password> -k -X POST "https://localhost:55000/security/user/authenticate?raw=true")
+        # TOKEN=$(curl -u <USER>:<PASSWORD> -k -X POST "https://localhost:55000/security/user/authenticate?raw=true")
 
     By default (``raw=false``), the token is obtained in an ``application/json`` format. If using this option, copy the token found in ``<YOUR_JWT_TOKEN>`` without the quotes.
 
@@ -84,7 +84,7 @@ Wazuh API endpoints require authentication in order to be used. Therefore, all c
         }
 
 
-Once logged in, it is possible to run any API endpoint following the structure below. Please, do not forget to replace <endpoint> with the string corresponding to the chosen endpoint. If the environment variable is not going to be used, replace $TOKEN with the JWT token obtained.
+Once logged in, it is possible to run any API endpoint following the structure below. Please, do not forget to replace <ENDPOINT> with the string corresponding to the chosen endpoint. If the environment variable is not going to be used, replace $TOKEN with the JWT token obtained.
 
 .. code-block:: console
 

--- a/source/user-manual/capabilities/file-integrity/advanced-settings.rst
+++ b/source/user-manual/capabilities/file-integrity/advanced-settings.rst
@@ -694,7 +694,7 @@ Recursion level
 
 You can configure the maximum recursion level allowed for a specific directory by using the ``recursion_level`` attribute of the :ref:`directories <reference_ossec_syscheck_directories>`   option. The ``recursion_level`` value must be an integer between 0 and 320.
 
-In the configuration example below, you can see how to set the ``recursion_level`` of the ``folder_test``  directory to 3. Replace ``＜FILEPATH/OF/MONITORED/DIRECTORY＞`` with your own file paths.
+In the configuration example below, you can see how to set the ``recursion_level`` of the ``folder_test``  directory to 3. Replace ``<FILEPATH_OF_MONITORED_DIRECTORY>`` with your own file paths.
 
 #. Add the following settings to the Wazuh agent configuration file:
 
@@ -706,7 +706,7 @@ In the configuration example below, you can see how to set the ``recursion_level
       :emphasize-lines: 2
 
       <syscheck>
-         <directories check_all="yes" recursion_level="3">＜FILEPATH/OF/MONITORED/DIRECTORY＞</directories>
+         <directories check_all="yes" recursion_level="3"><FILEPATH_OF_MONITORED_DIRECTORY></directories>
       </syscheck>
 
 #. Restart the Wazuh agent with administrator privilege to apply any configuration change:
@@ -715,11 +715,11 @@ In the configuration example below, you can see how to set the ``recursion_level
    - Windows: ``Restart-Service -Name wazuh``
    - macOS: ``/Library/Ossec/bin/wazuh-control restart``
 
-If you have the following directory structure and the above setting with ``recursion_level="3"``, FIM then generates alerts for ``file_3.txt`` and all files up to ``＜FILEPATH/OF/MONITORED/DIRECTORY＞/level_1/level_2/level_3/`` but not for any files in the directory deeper than ``level_3``.
+If you have the following directory structure and the above setting with ``recursion_level="3"``, FIM then generates alerts for ``file_3.txt`` and all files up to ``<FILEPATH_OF_MONITORED_DIRECTORY>/level_1/level_2/level_3/`` but not for any files in the directory deeper than ``level_3``.
 
    .. code-block:: console
   
-      ＜FILEPATH/OF/MONITORED/DIRECTORY＞
+      <FILEPATH_OF_MONITORED_DIRECTORY>
       ├── file_0.txt
       └── level_1
           ├── file_1.txt

--- a/source/user-manual/capabilities/file-integrity/advanced-settings.rst
+++ b/source/user-manual/capabilities/file-integrity/advanced-settings.rst
@@ -694,7 +694,7 @@ Recursion level
 
 You can configure the maximum recursion level allowed for a specific directory by using the ``recursion_level`` attribute of the :ref:`directories <reference_ossec_syscheck_directories>`   option. The ``recursion_level`` value must be an integer between 0 and 320.
 
-In the configuration example below, you can see how to set the ``recursion_level`` of the ``folder_test``  directory to 3. Replace ``FILEPATH/OF/MONITORED/DIRECTORY`` with your own file paths.
+In the configuration example below, you can see how to set the ``recursion_level`` of the ``folder_test``  directory to 3. Replace ``＜FILEPATH/OF/MONITORED/DIRECTORY＞`` with your own file paths.
 
 #. Add the following settings to the Wazuh agent configuration file:
 
@@ -706,7 +706,7 @@ In the configuration example below, you can see how to set the ``recursion_level
       :emphasize-lines: 2
 
       <syscheck>
-         <directories check_all="yes" recursion_level="3">FILEPATH/OF/MONITORED/DIRECTORY</directories>
+         <directories check_all="yes" recursion_level="3">＜FILEPATH/OF/MONITORED/DIRECTORY＞</directories>
       </syscheck>
 
 #. Restart the Wazuh agent with administrator privilege to apply any configuration change:
@@ -715,11 +715,11 @@ In the configuration example below, you can see how to set the ``recursion_level
    - Windows: ``Restart-Service -Name wazuh``
    - macOS: ``/Library/Ossec/bin/wazuh-control restart``
 
-If you have the following directory structure and the above setting with ``recursion_level="3"``, FIM then generates alerts for ``file_3.txt`` and all files up to ``FILEPATH/OF/MONITORED/DIRECTORY/level_1/level_2/level_3/`` but not for any files in the directory deeper than ``level_3``.
+If you have the following directory structure and the above setting with ``recursion_level="3"``, FIM then generates alerts for ``file_3.txt`` and all files up to ``＜FILEPATH/OF/MONITORED/DIRECTORY＞/level_1/level_2/level_3/`` but not for any files in the directory deeper than ``level_3``.
 
    .. code-block:: console
   
-      FILEPATH/OF/MONITORED/DIRECTORY
+      ＜FILEPATH/OF/MONITORED/DIRECTORY＞
       ├── file_0.txt
       └── level_1
           ├── file_1.txt

--- a/source/user-manual/capabilities/file-integrity/basic-settings.rst
+++ b/source/user-manual/capabilities/file-integrity/basic-settings.rst
@@ -21,7 +21,7 @@ The ``realtime`` attribute enables real-time/continuous monitoring of directorie
 
 To monitor files in real time, configure the FIM module with the ``realtime`` attribute of the :ref:`directories <reference_ossec_syscheck_directories>` option. The allowed values for the ``realtime`` attribute are ``yes`` and ``no``, and it only works with directories, not individual files. Real-time change detection is paused during scheduled FIM module scans and reactivates as soon as these scans are complete.
 
-Below, you can see how to configure the FIM module to monitor a directory in real time. Replace ``FILEPATH/OF/MONITORED/DIRECTORY`` with your own filepath. 
+Below, you can see how to configure the FIM module to monitor a directory in real time. Replace ``＜FILEPATH/OF/MONITORED/DIRECTORY＞`` with your own filepath. 
 
 .. note::
 
@@ -36,7 +36,7 @@ Below, you can see how to configure the FIM module to monitor a directory in rea
       :emphasize-lines: 2
       
          <syscheck>
-            <directories realtime="yes">FILEPATH/OF/MONITORED/DIRECTORY</directories>
+            <directories realtime="yes">＜FILEPATH/OF/MONITORED/DIRECTORY＞</directories>
          </syscheck>
 
 
@@ -94,7 +94,7 @@ While the following configuration disables recording of all attributes including
    
    <directories check_mtime="yes" check_all="no">/etc</directories>
 
-You can see below an example configuration of how to disable the recording of SHA-1 hash of a monitored file. Replace ``FILEPATH/OF/MONITORED/FILE`` with your own filepath.
+You can see below an example configuration of how to disable the recording of SHA-1 hash of a monitored file. Replace ``＜FILEPATH/OF/MONITORED/FILE＞`` with your own filepath.
 
 #. Add the following settings to the Wazuh agent configuration file:
 
@@ -106,7 +106,7 @@ You can see below an example configuration of how to disable the recording of SH
       :emphasize-lines: 2
 
          <syscheck>
-            <directories check_sha1sum="no">FILEPATH/OF/MONITORED/FILE</directories>
+            <directories check_sha1sum="no">＜FILEPATH/OF/MONITORED/FILE＞</directories>
          </syscheck>
 
 #. Restart the Wazuh agent with administrator privilege to apply any configuration change:
@@ -182,7 +182,7 @@ You must use the ``report_changes`` attribute with caution when you enable this 
 - ``Library/Ossec/queue/diff/local/`` on macOS.
 - ``C:\Program Files (x86)\ossec-agent\queue\diff\local\`` on Windows.
 
-Below, you can see how to configure the FIM module to report file changes. Replace ``FILEPATH/OF/MONITORED/FILE`` with your own filepath.
+Below, you can see how to configure the FIM module to report file changes. Replace ``＜FILEPATH/OF/MONITORED/FILE＞`` with your own filepath.
 
 #. Add the following settings to the Wazuh agent configuration file:
 
@@ -194,7 +194,7 @@ Below, you can see how to configure the FIM module to report file changes. Repla
       :emphasize-lines: 2
 
       <syscheck>
-         <directories check_all="yes" report_changes="yes">FILEPATH/OF/MONITORED/FILE</directories>
+         <directories check_all="yes" report_changes="yes">＜FILEPATH/OF/MONITORED/FILE＞</directories>
       </syscheck>
 
 #. Restart the Wazuh agent with administrator privilege to apply the configuration changes:
@@ -203,7 +203,7 @@ Below, you can see how to configure the FIM module to report file changes. Repla
    - Windows: ``Restart-Service -Name wazuh``
    - macOS: ``/Library/Ossec/bin/wazuh-control restart``
 
-   In the configuration example below, you can see how to use the ``report_changes`` attribute for all files in the ``FILEPATH/OF/MONITORED/DIRECTORY`` directory. You can see how to prevent the FIM module from reporting the exact content changes to the ``FILEPATH/OF/MONITORED/DIRECTORY/private.txt`` file. Replace ``FILEPATH/OF/MONITORED/DIRECTORY`` with your own filepath.
+   In the configuration example below, you can see how to use the ``report_changes`` attribute for all files in the ``＜FILEPATH/OF/MONITORED/DIRECTORY＞`` directory. You can see how to prevent the FIM module from reporting the exact content changes to the ``＜FILEPATH/OF/MONITORED/DIRECTORY＞/private.txt`` file. Replace ``＜FILEPATH/OF/MONITORED/DIRECTORY＞`` with your own filepath.
 
    When using the ``report_changes`` option, you can use the :ref:`nodiff <reference_ossec_syscheck_nodiff>` option to create an exception. This option alerts modifications of the file  but it prevents the Wazuh FIM module from reporting the exact content changed in a text file. Using the nodiff option avoids data leakage that might occur by sending the file content changes through alerts.
 
@@ -217,8 +217,8 @@ Below, you can see how to configure the FIM module to report file changes. Repla
       :emphasize-lines: 2,3
 
       <syscheck>
-         <directories check_all="yes" report_changes="yes">FILEPATH/OF/MONITORED/DIRECTORY</directories>
-         <nodiff>FILEPATH/OF/MONITORED/DIRECTORY/private.txt</nodiff>
+         <directories check_all="yes" report_changes="yes">＜FILEPATH/OF/MONITORED/DIRECTORY＞</directories>
+         <nodiff>＜FILEPATH/OF/MONITORED/DIRECTORY＞/private.txt</nodiff>
       </syscheck>
 
 #. Restart the Wazuh agent with administrator privilege to apply the configuration changes:
@@ -237,7 +237,7 @@ Using the ignore option
 
 You can use the :ref:`ignore <reference_ossec_syscheck_ignore>` option to ignore a path. It allows one entry of either file or directory per line. However, you can use multiple lines to add exclusions for multiple paths. 
 
-In this example, you can see how to configure the FIM module to ignore a filepath. This also ignores the regex match for the file extensions ``.log`` and ``.tmp``. Replace ``FILEPATH/OF/MONITORED/FILE`` with your own filepaths. 
+In this example, you can see how to configure the FIM module to ignore a filepath. This also ignores the regex match for the file extensions ``.log`` and ``.tmp``. Replace ``＜FILEPATH/OF/MONITORED/FILE＞`` with your own filepaths. 
 
 #. Add the following settings to the Wazuh agent configuration file:
 
@@ -249,7 +249,7 @@ In this example, you can see how to configure the FIM module to ignore a filepat
       :emphasize-lines: 2
 
       <syscheck>
-         <ignore>FILEPATH/OF/MONITORED/FILE</ignore>
+         <ignore>＜FILEPATH/OF/MONITORED/FILE＞</ignore>
          <ignore type="sregex">.log$|.tmp$</ignore>
       </syscheck>
 

--- a/source/user-manual/capabilities/file-integrity/basic-settings.rst
+++ b/source/user-manual/capabilities/file-integrity/basic-settings.rst
@@ -21,7 +21,7 @@ The ``realtime`` attribute enables real-time/continuous monitoring of directorie
 
 To monitor files in real time, configure the FIM module with the ``realtime`` attribute of the :ref:`directories <reference_ossec_syscheck_directories>` option. The allowed values for the ``realtime`` attribute are ``yes`` and ``no``, and it only works with directories, not individual files. Real-time change detection is paused during scheduled FIM module scans and reactivates as soon as these scans are complete.
 
-Below, you can see how to configure the FIM module to monitor a directory in real time. Replace ``＜FILEPATH/OF/MONITORED/DIRECTORY＞`` with your own filepath. 
+Below, you can see how to configure the FIM module to monitor a directory in real time. Replace ``<FILEPATH_OF_MONITORED_DIRECTORY>`` with your own filepath. 
 
 .. note::
 
@@ -36,7 +36,7 @@ Below, you can see how to configure the FIM module to monitor a directory in rea
       :emphasize-lines: 2
       
          <syscheck>
-            <directories realtime="yes">＜FILEPATH/OF/MONITORED/DIRECTORY＞</directories>
+            <directories realtime="yes"><FILEPATH_OF_MONITORED_DIRECTORY></directories>
          </syscheck>
 
 
@@ -94,7 +94,7 @@ While the following configuration disables recording of all attributes including
    
    <directories check_mtime="yes" check_all="no">/etc</directories>
 
-You can see below an example configuration of how to disable the recording of SHA-1 hash of a monitored file. Replace ``＜FILEPATH/OF/MONITORED/FILE＞`` with your own filepath.
+You can see below an example configuration of how to disable the recording of SHA-1 hash of a monitored file. Replace ``<FILEPATH_OF_MONITORED_FILE>`` with your own filepath.
 
 #. Add the following settings to the Wazuh agent configuration file:
 
@@ -106,7 +106,7 @@ You can see below an example configuration of how to disable the recording of SH
       :emphasize-lines: 2
 
          <syscheck>
-            <directories check_sha1sum="no">＜FILEPATH/OF/MONITORED/FILE＞</directories>
+            <directories check_sha1sum="no"><FILEPATH_OF_MONITORED_FILE></directories>
          </syscheck>
 
 #. Restart the Wazuh agent with administrator privilege to apply any configuration change:
@@ -182,7 +182,7 @@ You must use the ``report_changes`` attribute with caution when you enable this 
 - ``Library/Ossec/queue/diff/local/`` on macOS.
 - ``C:\Program Files (x86)\ossec-agent\queue\diff\local\`` on Windows.
 
-Below, you can see how to configure the FIM module to report file changes. Replace ``＜FILEPATH/OF/MONITORED/FILE＞`` with your own filepath.
+Below, you can see how to configure the FIM module to report file changes. Replace ``<FILEPATH_OF_MONITORED_FILE>`` with your own filepath.
 
 #. Add the following settings to the Wazuh agent configuration file:
 
@@ -194,7 +194,7 @@ Below, you can see how to configure the FIM module to report file changes. Repla
       :emphasize-lines: 2
 
       <syscheck>
-         <directories check_all="yes" report_changes="yes">＜FILEPATH/OF/MONITORED/FILE＞</directories>
+         <directories check_all="yes" report_changes="yes"><FILEPATH_OF_MONITORED_FILE></directories>
       </syscheck>
 
 #. Restart the Wazuh agent with administrator privilege to apply the configuration changes:
@@ -203,7 +203,7 @@ Below, you can see how to configure the FIM module to report file changes. Repla
    - Windows: ``Restart-Service -Name wazuh``
    - macOS: ``/Library/Ossec/bin/wazuh-control restart``
 
-   In the configuration example below, you can see how to use the ``report_changes`` attribute for all files in the ``＜FILEPATH/OF/MONITORED/DIRECTORY＞`` directory. You can see how to prevent the FIM module from reporting the exact content changes to the ``＜FILEPATH/OF/MONITORED/DIRECTORY＞/private.txt`` file. Replace ``＜FILEPATH/OF/MONITORED/DIRECTORY＞`` with your own filepath.
+   In the configuration example below, you can see how to use the ``report_changes`` attribute for all files in the ``<FILEPATH_OF_MONITORED_DIRECTORY>`` directory. You can see how to prevent the FIM module from reporting the exact content changes to the ``<FILEPATH_OF_MONITORED_DIRECTORY>/private.txt`` file. Replace ``<FILEPATH_OF_MONITORED_DIRECTORY>`` with your own filepath.
 
    When using the ``report_changes`` option, you can use the :ref:`nodiff <reference_ossec_syscheck_nodiff>` option to create an exception. This option alerts modifications of the file  but it prevents the Wazuh FIM module from reporting the exact content changed in a text file. Using the nodiff option avoids data leakage that might occur by sending the file content changes through alerts.
 
@@ -217,8 +217,8 @@ Below, you can see how to configure the FIM module to report file changes. Repla
       :emphasize-lines: 2,3
 
       <syscheck>
-         <directories check_all="yes" report_changes="yes">＜FILEPATH/OF/MONITORED/DIRECTORY＞</directories>
-         <nodiff>＜FILEPATH/OF/MONITORED/DIRECTORY＞/private.txt</nodiff>
+         <directories check_all="yes" report_changes="yes"><FILEPATH_OF_MONITORED_DIRECTORY></directories>
+         <nodiff><FILEPATH_OF_MONITORED_DIRECTORY>/private.txt</nodiff>
       </syscheck>
 
 #. Restart the Wazuh agent with administrator privilege to apply the configuration changes:
@@ -237,7 +237,7 @@ Using the ignore option
 
 You can use the :ref:`ignore <reference_ossec_syscheck_ignore>` option to ignore a path. It allows one entry of either file or directory per line. However, you can use multiple lines to add exclusions for multiple paths. 
 
-In this example, you can see how to configure the FIM module to ignore a filepath. This also ignores the regex match for the file extensions ``.log`` and ``.tmp``. Replace ``＜FILEPATH/OF/MONITORED/FILE＞`` with your own filepaths. 
+In this example, you can see how to configure the FIM module to ignore a filepath. This also ignores the regex match for the file extensions ``.log`` and ``.tmp``. Replace ``<FILEPATH_OF_MONITORED_FILE>`` with your own filepaths. 
 
 #. Add the following settings to the Wazuh agent configuration file:
 
@@ -249,7 +249,7 @@ In this example, you can see how to configure the FIM module to ignore a filepat
       :emphasize-lines: 2
 
       <syscheck>
-         <ignore>＜FILEPATH/OF/MONITORED/FILE＞</ignore>
+         <ignore><FILEPATH_OF_MONITORED_FILE></ignore>
          <ignore type="sregex">.log$|.tmp$</ignore>
       </syscheck>
 

--- a/source/user-manual/capabilities/file-integrity/creating-custom-fim-rules.rst
+++ b/source/user-manual/capabilities/file-integrity/creating-custom-fim-rules.rst
@@ -325,7 +325,7 @@ Perform the following steps on the Wazuh server.
 
       # touch /var/ossec/etc/rules/fim_win_test.xml
 
-#. Add the following rule definition to the ``/var/ossec/etc/rules/fim_win_test.xml`` file. This rule triggers alerts when a user deletes files with File Explorer. Replace ``USER`` with the username of your Windows endpoint:
+#. Add the following rule definition to the ``/var/ossec/etc/rules/fim_win_test.xml`` file. This rule triggers alerts when a user deletes files with File Explorer. Replace ``<USER>`` with the username of your Windows endpoint:
 
    .. code-block:: xml
       :emphasize-lines: 4,5
@@ -334,7 +334,7 @@ Perform the following steps on the Wazuh server.
         <rule id="100003" level="8">
           <if_sid>553</if_sid>
           <field name="process_name">explorer.exe$</field>
-          <field name="uname">USER$</field>
+          <field name="uname"><USER>$</field>
           <match>deleted</match>
           <description>The user "$(uname)" deleted a monitored file with  File Explorer</description>
           <mitre>

--- a/source/user-manual/capabilities/file-integrity/how-to-configure-fim.rst
+++ b/source/user-manual/capabilities/file-integrity/how-to-configure-fim.rst
@@ -14,7 +14,7 @@ You have to set the files and directories to monitor with the :ref:`directories 
 
 Any time the FIM module runs a scan, it triggers alerts if it finds modified files and depending on the changed file attributes. You can view these alerts in the Wazuh dashboard. 
 
-Following, you can see how to configure the FIM module to monitor a file and directory. Replace ``＜FILEPATH/OF/MONITORED/FILE＞`` and ``＜FILEPATH/OF/MONITORED/DIRECTORY＞`` with your own filepaths. 
+Following, you can see how to configure the FIM module to monitor a file and directory. Replace ``<FILEPATH_OF_MONITORED_FILE>`` and ``<FILEPATH_OF_MONITORED_DIRECTORY>`` with your own filepaths. 
 
 #. Add the following settings to the Wazuh agent configuration file, replacing the directories values with your own filepaths:
    
@@ -26,8 +26,8 @@ Following, you can see how to configure the FIM module to monitor a file and dir
       :emphasize-lines: 2,3
 
       <syscheck>
-         <directories>＜FILEPATH/OF/MONITORED/FILE＞</directories>
-         <directories>＜FILEPATH/OF/MONITORED/DIRECTORY＞</directories>
+         <directories><FILEPATH_OF_MONITORED_FILE></directories>
+         <directories><FILEPATH_OF_MONITORED_DIRECTORY></directories>
       </syscheck>
 
 #. Restart the Wazuh agent with administrator privilege to apply any configuration change:

--- a/source/user-manual/capabilities/file-integrity/how-to-configure-fim.rst
+++ b/source/user-manual/capabilities/file-integrity/how-to-configure-fim.rst
@@ -14,7 +14,7 @@ You have to set the files and directories to monitor with the :ref:`directories 
 
 Any time the FIM module runs a scan, it triggers alerts if it finds modified files and depending on the changed file attributes. You can view these alerts in the Wazuh dashboard. 
 
-Following, you can see how to configure the FIM module to monitor a file and directory. Replace ``FILEPATH/OF/MONITORED/FILE`` and ``FILEPATH/OF/MONITORED/DIRECTORY`` with your own filepaths. 
+Following, you can see how to configure the FIM module to monitor a file and directory. Replace ``＜FILEPATH/OF/MONITORED/FILE＞`` and ``＜FILEPATH/OF/MONITORED/DIRECTORY＞`` with your own filepaths. 
 
 #. Add the following settings to the Wazuh agent configuration file, replacing the directories values with your own filepaths:
    
@@ -26,8 +26,8 @@ Following, you can see how to configure the FIM module to monitor a file and dir
       :emphasize-lines: 2,3
 
       <syscheck>
-         <directories>FILEPATH/OF/MONITORED/FILE</directories>
-         <directories>FILEPATH/OF/MONITORED/DIRECTORY</directories>
+         <directories>＜FILEPATH/OF/MONITORED/FILE＞</directories>
+         <directories>＜FILEPATH/OF/MONITORED/DIRECTORY＞</directories>
       </syscheck>
 
 #. Restart the Wazuh agent with administrator privilege to apply any configuration change:

--- a/source/user-manual/capabilities/malware-detection/cdb-lists-threat-intelligence.rst
+++ b/source/user-manual/capabilities/malware-detection/cdb-lists-threat-intelligence.rst
@@ -91,7 +91,7 @@ Linux endpoint
       <ossec_config>
         <syscheck>
           <disabled>no</disabled>
-          <directories check_all="yes" realtime="yes">/PATH/TO/MONITORED/DIRECTORY</directories>
+          <directories check_all="yes" realtime="yes">＜PATH/TO/MONITORED/DIRECTORY＞</directories>
         </syscheck>
       </ossec_config>
 
@@ -114,12 +114,12 @@ To test that everything works correctly, download the *Mirai* and *Xbash* malwar
 
    These malicious files are dangerous, so use them for testing purposes only. Do not install them in production environments.
 
-#. Download the malware samples. Replace ``/PATH/TO/MONITORED/DIRECTORY`` with the path of the monitored directory.
+#. Download the malware samples. Replace ``＜/PATH/TO/MONITORED/DIRECTORY＞`` with the path of the monitored directory.
 
    .. code-block:: console
 
-      $ sudo curl https://wazuh-demo.s3-us-west-1.amazonaws.com/mirai --output /PATH/TO/MONITORED/DIRECTORY/mirai
-      $ sudo curl https://wazuh-demo.s3-us-west-1.amazonaws.com/xbash --output /PATH/TO/MONITORED/DIRECTORY/Xbash
+      $ sudo curl https://wazuh-demo.s3-us-west-1.amazonaws.com/mirai --output ＜/PATH/TO/MONITORED/DIRECTORY＞/mirai
+      $ sudo curl https://wazuh-demo.s3-us-west-1.amazonaws.com/xbash --output ＜/PATH/TO/MONITORED/DIRECTORY＞/Xbash
 
 Visualize the alerts
 ^^^^^^^^^^^^^^^^^^^^

--- a/source/user-manual/capabilities/malware-detection/cdb-lists-threat-intelligence.rst
+++ b/source/user-manual/capabilities/malware-detection/cdb-lists-threat-intelligence.rst
@@ -91,7 +91,7 @@ Linux endpoint
       <ossec_config>
         <syscheck>
           <disabled>no</disabled>
-          <directories check_all="yes" realtime="yes">＜PATH/TO/MONITORED/DIRECTORY＞</directories>
+          <directories check_all="yes" realtime="yes"><PATH_TO_MONITORED_DIRECTORY></directories>
         </syscheck>
       </ossec_config>
 
@@ -114,12 +114,12 @@ To test that everything works correctly, download the *Mirai* and *Xbash* malwar
 
    These malicious files are dangerous, so use them for testing purposes only. Do not install them in production environments.
 
-#. Download the malware samples. Replace ``＜/PATH/TO/MONITORED/DIRECTORY＞`` with the path of the monitored directory.
+#. Download the malware samples. Replace ``<PATH_TO_MONITORED_DIRECTORY>`` with the path of the monitored directory.
 
    .. code-block:: console
 
-      $ sudo curl https://wazuh-demo.s3-us-west-1.amazonaws.com/mirai --output ＜/PATH/TO/MONITORED/DIRECTORY＞/mirai
-      $ sudo curl https://wazuh-demo.s3-us-west-1.amazonaws.com/xbash --output ＜/PATH/TO/MONITORED/DIRECTORY＞/Xbash
+      $ sudo curl https://wazuh-demo.s3-us-west-1.amazonaws.com/mirai --output <PATH_TO_MONITORED_DIRECTORY>/mirai
+      $ sudo curl https://wazuh-demo.s3-us-west-1.amazonaws.com/xbash --output <PATH_TO_MONITORED_DIRECTORY>/Xbash
 
 Visualize the alerts
 ^^^^^^^^^^^^^^^^^^^^

--- a/source/user-manual/manager/configuring-cluster/advanced-settings.rst
+++ b/source/user-manual/manager/configuring-cluster/advanced-settings.rst
@@ -60,12 +60,12 @@ Pointing agents to the cluster with a load balancer
                 stream {
                     upstream cluster {
                         hash $remote_addr consistent;
-                        server <WAZUH-MASTER-IP>:1514;
-                        server <WAZUH-WORKER1-IP>:1514;
-                        server <WAZUH-WORKER2-IP>:1514;
+                        server <WAZUH_MASTER_IP_ADDRESS>:1514;
+                        server <WAZUH_WORKER1_IP_ADDRESS>:1514;
+                        server <WAZUH_WORKER2_IP_ADDRESS>:1514;
                     }
                     upstream master {
-                        server <WAZUH-MASTER-IP>:1515;
+                        server <WAZUH_MASTER_IP_ADDRESS>:1515;
                     }
                     server {
                         listen 1514;

--- a/source/user-manual/manager/manual-email-report/smtp-authentication.rst
+++ b/source/user-manual/manager/manual-email-report/smtp-authentication.rst
@@ -51,11 +51,11 @@ Wazuh email alerts does not support SMTP servers with authentication such as Gma
             smtp_use_tls = yes
             smtpd_relay_restrictions = permit_mynetworks, permit_sasl_authenticated, defer_unauth_destination
 
-#. Set the sender email address and password. Replace *USERNAME* and *PASSWORD* with your own data.
+#. Set the sender email address and password. Replace ``<USERNAME>`` and ``<PASSWORD>`` with your own data.
 
    .. code-block:: console
 
-      # echo [smtp.gmail.com]:587 USERNAME@gmail.com:PASSWORD > /etc/postfix/sasl_passwd
+      # echo [smtp.gmail.com]:587 <USERNAME>@gmail.com:<PASSWORD> > /etc/postfix/sasl_passwd
       # postmap /etc/postfix/sasl_passwd
       # chmod 400 /etc/postfix/sasl_passwd
 
@@ -100,7 +100,7 @@ Wazuh email alerts does not support SMTP servers with authentication such as Gma
       <global>
         <email_notification>yes</email_notification>
         <smtp_server>localhost</smtp_server>
-        <email_from>USERNAME@gmail.com</email_from>
+        <email_from><USERNAME>@gmail.com</email_from>
         <email_to>you@example.com</email_to>
       </global>
 

--- a/source/user-manual/manager/manual-integration.rst
+++ b/source/user-manual/manager/manual-integration.rst
@@ -64,13 +64,13 @@ To set up this integration, follow these steps.
 
 #. Enable Incoming Webhooks and create one for your Slack channel. Follow the Slack guide on `Incoming Webhooks <https://api.slack.com/messaging/webhooks>`__ for this.
 
-#. Edit ``/var/ossec/etc/ossec.conf`` in the Wazuh server and include a configuration block such as the following. Replace ``WEBHOOK_URL`` with your Incoming Webhook URL.
+#. Edit ``/var/ossec/etc/ossec.conf`` in the Wazuh server and include a configuration block such as the following. Replace ``<WEBHOOK_URL>`` with your Incoming Webhook URL.
 
    .. code-block:: xml
 
      <integration>
        <name>slack</name>
-       <hook_url>WEBHOOK_URL</hook_url> <!-- Replace with your Slack hook URL -->
+       <hook_url><WEBHOOK_URL></hook_url> <!-- Replace with your Slack hook URL -->
        <alert_format>json</alert_format>
      </integration>
 
@@ -101,14 +101,14 @@ To set up this integration, do the following.
 
 #. Get your own *Events API v2* integration key by creating a `Pagerduty new service <https://support.pagerduty.com/docs/services-and-integrations#create-a-service>`__.
 
-#. Edit ``/var/ossec/etc/ossec.conf`` in the Wazuh server and include a configuration block such as the following. Replace ``API_KEY`` with your Pagerduty integration key. The rule level filter is optional and you can remove it or set another level value for the integration.
+#. Edit ``/var/ossec/etc/ossec.conf`` in the Wazuh server and include a configuration block such as the following. Replace ``<API_KEY>`` with your Pagerduty integration key. The rule level filter is optional and you can remove it or set another level value for the integration.
 
    .. code-block:: xml
       :emphasize-lines: 3
 
       <integration>
         <name>pagerduty</name>
-        <api_key>API_KEY</api_key> <!-- Replace with your PagerDuty API key -->
+        <api_key><API_KEY></api_key> <!-- Replace with your PagerDuty API key -->
         <level>10</level>
         <alert_format>json</alert_format> <!-- New mandatory parameter since v4.7.0 -->
       </integration>
@@ -138,14 +138,14 @@ To set up this integration, follow these steps.
 
 #. Get your API key from the `Virustotal API key <https://www.virustotal.com/gui/my-apikey>`__ page.
 
-#. Edit ``/var/ossec/etc/ossec.conf`` in the Wazuh server and include a configuration block such as the following. Replace ``API_KEY`` with your Virustotal API key.
+#. Edit ``/var/ossec/etc/ossec.conf`` in the Wazuh server and include a configuration block such as the following. Replace ``<API_KEY>`` with your Virustotal API key.
 
    .. code-block:: xml
       :emphasize-lines: 3
 
       <integration>
         <name>virustotal</name>
-        <api_key>API_KEY</api_key> <!-- Replace with your VirusTotal API key -->
+        <api_key><API_KEY></api_key> <!-- Replace with your VirusTotal API key -->
         <group>syscheck</group>
         <alert_format>json</alert_format>
       </integration>
@@ -208,7 +208,7 @@ To set up this integration, do the following.
 
 #. Get your API key from the `Maltiverse <https://www.maltiverse.com>`__ page.
 
-#. Edit ``/var/ossec/etc/ossec.conf`` in the Wazuh server and include a configuration block such as the following. Replace ``API_KEY`` with your Maltiverse API key. The rule level filter is optional. You can remove it or set another level value for the integration.
+#. Edit ``/var/ossec/etc/ossec.conf`` in the Wazuh server and include a configuration block such as the following. Replace ``<API_KEY>`` with your Maltiverse API key. The rule level filter is optional. You can remove it or set another level value for the integration.
 
    .. code-block:: xml
       :emphasize-lines: 5
@@ -217,7 +217,7 @@ To set up this integration, do the following.
          <name>maltiverse</name>
          <hook_url>https://api.maltiverse.com</hook_url>
          <level>3</level>
-         <api_key>API_KEY</api_key> <!-- Replace with your Maltiverse API key -->
+         <api_key><API_KEY></api_key> <!-- Replace with your Maltiverse API key -->
          <alert_format>json</alert_format>
       </integration>
 

--- a/source/user-manual/upscaling/adding-indexer-node.rst
+++ b/source/user-manual/upscaling/adding-indexer-node.rst
@@ -54,9 +54,9 @@ We recommend creating entirely new certificates for your Wazuh indexer nodes. Pe
       # Wazuh indexer nodes
         indexer:
           - name: <EXISTING_WAZUH_INDEXER_NODE_NAME>
-            ip: <EXISTING_WAZUH_INDEXER_IP>
+            ip: <EXISTING_WAZUH_INDEXER_IP_ADDRESS>
           - name: <NEW_WAZUH_INDEXER_NODE_NAME>
-            ip: <NEW_WAZUH_INDEXER_IP>
+            ip: <NEW_WAZUH_INDEXER_IP_ADDRESS>
 
       # Wazuh server nodes
         server:
@@ -104,7 +104,7 @@ Perform the steps below on one indexer node only.
         # Wazuh indexer nodes
         indexer:
           - name: <NEW_WAZUH_INDEXER_NODE_NAME>
-            ip: <NEW_WAZUH_INDEXER_IP>
+            ip: <NEW_WAZUH_INDEXER_IP_ADDRESS>
 
    Replace the values with your node names and their corresponding IP addresses.
 
@@ -141,9 +141,9 @@ Perform the steps below on one indexer node only.
             # Wazuh indexer nodes
               indexer:
                 - name: <EXISTING_WAZUH_INDEXER_NODE_NAME>
-                  ip: <EXISTING_WAZUH_INDEXER_IP>
+                  ip: <EXISTING_WAZUH_INDEXER_IP_ADDRESS>
                 - name: <NEW_WAZUH_INDEXER_NODE_NAME>
-                  ip: <NEW_WAZUH_INDEXER_IP>
+                  ip: <NEW_WAZUH_INDEXER_IP_ADDRESS>
 
             # Wazuh server nodes
               server:
@@ -248,18 +248,18 @@ All-in-one deployment
    .. code-block:: yaml
       :emphasize-lines: 5, 9, 12
 
-      network.host: "<EXISTING_WAZUH_INDEXER_IP>"
+      network.host: "<EXISTING_WAZUH_INDEXER_IP_ADDRESS>"
       node.name: "<EXISTING_WAZUH_INDEXER_NODE_NAME>"
       cluster.initial_master_nodes:
       - "<EXISTING_WAZUH_INDEXER_NODE_NAME>"
-      - "<NEW-WAZUH-INDEXER-NODE-NAME>"
+      - "<NEW_WAZUH_INDEXER_NODE_NAME>"
       cluster.name: "wazuh-cluster"
       discovery.seed_hosts:
-        - "<EXISTING_WAZUH_INDEXER_IP>"
-        - "<NEW_WAZUH_INDEXER_IP>"
+        - "<EXISTING_WAZUH_INDEXER_IP_ADDRESS>"
+        - "<NEW_WAZUH_INDEXER_IP_ADDRESS>"
       plugins.security.nodes_dn:
-      - "CN=<EXISTING-WAZUH-INDEXER-NODE-NAME>,OU=Wazuh,O=Wazuh,L=California,C=US"
-      - "CN=<NEW-WAZUH-INDEXER-NODE-NAME>,OU=Wazuh,O=Wazuh,L=California,C=US"
+      - "CN=<EXISTING_WAZUH_INDEXER_NODE_NAME>,OU=Wazuh,O=Wazuh,L=California,C=US"
+      - "CN=<NEW_WAZUH_INDEXER_NODE_NAME>,OU=Wazuh,O=Wazuh,L=California,C=US"
 
 #. Edit the filebeat configuration file ``/etc/filebeat/filebeat.yml`` (In case you are running a distributed deployment, the file is located in the Wazuh server) to add the new Wazuh indexer node(s). Uncomment or add more lines, according to your ``/root/config.yml`` definitions.
 
@@ -267,8 +267,8 @@ All-in-one deployment
       :emphasize-lines: 3
 
       output.elasticsearch.hosts:
-              - <EXISTING_WAZUH_INDEXER_IP>:9200
-              - <NEW_WAZUH_INDEXER_IP>:9200
+              - <EXISTING_WAZUH_INDEXER_IP_ADDRESS>:9200
+              - <NEW_WAZUH_INDEXER_IP_ADDRESS>:9200
       output.elasticsearch:
         protocol: https
         username: ${username}
@@ -278,7 +278,7 @@ All-in-one deployment
 
    .. code-block:: yaml
 
-      opensearch.hosts: ["https://<EXISTING_WAZUH_INDEXER_IP>:9200", "https://<NEW_WAZUH_INDEXER_IP>:9200"]
+      opensearch.hosts: ["https://<EXISTING_WAZUH_INDEXER_IP_ADDRESS>:9200", "https://<NEW_WAZUH_INDEXER_IP_ADDRESS>:9200"]
 
 #. Restart the Wazuh services to apply the changes.
 
@@ -310,18 +310,18 @@ Distributed deployment
    .. code-block:: yaml
       :emphasize-lines: 5, 9, 12
 
-      network.host: "<EXISTING_WAZUH_INDEXER_IP>"
+      network.host: "<EXISTING_WAZUH_INDEXER_IP_ADDRESS>"
       node.name: "<EXISTING_WAZUH_INDEXER_NODE_NAME>"
       cluster.initial_master_nodes:
       - "<EXISTING_WAZUH_INDEXER_NODE_NAME>"
-      - "<NEW-WAZUH-INDEXER-NODE-NAME>"
+      - "<NEW_WAZUH_INDEXER_NODE_NAME>"
       cluster.name: "wazuh-cluster"
       discovery.seed_hosts:
-        - "<EXISTING_WAZUH_INDEXER_IP>"
-        - "<NEW_WAZUH_INDEXER_IP>"
+        - "<EXISTING_WAZUH_INDEXER_IP_ADDRESS>"
+        - "<NEW_WAZUH_INDEXER_IP_ADDRESS>"
       plugins.security.nodes_dn:
       - "CN=indexer,OU=Wazuh,O=Wazuh,L=California,C=US"
-      - "CN=<WAZUH-INDEXER2-NODE-NAME>,OU=Wazuh,O=Wazuh,L=California,C=US"
+      - "CN=<WAZUH_INDEXER2_NODE_NAME>,OU=Wazuh,O=Wazuh,L=California,C=US"
 
 #. Edit the filebeat configuration file ``/etc/filebeat/filebeat.yml`` (the file is located in the Wazuh server) to add the new Wazuh indexer node(s). Uncomment or add more lines, according to your ``/root/config.yml`` definitions.
 
@@ -329,8 +329,8 @@ Distributed deployment
       :emphasize-lines: 3
 
       output.elasticsearch.hosts:
-              - <EXISTING_WAZUH_INDEXER_IP>:9200
-              - <NEW_WAZUH_INDEXER_IP>:9200
+              - <EXISTING_WAZUH_INDEXER_IP_ADDRESS>:9200
+              - <NEW_WAZUH_INDEXER_IP_ADDRESS>:9200
       output.elasticsearch:
         protocol: https
         username: ${username}
@@ -340,7 +340,7 @@ Distributed deployment
 
    .. code-block:: yaml
 
-      opensearch.hosts: ["https://<EXISTING_WAZUH_INDEXER_IP>:9200", "https://<NEW_WAZUH_INDEXER_IP>:9200"]
+      opensearch.hosts: ["https://<EXISTING_WAZUH_INDEXER_IP_ADDRESS>:9200", "https://<NEW_WAZUH_INDEXER_IP_ADDRESS>:9200"]
 
    .. note::
 
@@ -518,8 +518,8 @@ Edit the ``/etc/wazuh-indexer/opensearch.yml`` configuration file and replace th
    .. code-block:: yaml
 
       discovery.seed_hosts:
-        - "<EXISTING_WAZUH_INDEXER_IP>"
-        - "<NEW_WAZUH_INDEXER_IP>"
+        - "<EXISTING_WAZUH_INDEXER_IP_ADDRESS>"
+        - "<NEW_WAZUH_INDEXER_IP_ADDRESS>"
 
 #. ``plugins.security.nodes_dn``: List of the Distinguished Names of the certificates of all the Wazuh indexer cluster nodes. Uncomment the line for ``node-2`` and change the common names (CN) and values according to your settings and your ``/root/config.yml`` definitions:
 
@@ -690,9 +690,9 @@ Run the command below on any of Wazuh indexer nodes and check the output for the
 
    .. code-block:: console
 
-      # curl -XGET https:/<EXISTING_WAZUH_INDEXER_IP>:9200/_cluster/health?pretty -u admin:<admin-password> -k
+      # curl -XGET https:/<EXISTING_WAZUH_INDEXER_IP_ADDRESS>:9200/_cluster/health?pretty -u admin:<ADMIN_PASSWORD> -k
 
-Replace ``<EXISTING_WAZUH_INDEXER_IP>`` by the IP address of any of your indexer nodes and ``<admin-password>`` with your administrator password. The output of the command should be similar to the following:
+Replace ``<EXISTING_WAZUH_INDEXER_IP_ADDRESS>`` by the IP address of any of your indexer nodes and ``<ADMIN_PASSWORD>`` with your administrator password. The output of the command should be similar to the following:
 
    .. code-block:: none
       :class: output

--- a/source/user-manual/upscaling/adding-server-node.rst
+++ b/source/user-manual/upscaling/adding-server-node.rst
@@ -57,7 +57,7 @@ We recommend creating entirely new certificates for your Wazuh server nodes. Per
         # Wazuh server nodes
         server:
           - name: <EXISTING_WAZUH_SERVER_NODE_NAME>
-            ip: <EXISTING_WAZUH_SERVER_IP>
+            ip: <EXISTING_WAZUH_SERVER_IP_ADDRESS>
             node_type: master
           - name: <NEW_WAZUH_SERVER_NODE_NAME>
             ip: <NEW_WAZUH_SERVER_IP>
@@ -105,7 +105,7 @@ We recommend you utilize pre-existing root-ca keys to generate certificates for 
         # Wazuh server nodes
         server:
           - name: <EXISTING_WAZUH_SERVER_NODE_NAME>
-            ip: <EXISTING_WAZUH_SERVER_IP>
+            ip: <EXISTING_WAZUH_SERVER_IP_ADDRESS>
             node_type: master
           - name: <NEW_WAZUH_SERVER_NODE_NAME>
             ip: <NEW_WAZUH_SERVER_IP>
@@ -153,7 +153,7 @@ We recommend you utilize pre-existing root-ca keys to generate certificates for 
               # Wazuh server nodes
               server:
                 - name: <EXISTING_WAZUH_SERVER_NODE_NAME>
-                  ip: <EXISTING_WAZUH_SERVER_IP>
+                  ip: <EXISTING_WAZUH_SERVER_IP_ADDRESS>
                   node_type: master
                 - name: <NEW_WAZUH_SERVER_NODE_NAME>
                   ip: <NEW_WAZUH_SERVER_IP>
@@ -296,10 +296,10 @@ All-in-one deployment
 
       hosts:
         - default:
-            url: https://<EXISTING_WAZUH_SERVER_IP>
+            url: https://<EXISTING_WAZUH_SERVER_IP_ADDRESS>
             port: 55000
             username: wazuh-wui
-            password: <WAZUH-WUI-PASSWORD>
+            password: <WAZUH_WUI_PASSWORD>
             run_as: false
 
 #. Edit the Wazuh server configuration file at ``/var/ossec/etc/ossec.conf`` to enable cluster mode:
@@ -311,11 +311,11 @@ All-in-one deployment
           <name>wazuh</name>
           <node_name><EXISTING_WAZUH_SERVER_NODE_NAME></node_name>
           <node_type>master</node_type>
-          <key><ENCRYPTION-KEY></key>
+          <key><ENCRYPTION_KEY></key>
           <port>1516</port>
           <bind_addr>0.0.0.0</bind_addr>
           <nodes>
-              <node><MASTER_NODE_IP></node>
+              <node><MASTER_NODE_IP_ADDRESS></node>
           </nodes>
           <hidden>no</hidden>
           <disabled>no</disabled>
@@ -329,7 +329,7 @@ All-in-one deployment
    -  :ref:`key <cluster_key>` represents a :ref:`key <generate_encryption_key>` used to encrypt communication between cluster nodes. It should be the same on all the server nodes. To generate a unique key you can use the command ``openssl rand -hex 16``.
    -  :ref:`port <cluster_port>` indicates the destination port for cluster communication. Leave the default as ``1516``.
    -  :ref:`bind_addr <cluster_bind_addr>` is the network IP to which the node is bound to listen for incoming requests (0.0.0.0 means the node will use any IP).
-   -  :ref:`nodes <cluster_nodes>` is the address of the master node and can be either an IP or a DNS hostname. This parameter must be specified in all nodes, including the master itself. Replace ``<MASTER_NODE_IP>`` with the IP address of your master node.
+   -  :ref:`nodes <cluster_nodes>` is the address of the master node and can be either an IP or a DNS hostname. This parameter must be specified in all nodes, including the master itself. Replace ``<MASTER_NODE_IP_ADDRESS>`` with the IP address of your master node.
    -  :ref:`hidden <cluster_hidden>` shows or hides the cluster information in the generated alerts.
    -  :ref:`disabled <cluster_disabled>` indicates whether the node is enabled or disabled in the cluster. This option must be set to ``no``.
 
@@ -465,10 +465,10 @@ Distributed deployment
 
       hosts:
         - default:
-            url: https://<EXISTING_WAZUH_SERVER_IP>
+            url: https://<EXISTING_WAZUH_SERVER_IP_ADDRESS>
             port: 55000
             username: wazuh-wui
-            password: <WAZUH-WUI-PASSWORD>
+            password: <WAZUH_WUI_PASSWORD>
             run_as: false
 
 #. Edit the Wazuh server configuration file at ``/var/ossec/etc/ossec.conf`` to enable cluster mode:
@@ -480,11 +480,11 @@ Distributed deployment
           <name>wazuh</name>
           <node_name><EXISTING_WAZUH_SERVER_NODE_NAME></node_name>
           <node_type>master</node_type>
-          <key><ENCRYPTION-KEY></key>
+          <key><ENCRYPTION_KEY></key>
           <port>1516</port>
           <bind_addr>0.0.0.0</bind_addr>
           <nodes>
-              <node><MASTER_NODE_IP></node>
+              <node><MASTER_NODE_IP_ADDRESS></node>
           </nodes>
           <hidden>no</hidden>
           <disabled>no</disabled>
@@ -498,7 +498,7 @@ Distributed deployment
    -  :ref:`key <cluster_key>` represents a :ref:`key <distributed_generate_encryption_key>` used to encrypt communication between cluster nodes. It should be the same on all the server nodes. To generate a unique key you can use the command ``openssl rand -hex 16``.
    -  :ref:`port <cluster_port>` indicates the destination port for cluster communication. Leave the default as ``1516``.
    -  :ref:`bind_addr <cluster_bind_addr>` is the network IP to which the node is bound to listen for incoming requests (0.0.0.0 means the node will use any IP).
-   -  :ref:`nodes <cluster_nodes>` is the address of the master node and can be either an IP or a DNS hostname. This parameter must be specified in all nodes, including the master itself. Replace ``<MASTER_NODE_IP>`` with the IP address of your master node.
+   -  :ref:`nodes <cluster_nodes>` is the address of the master node and can be either an IP or a DNS hostname. This parameter must be specified in all nodes, including the master itself. Replace ``<MASTER_NODE_IP_ADDRESS>`` with the IP address of your master node.
    -  :ref:`hidden <cluster_hidden>` shows or hides the cluster information in the generated alerts.
    -  :ref:`disabled <cluster_disabled>` indicates whether the node is enabled or disabled in the cluster. This option must be set to ``no``.
 
@@ -733,11 +733,11 @@ Configuring the Wazuh server worker nodes
           <name>wazuh</name>
           <node_name><NEW_WAZUH_SERVER_NODE_NAME></node_name>
           <node_type>worker</node_type>
-          <key><ENCRYPTION-KEY></key>
+          <key><ENCRYPTION_KEY></key>
           <port>1516</port>
           <bind_addr>0.0.0.0</bind_addr>
           <nodes>
-              <node><MASTER_NODE_IP></node>
+              <node><MASTER_NODE_IP_ADDRESS></node>
           </nodes>
           <hidden>no</hidden>
           <disabled>no</disabled>
@@ -751,7 +751,7 @@ Configuring the Wazuh server worker nodes
    -  :ref:`key <cluster_key>` represents a :ref:`key <distributed_generate_encryption_key>` used to encrypt communication between cluster nodes. It should be the same on all the server nodes. To generate a unique key you can use the command ``openssl rand -hex 16``.
    -  :ref:`port <cluster_port>` indicates the destination port for cluster communication. Leave the default as ``1516``.
    -  :ref:`bind_addr <cluster_bind_addr>` is the network IP to which the node is bound to listen for incoming requests (0.0.0.0 means the node will use any IP).
-   -  :ref:`nodes <cluster_nodes>` is the address of the master node and can be either an IP or a DNS hostname. This parameter must be specified in all nodes, including the master itself. Replace ``<MASTER_NODE_IP>`` with the IP address of your master node.
+   -  :ref:`nodes <cluster_nodes>` is the address of the master node and can be either an IP or a DNS hostname. This parameter must be specified in all nodes, including the master itself. Replace ``<MASTER_NODE_IP_ADDRESS>`` with the IP address of your master node.
    -  :ref:`hidden <cluster_hidden>` shows or hides the cluster information in the generated alerts.
    -  :ref:`disabled <cluster_disabled>` indicates whether the node is enabled or disabled in the cluster. This option must be set to ``no``.
 

--- a/source/user-manual/user-administration/ldap.rst
+++ b/source/user-manual/user-administration/ldap.rst
@@ -53,11 +53,11 @@ Authentication and authorization configuration
 
 The ``auhtc`` section of the Wazuh indexer security configuration file handles authentication, while the ``authz`` section handles authorization. We recommend that you back up the ``/etc/wazuh-indexer/opensearch-security/config.yml`` file before you carry out this configuration.
 
-#. Save the LDAP server certificate. If you don’t have access to the root CA file of the LDAP server, run the following command on the Wazuh indexer node to retrieve the certificate. Replace ``<FQDN-LDAP-SERVER>`` with the Fully Qualified Domain Name of your LDAP server:
+#. Save the LDAP server certificate. If you don’t have access to the root CA file of the LDAP server, run the following command on the Wazuh indexer node to retrieve the certificate. Replace ``<FQDN_LDAP_SERVER>`` with the Fully Qualified Domain Name of your LDAP server:
 
    .. code-block:: console
 
-      $ echo -n | openssl s_client -connect <FQDN-LDAP-SERVER>:636 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > ldapcacert.pem
+      $ echo -n | openssl s_client -connect <FQDN_LDAP_SERVER>:636 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > ldapcacert.pem
 
    The command copies everything between ``-----BEGIN CERTIFICATE-----`` and ``-----END CERTIFICATE-----`` (including these delimiters) and saves it in a new text file.
 
@@ -93,7 +93,7 @@ The ``auhtc`` section of the Wazuh indexer security configuration file handles a
                  enable_ssl_client_auth: false
                  verify_hostnames: true
                  hosts:
-                 - <FQDN-LDAP-SERVER>:636 #Port 389 for LDAP, 636 for LDAPS
+                 - <FQDN_LDAP_SERVER>:636 #Port 389 for LDAP, 636 for LDAPS
                  bind_dn: cn=admin,dc=example,dc=org
                  password: <PASSWORD>
                  userbase: 'ou=people,dc=example,dc=org'
@@ -119,7 +119,7 @@ The ``auhtc`` section of the Wazuh indexer security configuration file handles a
                  enable_ssl_client_auth: false
                  verify_hostnames: true
                  hosts:
-                 - <FQDN-LDAP-SERVER>:636 #Port 389 for LDAP, 636 for LDAPS
+                 - <FQDN_LDAP_SERVER>:636 #Port 389 for LDAP, 636 for LDAPS
                  bind_dn: cn=admin,dc=example,dc=org
                  password: <PASSWORD>
                  userbase: 'ou=people,dc=example,dc=org'

--- a/source/user-manual/user-administration/password-management.rst
+++ b/source/user-manual/user-administration/password-management.rst
@@ -200,12 +200,12 @@ Follow the instructions below to change the passwords for all the Wazuh indexer 
       INFO: The password for user snapshotrestore is Mb2EHw8SIc1d.oz.nM?dHiPBGk7s?UZB
       WARNING: Wazuh indexer passwords changed. Remember to update the password in the Wazuh dashboard and Filebeat nodes if necessary, and restart the services.
 
-#. On your `Wazuh server master node`, download the Wazuh passwords tool and use it to change the passwords of the Wazuh API users. Replace ``<wazuh-password>`` with the *wazuh* user password. 
+#. On your `Wazuh server master node`, download the Wazuh passwords tool and use it to change the passwords of the Wazuh API users. Replace ``<WAZUH_PASSWORD>`` with the *wazuh* user password. 
 
    .. code-block:: console
   
       # curl -sO https://packages.wazuh.com/|WAZUH_CURRENT_MINOR|/wazuh-passwords-tool.sh
-      # bash wazuh-passwords-tool.sh --change-all --admin-user wazuh --admin-password <wazuh-password>
+      # bash wazuh-passwords-tool.sh --change-all --admin-user wazuh --admin-password <WAZUH_PASSWORD>
   
    .. code-block:: console
       :class: output
@@ -213,11 +213,11 @@ Follow the instructions below to change the passwords for all the Wazuh indexer 
       INFO: The password for Wazuh API user wazuh is ivLOfmj7.jL6*7Ev?UJoFjrkGy9t6Je.
       INFO: The password for Wazuh API user wazuh-wui is fL+f?sFRPEv5pYRE559rqy9b6G4Z5pVi
 
-#. On `all your Wazuh server nodes`, run the following command to update the `admin` password in the Filebeat keystore. Replace ``<admin-password>`` with the random password generated in the first step.
+#. On `all your Wazuh server nodes`, run the following command to update the `admin` password in the Filebeat keystore. Replace ``<ADMIN_PASSWORD>`` with the random password generated in the first step.
       
    .. code-block:: console
 
-      # echo <admin-password> | filebeat keystore add password --stdin --force
+      # echo <ADMIN_PASSWORD> | filebeat keystore add password --stdin --force
 
 #. Restart Filebeat to apply the change.
 
@@ -225,11 +225,11 @@ Follow the instructions below to change the passwords for all the Wazuh indexer 
 
    .. note:: Repeat steps 3 and 4 on `every Wazuh server node`.
        
-#. On your `Wazuh dashboard node`, run the following command to update the `kibanaserver` password in the Wazuh dashboard keystore. Replace ``<kibanaserver-password>`` with the random password generated in the first step.
+#. On your `Wazuh dashboard node`, run the following command to update the `kibanaserver` password in the Wazuh dashboard keystore. Replace ``<KIBANASERVER_PASSWORD>`` with the random password generated in the first step.
 
    .. code-block:: console
 
-      # echo <kibanaserver-password> | /usr/share/wazuh-dashboard/bin/opensearch-dashboards-keystore --allow-root add -f --stdin opensearch.password
+      # echo <KIBANASERVER_PASSWORD> | /usr/share/wazuh-dashboard/bin/opensearch-dashboards-keystore --allow-root add -f --stdin opensearch.password
 
 #. Update the ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` configuration file with the new `wazuh-wui` password generated in the second step.
 

--- a/source/user-manual/user-administration/single-sign-on/administrator/keycloak.rst
+++ b/source/user-manual/user-administration/single-sign-on/administrator/keycloak.rst
@@ -54,7 +54,7 @@ KeyCloak configuration
       - **Canonicalization method**: ``EXCLUSIVE``
       - **Front channel logout**: ``ON``
 
-      Replace the ``WAZUH_DASHBOARD_URL`` field with the corresponding URL of your Wazuh dashboard instance.
+      Replace the ``<WAZUH_DASHBOARD_URL>`` field with the corresponding URL of your Wazuh dashboard instance.
 
       The configuration must be similar to the highlighted blue rectangles:   
 

--- a/source/user-manual/user-administration/single-sign-on/read-only/keycloak.rst
+++ b/source/user-manual/user-administration/single-sign-on/read-only/keycloak.rst
@@ -54,7 +54,7 @@ KeyCloak configuration
       - **Canonicalization method**: ``EXCLUSIVE``
       - **Front channel logout**: ``ON``
 
-      Replace the ``WAZUH_DASHBOARD_URL`` field with the corresponding URL of your Wazuh dashboard instance.
+      Replace the ``<WAZUH_DASHBOARD_URL>`` field with the corresponding URL of your Wazuh dashboard instance.
 
       The configuration must be similar to the highlighted blue rectangles:   
 

--- a/source/user-manual/wazuh-dashboard/configuring-third-party-certs/ssl-nginx.rst
+++ b/source/user-manual/wazuh-dashboard/configuring-third-party-certs/ssl-nginx.rst
@@ -150,7 +150,7 @@ Configure the proxy and the certificates
          server_name <YOUR_DOMAIN_NAME>;
 
          location / {
-            proxy_pass https://<WAZUH_DASHBOARD_IP>:<PORT_NUMBER>;
+            proxy_pass https://<WAZUH_DASHBOARD_IP_ADDRESS>:<PORT_NUMBER>;
             proxy_set_header Host $host;
          }
       }
@@ -158,7 +158,7 @@ Configure the proxy and the certificates
    Replace the following:
 
    - ``<YOUR_DOMAIN_NAME>`` with your domain name.
-   - ``<WAZUH_DASHBOARD_IP>`` with your Wazuh dashboard IP address.
+   - ``<WAZUH_DASHBOARD_IP_ADDRESS>`` with your Wazuh dashboard IP address.
    - ``<PORT_NUMBER>`` with your new port number.
 
 #. Restart the Wazuh dashboard and the Wazuh server
@@ -184,7 +184,7 @@ Configure the proxy and the certificates
          server_name <YOUR_DOMAIN_NAME>;
 
          location / {
-            proxy_pass https://<WAZUH_DASHBOARD_IP>:<PORT_NUMBER>;
+            proxy_pass https://<WAZUH_DASHBOARD_IP_ADDRESS>:<PORT_NUMBER>;
             proxy_set_header Host $host;
          }
 

--- a/source/user-manual/wazuh-indexer/migrating-wazuh-indices.rst
+++ b/source/user-manual/wazuh-indexer/migrating-wazuh-indices.rst
@@ -95,11 +95,11 @@ Perform the following steps on the Wazuh indexer node (s) to complete the shared
 
             # apt -y install nfs-common
 
-#. Mount the shared directory ``/mnt/snapshots`` on the Wazuh indexer node(s). Replace the ``<SERVER_IP>`` variable with the IP address of the NFS server:
+#. Mount the shared directory ``/mnt/snapshots`` on the Wazuh indexer node(s). Replace the ``<SERVER_IP_ADDRESS>`` variable with the IP address of the NFS server:
 
    .. code-block:: console
 
-      # mount -t nfs <SERVER_IP>:/mnt/snapshots /mnt/snapshots
+      # mount -t nfs <SERVER_IP_ADDRESS>:/mnt/snapshots /mnt/snapshots
 
 #. Grant the ``wazuh-indexer`` user ownership of the ``/mnt/snapshots`` directory:
 


### PR DESCRIPTION
## Description
This PR adapts the format of some of the placeholders to comply with the current Wazuh documentation style for placeholders.

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
