### PR TITLE
Move SCA policies for Rocky Linux 8 to 4.9.0

### DIFF
--- a/source/release-notes/release-4-8-0.rst
+++ b/source/release-notes/release-4-8-0.rst
@@ -97,7 +97,6 @@ Ruleset
 
 -  `#19528 <https://github.com/wazuh/wazuh/pull/19528>`__ Added rules to detect IcedID attacks.
 -  `#17780 <https://github.com/wazuh/wazuh/pull/17780>`__ Added new SCA policy for Amazon Linux 2023.
--  `#17784 <https://github.com/wazuh/wazuh/pull/17784>`__ Added new SCA policy for Rocky Linux 8.
 -  `#18721 <https://github.com/wazuh/wazuh/pull/18721>`__ Revised SCA policy for Ubuntu Linux 18.04.
 -  `#17515 <https://github.com/wazuh/wazuh/pull/17515>`__ Revised SCA policy for Ubuntu Linux 22.04.
 -  `#18440 <https://github.com/wazuh/wazuh/pull/18440>`__ Revised SCA policy for Red Hat Enterprise Linux 7.
@@ -168,7 +167,6 @@ Packages
 -  `#2365 <https://github.com/wazuh/wazuh-packages/pull/2365>`__ Removed the ``postProvision.sh`` script. It's no longer used in OVA generation.
 -  `#2364 <https://github.com/wazuh/wazuh-packages/pull/2364>`__ Added ``curl`` error messages in downloads.
 -  `#2469 <https://github.com/wazuh/wazuh-packages/pull/2469>`__ Improved debug output in the installation assistant.
--  `#2300 <https://github.com/wazuh/wazuh-packages/pull/2300>`__ Added SCA policy for Rocky Linux 8 in SPECS.
 -  `#2557 <https://github.com/wazuh/wazuh-packages/pull/2557>`__ Added SCA policy for Amazon Linux 2023 in SPECS.
 -  `#2558 <https://github.com/wazuh/wazuh-packages/pull/2558>`__ Wazuh password tool now recognizes UI created users.
 -  `#2562 <https://github.com/wazuh/wazuh-packages/pull/2562>`__ Bumped Wazuh indexer to OpenSearch 2.10.0.

--- a/source/release-notes/release-4-9-0.rst
+++ b/source/release-notes/release-4-9-0.rst
@@ -84,6 +84,7 @@ Ruleset
 ^^^^^^^
 
 -  `#19754 <https://github.com/wazuh/wazuh/pull/19754>`__ Clarified the description for rule ID ``23502`` about solved vulnerabilities.
+-  `#17784 <https://github.com/wazuh/wazuh/pull/17784>`__ Added new SCA policy for Rocky Linux 8.
 
 Other
 ^^^^^
@@ -149,6 +150,7 @@ Packages
 -  `#2882 <https://github.com/wazuh/wazuh-packages/pull/2882>`__ Added rollBack to several exit points
 -  `#2753 <https://github.com/wazuh/wazuh-packages/pull/2753>`__ Adding support for Amazon Linux 1, 2, and 2023
 -  `#2790 <https://github.com/wazuh/wazuh-packages/pull/2790>`__ Added support for AL2023 in WIA
+-  `#2300 <https://github.com/wazuh/wazuh-packages/pull/2300>`__ Added SCA policy for Rocky Linux 8 in SPECS.
 
 Resolved issues
 ---------------


### PR DESCRIPTION
## Description

This PR closes #7624. 

Since SCA policies for Rocky Linux were reverted in 4.8.0 (after merging to 4.9.0), this PR aims to move such feature from release notes for 4.8.0 to 4.9.0.

## Checks
### Docs building
- [ ] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
