### PR TITLE
Fixed PDF custom branding logo property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ All notable changes to this project will be documented in this file.
 - Fix Amazon Security Lake Source integration validation step. ([#7360](https://github.com/wazuh/wazuh-documentation/pull/7360))
 - Updated commands in installing the Wazuh agent from sources section. ([#6973](https://github.com/wazuh/wazuh-documentation/pull/6973))
 - Fixed **Indexer management** and **Dashboard management** references. ([#7583](https://github.com/wazuh/wazuh-documentation/pull/7583))
+- Fixed the name of the property **customization.logo.reports** ([#7646](https://github.com/wazuh/wazuh-documentation/pull/7646))
 
 ### Removed
 

--- a/source/user-manual/wazuh-dashboard/custom-branding.rst
+++ b/source/user-manual/wazuh-dashboard/custom-branding.rst
@@ -72,7 +72,7 @@ Custom branding of the PDF reports
 
 To customize the PDF reports, click **Dashboard management** > **App Settings**. Under the **Custom branding** section, set up the following properties:
 
--  ``customization.reports.logo``. This property sets the `PDF reports logo` image. It has a size limit of 1 MB. It's printed in the top left corner of the PDF reports. Recommended size: 190 pixels width, 40 pixels height. See #1 in the image below.
+-  ``customization.logo.reports``. This property sets the `PDF reports logo` image. It has a size limit of 1 MB. It's printed in the top left corner of the PDF reports. Recommended size: 190 pixels width, 40 pixels height. See #1 in the image below.
 
 -  ``customization.reports.footer``. This property sets the `Reports footer` text block. It has a size limit of 2 lines of 50 characters each. It's printed in the bottom left corner of the PDF reports. See #2 in the image below.
 


### PR DESCRIPTION
## Description

In User manual > Wazuh dashboard > Setting up custom branding customization.reports.logo is incorrectly named. It was changed to customization.logo.reports


### Evidences

![image](https://github.com/user-attachments/assets/061a1e20-7ef9-452f-bc2e-d2faf2bfe148)
![image](https://github.com/user-attachments/assets/e5328ffd-c228-4d54-b4a9-ed6a7aaf27fa)


## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
