### PR TITLE
Upgrade docker and urllib packages versions

### DIFF
--- a/source/proof-of-concept-guide/monitoring-docker.rst
+++ b/source/proof-of-concept-guide/monitoring-docker.rst
@@ -38,10 +38,27 @@ Perform the following steps to install Docker on the Ubuntu endpoint and configu
 
 #. Install Docker and Python Docker Library:
 
-   .. code-block:: console
+.. tabs::
 
-      $ curl -sSL https://get.docker.com/ | sh
-      $ sudo pip3 install docker==6.0.0 urllib3==1.26.18
+   .. group-tab:: Python 3.7–3.10
+
+      .. code-block:: console
+
+         $ curl -sSL https://get.docker.com/ | sh
+         $ sudo pip3 install docker==7.1.0 urllib3==2.2.2 requests==2.32.2
+
+   .. group-tab:: Python 3.11
+
+      .. code-block:: console
+
+         $ curl -sSL https://get.docker.com/ | sh
+         $ sudo pip3 install docker==7.1.0 urllib3==2.2.2 requests==2.32.2 --break-system-packages
+      
+      .. note::
+
+         This command modifies the default externally managed Python environment. See the `PEP 668 <https://peps.python.org/pep-0668/>`__ description for more information.
+         
+         To prevent the modification, you can run ``pip3 install --upgrade pip`` within a virtual environment. You must update the docker ``/var/ossec/wodles/docker/DockerListener`` script shebang with your virtual environment interpreter. For example: ``#!</path/to/your/virtual/environment>/bin/python3``.
 
 #. Edit the Wazuh agent configuration file ``/var/ossec/etc/ossec.conf`` and add this block to enable the ``docker-listener`` module:
 

--- a/source/user-manual/capabilities/container-security/monitoring-docker.rst
+++ b/source/user-manual/capabilities/container-security/monitoring-docker.rst
@@ -39,9 +39,25 @@ Docker library for Python
 
 `Python Docker library <https://pypi.org/project/docker/>`_ is the official Python library for the Docker Engine API. The Wazuh docker integration requires ``docker 6.0.0``.
 
-.. code-block:: console
+.. tabs::
 
-   # pip3 install docker==6.0.0 urllib3==1.26.18
+   .. group-tab:: Python 3.7–3.10
+
+      .. code-block:: console
+
+         $ pip3 install docker==7.1.0 urllib3==2.2.2 requests==2.32.2
+
+   .. group-tab:: Python 3.11
+
+      .. code-block:: console
+
+         $ pip3 install docker==7.1.0 urllib3==2.2.2 requests==2.32.2 --break-system-packages
+      
+      .. note::
+
+         This command modifies the default externally managed Python environment. See the `PEP 668 <https://peps.python.org/pep-0668/>`__ description for more information.
+         
+         To prevent the modification, you can run ``pip3 install --upgrade pip`` within a virtual environment. You must update the docker ``/var/ossec/wodles/docker/DockerListener`` script shebang with your virtual environment interpreter. For example: ``#!</path/to/your/virtual/environment>/bin/python3``.
 
 Configure the Wazuh agent
 ^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Description

Upgrades the versions used by the `docker` and `urllib3` packages to their latest versions to be compatible with `requests==2.32.2`.

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
