### PR TITLE
add some minikube port forwading info contribution

### DIFF
--- a/source/deployment-options/deploying-with-kubernetes/kubernetes-deployment.rst
+++ b/source/deployment-options/deploying-with-kubernetes/kubernetes-deployment.rst
@@ -403,3 +403,18 @@ Wazuh agents are designed to monitor hosts. To start using them:
 #. Enroll the agent by modifying the file ``/var/ossec/etc/ossec.conf``. Change the “transport protocol” to TCP and replace the ``MANAGER_IP`` with the external IP address of the service pointing to port 1514 or with the hostname provided by the cloud provider
 
 To learn more about registering agents, see the :doc:`Wazuh agent enrollment </user-manual/agent/agent-enrollment/index>` section of the documentation.
+
+.. note:: Quick Tip for Minikube Users
+
+   Before deploying Wazuh in a production Kubernetes cluster, you may want to deploy it on Minikube for testing purposes. If you are using Minikube and need to connect Wazuh agents, you must also expose the following services using port-forwarding to avoid connection errors such as ``'[10.10.5.45]:1514/tcp': 'Connection refused'``.
+
+   Use the following commands to port-forward the necessary services:
+
+   .. code-block:: shell
+
+      kubectl port-forward svc/wazuh-workers --address <address> 1514:1514 -n wazuh
+      kubectl port-forward svc/wazuh --address <address> 1515:1515 55000:55000 -n wazuh
+
+   Replace ``<address>`` with the appropriate IP address or hostname.
+
+This addition will help Minikube users to correctly map the necessary ports for connecting Wazuh agents and prevent connection issues.


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
contribution
-->
## Description
contribution
In the Local Installation for minikube users where linking an agent https://documentation.wazuh.com/current/deployment-options/deploying-with-kubernetes/kubernetes-deployment.html , for people who is new in wazuh, ports 1515 and 1414 should be expose (port-forward), so that two port forwand commands are added and short explained why they are required.
## Checks
### Docs building
- [X ] Compiles without warnings.
### Code formatting and web optimization
- [X ] Uses three spaces indentation.
- [ X] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ X] Uses present tense, active voice, and semi-formal registry.
- [ X] Uses short, simple sentences.
- [X ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
