### PR TITLE
 Revert syscheck and syscollector endpoints deprecation

### DIFF
--- a/source/user-manual/api/rbac/reference.rst
+++ b/source/user-manual/api/rbac/reference.rst
@@ -628,15 +628,11 @@ Syscheck
 syscheck:clear
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. deprecated:: 4.9
-
 - :api-ref:`DELETE /experimental/syscheck <operation/api.controllers.experimental_controller.clear_syscheck_database>` (`agent:id`_, `agent:group`_)
 - :api-ref:`DELETE /syscheck/{agent_id} <operation/api.controllers.syscheck_controller.delete_syscheck_agent>` (`agent:id`_, `agent:group`_)
 
 syscheck:read
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. deprecated:: 4.9
 
 - :api-ref:`GET /syscheck/{agent_id} <operation/api.controllers.syscheck_controller.get_syscheck_agent>` (`agent:id`_, `agent:group`_)
 - :api-ref:`GET /syscheck/{agent_id}/last_scan <operation/api.controllers.syscheck_controller.get_last_scan_agent>` (`agent:id`_, `agent:group`_)
@@ -650,8 +646,6 @@ Syscollector
 ^^^^^^^^^^^^^^^
 syscollector:read
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. deprecated:: 4.9
   
 - :api-ref:`GET /experimental/syscollector/hardware <operation/api.controllers.experimental_controller.get_hardware_info>` (`agent:id`_, `agent:group`_)
 - :api-ref:`GET /experimental/syscollector/hotfixes <operation/api.controllers.experimental_controller.get_hotfixes_info>` (`agent:id`_, `agent:group`_)

--- a/source/user-manual/api/use-cases.rst
+++ b/source/user-manual/api/use-cases.rst
@@ -194,8 +194,6 @@ With the Wazuh API, it is possible to start a **wazuh-logtest** session or use a
 Mining the file integrity monitoring database of an agent
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. deprecated:: 4.9
-
 The API can be used to show information about all monitored files by syscheck. The following example shows all events related with *.py* files in agent *000* (the manager):
 
 .. code-block:: console

--- a/source/user-manual/capabilities/system-inventory/viewing-system-inventory-data.rst
+++ b/source/user-manual/capabilities/system-inventory/viewing-system-inventory-data.rst
@@ -31,8 +31,6 @@ The Syscollector module runs periodic scans and sends the updated data in JSON f
 Using the Wazuh API
 ^^^^^^^^^^^^^^^^^^^
 
-.. deprecated:: 4.9
-
 You can query the Wazuh inventory data using the `Wazuh API <https://documentation.wazuh.com/current/user-manual/api/reference.html#tag/Syscollector>`_, which retrieves nested data in JSON format. You can use the Wazuh API GUI on the dashboard or a command line tool like ``cURL`` to query the inventory database. 
 
 Wazuh API GUI


### PR DESCRIPTION
## Description

Reverts the syscheck and syscollector endpoints deprecation introduced in https://github.com/wazuh/wazuh-documentation/pull/6853.

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
