### PR TITLE
Remove SCA for Rocky Linux 8

### DIFF
--- a/source/release-notes/release-4-8-0.rst
+++ b/source/release-notes/release-4-8-0.rst
@@ -97,7 +97,6 @@ Ruleset
 
 -  `#19528 <https://github.com/wazuh/wazuh/pull/19528>`__ Added rules to detect IcedID attacks.
 -  `#17780 <https://github.com/wazuh/wazuh/pull/17780>`__ Added new SCA policy for Amazon Linux 2023.
--  `#17784 <https://github.com/wazuh/wazuh/pull/17784>`__ Added new SCA policy for Rocky Linux 8.
 -  `#18721 <https://github.com/wazuh/wazuh/pull/18721>`__ Revised SCA policy for Ubuntu Linux 18.04.
 -  `#17515 <https://github.com/wazuh/wazuh/pull/17515>`__ Revised SCA policy for Ubuntu Linux 22.04.
 -  `#18440 <https://github.com/wazuh/wazuh/pull/18440>`__ Revised SCA policy for Red Hat Enterprise Linux 7.
@@ -168,7 +167,6 @@ Packages
 -  `#2365 <https://github.com/wazuh/wazuh-packages/pull/2365>`__ Removed the ``postProvision.sh`` script. It's no longer used in OVA generation.
 -  `#2364 <https://github.com/wazuh/wazuh-packages/pull/2364>`__ Added ``curl`` error messages in downloads.
 -  `#2469 <https://github.com/wazuh/wazuh-packages/pull/2469>`__ Improved debug output in the installation assistant.
--  `#2300 <https://github.com/wazuh/wazuh-packages/pull/2300>`__ Added SCA policy for Rocky Linux 8 in SPECS.
 -  `#2557 <https://github.com/wazuh/wazuh-packages/pull/2557>`__ Added SCA policy for Amazon Linux 2023 in SPECS.
 -  `#2558 <https://github.com/wazuh/wazuh-packages/pull/2558>`__ Wazuh password tool now recognizes UI created users.
 -  `#2562 <https://github.com/wazuh/wazuh-packages/pull/2562>`__ Bumped Wazuh indexer to OpenSearch 2.10.0.

--- a/source/user-manual/capabilities/sec-config-assessment/available-sca-policies.rst
+++ b/source/user-manual/capabilities/sec-config-assessment/available-sca-policies.rst
@@ -22,7 +22,7 @@ The table below shows SCA policies pre-installed in Wazuh out-of-the-box. The Wa
     | cis_win10_enterprise        |  CIS Benchmark for Windows 10 Enterprise                   | Windows 10                    |
     +-----------------------------+------------------------------------------------------------+-------------------------------+
     | cis_win11_enterprise        |  CIS Benchmark for Windows 11 Enterprise                   | Windows 11                    |
-    +-----------------------------+------------------------------------------------------------+-------------------------------+    
+    +-----------------------------+------------------------------------------------------------+-------------------------------+
     | cis_win2016                 |  CIS Benchmark for Windows Server 2016                     | Windows Server 2016           |
     +-----------------------------+------------------------------------------------------------+-------------------------------+
     | cis_win2019                 |  CIS Benchmark for Windows Server 2019 RTM                 | Windows Server 2019           |
@@ -47,8 +47,6 @@ The table below shows SCA policies pre-installed in Wazuh out-of-the-box. The Wa
     +-----------------------------+------------------------------------------------------------+-------------------------------+
     | cis_rhel9_linux             |  CIS Benchmark for Red Hat Enterprise Linux 9              | Red Hat Enterprise Linux 9    |
     +-----------------------------+------------------------------------------------------------+-------------------------------+
-    | cis_rocky_linux_8           |  CIS Benchmark for Rocky Linux 8                           | Rocky Linux 8                 |
-    +-----------------------------+------------------------------------------------------------+-------------------------------+    
     | cis_debian7                 |  CIS Benchmark for Debian/Linux 7                          | Debian 7                      |
     +-----------------------------+------------------------------------------------------------+-------------------------------+
     | cis_debian8                 |  CIS Benchmark for Debian/Linux 8                          | Debian 8                      |


### PR DESCRIPTION
## Description

This PR closes #7624. It aims to delete reference to the SCA policy for Rocky Linux 8.

**Note:** this change must apply to 4.8.1 but not to 4.9.0+.


## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
