### PR TITLE
Repaired wazuh-template.json links

### DIFF
--- a/source/user-manual/manager/wazuh-server-cluster.rst
+++ b/source/user-manual/manager/wazuh-server-cluster.rst
@@ -1097,7 +1097,7 @@ Install and configure Filebeat
 
    .. code-block:: console
 
-      # curl -so /etc/filebeat/wazuh-template.json https://raw.githubusercontent.com/wazuh/wazuh/|WAZUH_CURRENT_MINOR|/extensions/elasticsearch/7.x/wazuh-template.json
+      # curl -so /etc/filebeat/wazuh-template.json https://raw.githubusercontent.com/wazuh/wazuh/v|WAZUH_CURRENT|/extensions/elasticsearch/7.x/wazuh-template.json
       # chmod go+r /etc/filebeat/wazuh-template.json
 
 #. Install the Wazuh module for Filebeat:

--- a/source/user-manual/upscaling/adding-server-node.rst
+++ b/source/user-manual/upscaling/adding-server-node.rst
@@ -664,7 +664,7 @@ Install and configure Filebeat
 
    .. code-block:: console
 
-      # curl -so /etc/filebeat/wazuh-template.json https://raw.githubusercontent.com/wazuh/wazuh/|WAZUH_CURRENT_MINOR|/extensions/elasticsearch/7.x/wazuh-template.json
+      # curl -so /etc/filebeat/wazuh-template.json https://raw.githubusercontent.com/wazuh/wazuh/v|WAZUH_CURRENT|/extensions/elasticsearch/7.x/wazuh-template.json
       # chmod go+r /etc/filebeat/wazuh-template.json
 
 #. Install the Wazuh module for Filebeat:

--- a/source/user-manual/wazuh-indexer/wazuh-indexer-indices.rst
+++ b/source/user-manual/wazuh-indexer/wazuh-indexer-indices.rst
@@ -30,7 +30,7 @@ This section describes creating a custom index pattern, ``my-custom-alerts-*``, 
 
    .. code-block:: console
 
-      # curl -so template.json https://raw.githubusercontent.com/wazuh/wazuh/|WAZUH_CURRENT_MINOR|/extensions/elasticsearch/7.x/wazuh-template.json
+      # curl -so template.json https://raw.githubusercontent.com/wazuh/wazuh/v|WAZUH_CURRENT|/extensions/elasticsearch/7.x/wazuh-template.json
 
 #. Open the template file and locate this line at the beginning of the file:
 

--- a/source/user-manual/wazuh-indexer/wazuh-indexer-tuning.rst
+++ b/source/user-manual/wazuh-indexer/wazuh-indexer-tuning.rst
@@ -165,7 +165,7 @@ In the following example, we set the number of shards for a single-node Wazuh in
 
    .. code-block:: console
 
-      # curl https://raw.githubusercontent.com/wazuh/wazuh/|WAZUH_CURRENT_MINOR|/extensions/elasticsearch/7.x/wazuh-template.json -o w-indexer-template.json
+      # curl https://raw.githubusercontent.com/wazuh/wazuh/v|WAZUH_CURRENT|/extensions/elasticsearch/7.x/wazuh-template.json -o w-indexer-template.json
 
 #. Edit ``w-indexer-template.json`` to set ``index.number_of_shards`` to ``1``. To avoid Filebeat overwriting the existing template, set the ``order`` to ``1``. Multiple matching templates in the same order result in a non-deterministic merging order.
 


### PR DESCRIPTION
## Description
Repair wazuh-template.json links on
- [Indexer indices](https://documentation.wazuh.com/current/user-manual/wazuh-indexer/wazuh-indexer-indices.html)
- [Server Cluster](https://documentation.wazuh.com/current/user-manual/manager/wazuh-server-cluster.html)
- [Indexer Tunning](https://documentation.wazuh.com/current/user-manual/wazuh-indexer/wazuh-indexer-tuning.html)
- [Server Node](https://documentation.wazuh.com/current/user-manual/upscaling/adding-server-node.html)


> This update is made from `4.9.0`, so the `4.9.0` tag doesn't exist. To test correctly this pull links must be tested with `v4.8.0` tag

## Checks
### Docs building
- [ ] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
