### PR TITLE
Fixed the api_type tag in the MS-Graph configuration example.

### DIFF
--- a/source/user-manual/reference/ossec-conf/ms-graph-module.rst
+++ b/source/user-manual/reference/ossec-conf/ms-graph-module.rst
@@ -279,7 +279,7 @@ Example of configuration
           <client_id>your_client_id</client_id>
           <tenant_id>your_tenant_id</tenant_id>
           <secret_value>your_secret_value</secret_value>
-          <api_auth>global</api_auth>
+          <api_type>global</api_type>
         </api_auth>
         <resource>
           <name>security</name>


### PR DESCRIPTION
## Description
 This PR fixes the MS-Graph module configuration example, changing `<api_auth>global</api_auth>` to `<api_type>global</api_type> `


## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.

