### PR TITLE
Move configuring indexer connection subsection

### DIFF
--- a/source/installation-guide/wazuh-server/step-by-step.rst
+++ b/source/installation-guide/wazuh-server/step-by-step.rst
@@ -68,28 +68,6 @@ Installing the Wazuh manager
 
             # apt-get -y install wazuh-manager|WAZUH_MANAGER_DEB_PKG_INSTALL|
 
-Configuring the Wazuh indexer connection
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. note::
-
-   You can skip this step if you are not going to use the vulnerability detection capability.
-
-#. Save the Wazuh indexer username and password into the Wazuh manager keystore using the wazuh-keystore tool:
-
-   .. code-block:: console
-
-      # /var/ossec/bin/wazuh-keystore -f indexer -k username -v <INDEXER_USERNAME>
-      # /var/ossec/bin/wazuh-keystore -f indexer -k password -v <INDEXER_PASSWORD>
-
-   .. note::
-
-      The default step-by-step installation credentials are ``admin``:``admin``
-
-#. Edit ``/var/ossec/etc/ossec.conf`` to configure the indexer connection.
-
-   .. include:: /_templates/installations/manager/configure_indexer_connection.rst
-
 .. _wazuh_server_multi_node_filebeat:
 
 Installing Filebeat
@@ -163,6 +141,28 @@ Deploying certificates
   #. Replace ``<SERVER_NODE_NAME>`` with your Wazuh server node certificate name, the same one used in ``config.yml`` when creating the certificates. Then, move the certificates to their corresponding location.
 
       .. include:: /_templates/installations/filebeat/opensearch/copy_certificates_filebeat_wazuh_cluster.rst
+
+Configuring the Wazuh indexer connection
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. note::
+
+   You can skip this step if you are not going to use the vulnerability detection capability.
+
+#. Save the Wazuh indexer username and password into the Wazuh manager keystore using the wazuh-keystore tool:
+
+   .. code-block:: console
+
+      # /var/ossec/bin/wazuh-keystore -f indexer -k username -v <INDEXER_USERNAME>
+      # /var/ossec/bin/wazuh-keystore -f indexer -k password -v <INDEXER_PASSWORD>
+
+   .. note::
+
+      The default step-by-step installation credentials are ``admin``:``admin``
+
+#. Edit ``/var/ossec/etc/ossec.conf`` to configure the indexer connection.
+
+   .. include:: /_templates/installations/manager/configure_indexer_connection.rst
 
 Starting the Wazuh manager
 ^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Description
This PR moves the [Configuring the Wazuh indexer connection](http://127.0.0.1:8000/installation-guide/wazuh-server/step-by-step.html#configuring-the-wazuh-indexer-connection) a few steps down after Filebeat instalation and certificates deployment.

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
