### PR TITLE
Changed API configuration step in offline documentation

### DIFF
--- a/source/deployment-options/offline-installation.rst
+++ b/source/deployment-options/offline-installation.rst
@@ -166,11 +166,11 @@ Installing the Wazuh indexer
 
         # /usr/share/wazuh-indexer/bin/indexer-security-init.sh
   
-#. Run the following command to check that the installation is successful. Note that this command uses localhost, set your Wazuh indexer address if necessary. 
+#. Run the following command to check that the installation is successful. Note that this command uses ``127.0.0.1``, set your Wazuh indexer address if necessary. 
 
    .. code-block:: console
 
-      # curl -XGET https://localhost:9200 -u admin:admin -k
+      # curl -XGET https://127.0.0.1:9200 -u admin:admin -k
 
    Expand the output to see an example response.
 
@@ -437,21 +437,21 @@ Installing the Wazuh dashboard
 
              server.host: 0.0.0.0
              server.port: 443
-             opensearch.hosts: https://localhost:9200
+             opensearch.hosts: https://127.0.0.1:9200
              opensearch.ssl.verificationMode: certificate
 
 #.  Enable and start the Wazuh dashboard.
 
     .. include:: /_templates/installations/dashboard/enable_dashboard.rst
 
-#.  Edit the file ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` and replace the ``url`` value with the IP address or hostname of the Wazuh server master node.
+#. Edit the file ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` and replace the ``url`` value with the IP address or hostname of the Wazuh server master node.
 
             .. code-block:: yaml
                :emphasize-lines: 3
 
                hosts:
                  - default:
-                     url: https://<wazuh_server_ip>
+                     url: https://<WAZUH_SERVER_IP_ADDRESS>
                      port: 55000
                      username: wazuh-wui
                      password: wazuh-wui
@@ -463,7 +463,7 @@ Installing the Wazuh dashboard
 
 #.  Access the web interface.
 
-    -   URL: *https://<wazuh_dashboard_ip>*
+    -   URL: *https://<WAZUH_DASHBOARD_IP_ADDRESS>*
     -   **Username**: admin
     -   **Password**: admin
 
@@ -525,19 +525,19 @@ Select your deployment type and follow the instructions to change the default pa
 
 
 
-      #. On your `Wazuh server master node`, change the default password of the admin users: `wazuh` and `wazuh-wui`. Note that the commands below use localhost, set your Wazuh manager IP address if necessary.
+      #. On your `Wazuh server master node`, change the default password of the admin users: `wazuh` and `wazuh-wui`. Note that the commands below use 127.0.0.1, set your Wazuh manager IP address if necessary.
 
          #. Get an authorization TOKEN.
 
             .. code-block:: console
 
-               # TOKEN=$(curl -u wazuh-wui:wazuh-wui -k -X GET "https://localhost:55000/security/user/authenticate?raw=true")
+               # TOKEN=$(curl -u wazuh-wui:wazuh-wui -k -X GET "https://127.0.0.1:55000/security/user/authenticate?raw=true")
 
          #. Change the `wazuh` user credentials (ID 1). Select a password between 8 and 64 characters long, it should contain at least one uppercase and one lowercase letter, a number, and a symbol. See :api-ref:`PUT /security/users/{user_id} <operation/api.controllers.security_controller.update_user>` to learn more.
 
             .. code-block:: console
 
-               curl -k -X PUT "https://localhost:55000/security/users/1" -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -d'
+               curl -k -X PUT "https://127.0.0.1:55000/security/users/1" -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -d'
                {
                  "password": "SuperS3cretPassword!"
                }'
@@ -552,7 +552,7 @@ Select your deployment type and follow the instructions to change the default pa
 
             .. code-block:: console
 
-               curl -k -X PUT "https://localhost:55000/security/users/2" -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -d'
+               curl -k -X PUT "https://127.0.0.1:55000/security/users/2" -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -d'
                {
                  "password": "SuperS3cretPassword!"
                }'
@@ -592,7 +592,7 @@ Select your deployment type and follow the instructions to change the default pa
 
             hosts:
               - default:
-                  url: https://localhost
+                  url: https://127.0.0.1
                   port: 55000
                   username: wazuh-wui
                   password: "<wazuh-wui-password>"

--- a/source/deployment-options/offline-installation.rst
+++ b/source/deployment-options/offline-installation.rst
@@ -444,14 +444,14 @@ Installing the Wazuh dashboard
 
     .. include:: /_templates/installations/dashboard/enable_dashboard.rst
 
-#. **Only for distributed deployments**:  Edit the file ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` and replace the ``url`` value with the IP address or hostname of the Wazuh server master node.
+#.  Edit the file ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` and replace the ``url`` value with the IP address or hostname of the Wazuh server master node.
 
             .. code-block:: yaml
                :emphasize-lines: 3
 
                hosts:
                  - default:
-                     url: https://localhost
+                     url: https://<wazuh_server_ip>
                      port: 55000
                      username: wazuh-wui
                      password: wazuh-wui
@@ -463,7 +463,7 @@ Installing the Wazuh dashboard
 
 #.  Access the web interface.
 
-    -   URL: *https://<wazuh_server_ip>*
+    -   URL: *https://<wazuh_dashboard_ip>*
     -   **Username**: admin
     -   **Password**: admin
 

--- a/source/installation-guide/wazuh-dashboard/step-by-step.rst
+++ b/source/installation-guide/wazuh-dashboard/step-by-step.rst
@@ -98,9 +98,6 @@ Starting the Wazuh dashboard service
 
       .. include:: /_templates/installations/dashboard/enable_dashboard.rst
 
-      
-       
-      
   #. Edit the ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` file and replace the ``url`` value with the IP address or hostname of the Wazuh server master node.
    
       .. code-block:: yaml
@@ -108,7 +105,7 @@ Starting the Wazuh dashboard service
       
          hosts:
             - default:
-               url: https://<wazuh_server_ip>
+               url: https://<WAZUH_SERVER_IP_ADDRESS>
                port: 55000
                username: wazuh-wui
                password: wazuh-wui
@@ -117,7 +114,7 @@ Starting the Wazuh dashboard service
 
   #. Access the Wazuh web interface with your credentials.
 
-      - URL: *https://<wazuh-dashboard-ip>*
+      - URL: *https://<WAZUH_DASHBOARD_IP_ADDRESS>*
       - **Username**: *admin*
       - **Password**: *admin*
 
@@ -216,7 +213,7 @@ Select your deployment type and follow the instructions to change the default pa
            
             hosts:
               - default:
-                  url: https://localhost
+                  url: https://127.0.0.1
                   port: 55000
                   username: wazuh-wui
                   password: "<wazuh-wui-password>"

--- a/source/installation-guide/wazuh-dashboard/step-by-step.rst
+++ b/source/installation-guide/wazuh-dashboard/step-by-step.rst
@@ -99,20 +99,20 @@ Starting the Wazuh dashboard service
       .. include:: /_templates/installations/dashboard/enable_dashboard.rst
 
       
-      **Only for distributed deployments**  
+       
       
-          Edit the ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` file and replace the ``url`` value with the IP address or hostname of the Wazuh server master node.
-          
-            .. code-block:: yaml
-               :emphasize-lines: 3
-            
-               hosts:
-                 - default:
-                     url: https://localhost
-                     port: 55000
-                     username: wazuh-wui
-                     password: wazuh-wui
-                     run_as: false
+  #. Edit the ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` file and replace the ``url`` value with the IP address or hostname of the Wazuh server master node.
+   
+      .. code-block:: yaml
+         :emphasize-lines: 3
+      
+         hosts:
+            - default:
+               url: https://<wazuh_server_ip>
+               port: 55000
+               username: wazuh-wui
+               password: wazuh-wui
+               run_as: false
 
 
   #. Access the Wazuh web interface with your credentials.


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
<!--
Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->
Closes: https://github.com/wazuh/wazuh-documentation/issues/7225

The aim of this to change the `localhost` value of the `/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml` file of the Wazuh offline documentation and the Step-by-step documentation of the Wazuh dashboard installation.

This change is done because we do not support the `localhost` value in that file due to https://github.com/wazuh/wazuh-packages/issues/2771. This also implies to remove the `Only for distributed deployments` note.
 
Also, I flxed a typo in the Offline documentation.


![Screenshot from 2024-04-25 12-25-05](https://github.com/wazuh/wazuh-documentation/assets/72193239/e2a4a1d7-b7e4-4cc6-8287-e7ac8e55e178)
![Screenshot from 2024-04-25 12-25-16](https://github.com/wazuh/wazuh-documentation/assets/72193239/7ea77456-9ae4-47fe-89f2-5ec468400c89)


## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
