### PR TITLE
Removed the notes "Multi-tenant is not supported" in MS-Graph section

### DIFF
--- a/source/cloud-security/ms-graph/monitoring-ms-graph-activity.rst
+++ b/source/cloud-security/ms-graph/monitoring-ms-graph-activity.rst
@@ -136,8 +136,6 @@ In this case, we will search for `alerts_v2` and `incidents` type events within 
         </resource>
     </ms-graph>
 
-.. note:: Multi-tenant is not supported. You can only configure one block of ``api_auth``. To learn more about the module options, see the :doc:`ms-graph </user-manual/reference/ossec-conf/ms-graph-module>` reference.
-
 Using the configuration mentioned above, we can examine a classic example of a security event: malicious spam emails.
 
 Examining Microsoft Graph logs

--- a/source/user-manual/reference/ossec-conf/ms-graph-module.rst
+++ b/source/user-manual/reference/ossec-conf/ms-graph-module.rst
@@ -156,11 +156,6 @@ This block configures the credentials used for authenticating with the Microsoft
 
 .. warning:: In the case of an invalid configuration, a warning message will be generated in the log file.
 
-.. note::
-  
-   Multi-tenant is not supported. You can only configure one block of ``api_auth``.
-
-
 +----------------------------------------+----------------------------------------------+
 | Options                                | Allowed values                               |
 +========================================+==============================================+


### PR DESCRIPTION

## Description
This PR removes the “Multi-tenant is not supported” notes from the MS-Graph module section.

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
