### PR TITLE
Added warning message in changing passwords in Docker and Kubernetes

### DIFF
--- a/source/deployment-options/deploying-with-kubernetes/kubernetes-deployment.rst
+++ b/source/deployment-options/deploying-with-kubernetes/kubernetes-deployment.rst
@@ -263,7 +263,7 @@ Setting the new password
 
 .. warning::
 
-    Do not specify the ``$`` or ``&`` characters in your new passwords.
+   Don't use the ``$`` or ``&`` characters in your new password. These characters can cause errors during deployment.
 
 #. Encode your new password in base64 format. Avoid inserting a trailing newline character to maintain the hash value. For example, use the ``-n`` option with the ``echo`` command as follows.
 

--- a/source/deployment-options/deploying-with-kubernetes/kubernetes-deployment.rst
+++ b/source/deployment-options/deploying-with-kubernetes/kubernetes-deployment.rst
@@ -261,6 +261,10 @@ Setting a new hash
 Setting the new password
 ........................
 
+.. warning::
+
+    Do not specify the ``$`` or ``&`` characters in your new passwords.
+
 #. Encode your new password in base64 format. Avoid inserting a trailing newline character to maintain the hash value. For example, use the ``-n`` option with the ``echo`` command as follows.
 
    .. code-block::

--- a/source/deployment-options/docker/wazuh-container.rst
+++ b/source/deployment-options/docker/wazuh-container.rst
@@ -322,7 +322,7 @@ Setting the new password
 
 .. warning::
 
-    Do not specify the ``$`` or ``&`` characters in your new passwords.
+   Don't use the ``$`` or ``&`` characters in your new password. These characters can cause errors during deployment.
 
 #. Open  the ``docker-compose.yml`` file. Change all occurrences of the old password with the new one. For example, for a single-node deployment:
 

--- a/source/deployment-options/docker/wazuh-container.rst
+++ b/source/deployment-options/docker/wazuh-container.rst
@@ -320,6 +320,10 @@ Setting a new hash
 Setting the new password
 ........................
 
+.. warning::
+
+    Do not specify the ``$`` or ``&`` characters in your new passwords.
+
 #. Open  the ``docker-compose.yml`` file. Change all occurrences of the old password with the new one. For example, for a single-node deployment:
 
    -  ``admin`` user


### PR DESCRIPTION
## Description

Closes: https://github.com/wazuh/wazuh-documentation/issues/7319
The aim of this PR is to add a warning message in the Docker and Kubernetes change password documentation:
- https://documentation.wazuh.com/current/deployment-options/docker/wazuh-container.html#change-the-password-of-wazuh-users
- https://documentation.wazuh.com/current/deployment-options/deploying-with-kubernetes/kubernetes-deployment.html#change-the-password-of-wazuh-users

The message informs the user not to specify the `&` and the `$` characters in the new passwords, as they can break the deployment.

The final result is the following:
![Screenshot from 2024-05-22 00-15-10](https://github.com/wazuh/wazuh-documentation/assets/72193239/f0307cb0-fedd-4f79-a9da-6ad779c7bb49)
