### PR TITLE
Add description and note for new parameters to `generate_wazuh_msi.ps1` script to sign Windows packages

### DIFF
--- a/source/development/packaging/generate-windows-package.rst
+++ b/source/development/packaging/generate-windows-package.rst
@@ -106,27 +106,22 @@ Execute the ``generate_wazuh_msi.ps1`` script, with the different options you de
       USAGE:
           ./generate_wazuh_msi.ps1  -MSI_NAME {{ NAME }} -SIGN {{ yes|no }} -WIX_TOOLS_PATH {{ PATH }} -SIGN_TOOLS_PATH {{ PATH }} -CERTIFICATE_PATH {{ PFX_CERT_PATH }} -CERTIFICATE_PASSWORD {{ PFX_CERT_PASSWORD }}
 
-Below, you will find an example of how to build a Windows msi package.
+Below is an example of how to build a Windows MSI package.
 
 .. code-block:: console
 
-  # ./generate_wazuh_msi.ps1 -MSI_NAME mypackage.msi -SIGN no
+   # ./generate_wazuh_msi.ps1 -MSI_NAME mypackage.msi -SIGN no
 
-.. note::
+Here is an example of using a specific certificate and password.
 
-  If the ``WIX_TOOLS`` and/or ``SIGN_TOOLS`` binaries are not added to the environment PATH, it will be necessary to specify the path,
-  as shown in the following example:
+.. code-block:: console
 
-  .. code-block:: console
+   # ./generate_wazuh_msi.ps1 -MSI_NAME mypackage.msi -SIGN yes -CERTIFICATE_PATH .\certificate.pfx -CERTIFICATE_PASSWORD mypassword
 
-    # ./generate_wazuh_msi.ps1 -MSI_NAME mypackage.msi -SIGN yes -WIX_TOOLS_PATH C:\path_to_wix_tools_binary_files -SIGN_TOOLS_PATH C:\path_to_sign_tools_binary_files
+If you don't specify the ``CERTIFICATE_PATH`` and ``CERTIFICATE_PASSWORD`` parameters, the best matching certificate from the Certificate Store is selected for signing the package. For more details, check the `/a option of the sign command in SignTool <https://learn.microsoft.com/en-us/windows/win32/seccrypto/signtool#sign-command-options>`__ .
 
-.. note::
+If the ``WIX_TOOLS`` and/or ``SIGN_TOOLS`` binaries are not added to the environment PATH, specify the path as shown in the following example:
 
-  If the ``CERTIFICATE_PATH`` and ``CERTIFICATE_PASSWORD`` parameters are not indicated, the certificate to be used for signing the package will be chosen as the best match
-  from the Certificate Store, using the ``/a`` `parameter of the signtool <https://learn.microsoft.com/es-es/windows/win32/seccrypto/signtool#sign-command-options>`__.
-  If not, the indicated certificate together with the password will be used:
+.. code-block:: console
 
-  .. code-block:: console
-
-    # ./generate_wazuh_msi.ps1 -MSI_NAME mypackage.msi -SIGN yes -CERTIFICATE_PATH .\certificate.pfx -CERTIFICATE_PASSWORD mypassword
+   # ./generate_wazuh_msi.ps1 -MSI_NAME mypackage.msi -SIGN yes -WIX_TOOLS_PATH C:\path_to_wix_tools_binary_files -SIGN_TOOLS_PATH C:\path_to_sign_tools_binary_files

--- a/source/development/packaging/generate-windows-package.rst
+++ b/source/development/packaging/generate-windows-package.rst
@@ -95,20 +95,22 @@ Execute the ``generate_wazuh_msi.ps1`` script, with the different options you de
 
   This tool can be used to generate the Windows Wazuh agent msi package.
       PARAMETERS TO BUILD WAZUH-AGENT MSI:
-          1. OPTIONAL_REVISION: 1 or different
-          2. SIGN: yes or no.
+          1. MSI_NAME: MSI package name output.
+          2. SIGN: yes or no. By default 'no'.
       OPTIONAL PARAMETERS:
-          3. WIX_TOOLS_PATH: Wix tools path
-          4. SIGN_TOOLS_PATH: sign tools path
+          3. WIX_TOOLS_PATH: Wix tools path.
+          4. SIGN_TOOLS_PATH: sign tools path.
+          5. CERTIFICATE_PATH: Path to the .pfx certificate file.
+          6. CERTIFICATE_PASSWORD: Password for the .pfx certificate file.
 
       USAGE:
-          ./generate_wazuh_msi.ps1  -OPTIONAL_REVISION {{ REVISION }} -SIGN {{ yes|no }} -WIX_TOOLS_PATH {{ PATH }} -SIGN_TOOLS_PATH {{ PATH }}
+          ./generate_wazuh_msi.ps1  -MSI_NAME {{ NAME }} -SIGN {{ yes|no }} -WIX_TOOLS_PATH {{ PATH }} -SIGN_TOOLS_PATH {{ PATH }} -CERTIFICATE_PATH {{ PFX_CERT_PATH }} -CERTIFICATE_PASSWORD {{ PFX_CERT_PASSWORD }}
 
 Below, you will find an example of how to build a Windows msi package.
 
 .. code-block:: console
 
-  # ./generate_wazuh_msi.ps1 -OPTIONAL_REVISION my.revision -SIGN no
+  # ./generate_wazuh_msi.ps1 -MSI_NAME mypackage.msi -SIGN no
 
 .. note::
 
@@ -117,4 +119,14 @@ Below, you will find an example of how to build a Windows msi package.
 
   .. code-block:: console
 
-    # ./generate_wazuh_msi.ps1 -OPTIONAL_REVISION my.revision -SIGN yes -WIX_TOOLS_PATH C:\path_to_wix_tools_binary_files -SIGN_TOOLS_PATH C:\path_to_sign_tools_binary_files
+    # ./generate_wazuh_msi.ps1 -MSI_NAME mypackage.msi -SIGN yes -WIX_TOOLS_PATH C:\path_to_wix_tools_binary_files -SIGN_TOOLS_PATH C:\path_to_sign_tools_binary_files
+
+.. note::
+
+  If the ``CERTIFICATE_PATH`` and ``CERTIFICATE_PASSWORD`` parameters are not indicated, the certificate to be used for signing the package will be chosen as the best match
+  from the Certificate Store, using the ``/a`` `parameter of the signtool <https://learn.microsoft.com/es-es/windows/win32/seccrypto/signtool#sign-command-options>`__.
+  If not, the indicated certificate together with the password will be used:
+
+  .. code-block:: console
+
+    # ./generate_wazuh_msi.ps1 -MSI_NAME mypackage.msi -SIGN yes -CERTIFICATE_PATH .\certificate.pfx -CERTIFICATE_PASSWORD mypassword


### PR DESCRIPTION

## Description
In this PR we want to add a brief description about the new parameters added in this wazuh/wazuh PR:

Its use is to give the possibility to the user to be able to indicate a specific certificate with his name and password, instead of the default option that selects the best match certificate of the Store.

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
