### PR TITLE
Add how to create wazuh-archives-* index via curl

### DIFF
--- a/source/user-manual/manager/wazuh-archives.rst
+++ b/source/user-manual/manager/wazuh-archives.rst
@@ -92,6 +92,13 @@ Wazuh dashboard
       :align: center
       :width: 80%
 
+#. Alternatively, the ``wazuh-archives-*`` index can be created via the command line using curl with the admin password:
+
+   .. code-block:: bash
+
+     $ curl -k -u admin:"$ADMIN_PASS" -X PUT "https://127.0.0.1:9200/_index_pattern/wazuh-archives-" -H 'Content-Type: application/json' -d '{"index_pattern":"wazuh-archives-*","priority":100,"time_field":"timestamp","fields":[{"name":"@timestamp","type":"date","format":"date_time"}]}'
+
+
 Use case: Detecting signed binary proxy execution
 -------------------------------------------------
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
This makes it easy for scripting where you would want to enable the wazuh-archives-* index and where we have cli commands for all the other parts but only UI guide for this previously.  This helped immensely and figured it would save other people time hunting down how to do so.
## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
