### PR TITLE
Move SCA policies for Rocky Linux 8 to 4.9.0

### DIFF
--- a/source/release-notes/release-4-9-0.rst
+++ b/source/release-notes/release-4-9-0.rst
@@ -84,6 +84,7 @@ Ruleset
 ^^^^^^^
 
 -  `#19754 <https://github.com/wazuh/wazuh/pull/19754>`__ Clarified the description for rule ID ``23502`` about solved vulnerabilities.
+-  `#17784 <https://github.com/wazuh/wazuh/pull/17784>`__ Added new SCA policy for Rocky Linux 8.
 
 Other
 ^^^^^
@@ -149,6 +150,7 @@ Packages
 -  `#2882 <https://github.com/wazuh/wazuh-packages/pull/2882>`__ Added rollBack to several exit points
 -  `#2753 <https://github.com/wazuh/wazuh-packages/pull/2753>`__ Adding support for Amazon Linux 1, 2, and 2023
 -  `#2790 <https://github.com/wazuh/wazuh-packages/pull/2790>`__ Added support for AL2023 in WIA
+-  `#2300 <https://github.com/wazuh/wazuh-packages/pull/2300>`__ Added SCA policy for Rocky Linux 8 in SPECS.
 
 Resolved issues
 ---------------

--- a/source/user-manual/capabilities/sec-config-assessment/available-sca-policies.rst
+++ b/source/user-manual/capabilities/sec-config-assessment/available-sca-policies.rst
@@ -47,6 +47,8 @@ The table below shows SCA policies pre-installed in Wazuh out-of-the-box. The Wa
     +-----------------------------+------------------------------------------------------------+-------------------------------+
     | cis_rhel9_linux             |  CIS Benchmark for Red Hat Enterprise Linux 9              | Red Hat Enterprise Linux 9    |
     +-----------------------------+------------------------------------------------------------+-------------------------------+
+    | cis_rocky_linux_8           |  CIS Benchmark for Rocky Linux 8                           | Rocky Linux 8                 |
+    +-----------------------------+------------------------------------------------------------+-------------------------------+
     | cis_debian7                 |  CIS Benchmark for Debian/Linux 7                          | Debian 7                      |
     +-----------------------------+------------------------------------------------------------+-------------------------------+
     | cis_debian8                 |  CIS Benchmark for Debian/Linux 8                          | Debian 8                      |


### PR DESCRIPTION
## Description

This PR closes #7624. 

Since SCA policies for Rocky Linux were reverted in 4.8.0 (after merging to 4.9.0), this PR aims to move such feature from release notes for 4.8.0 to 4.9.0.

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
