### PR TITLE
Fix wrong option for wazuh-keystore

### DIFF
--- a/source/upgrade-guide/upgrading-central-components.rst
+++ b/source/upgrade-guide/upgrading-central-components.rst
@@ -200,7 +200,7 @@ If upgrading from version 4.7 and earlier, edit ``/var/ossec/etc/ossec.conf`` to
    .. code-block:: console
   
       # /var/ossec/bin/wazuh-keystore -f indexer -k username -v <INDEXER_USERNAME>
-      # /var/ossec/bin/wazuh-keystore -f indexer -k username -v <INDEXER_PASSWORD>
+      # /var/ossec/bin/wazuh-keystore -f indexer -k password -v <INDEXER_PASSWORD>
 
 Configuring Filebeat
 ^^^^^^^^^^^^^^^^^^^^

--- a/source/user-manual/capabilities/vulnerability-detection/configuring-scans.rst
+++ b/source/user-manual/capabilities/vulnerability-detection/configuring-scans.rst
@@ -60,7 +60,7 @@ You must save the Wazuh indexer username and password into the Wazuh manager key
 .. code-block:: console
   
    # /var/ossec/bin/wazuh-keystore -f indexer -k username -v <INDEXER_USERNAME>
-   # /var/ossec/bin/wazuh-keystore -f indexer -k username -v <INDEXER_PASSWORD>
+   # /var/ossec/bin/wazuh-keystore -f indexer -k password -v <INDEXER_PASSWORD>
 
 The Vulnerability Detection module generates logs in the Wazuh server that trigger alerts. Every alert contains the following fields:
 


### PR DESCRIPTION
## Description
This PR fixed some typos related to the wazuh-keystore tool, where the wrong option was provided

## Checks
### Docs building
- [ ] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
