### PR TITLE
Add logformat journald to localfile reference

### DIFF
--- a/source/user-manual/reference/ossec-conf/localfile.rst
+++ b/source/user-manual/reference/ossec-conf/localfile.rst
@@ -102,11 +102,6 @@ Below we have some Windows wildcard examples.
       <log_format>syslog</log_format>
   </localfile>
 
-+--------------------+--------------------------+
-| **Default value**  | n/a                      |
-+--------------------+--------------------------+
-| **Allowed values** | Any log file or wildcard |
-+--------------------+--------------------------+
 
 .. note::
   * ``strftime`` format strings and wildcards cannot be used on the same entry.
@@ -707,6 +702,7 @@ You can use the ``ignore_if_missing`` attribute to ignore logs without the speci
 
 +-----------------------+--------------------------------------------------------------------------------------------------------------+
 | **ignore_if_missing** | When the attribute `ignore_if_missing` is set to `yes` it ignores the filter if the field does not exist.    |
+|                       | If is set to `no` and the field does not exist, the filter will fail and the log will be ignored.            |
 +                       +------------------+-------------------------------------------------------------------------------------------+
 |                       | Default value    | no                                                                                        |
 |                       +------------------+-------------------------------------------------------------------------------------------+
@@ -714,11 +710,19 @@ You can use the ``ignore_if_missing`` attribute to ignore logs without the speci
 +-----------------------+------------------+-------------------------------------------------------------------------------------------+
 
 
-Configuration example:
+In the following example configuration the journald logs will be collected if any of the following conditions are met:
+  - Field `_SYSTEMD_UNIT` exists and its value is `ssh.service`.
+  - Field `_SYSTEMD_UNIT` exists and its value is `cron.service` and if the field `PRIORITY` exists, it has the value 0,1,2 or 3.
 
 .. code-block:: xml
 
     <!-- For monitoring log files -->
+    <localfile>
+      <location>journald</location>
+      <log_format>journald</log_format>
+      <filter field="_SYSTEMD_UNIT">^ssh.service$</filter>
+    <localfile>
+
     <localfile>
       <location>journald</location>
       <log_format>journald</log_format>

--- a/source/user-manual/reference/ossec-conf/localfile.rst
+++ b/source/user-manual/reference/ossec-conf/localfile.rst
@@ -63,7 +63,6 @@ The ``location`` field specifies where the log data comes from. It includes the 
 
 For log file names, you can use ``strftime`` format strings. For example, you can reference a log file named ``file.log-2024-04-26`` by ``file.log-%Y-%m-%d``.
 
-
 Wildcards can be used on Linux and Windows systems, if the log file doesn't exist at ``wazuh-logcollector`` start time, such log will be re-scanned after ``logcollector.vcheck_files`` seconds.
 
 The location field is also valid to filter by channel in case of using an ``eventchannel`` supporting Windows.
@@ -101,7 +100,6 @@ Below we have some Windows wildcard examples.
       <location>C:\logs\file-%Y-%m-%d.log</location>
       <log_format>syslog</log_format>
   </localfile>
-
 
 .. note::
   * ``strftime`` format strings and wildcards cannot be used on the same entry.
@@ -691,28 +689,27 @@ Collects ``journald`` logs selectively by filtering specific fields.
 
 You must specify a PCRE2 regex pattern as your filter. Use the ``field`` attribute to define the journald field where to apply the regular expression.
 
-
 +--------------------+---------------------------------------------------------------+
 | **Default Value**  | n/a                                                           |
 +--------------------+---------------------------------------------------------------+
 | **Allowed values** | Any :ref:`PCRE2 <pcre2_syntax>` expression.                   |
 +--------------------+---------------------------------------------------------------+
 
-You can use the ``ignore_if_missing`` attribute to ignore logs without the specified field.
+You can use the ``ignore_if_missing`` attribute to ignore the filtering condition for logs without the specified field.
 
 +-----------------------+--------------------------------------------------------------------------------------------------------------+
-| **ignore_if_missing** | When the attribute `ignore_if_missing` is set to `yes` it ignores the filter if the field does not exist.    |
-|                       | If is set to `no` and the field does not exist, the filter will fail and the log will be ignored.            |
+| **ignore_if_missing** | When set to ``yes``, it accepts logs without the specified field. Conversely, when set to ``no``,            |
+|                       | logs without the specified field fail to meet the filtering criteria and are disregarded.                    |
 +                       +------------------+-------------------------------------------------------------------------------------------+
 |                       | Default value    | no                                                                                        |
 |                       +------------------+-------------------------------------------------------------------------------------------+
 |                       | Allowed values   | no, yes                                                                                   |
 +-----------------------+------------------+-------------------------------------------------------------------------------------------+
 
+In the following configuration example Wazuh collects the ``journald`` logs if any of the following conditions are met.
 
-In the following example configuration the journald logs will be collected if any of the following conditions are met:
-  - Field `_SYSTEMD_UNIT` exists and its value is `ssh.service`.
-  - Field `_SYSTEMD_UNIT` exists and its value is `cron.service` and if the field `PRIORITY` exists, it has the value 0,1,2 or 3.
+-  The field ``_SYSTEMD_UNIT`` is present with the value ``ssh.service``.
+-  The field ``_SYSTEMD_UNIT`` is present with the value ``cron.service`` and the field ``PRIORITY`` is present with the value ``0``, ``1``, ``2``, or ``3``.
 
 .. code-block:: xml
 
@@ -731,7 +728,8 @@ In the following example configuration the journald logs will be collected if an
     <localfile>
 
 .. note::
-    Filters within the same `<localfile>` block follow an AND logic, while multiple blocks are evaluated in OR logic regarding log collection.
+
+   Filters within the same ``<localfile>`` block follow an AND logic, while multiple blocks are evaluated in OR logic regarding log collection.
 
 
 Configuration examples

--- a/source/user-manual/reference/ossec-conf/localfile.rst
+++ b/source/user-manual/reference/ossec-conf/localfile.rst
@@ -43,11 +43,26 @@ Options
 location
 ^^^^^^^^
 
-The location field specifies where the log data comes from. This can be a path to a log file, a Windows event channel, macos, or a journald system.
+The ``location`` field specifies where the log data comes from. It includes the following options.
 
-Option to get the location of a log or a group of logs. ``strftime`` format strings may be used for log file names.
+-  A path to a log file
+-  A Windows event channel
+-  The macOS ULS
+-  The ``journald`` system
 
-For instance, a log file named ``file.log-2019-07-30`` can be referenced with ``file.log-%Y-%m-%d`` (assuming today is July 30th, 2019).
++--------------------+----------------------------------------------------------+
+| **Default value**  | n/a                                                      |
++--------------------+----------------------------------------------------------+
+| **Allowed values** | File path, Event channel, ``macos``, ``journald``        |
++--------------------+----------------------------------------------------------+
+
+.. note::
+
+   -  To collect logs from the macOS ULS, you must set both ``location`` and ``log_format`` to ``macos``.
+   -  To collect logs from the ``journald`` system, you must set both ``location`` and ``log_format`` to ``journald``.
+
+For log file names, you can use ``strftime`` format strings. For example, you can reference a log file named ``file.log-2024-04-26`` by ``file.log-%Y-%m-%d``.
+
 
 Wildcards can be used on Linux and Windows systems, if the log file doesn't exist at ``wazuh-logcollector`` start time, such log will be re-scanned after ``logcollector.vcheck_files`` seconds.
 
@@ -98,8 +113,6 @@ Below we have some Windows wildcard examples.
 
   * On Windows systems, only character ``*`` is supported as a wildcard. For instance ``*ANY_STRING*``, will match all files that have ``ANY_STRING`` inside its name, another example is ``*.log`` this will match any log file.
   * The maximum amount of files monitored at same time is limited to 1000.
-  * When setting ``log_format`` to ``macos``, ``location`` should also be set to ``macos``.
-  * When setting ``log_format`` to ``journald``, ``location`` should also be set to ``journald``.
 
 .. _command:
 
@@ -337,9 +350,7 @@ Set the format of the log to be read. **field is required**
 |                    |                    | Monitors all the logs that match the query filter.                                               |
 |                    |                    | See :ref:`How to collect macOS ULS logs <how-to-collect-macoslogs>`.                             |
 +                    +--------------------+--------------------------------------------------------------------------------------------------+
-|                    | journald           | Used to monitor all systemd-journal events, collecting them in syslog format.                    |
-|                    |                    |                                                                                                  |
-|                    |                    | See `How to collect systemd-joyrnald logs <how-to-collect-journald>`.                            |
+|                    | journald           | Required to monitor systemd-journal events. Events are collected in syslog format.               |
 +                    +--------------------+--------------------------------------------------------------------------------------------------+
 |                    | audit              | Used for events from Auditd.                                                                     |
 |                    |                    |                                                                                                  |
@@ -681,17 +692,18 @@ For example, to restrict syslog events related to a particular user name:
 filter
 ^^^^^^
 
-The `filter` tag is used to include PCRE2 regex filters for selectively collecting logs based on specific fields within `journald`.
-Each filter must specify a field and a regex pattern. The `ignore_if_missing` attribute can be used to indicate whether to ignore logs where the specified field is missing.
+Collects ``journald`` logs selectively by filtering specific fields.
+
+You must specify a PCRE2 regex pattern as your filter. Use the ``field`` attribute to define the journald field where to apply the regular expression.
 
 
 +--------------------+---------------------------------------------------------------+
 | **Default Value**  | n/a                                                           |
 +--------------------+---------------------------------------------------------------+
-| **Allowed values** | Any `PCRE2 <regex.html#pcre2-syntax>`_ expression.            |
+| **Allowed values** | Any :ref:`PCRE2 <pcre2_syntax>` expression.                   |
 +--------------------+---------------------------------------------------------------+
 
-Use the `field` attribute to define in which journald field to apply the regex (Mandatory).
+You can use the ``ignore_if_missing`` attribute to ignore logs without the specified field.
 
 +-----------------------+--------------------------------------------------------------------------------------------------------------+
 | **ignore_if_missing** | When the attribute `ignore_if_missing` is set to `yes` it ignores the filter if the field does not exist.    |


### PR DESCRIPTION
Closes #7201



## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
