### PR TITLE
Add note related to 'never,task' rule in auditd

### DIFF
--- a/source/user-manual/capabilities/file-integrity/advanced-settings.rst
+++ b/source/user-manual/capabilities/file-integrity/advanced-settings.rst
@@ -71,10 +71,6 @@ In most systems, auditd includes a rule to skip processing of every audit rule b
 
 #. Check the output of this command to find out if the auditd rules include the ``-a never,task`` rule.
 
-   Link to auditd Linux manual: https://man7.org/linux/man-pages/man8/auditctl.8.html#DISABLED_BY_DEFAULT
- 
-   Check auditd rules:
- 
    .. code-block:: console
  
       # auditctl -l | grep task

--- a/source/user-manual/capabilities/file-integrity/advanced-settings.rst
+++ b/source/user-manual/capabilities/file-integrity/advanced-settings.rst
@@ -67,7 +67,34 @@ You need to install the audit daemon if you don’t have it already installed on
          # cp /usr/sbin/audisp-af_unix /sbin/audisp-af_unix
          # rc-service auditd restart
 
-Perform the following steps to enable who-data monitoring. In this example, you configure who-data monitoring for ``/etc`` directory.
+In most systems, auditd includes a rule to skip processing of every audit rule by default. This setting prevents the reporting of any whodata-related information. To ensure that auditd is not `DISABLED BY DEFAULT <https://man7.org/linux/man-pages/man8/auditctl.8.html#DISABLED_BY_DEFAULT>`__, follow these steps.
+
+#. Check the output of this command to find out if the auditd rules include the ``-a never,task`` rule.
+
+   Link to auditd Linux manual: https://man7.org/linux/man-pages/man8/auditctl.8.html#DISABLED_BY_DEFAULT
+ 
+   Check auditd rules:
+ 
+   .. code-block:: console
+ 
+      # auditctl -l | grep task
+ 
+#. If the output displays the ``-a never,task`` rule, add the following filter rule in ``/etc/audit/rules.d/audit.rules``. Make sure to place it before the mentioned rule.
+ 
+   .. code-block:: none
+      :emphasize-lines: 1
+ 
+      -a always,task -F exe=‘/var/ossec/bin/wazuh-syscheckd’
+      -a never,task
+ 
+#. After that, restart auditd and Wazuh agent to apply the changes:
+ 
+   .. code-block:: console
+ 
+      # systemctl restart auditd
+      # systemctl restart wazuh-agent
+ 
+Next, perform the following steps to enable who-data monitoring. In this example, you configure who-data monitoring for the ``/etc/`` directory.
 
 #. Edit the Wazuh agent ``/var/ossec/etc/ossec.conf`` configuration file and add the configuration below:
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
In this PR we are adding a note in the advanced settings of FIM to warn that in some systems auditd comes by default with a rule that prevents Wazuh (and any other process) of the audit rules from working properly.

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
