### PR TITLE
Add multiple agents group assignment section

### DIFF
--- a/source/user-manual/agent/agent-management/grouping-agents.rst
+++ b/source/user-manual/agent/agent-management/grouping-agents.rst
@@ -362,52 +362,54 @@ In the case of belonging to multiple groups, the configuration files of every gr
 Assigning multiple agents to a group
 ------------------------------------
 
-It's also possible to assign multiple agents to a single group using the **Wazuh API** endpoint :api-ref:`PUT /agents/group <operation/api.controllers.agent_controller.put_multiple_agent_single_group>`:
+It's also possible to assign multiple agents to a single group using the Wazuh API endpoint :api-ref:`PUT /agents/group <operation/api.controllers.agent_controller.put_multiple_agent_single_group>`. For instance, to assign agents with IDs ``001`` and ``002`` to the ``aws_agents`` group, execute the following request.
 
-   .. code-block:: console
+.. code-block:: console
 
-      # curl -k -X PUT "https://localhost:55000/agents/group?agents_list=001,002&group_id=aws_agents" -H  "Authorization: Bearer $TOKEN"
+   # curl -k -X PUT "https://localhost:55000/agents/group?agents_list=001,002&group_id=aws_agents" -H  "Authorization: Bearer $TOKEN"
 
-   .. code-block:: json
-        :class: output
+.. code-block:: json
+   :class: output
+   :emphasize-lines: 4,5,11
 
-        {
-           "data": {
-               "affected_items": [
-                   "001",
-                   "002"
-               ],
-               "total_affected_items": 2,
-               "total_failed_items": 0,
-               "failed_items": []
-           },
-           "message": "All selected agents were assigned to aws_agents",
-           "error": 0
-        }
+   {
+      "data": {
+          "affected_items": [
+              "001",
+              "002"
+          ],
+          "total_affected_items": 2,
+          "total_failed_items": 0,
+          "failed_items": []
+      },
+      "message": "All selected agents were assigned to aws_agents",
+      "error": 0
+   }
 
-After that, we can get the agents that belong to the group using the **Wazuh API** endpoint :api-ref:`GET /groups/{group_id}/agents <operation/api.controllers.agent_controller.get_agents_in_group>`:
+Then, you can list the agents belonging to the ``aws_agents`` group using the Wazuh API endpoint :api-ref:`GET /groups/{group_id}/agents <operation/api.controllers.agent_controller.get_agents_in_group>`.
 
-    .. code-block:: console
+.. code-block:: console
 
-        # curl -k -X GET "https://localhost:55000/groups/aws_agents/agents?select=id" -H  "Authorization: Bearer $TOKEN"
+   # curl -k -X GET "https://localhost:55000/groups/aws_agents/agents?select=id" -H  "Authorization: Bearer $TOKEN"
 
-    .. code-block:: json
-        :class: output
+.. code-block:: json
+   :class: output
+   :emphasize-lines: 5,8
 
-        {
-           "data": {
-               "affected_items": [
-                   {
-                       "id": "001"
-                   },
-                   {
-                       "id": "002"
-                   }
-               ],
-               "total_affected_items": 2,
-               "total_failed_items": 0,
-               "failed_items": []
-           },
-           "message": "All selected agents information was returned",
-           "error": 0
-        }
+   {
+      "data": {
+          "affected_items": [
+              {
+                  "id": "001"
+              },
+              {
+                  "id": "002"
+              }
+          ],
+          "total_affected_items": 2,
+          "total_failed_items": 0,
+          "failed_items": []
+      },
+      "message": "All selected agents information was returned",
+      "error": 0
+   }

--- a/source/user-manual/agent/agent-management/grouping-agents.rst
+++ b/source/user-manual/agent/agent-management/grouping-agents.rst
@@ -358,3 +358,56 @@ In the case of belonging to multiple groups, the configuration files of every gr
     :alt: Multi-group shared files
     :align: center
     :width: 70%
+
+Assigning multiple agents to a group
+------------------------------------
+
+It's also possible to assign multiple agents to a single group using the **Wazuh API** endpoint :api-ref:`PUT /agents/group <operation/api.controllers.agent_controller.put_multiple_agent_single_group>`:
+
+   .. code-block:: console
+
+      # curl -k -X PUT "https://localhost:55000/agents/group?agents_list=001,002&group_id=aws_agents" -H  "Authorization: Bearer $TOKEN"
+
+   .. code-block:: json
+        :class: output
+
+        {
+           "data": {
+               "affected_items": [
+                   "001",
+                   "002"
+               ],
+               "total_affected_items": 2,
+               "total_failed_items": 0,
+               "failed_items": []
+           },
+           "message": "All selected agents were assigned to aws_agents",
+           "error": 0
+        }
+
+After that, we can get the agents that belong to the group using the **Wazuh API** endpoint :api-ref:`GET /groups/{group_id}/agents <operation/api.controllers.agent_controller.get_agents_in_group>`:
+
+    .. code-block:: console
+
+        # curl -k -X GET "https://localhost:55000/groups/aws_agents/agents?select=id" -H  "Authorization: Bearer $TOKEN"
+
+    .. code-block:: json
+        :class: output
+
+        {
+           "data": {
+               "affected_items": [
+                   {
+                       "id": "001"
+                   },
+                   {
+                       "id": "002"
+                   }
+               ],
+               "total_affected_items": 2,
+               "total_failed_items": 0,
+               "failed_items": []
+           },
+           "message": "All selected agents information was returned",
+           "error": 0
+        }


### PR DESCRIPTION
## Description

Closes https://github.com/wazuh/wazuh-documentation/issues/7205.

Adds a section to the `Grouping agents` document to explain how to assign multiple agents to a single group and then list the agents belonging to a group.

> Pointed to 4.8.0 since it will be the new production branch soon. It mat require a rebase if it isn't merged in time.

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
