### PR TITLE
fixed typo of white_list

### DIFF
--- a/source/user-manual/reference/ossec-conf/global.rst
+++ b/source/user-manual/reference/ossec-conf/global.rst
@@ -264,7 +264,7 @@ This sets the memory size for the event correlation engine.
 white_list
 ^^^^^^^^^^
 
-This specifies an IPv4/IPv6 address, netblock, or hostname that will not trigger an active response. Only one of those values may be specified for each ``<while_list>`` tag, but several values may be used by including multiple ``<white_list>`` tags. This configuration is compared against the extracted **srcip** field in the alert.
+This specifies an IPv4/IPv6 address, netblock, or hostname that will not trigger an active response. Only one of those values may be specified for each ``<white_list>`` tag, but several values may be used by including multiple ``<white_list>`` tags. This configuration is compared against the extracted **srcip** field in the alert.
 
 +--------------------+--------------------------------------------------------------------+
 | **Default value**  | n/a                                                                |


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
<!--
Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->
Currently in 4.7 version, there is a typo: <while_list>
Here is the reference: https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/global.html#white-list
![white_list](https://github.com/wazuh/wazuh-documentation/assets/22550682/af4cc1ca-01ae-44dc-9be1-826b033cb8ec)

**Fixed** this to: <white_list>
## Checks
### Docs building
- [X] Compiles without warnings.
### Code formatting and web optimization
- [X] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [X] Uses present tense, active voice, and semi-formal registry.
- [X] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
