### PR TITLE
Update help command in password management with the requiere options when trying to change the API user password

### DIFF
--- a/source/user-manual/user-administration/password-management.rst
+++ b/source/user-manual/user-administration/password-management.rst
@@ -45,8 +45,10 @@ All the available options to run the script are:
 |                                              | Requires -u|--user, and -p|--password, -au|--admin-user and -ap|--admin-password.                           |
 +----------------------------------------------+-------------------------------------------------------------------------------------------------------------+
 | -au,--admin-user <adminUser>                 | Admin user for the Wazuh API. Required for changing the Wazuh API passwords.                                |
+|                                              | Requires -A|--api.                                                                                          |               
 +----------------------------------------------+-------------------------------------------------------------------------------------------------------------+
 | -ap, --admin-password <adminPassword>        | Password for the Wazuh API admin user. Required for changing the Wazuh API passwords.                       |
+|                                              | Requires -A|--api.                                                                                          |      
 +----------------------------------------------+-------------------------------------------------------------------------------------------------------------+
 | -u / --user <user>                           | Indicates the name of the user whose password will be changed.                                              |
 |                                              | If no password is specified, it will generate a random one.                                                 |


### PR DESCRIPTION
| Related PR |
|---|
| https://github.com/wazuh/wazuh-packages/pull/3005 | 

## Description

In the `wazuh-password-tool.sh` script, to change the password of an api user, it is necessary for the api user to specify the `--api` option. Failure to do so would result in the script's help being displayed. 
To this end, a message has been added to the help in the `-au` and `-ap` options saying that it is necessary to specify the `-A|--api` option when using those options.

### Tests

![Captura de pantalla 2024-06-17 a las 13 21 23](https://github.com/wazuh/wazuh-documentation/assets/74021522/6ed6abd7-5be2-4f95-baae-c7ac2472f488)

