### PR TITLE
Update GCP wodle storage required roles

### DIFF
--- a/source/cloud-security/gcp/prerequisites/credentials.rst
+++ b/source/cloud-security/gcp/prerequisites/credentials.rst
@@ -17,7 +17,7 @@ Creating a service account
 #. Add roles to the service account:
 
    -  For the Wazuh module for Google Cloud Pub/Sub, add two roles with *Pub/Sub* permissions: **Pub/Sub Publisher** and **Pub/Sub Subscriber**.
-   -  For the Wazuh module for Google Cloud Storage buckets, add the following role with *Google Cloud Storage bucket* permissions: **Storage Object User**.
+   -  For the Wazuh module for Google Cloud Storage buckets, add the following roles with *Google Cloud Storage bucket* permissions: **Storage Object User** and **Storage Insights Collector Service**.
 
       Depending on your requirement, the service account can have the roles for authenticating to both Google Cloud Pub/Sub and Storage services.
 

--- a/source/cloud-security/gcp/prerequisites/credentials.rst
+++ b/source/cloud-security/gcp/prerequisites/credentials.rst
@@ -16,10 +16,17 @@ Creating a service account
 #. Add a name and description and click on **CREATE AND CONTINUE**.
 #. Add roles to the service account:
 
-   -  For the Wazuh module for Google Cloud Pub/Sub, add two roles with *Pub/Sub* permissions: **Pub/Sub Publisher** and **Pub/Sub Subscriber**.
-   -  For the Wazuh module for Google Cloud Storage buckets, add the following roles with *Google Cloud Storage bucket* permissions: **Storage Object User** and **Storage Insights Collector Service**.
+   -  For the Wazuh module for Google Cloud Pub/Sub, add two roles with *Pub/Sub* permissions:
 
-      Depending on your requirement, the service account can have the roles for authenticating to both Google Cloud Pub/Sub and Storage services.
+      -  **Pub/Sub Publisher**
+      -  **Pub/Sub Subscriber**
+
+   -  For the Wazuh module for Google Cloud Storage buckets, add the following roles with *Google Cloud Storage bucket* permissions:
+
+      -  **Storage Object User**
+      -  **Storage Insights Collector Service**
+
+   Depending on your requirement, the service account can have the roles for authenticating to both Google Cloud Pub/Sub and Storage services.
 
 #. Click **Done** to complete the creation of the service account.
 


### PR DESCRIPTION
## Description

Added the role **Storage Insights Collector Service** to the roles required to execute the Google Cloud Access Logs module.

A test execution with a service account having only those roles can be found [here](https://github.com/wazuh/wazuh/issues/24918#issuecomment-2250963978).

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
