### PR TITLE
Add custom Filebeat user information and delete obsolete information about ossec.conf file on Wazuh server.

### DIFF
--- a/source/user-manual/user-administration/password-management.rst
+++ b/source/user-manual/user-administration/password-management.rst
@@ -213,24 +213,16 @@ Follow the instructions below to change the passwords for all the Wazuh indexer 
       INFO: The password for Wazuh API user wazuh is ivLOfmj7.jL6*7Ev?UJoFjrkGy9t6Je.
       INFO: The password for Wazuh API user wazuh-wui is fL+f?sFRPEv5pYRE559rqy9b6G4Z5pVi
 
-#. On `all your Wazuh server nodes`, run the following command to update the `admin` password in the Filebeat keystore. Replace ``<ADMIN_PASSWORD>`` with the random password generated in the first step.
-
-   .. code-block:: console
-
-      # echo <ADMIN_PASSWORD> | filebeat keystore add password --stdin --force
-
-   .. note:: If you set up a user other than admin for Filebeat you will have to add the user manually.
+   .. note:: If you set up a user other than admin for Filebeat you will have to add the username and password manually by running the following commands. Replace ``<CUSTOM_USERNAME>`` with your custom username and ``<CUSTOM_PASSWORD>`` with your custom password.
 
       .. code-block:: console
 
          # echo <CUSTOM_USERNAME> | filebeat keystore add username --stdin --force
+         # echo <CUSTOM_PASSWORD> | filebeat keystore add password --stdin --force
+         
+      Then, restart Filebeat to apply the changes.
 
-#. Restart Filebeat and the Wazuh server to apply the change.
-
-   .. include:: /_templates/common/restart_filebeat.rst
-   .. include:: /_templates/common/restart_manager.rst
-
-   .. note:: Repeat steps 3 and 4 on `every Wazuh server node`.
+      .. include:: /_templates/common/restart_filebeat.rst
        
 #. On your `Wazuh dashboard node`, run the following command to update the `kibanaserver` password in the Wazuh dashboard keystore. Replace ``<KIBANASERVER_PASSWORD>`` with the random password generated in the first step.
 

--- a/source/user-manual/user-administration/password-management.rst
+++ b/source/user-manual/user-administration/password-management.rst
@@ -213,12 +213,17 @@ Follow the instructions below to change the passwords for all the Wazuh indexer 
       INFO: The password for Wazuh API user wazuh is ivLOfmj7.jL6*7Ev?UJoFjrkGy9t6Je.
       INFO: The password for Wazuh API user wazuh-wui is fL+f?sFRPEv5pYRE559rqy9b6G4Z5pVi
 
-#. On `all your Wazuh server nodes`, run the following command to update the `admin` password in the Filebeat keystore and in the ``ossec.conf`` file for the Wazuh server. Replace ``<ADMIN_PASSWORD>`` with the random password generated in the first step.
+#. On `all your Wazuh server nodes`, run the following command to update the `admin` password in the Filebeat keystore. Replace ``<ADMIN_PASSWORD>`` with the random password generated in the first step.
 
    .. code-block:: console
 
       # echo <ADMIN_PASSWORD> | filebeat keystore add password --stdin --force
-      # sed -i 's/<password>.*<\/password>/<password><ADMIN_PASSWORD><\/password>/g' /var/ossec/etc/ossec.conf
+
+   .. note:: If you set up a user other than admin for Filebeat you will have to add the user manually.
+
+      .. code-block:: console
+
+         # echo <CUSTOM_USERNAME> | filebeat keystore add username --stdin --force
 
 #. Restart Filebeat and the Wazuh server to apply the change.
 

--- a/source/user-manual/user-administration/password-management.rst
+++ b/source/user-manual/user-administration/password-management.rst
@@ -213,16 +213,16 @@ Follow the instructions below to change the passwords for all the Wazuh indexer 
       INFO: The password for Wazuh API user wazuh is ivLOfmj7.jL6*7Ev?UJoFjrkGy9t6Je.
       INFO: The password for Wazuh API user wazuh-wui is fL+f?sFRPEv5pYRE559rqy9b6G4Z5pVi
 
-   .. note:: If you set up a user other than admin for Filebeat you will have to add the username and password manually by running the following commands. Replace ``<CUSTOM_USERNAME>`` with your custom username and ``<CUSTOM_PASSWORD>`` with your custom password.
+#. If you've set up a user other than ``admin`` for Filebeat, manually add the username and password using the following commands. Replace ``<CUSTOM_USERNAME>`` and ``<CUSTOM_PASSWORD>`` with your custom username and password.
 
-      .. code-block:: console
+   .. code-block:: console
 
-         # echo <CUSTOM_USERNAME> | filebeat keystore add username --stdin --force
-         # echo <CUSTOM_PASSWORD> | filebeat keystore add password --stdin --force
+      # echo <CUSTOM_USERNAME> | filebeat keystore add username --stdin --force
+      # echo <CUSTOM_PASSWORD> | filebeat keystore add password --stdin --force
          
-      Then, restart Filebeat to apply the changes.
+   Restart Filebeat to apply the changes.
 
-      .. include:: /_templates/common/restart_filebeat.rst
+   .. include:: /_templates/common/restart_filebeat.rst
        
 #. On your `Wazuh dashboard node`, run the following command to update the `kibanaserver` password in the Wazuh dashboard keystore. Replace ``<KIBANASERVER_PASSWORD>`` with the random password generated in the first step.
 


### PR DESCRIPTION
Related issue: https://github.com/wazuh/wazuh-packages/issues/1369
Related PR: https://github.com/wazuh/wazuh-packages/pull/2989 
## Description

The aim of this PR is to add information to the use if he wants to use a custom user for Filebeat. He will have to update it manually through the Filebeat Keystore tool.

## Checks
### Docs building
The doc has been builded without problems. A screenshot of how it would result:
![imagen](https://github.com/wazuh/wazuh-documentation/assets/93655331/0257726a-e1a2-4daf-ba32-a496679409ff)


