### PR TITLE
Added warning note for Ansible deployment when using macOS as Ansible node

### DIFF
--- a/source/deployment-options/deploying-with-ansible/guide/install-wazuh-cluster.rst
+++ b/source/deployment-options/deploying-with-ansible/guide/install-wazuh-cluster.rst
@@ -86,15 +86,13 @@ And we can see the preconfigured playbooks we have by running the command below.
 
 Using the wazuh-production-ready playbook, we will deploy a Wazuh manager and indexer cluster using Ansible.
 
+If you are running Ansible on macOS, ensure Docker is installed on your system. Modify the ``macos_localhost`` variable in ``wazuh-production-ready.yml`` from ``false`` to ``true`` to ensure the certificates are created correctly.
+
 Let’s see below, the content of the YAML file ``/etc/ansible/roles/wazuh-ansible/playbooks/wazuh-production-ready.yml`` that we are going to run for a complete installation of the server.
 
 .. code-block:: console
 
    # cat wazuh-production-ready.yml
-
-.. warning::
-
-   In case you are running ansible on macOS, for the certificates to be created correctly you must have Docker installed on your system and you must change the "macos_localhost" variable from "false" to "true" for the certificates to be created correctly.
 
 .. code-block:: yaml
    :class: output

--- a/source/deployment-options/deploying-with-ansible/guide/install-wazuh-cluster.rst
+++ b/source/deployment-options/deploying-with-ansible/guide/install-wazuh-cluster.rst
@@ -92,6 +92,10 @@ Let’s see below, the content of the YAML file ``/etc/ansible/roles/wazuh-ansib
 
    # cat wazuh-production-ready.yml
 
+.. warning::
+
+   In case you are running ansible on macOS, for the certificates to be created correctly you must have Docker installed on your system and you must change the "macos_localhost" variable from "false" to "true" for the certificates to be created correctly.
+
 .. code-block:: yaml
    :class: output
 
@@ -139,6 +143,7 @@ Let’s see below, the content of the YAML file ``/etc/ansible/roles/wazuh-ansib
              name: node-6
              ip: "{{ hostvars.dashboard.private_ip }}"
              role: dashboard
+         macos_localhost: false
        tags:
          - generate-certs
 
@@ -302,7 +307,7 @@ The contents of the host file is:
    ansible_ssh_user=centos
    ansible_ssh_private_key_file=/path/to/ssh/key.pem
    ansible_ssh_extra_args='-o StrictHostKeyChecking=no'
- 
+
 Let’s take a closer look at the content.
 
 -  The ``ansible_host`` variable should contain the public IP address/FQDN for each node.
@@ -332,7 +337,7 @@ Now, we are ready to run the playbook and start the installation. However, some 
          # systemctl status wazuh-indexer
 
    -  Wazuh dashboard
-    
+
       .. code-block:: console
 
          # systemctl status wazuh-dashboard
@@ -344,13 +349,13 @@ Now, we are ready to run the playbook and start the installation. However, some 
          # systemctl status wazuh-manager
 
    -  Filebeat.
-    
+
       .. code-block:: console
 
          # systemctl status filebeat
 
 .. note::
-	
+
 	- 	The Wazuh dashboard can be accessed by visiting ``https://<dashboard_server_IP>``
 
 	- 	The default credentials for Wazuh deployed using ansible is:


### PR DESCRIPTION
… node

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
<!--
Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->
related: https://github.com/wazuh/wazuh-ansible/issues/1115

The necessary changes are made so that if it is run on an Ansible node with macOS, the certificates can be created with the Docker image that contains the Wazuh certificates tool

![Screenshot_20240628_125505](https://github.com/wazuh/wazuh-documentation/assets/64099752/f3fe9b39-6c85-4a53-aea5-37859059b4a2)


## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
