### PR TITLE
Set 4.7 release as not latest

### DIFF
--- a/source/_variables/settings.py
+++ b/source/_variables/settings.py
@@ -16,7 +16,7 @@
 
 # The short X.Y version
 version = '4.7'
-is_latest_release = True
+is_latest_release = False
 
 # The full version, including alpha/beta/rc tags
 # Important: use a valid branch (4.0) or, preferably, tag name (v4.0.0)


### PR DESCRIPTION
## Description
This PR demotes 4.7 version as not the latest version.

## Checks
### Docs building
- [ ] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
