### PR TITLE
Split AWS Security Lake integration in Source and Subscriber sections

### DIFF
--- a/source/_static/js/redirects.js
+++ b/source/_static/js/redirects.js
@@ -117,7 +117,6 @@ newUrls['4.9'] = [
   '/development/packaging/generate-indexer-package.html',
   '/development/packaging/generate-deb-rpm-package.html',
   '/cloud-security/amazon/services/supported-services/amazon-security-lake/index.html',
-  '/cloud-security/amazon/services/supported-services/amazon-security-lake/security-lake-source.html',
   '/cloud-security/amazon/services/supported-services/amazon-security-lake/security-lake-subscriber.html',
   '/user-manual/capabilities/log-data-collection/journald.html',
 ];
@@ -128,7 +127,8 @@ removedUrls['4.9'] = [
   '/deployment-options/offline-installation.html',
   '/development/packaging/generate-deb-package.html',
   '/development/packaging/generate-rpm-package.html',
-  '/cloud-security/amazon/services/supported-services/security-lake.html'
+  '/cloud-security/amazon/services/supported-services/security-lake.html',
+  '/integrations-guide/amazon-security-lake/index.html'
 ];
 
 /* *** RELEASE 4.8 ****/

--- a/source/cloud-security/amazon/services/supported-services/amazon-security-lake/index.rst
+++ b/source/cloud-security/amazon/services/supported-services/amazon-security-lake/index.rst
@@ -11,5 +11,4 @@ Amazon Security Lake is a fully-managed security data lake service that consolid
 .. toctree::
    :maxdepth: 1
 
-   security-lake-source
    security-lake-subscriber

--- a/source/cloud-security/amazon/services/supported-services/amazon-security-lake/security-lake-subscriber.rst
+++ b/source/cloud-security/amazon/services/supported-services/amazon-security-lake/security-lake-subscriber.rst
@@ -18,6 +18,13 @@ To set up the Wazuh integration for Amazon Security Lake as a subscriber, you ne
     #. Create a subscriber in Amazon Security Lake.
     #. Set up the Wazuh integration for Amazon Security Lake.
 
+.. note::
+   :class: not-long
+
+   This document guides you through setting up Wazuh as a subscriber to AWS Security Lake data.
+   In order to configure Wazuh as a source to Amazon Security Lake, head to: :doc:`Amazon Security Lake integration </integrations-guide/amazon-security-lake/index>`
+
+
 AWS configuration
 -----------------
 

--- a/source/integrations-guide/amazon-security-lake/index.rst
+++ b/source/integrations-guide/amazon-security-lake/index.rst
@@ -3,8 +3,8 @@
 .. meta::
    :description: Learn how to configure Amazon Security Lake.
 
-Wazuh as a custom source
-========================
+Amazon Security Lake integration
+================================
 
 .. versionadded:: 4.9.0
 
@@ -17,6 +17,14 @@ The diagram below illustrates the process of converting Wazuh Security Events to
 .. thumbnail:: /images/aws/asl-overview.png
    :align: center
    :width: 80%
+
+.. note::
+   :class: not-long
+
+   This document guides you through setting up Wazuh as a data source to AWS Security Lake.
+   In order to configure Wazuh as a subscriber to Amazon Security Lake, head to: :doc:`Wazuh as a subscriber </cloud-security/amazon/services/supported-services/amazon-security-lake/index>`
+
+
 
 Prerequisites
 --------------

--- a/source/integrations-guide/index.rst
+++ b/source/integrations-guide/index.rst
@@ -150,3 +150,4 @@ After the integration, you might have the same data in both Wazuh and third-part
    elastic-stack/index
    opensearch/index
    splunk/index
+   amazon-security-lake/index


### PR DESCRIPTION
## Description
This PR moves the Source AWS Security Lake documentation pages to the `integrations-guide` section, as it is maintained by the Indexer team.

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
