### PR TITLE
Coredump generation config on Windows endpoints

### DIFF
--- a/source/development/coredump.rst
+++ b/source/development/coredump.rst
@@ -117,3 +117,36 @@ On macOS, most applications have core dump generation disabled by default. Howev
       # sysctl -w kern.corefile=/cores/core.%P
 
 Enabling core dump generation might consume significant disk space, so use it judiciously. Moreover, not all processes on macOS support or behave consistently with core dump generation.
+
+Windows endpoints
+-----------------
+
+To collect user-mode dumps on Windows, you can use the built-in Windows Error Reporting (WER) feature. Here's how you can set it up:
+
+* Open Registry Editor:
+    Press Win + R to open the Run dialog.
+
+* Type regedit and press Enter to open the Registry Editor.
+    Navigate to the Registry Key:
+
+* In the Registry Editor, navigate to the following key:
+    HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps
+
+  If the LocalDumps key doesn't exist, you may need to create it.
+
+* Create Dump Settings:
+    Right-click on the LocalDumps key and choose New > Key.
+    Name the new key with the executable name of the process for which you want to collect dumps. For example, if you want to collect dumps for Notepad.exe, name the key Notepad.exe.
+    Inside the newly created key, you can set various values to configure dump collection:
+    DumpFolder: Specify the folder where you want the dump files to be saved.
+    DumpType: Set the type of dump to collect. For user-mode dumps, set the value to 2.
+    CustomDumpFlags: You can set additional flags here if needed.
+
+* Configure Dump File Settings:
+    Set the DumpFolder value to the folder path where you want to save the dump files.
+    Set the DumpType value to 2 to specify user-mode dumps.
+
+* Restart the Application:
+    Restart the application or process for which you've configured the dump settings. The changes will take effect the next time the application encounters an unhandled exception.
+
+Remember to be cautious when modifying the Windows Registry. Incorrect changes can cause system instability or other issues. Always backup the registry or create a system restore point before making changes.

--- a/source/development/coredump.rst
+++ b/source/development/coredump.rst
@@ -120,41 +120,38 @@ Enabling core dump generation might consume significant disk space, so use it ju
 
 Windows endpoints
 -----------------
-    .. note:: Remember to be cautious when modifying the Windows Registry. Incorrect changes can cause system instability or other issues. Always backup the registry or create a system restore point before making changes.
 
-To collect user-mode dumps on Windows, you can use the built-in Windows Error Reporting (WER) feature. Here's how you can set it up:
+To collect user-mode crash dumps on Windows, you can use the Windows Error Reporting (WER) feature. You can set it to save crash dump files locally by editing the Windows Registry as follows.
 
-#. **Windows + R** keys on your keyboard to open the run dialog box.
+Accessing the Windows Registry
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-#. Type **regedit** in the search box and click **OK** to open the registry editor.
+#. Press **Windows + R** keys on your keyboard to open the **Run** dialog box.
 
-#. Navigate to the Registry Key:
+#. Type ``regedit`` in the search box and click **OK** to open the Registry editor.
+
+#. `Backup the Windows Registry <https://support.microsoft.com/en-us/topic/how-to-back-up-and-restore-the-registry-in-windows-855140ad-e318-2a13-2829-d428a2ab0692>`__ or `create a system restore point <https://support.microsoft.com/en-us/windows/create-a-system-restore-point-77e02e2a-3298-c869-9974-ef5658ea3be9>`__ to safeguard your system.
+
+Configuring Windows Error Reporting
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+#. Navigate to the ``LocalDumps`` registry key or create it, as it might not exist by default.
 
    .. code-block:: none
 
-        HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps
+      HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps
 
-   .. note:: If the ``LocalDumps`` key doesn't exist, you may need to create it.
+#. Right-click on the ``LocalDumps`` key and choose **New** > **Key**. Name the new key ``wazuh-agent.exe``.
 
-#. **Right-click** on the LocalDumps key and choose **New > Key**
+#. Right-click inside the ``wazuh-agent.exe`` key and choose **New** > **Expandable String Value**. Name the new value ``DumpFolder``.
 
-    * Name the new key ``wazuh-agent.exe``
+#. Right-click the ``DumpFolder`` value and select **Modify**. Change it to ``%LOCALAPPDATA%\WazuhCrashDumps``.
 
-   .. note:: Inside the newly created key, you will have to set some property values to configure dump collection
+#. Right-click inside the ``wazuh-agent.exe`` key again and choose **New** > **DWORD (32-bit) Value**. Name the new value ``DumpType``.
 
-#. **Right-click** inside the LocalDumps key and choose **New > Expandable String Value**
-    
-    * Name the new key ``DumpFolder``
-    * Press **Right-click** on the DumpFolder property and choose **Modify**
-    * Change the added string value to ``%LOCALAPPDATA%\WazuhCrashDumps``
+#. Right-click the ``DumpType`` value and select **Modify**. Change it to  ``2``.
 
-#. **Right-click** inside the LocalDumps key and choose **New > DWORD (32-bit) Value**
-
-    * Name the new key ``DumpType``
-    * Press **Right-click** on the DumpType property and choose **Modify**
-    * Change the added number value to ``2``
-
-#. Close the regedit tool and restart the Wazuh agent via PowerShell with administrator privileges:
+#. Close the regedit tool and restart the Wazuh agent using PowerShell with administrator privileges.
 
    .. code-block:: PowerShell
 

--- a/source/development/coredump.rst
+++ b/source/development/coredump.rst
@@ -123,30 +123,40 @@ Windows endpoints
 
 To collect user-mode dumps on Windows, you can use the built-in Windows Error Reporting (WER) feature. Here's how you can set it up:
 
-* Open Registry Editor:
-    Press Win + R to open the Run dialog.
+#. Press **Windows + R** keys on your keyboard to open the run dialog box.
 
-* Type regedit and press Enter to open the Registry Editor.
-    Navigate to the Registry Key:
+#. Type **regedit** in the search box and click **OK** to open the registry editor.
 
-* In the Registry Editor, navigate to the following key:
-    HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps
+#. Navigate to the Registry Key:
 
-  If the LocalDumps key doesn't exist, you may need to create it.
+   .. code-block:: none
 
-* Create Dump Settings:
-    Right-click on the LocalDumps key and choose New > Key.
-    Name the new key with the executable name of the process for which you want to collect dumps. For example, if you want to collect dumps for Notepad.exe, name the key Notepad.exe.
-    Inside the newly created key, you can set various values to configure dump collection:
-    DumpFolder: Specify the folder where you want the dump files to be saved.
-    DumpType: Set the type of dump to collect. For user-mode dumps, set the value to 2.
-    CustomDumpFlags: You can set additional flags here if needed.
+        HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps
 
-* Configure Dump File Settings:
-    Set the DumpFolder value to the folder path where you want to save the dump files.
-    Set the DumpType value to 2 to specify user-mode dumps.
+   .. note:: If the ``LocalDumps`` key doesn't exist, you may need to create it.
 
-* Restart the Application:
-    Restart the application or process for which you've configured the dump settings. The changes will take effect the next time the application encounters an unhandled exception.
+#. Press **Right-click** on the LocalDumps key and choose **New > Key**
+
+    * Name the new key how to ``wazuh-agent.exe``
+
+   .. note:: Inside the newly created key, you will have to set some property values to configure dump collection
+
+#. Press **Right-click** inside the LocalDumps key and choose **New > Expandable String Value**
+    
+    * Name the new key how to ``DumpFolder``
+    * Press **Right-click** on the DumpFolder property and choose **Modify**
+    * Change the added string value to ``%LOCALAPPDATA%\WazuhCrashDumps``
+
+#. Press **Right-click** inside the LocalDumps key and choose **New > DWORD (32-bit) Value**
+
+    * Name the new key how to ``DumpType``
+    * Press **Right-click** on the DumpType property and choose **Modify**
+    * Change the added number value to ``2``
+
+#. Close the regedit tool and restart the Wazuh agent via PowerShell with administrator privileges:
+
+   .. code-block:: PowerShell
+
+      > Restart-Service -Name wazuh
 
 Remember to be cautious when modifying the Windows Registry. Incorrect changes can cause system instability or other issues. Always backup the registry or create a system restore point before making changes.

--- a/source/development/coredump.rst
+++ b/source/development/coredump.rst
@@ -120,10 +120,11 @@ Enabling core dump generation might consume significant disk space, so use it ju
 
 Windows endpoints
 -----------------
+    .. note:: Remember to be cautious when modifying the Windows Registry. Incorrect changes can cause system instability or other issues. Always backup the registry or create a system restore point before making changes.
 
 To collect user-mode dumps on Windows, you can use the built-in Windows Error Reporting (WER) feature. Here's how you can set it up:
 
-#. Press **Windows + R** keys on your keyboard to open the run dialog box.
+#. **Windows + R** keys on your keyboard to open the run dialog box.
 
 #. Type **regedit** in the search box and click **OK** to open the registry editor.
 
@@ -135,21 +136,21 @@ To collect user-mode dumps on Windows, you can use the built-in Windows Error Re
 
    .. note:: If the ``LocalDumps`` key doesn't exist, you may need to create it.
 
-#. Press **Right-click** on the LocalDumps key and choose **New > Key**
+#. **Right-click** on the LocalDumps key and choose **New > Key**
 
-    * Name the new key how to ``wazuh-agent.exe``
+    * Name the new key ``wazuh-agent.exe``
 
    .. note:: Inside the newly created key, you will have to set some property values to configure dump collection
 
-#. Press **Right-click** inside the LocalDumps key and choose **New > Expandable String Value**
+#. **Right-click** inside the LocalDumps key and choose **New > Expandable String Value**
     
-    * Name the new key how to ``DumpFolder``
+    * Name the new key ``DumpFolder``
     * Press **Right-click** on the DumpFolder property and choose **Modify**
     * Change the added string value to ``%LOCALAPPDATA%\WazuhCrashDumps``
 
-#. Press **Right-click** inside the LocalDumps key and choose **New > DWORD (32-bit) Value**
+#. **Right-click** inside the LocalDumps key and choose **New > DWORD (32-bit) Value**
 
-    * Name the new key how to ``DumpType``
+    * Name the new key ``DumpType``
     * Press **Right-click** on the DumpType property and choose **Modify**
     * Change the added number value to ``2``
 
@@ -159,4 +160,3 @@ To collect user-mode dumps on Windows, you can use the built-in Windows Error Re
 
       > Restart-Service -Name wazuh
 
-Remember to be cautious when modifying the Windows Registry. Incorrect changes can cause system instability or other issues. Always backup the registry or create a system restore point before making changes.


### PR DESCRIPTION
| Related Issue |
| -- |
| #7287|
## Description
This pull request aims to conclude the development exposed in the related issue, adding documentation of the process and steps to enable/disable `coredump` generation to be made on Windows O.S. 
### Build output log
```shell
[sphinx-autobuild] > sphinx-build /home/python/docs /home/python/build/html
Running Sphinx v7.0.1
loading translations [en-US]... not available for built-in messages
building [mo]: targets for 0 po files that are out of date                                                                                                                                                         
writing output...                                                                                                                                                                                                  
building [html]: targets for 705 source files that are out of date                                                                                                                                                 
updating environment: [new config] 705 added, 0 changed, 0 removed                                                                                                                                                
reading sources... [100%] user-manual/wazuh-indexer/wazuh-indexer-tuning                                                                                                                                         
Copying static files for wazuh-doc-images...[100%] img/loading.gif                                                                                                                                                 
looking for now-outdated files... none found                                                                                                                                                                       
pickling environment... done                                                                                                                                                                                       
checking consistency... done                                                                                                                                                                                       
preparing documents... done                                                                                                                                                                                        
writing output... [100%] user-manual/wazuh-indexer/wazuh-indexer-tuning                                                                                                                                            
generating indices... done                                                                                                                                                                                         
writing additional pages... not_found moved-content search done                                                                                                                                                    
copying images... [100%] images/manual/wazuh-indexer/indexer-cluster-with-shard-replicas-diagram.png                                                                                                               
copying static files... done                                                                                                                                                                                       
copying extra files... done                                                                                                                                                                                        
dumping search index in English (code: en)... done                                                                                                                                                                 
dumping object inventory... done                                                                                                                                                                                   
build succeeded.                                                                                                                                                                                                   
``` 
### Output
![image](https://github.com/wazuh/wazuh-documentation/assets/93778492/354b1bb6-be2b-4f61-8d46-574e3f265ff2)

### Docs building
- [X] Compiles without warnings.