### PR TITLE
Added new parameter `--install-dependencies` to the Assistant commands

### DIFF
--- a/source/installation-guide/wazuh-dashboard/installation-assistant.rst
+++ b/source/installation-guide/wazuh-dashboard/installation-assistant.rst
@@ -17,7 +17,7 @@ Wazuh dashboard installation
 
       # curl -sO https://packages.wazuh.com/|WAZUH_CURRENT_MINOR|/wazuh-install.sh
 
-#. Run the Wazuh installation assistant with the option ``--wazuh-dashboard`` and the node name to install and configure the Wazuh dashboard. The node name must be the same one used in ``config.yml`` for the initial configuration, for example, ``dashboard``.
+#. Run the Wazuh installation assistant with the option ``--wazuh-dashboard`` and the node name to install and configure the Wazuh dashboard. The node name must be the same one used in ``config.yml`` for the initial configuration, for example, ``dashboard``. If you want the Wazuh installation assistant to install the necessary dependencies automatically, add the ``--install-dependencies`` option to the command.
    
    .. note::
       

--- a/source/installation-guide/wazuh-dashboard/installation-assistant.rst
+++ b/source/installation-guide/wazuh-dashboard/installation-assistant.rst
@@ -17,7 +17,7 @@ Wazuh dashboard installation
 
       # curl -sO https://packages.wazuh.com/|WAZUH_CURRENT_MINOR|/wazuh-install.sh
 
-#. Run the Wazuh installation assistant with the option ``--wazuh-dashboard`` and the node name to install and configure the Wazuh dashboard. The node name must be the same one used in ``config.yml`` for the initial configuration, for example, ``dashboard``. If you want the Wazuh installation assistant to install the necessary dependencies automatically, add the ``--install-dependencies`` option to the command.
+#. Run the Wazuh installation assistant with the option ``--wazuh-dashboard`` and the node name to install and configure the Wazuh dashboard. The node name must be the same one used in ``config.yml`` for the initial configuration, for example, ``dashboard``. The Wazuh installation assistant may need some dependencies to work, like ``openssl`` or ``lsof``. If you want the Wazuh installation assistant to install the necessary dependencies automatically, add the ``--install-dependencies`` option to the command.
    
    .. note::
       

--- a/source/installation-guide/wazuh-indexer/installation-assistant.rst
+++ b/source/installation-guide/wazuh-indexer/installation-assistant.rst
@@ -67,7 +67,7 @@ Indicate your deployment configuration, create the SSL certificates to encrypt c
               ip: "<dashboard-node-ip>"
 
 
-#. Run the Wazuh installation assistant with the option ``--generate-config-files`` to generate the  Wazuh cluster key, certificates, and passwords necessary for installation. You can find these files in ``./wazuh-install-files.tar``. If you want the Wazuh installation assistant to install the necessary dependencies automatically, add the ``--install-dependencies`` option to the command.
+#. Run the Wazuh installation assistant with the option ``--generate-config-files`` to generate the  Wazuh cluster key, certificates, and passwords necessary for installation. You can find these files in ``./wazuh-install-files.tar``. The Wazuh installation assistant may need some dependencies to work, like ``openssl`` or ``lsof``. If you want the Wazuh installation assistant to install the necessary dependencies automatically, add the ``--install-dependencies`` option to the command.
 
       .. code-block:: console
 
@@ -90,7 +90,7 @@ Install and configure the Wazuh indexer nodes.
         # curl -sO https://packages.wazuh.com/|WAZUH_CURRENT_MINOR|/wazuh-install.sh
 
 
-#. Run the Wazuh installation assistant with the option ``--wazuh-indexer`` and the node name to install and configure the Wazuh indexer. The node name must be the same one used in ``config.yml`` for the initial configuration, for example, ``node-1``. If you want the Wazuh installation assistant to install the necessary dependencies automatically, add the ``--install-dependencies`` option to the command.
+#. Run the Wazuh installation assistant with the option ``--wazuh-indexer`` and the node name to install and configure the Wazuh indexer. The node name must be the same one used in ``config.yml`` for the initial configuration, for example, ``node-1``. The Wazuh installation assistant may need some dependencies to work, like ``openssl`` or ``lsof``. If you want the Wazuh installation assistant to install the necessary dependencies automatically, add the ``--install-dependencies`` option to the command.
 
       .. note:: Make sure that a copy of ``wazuh-install-files.tar``, created during the initial configuration step, is placed in your working directory.
 

--- a/source/installation-guide/wazuh-indexer/installation-assistant.rst
+++ b/source/installation-guide/wazuh-indexer/installation-assistant.rst
@@ -67,7 +67,7 @@ Indicate your deployment configuration, create the SSL certificates to encrypt c
               ip: "<dashboard-node-ip>"
 
 
-#. Run the Wazuh installation assistant with the option ``--generate-config-files`` to generate the  Wazuh cluster key, certificates, and passwords necessary for installation. You can find these files in ``./wazuh-install-files.tar``.
+#. Run the Wazuh installation assistant with the option ``--generate-config-files`` to generate the  Wazuh cluster key, certificates, and passwords necessary for installation. You can find these files in ``./wazuh-install-files.tar``. If you want the Wazuh installation assistant to install the necessary dependencies automatically, add the ``--install-dependencies`` option to the command.
 
       .. code-block:: console
 
@@ -90,7 +90,7 @@ Install and configure the Wazuh indexer nodes.
         # curl -sO https://packages.wazuh.com/|WAZUH_CURRENT_MINOR|/wazuh-install.sh
 
 
-#. Run the Wazuh installation assistant with the option ``--wazuh-indexer`` and the node name to install and configure the Wazuh indexer. The node name must be the same one used in ``config.yml`` for the initial configuration, for example, ``node-1``.
+#. Run the Wazuh installation assistant with the option ``--wazuh-indexer`` and the node name to install and configure the Wazuh indexer. The node name must be the same one used in ``config.yml`` for the initial configuration, for example, ``node-1``. If you want the Wazuh installation assistant to install the necessary dependencies automatically, add the ``--install-dependencies`` option to the command.
 
       .. note:: Make sure that a copy of ``wazuh-install-files.tar``, created during the initial configuration step, is placed in your working directory.
 

--- a/source/installation-guide/wazuh-server/installation-assistant.rst
+++ b/source/installation-guide/wazuh-server/installation-assistant.rst
@@ -17,7 +17,7 @@ Wazuh server cluster installation
    
        # curl -sO https://packages.wazuh.com/|WAZUH_CURRENT_MINOR|/wazuh-install.sh
 
-#. Run the Wazuh installation assistant with the option ``--wazuh-server`` followed by the node name to install the Wazuh server. The node name must be the same one used in ``config.yml`` for the initial configuration, for example, ``wazuh-1``.
+#. Run the Wazuh installation assistant with the option ``--wazuh-server`` followed by the node name to install the Wazuh server. The node name must be the same one used in ``config.yml`` for the initial configuration, for example, ``wazuh-1``. If you want the Wazuh installation assistant to install the necessary dependencies automatically, add the ``--install-dependencies`` option to the command.
  
    .. note:: Make sure that a copy of the ``wazuh-install-files.tar``, created during the initial configuration step, is placed in your working directory.
 

--- a/source/installation-guide/wazuh-server/installation-assistant.rst
+++ b/source/installation-guide/wazuh-server/installation-assistant.rst
@@ -17,7 +17,7 @@ Wazuh server cluster installation
    
        # curl -sO https://packages.wazuh.com/|WAZUH_CURRENT_MINOR|/wazuh-install.sh
 
-#. Run the Wazuh installation assistant with the option ``--wazuh-server`` followed by the node name to install the Wazuh server. The node name must be the same one used in ``config.yml`` for the initial configuration, for example, ``wazuh-1``. If you want the Wazuh installation assistant to install the necessary dependencies automatically, add the ``--install-dependencies`` option to the command.
+#. Run the Wazuh installation assistant with the option ``--wazuh-server`` followed by the node name to install the Wazuh server. The node name must be the same one used in ``config.yml`` for the initial configuration, for example, ``wazuh-1``. The Wazuh installation assistant may need some dependencies to work, like ``openssl`` or ``lsof``. If you want the Wazuh installation assistant to install the necessary dependencies automatically, add the ``--install-dependencies`` option to the command.
  
    .. note:: Make sure that a copy of the ``wazuh-install-files.tar``, created during the initial configuration step, is placed in your working directory.
 

--- a/source/quickstart.rst
+++ b/source/quickstart.rst
@@ -77,7 +77,7 @@ Installing Wazuh
 
     .. code-block:: console
 
-        $ curl -sO https://packages.wazuh.com/|WAZUH_CURRENT_MINOR|/wazuh-install.sh && sudo bash ./wazuh-install.sh -a
+        $ curl -sO https://packages.wazuh.com/|WAZUH_CURRENT_MINOR|/wazuh-install.sh && sudo bash ./wazuh-install.sh -a --install-dependencies
 
 
     Once the assistant finishes the installation, the output shows the access credentials and a message that confirms that the installation was successful.


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description

Related issue: https://github.com/wazuh/wazuh-packages/issues/2879

The aim of this PR is to add a new parameter `--install-dependencies` to the commands that use the Wazuh installation assistant to install a central component or generate certificates. 

This new parameter is now necessary to make the Assistant install the necessary dependencies in the installation. It has been added to the central components installation and to the Quickstart (this last one was added too because we want the Quickstart to be all straight to the installation).

This is an example of how the changes look:
![image](https://github.com/wazuh/wazuh-documentation/assets/72193239/956cc8f7-d510-42b7-a715-00162300dfbb)


## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
