### PR TITLE
Improve vulnerability detector section

### DIFF
--- a/source/user-manual/reference/ossec-conf/vuln-detector.rst
+++ b/source/user-manual/reference/ossec-conf/vuln-detector.rst
@@ -6,6 +6,10 @@
 vulnerability-detection
 =======================
 
+.. note::
+
+   This section applies for 4.8.0 and later versions of the Wazuh. If you are using an older version, this section is called `vulnerability-detector`.
+
 This section covers the configuration for the :doc:`/user-manual/capabilities/vulnerability-detection/index` module.
 
 .. topic:: XML section name

--- a/source/user-manual/reference/ossec-conf/vuln-detector.rst
+++ b/source/user-manual/reference/ossec-conf/vuln-detector.rst
@@ -8,7 +8,7 @@ vulnerability-detection
 
 .. note::
 
-   This section applies for 4.8.0 and later versions of the Wazuh. If you are using an older version, this section is called `vulnerability-detector`.
+   This section applies to 4.8.0 and later versions of Wazuh. If you use an older version, this section is called `vulnerability-detector`.
 
 This section covers the configuration for the :doc:`/user-manual/capabilities/vulnerability-detection/index` module.
 

--- a/source/user-manual/reference/ossec-conf/vuln-detector.rst
+++ b/source/user-manual/reference/ossec-conf/vuln-detector.rst
@@ -6,18 +6,18 @@
 vulnerability-detection
 =======================
 
-.. note::
-
-   This section applies to 4.8.0 and later versions of Wazuh. If you use an older version, this section is called `vulnerability-detector`.
-
 This section covers the configuration for the :doc:`/user-manual/capabilities/vulnerability-detection/index` module.
 
 .. topic:: XML section name
 
-	.. code-block:: xml
+   .. note::
 
-		<vulnerability-detection>
-		</vulnerability-detection>
+      In Wazuh 4.8.0, we rename the previous ``<vulnerability-detector>`` tag to ``<vulnerability-detection>``.
+
+   .. code-block:: xml
+
+      <vulnerability-detection>
+      </vulnerability-detection>
 
 Options
 -------


### PR DESCRIPTION
# Objetive

This PR addresses the need to mark the new section as part of `4.8.0`, adding a note at the beginning of the current [vulnerability-detection](https://github.com/wazuh/wazuh-documentation/blob/4.8.0/source/user-manual/reference/ossec-conf/vuln-detector.rst) section.