### PR TITLE
Use launchctl to start and stop macos agent

### DIFF
--- a/source/installation-guide/uninstalling-wazuh/agent.rst
+++ b/source/installation-guide/uninstalling-wazuh/agent.rst
@@ -73,7 +73,7 @@ Follow these steps to uninstall the Wazuh agent from your macOS endpoint.
 
     .. code-block:: console
 
-      # sudo launchctl unload /Library/LaunchDaemons/com.wazuh.agent.plist
+      # launchctl unload /Library/LaunchDaemons/com.wazuh.agent.plist
 
 #. Remove the ``/Library/Ossec/`` folder.
 

--- a/source/installation-guide/uninstalling-wazuh/agent.rst
+++ b/source/installation-guide/uninstalling-wazuh/agent.rst
@@ -73,7 +73,7 @@ Follow these steps to uninstall the Wazuh agent from your macOS endpoint.
 
     .. code-block:: console
 
-      # /Library/Ossec/bin/wazuh-control stop
+      # sudo launchctl unload /Library/LaunchDaemons/com.wazuh.agent.plist
 
 #. Remove the ``/Library/Ossec/`` folder.
 

--- a/source/installation-guide/wazuh-agent/wazuh-agent-package-macos.rst
+++ b/source/installation-guide/wazuh-agent/wazuh-agent-package-macos.rst
@@ -54,7 +54,7 @@ The agent runs on the endpoint you want to monitor and communicates with the Waz
 
             .. code-block:: console
 
-               # sudo launchctl load /Library/LaunchDaemons/com.wazuh.agent.plist
+               # launchctl load /Library/LaunchDaemons/com.wazuh.agent.plist
 
 
          The installation process is now complete, and the Wazuh agent is successfully deployed and running on your macOS endpoint.
@@ -73,7 +73,7 @@ The agent runs on the endpoint you want to monitor and communicates with the Waz
 
             .. code-block:: console
 
-               # sudo launchctl load /Library/LaunchDaemons/com.wazuh.agent.plist
+               # launchctl load /Library/LaunchDaemons/com.wazuh.agent.plist
 
          The installation process is now complete, and the Wazuh agent is successfully installed on your macOS endpoint. The next step is to register and configure the agent to communicate with the Wazuh server. To perform this action, see the :doc:`Wazuh agent enrollment </user-manual/agent/agent-enrollment/index>` section.  
 

--- a/source/installation-guide/wazuh-agent/wazuh-agent-package-macos.rst
+++ b/source/installation-guide/wazuh-agent/wazuh-agent-package-macos.rst
@@ -54,7 +54,7 @@ The agent runs on the endpoint you want to monitor and communicates with the Waz
 
             .. code-block:: console
 
-               # /Library/Ossec/bin/wazuh-control start
+               # sudo launchctl load /Library/LaunchDaemons/com.wazuh.agent.plist
 
 
          The installation process is now complete, and the Wazuh agent is successfully deployed and running on your macOS endpoint.
@@ -73,7 +73,7 @@ The agent runs on the endpoint you want to monitor and communicates with the Waz
 
             .. code-block:: console
 
-               # sudo /Library/Ossec/bin/wazuh-control start
+               # sudo launchctl load /Library/LaunchDaemons/com.wazuh.agent.plist
 
          The installation process is now complete, and the Wazuh agent is successfully installed on your macOS endpoint. The next step is to register and configure the agent to communicate with the Wazuh server. To perform this action, see the :doc:`Wazuh agent enrollment </user-manual/agent/agent-enrollment/index>` section.  
 

--- a/source/migration-guide/files-backup/restoring/wazuh-agent.rst
+++ b/source/migration-guide/files-backup/restoring/wazuh-agent.rst
@@ -178,7 +178,7 @@ Perform the steps below to restore Wazuh agent files on a macOS endpoint.
 
    .. code-block:: console
 
-      # /Library/Ossec/bin/wazuh-control stop
+      # sudo launchctl unload /Library/LaunchDaemons/com.wazuh.agent.plist
 
 #. Restore Wazuh agent data, certificates, and configuration files:
 
@@ -204,7 +204,7 @@ Perform the steps below to restore Wazuh agent files on a macOS endpoint.
 
    .. code-block:: console
 
-      # /Library/Ossec/bin/wazuh-control start
+      # sudo launchctl load /Library/LaunchDaemons/com.wazuh.agent.plist
 
 Verifying data restoration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/migration-guide/files-backup/restoring/wazuh-agent.rst
+++ b/source/migration-guide/files-backup/restoring/wazuh-agent.rst
@@ -178,7 +178,7 @@ Perform the steps below to restore Wazuh agent files on a macOS endpoint.
 
    .. code-block:: console
 
-      # sudo launchctl unload /Library/LaunchDaemons/com.wazuh.agent.plist
+      # launchctl unload /Library/LaunchDaemons/com.wazuh.agent.plist
 
 #. Restore Wazuh agent data, certificates, and configuration files:
 
@@ -204,7 +204,7 @@ Perform the steps below to restore Wazuh agent files on a macOS endpoint.
 
    .. code-block:: console
 
-      # sudo launchctl load /Library/LaunchDaemons/com.wazuh.agent.plist
+      # launchctl load /Library/LaunchDaemons/com.wazuh.agent.plist
 
 Verifying data restoration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description

|Related Issue|
|-|
|https://github.com/wazuh/wazuh-documentation/issues/6359|
<!--
Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->

Hi team, this PR replaces the `/Library/Ossec/bin/wazuh-control` command usage with `launchctl` to start and stop the Wazuh agent service.

## Test

Starting with a stopped agent:

```
sh-3.2# /Library/Ossec/bin/wazuh-control status
wazuh-modulesd not running...
wazuh-logcollector not running...
wazuh-syscheckd not running...
wazuh-agentd not running...
wazuh-execd not running...
```

The service is launched:

```
sh-3.2# sudo launchctl load /Library/LaunchDaemons/com.wazuh.agent.plist
```

The service status is shown currently in both launchctl command and `/Library/Ossec/bin/wazuh-control`:
```

sh-3.2# /Library/Ossec/bin/wazuh-control status
cat: /Library/Ossec/var/start-script-lock/pid: No such file or directory
wazuh-modulesd is running...
wazuh-logcollector is running...
wazuh-syscheckd is running...
wazuh-agentd is running...
wazuh-execd is running...

sh-3.2# launchctl print system/com.wazuh.agent
com.wazuh.agent = {
	active count = 1
	copy count = 0
	one shot = 0
	path = /Library/LaunchDaemons/com.wazuh.agent.plist
	state = running

	program = /Library/StartupItems/WAZUH/Wazuh-launcher
	arguments = {
		/Library/StartupItems/WAZUH/Wazuh-launcher
	}

	default environment = {
		PATH => /usr/bin:/bin:/usr/sbin:/sbin
	}

	environment = {
		XPC_SERVICE_NAME => com.wazuh.agent
	}

	domain = com.apple.xpc.launchd.domain.system
	minimum runtime = 10
	exit timeout = 5
	runs = 1
	successive crashes = 0
	pid = 4517
	immediate reason = speculative
	forks = 3
	execs = 2
	initialized = 1
	trampolined = 1
	started suspended = 0
	proxy started suspended = 0
	last exit code = (never exited)

	event triggers = {
	}

	endpoints = {
	}

	dynamic endpoints = {
	}

	pid-local endpoints = {
	}

	instance-specific endpoints = {
	}

	event channels = {
	}

	sockets = {
	}

	instances = {
	}

	spawn type = daemon
	spawn role = (null)
	jetsam priority = 3
	jetsam memory limit (active) = (unlimited)
	jetsam memory limit (inactive) = (unlimited)
	jetsamproperties category = daemon
	submitted job. ignore execute allowed
	jetsam thread limit = 32
	cpumon = default

	properties = {
		partial import = 0
		launchd bundle = 0
		xpc bundle = 0
		keepalive = 0
		runatload = 1
		low priority i/o = 0
		low priority background i/o = 0
		dataless file mode = 0
		legacy timer behavior = 0
		exception handler = 0
		multiple instances = 0
		supports transactions = 0
		supports pressured exit = 0
		supports idle hysteresis = 0
		enter kdp before kill = 0
		wait for debugger = 0
		app = 0
		system app = 0
		creates session = 0
		inetd-compatible = 0
		inetd listener = 0
		abandon process group = 0
		one-shot = 0
		event monitor = 0
		penalty box = 0
		pended non-demand spawn = 0
		role account = 0
		launch only once = 0
		system support = 0
		app-like = 0
		inferred program = 1
		joins gui session = 0
		joins host session = 0
		parameterized sandbox = 1
		resolve program = 0
		abandon coalition = 0
		high bits aslr = 0
		extension = 0
		nano allocator = 0
		no initgroups = 0
		start on fs mount = 0
		endpoints initialized = 1
		is copy = 0
		disallow all lookups = 0
		system service = 0
		protected by submitter = 0
	}
}
```

Then the service is stopped:

```
sh-3.2# sudo launchctl unload /Library/LaunchDaemons/com.wazuh.agent.plist
/Library/LaunchDaemons/com.wazuh.agent.plist: Operation now in progress
```

And checking its status, it's not running, as expected:

```
sh-3.2# /Library/Ossec/bin/wazuh-control status
wazuh-modulesd not running...
wazuh-logcollector not running...
wazuh-syscheckd not running...
wazuh-agentd not running...
wazuh-execd not running...
```

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
