### PR TITLE
Add --api parameter when changing the API users passwords

### DIFF
--- a/source/deployment-options/offline-installation.rst
+++ b/source/deployment-options/offline-installation.rst
@@ -486,7 +486,7 @@ Select your deployment type and follow the instructions to change the default pa
 
          .. code-block:: console
 
-            # /usr/share/wazuh-indexer/plugins/opensearch-security/tools/wazuh-passwords-tool.sh --change-all --admin-user wazuh --admin-password wazuh
+            # /usr/share/wazuh-indexer/plugins/opensearch-security/tools/wazuh-passwords-tool.sh --api --change-all --admin-user wazuh --admin-password wazuh
 
          .. code-block:: console
             :class: output

--- a/source/installation-guide/wazuh-dashboard/step-by-step.rst
+++ b/source/installation-guide/wazuh-dashboard/step-by-step.rst
@@ -138,7 +138,7 @@ Select your deployment type and follow the instructions to change the default pa
       
          .. code-block:: console
          
-            # /usr/share/wazuh-indexer/plugins/opensearch-security/tools/wazuh-passwords-tool.sh --change-all --admin-user wazuh --admin-password wazuh
+            # /usr/share/wazuh-indexer/plugins/opensearch-security/tools/wazuh-passwords-tool.sh --api --change-all --admin-user wazuh --admin-password wazuh
          
          .. code-block:: console
             :class: output
@@ -180,7 +180,7 @@ Select your deployment type and follow the instructions to change the default pa
          .. code-block:: console
   
             # curl -sO https://packages.wazuh.com/|WAZUH_CURRENT_MINOR|/wazuh-passwords-tool.sh
-            # bash wazuh-passwords-tool.sh --change-all --admin-user wazuh --admin-password wazuh
+            # bash wazuh-passwords-tool.sh --api --change-all --admin-user wazuh --admin-password wazuh
   
          .. code-block:: console
             :class: output

--- a/source/user-manual/user-administration/password-management.rst
+++ b/source/user-manual/user-administration/password-management.rst
@@ -207,7 +207,7 @@ Follow the instructions below to change the passwords for all the Wazuh indexer 
    .. code-block:: console
 
       # curl -sO https://packages.wazuh.com/|WAZUH_CURRENT_MINOR|/wazuh-passwords-tool.sh
-      # bash wazuh-passwords-tool.sh --change-all --admin-user wazuh --admin-password <WAZUH_PASSWORD>
+      # bash wazuh-passwords-tool.sh --api --change-all --admin-user wazuh --admin-password <WAZUH_PASSWORD>
   
    .. code-block:: console
       :class: output


### PR DESCRIPTION
|Related issue|
|---|
|https://github.com/wazuh/wazuh-documentation/issues/7564|

## Description

In versions prior to 4.8, it was not necessary to use the --api option when changing the passwords of API users with the --change-all option. In this version, it was modified so that the --api option must also be used.

This change does not appear in the documentation, so the --api option has been added to the command.

## Changes

- Password management
![Captura de pantalla 2024-07-26 a las 12 52 41](https://github.com/user-attachments/assets/367a48da-3508-4f6a-9156-df345312a214)

- Wazuh dashboard

![Captura de pantalla 2024-07-26 a las 14 16 43](https://github.com/user-attachments/assets/76be0b22-e461-4d7a-9437-d59378b76a4d)

![Captura de pantalla 2024-07-29 a las 14 59 53](https://github.com/user-attachments/assets/358ed99f-5cd3-4906-ba3c-60a0578bbd81)


- Offline installation
![Captura de pantalla 2024-07-29 a las 16 10 08](https://github.com/user-attachments/assets/1093ff99-357c-4493-be27-a95ab64ed6df)

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
