### PR TITLE
Add compatibility with Python 3.12

### DIFF
--- a/source/_templates/cloud/pip_installation.rst
+++ b/source/_templates/cloud/pip_installation.rst
@@ -26,7 +26,7 @@ We recommend using Pip 19.3 or later to simplify the installation of the depende
 
          # pip3 install --upgrade pip
 
-   .. group-tab:: Python 3.11-3.12
+   .. group-tab:: Python 3.11–3.12
 
       .. code-block:: console
 

--- a/source/_templates/cloud/pip_installation.rst
+++ b/source/_templates/cloud/pip_installation.rst
@@ -26,7 +26,7 @@ We recommend using Pip 19.3 or later to simplify the installation of the depende
 
          # pip3 install --upgrade pip
 
-   .. group-tab:: Python 3.11
+   .. group-tab:: Python 3.11-3.12
 
       .. code-block:: console
 

--- a/source/_variables/replacements.py
+++ b/source/_variables/replacements.py
@@ -2,8 +2,8 @@
 #
 # Custom replacements
 #
-# This file contains the dictionary of custom replacements. Requires the 
-# variables 'version', 'release' and 'is_latest_release' from 
+# This file contains the dictionary of custom replacements. Requires the
+# variables 'version', 'release' and 'is_latest_release' from
 # source/_variables/settings.py
 #
 
@@ -40,7 +40,7 @@ custom_replacements = {
     "|WAZUH_CURRENT_MINOR|" : version,
     "|WAZUH_CURRENT|" : release,
     "|PYTHON_CLOUD_CONTAINERS_MIN|": "3.8",
-    "|PYTHON_CLOUD_CONTAINERS_MAX|": "3.11",
+    "|PYTHON_CLOUD_CONTAINERS_MAX|": "3.12",
 
     # --- Revision numbers for Wazuh agent and manager packages versions
     # Alpine APK packages revisions
@@ -75,7 +75,7 @@ custom_replacements = {
     "|WAZUH_REVISION_DEB_AGENT_ARMHF|" : "1",
     "|WAZUH_REVISION_DEB_MANAGER_ARMHF|" : "1",
     "|WAZUH_REVISION_DEB_AGENT_PPC|" : "1",
-    #"|WAZUH_REVISION_DEB_MANAGER_PPC|" : 
+    #"|WAZUH_REVISION_DEB_MANAGER_PPC|" :
     #
     # === Wazuh indexer version revisions
     "|WAZUH_INDEXER_CURRENT_REV|" : "1", # RPM and Deb

--- a/source/cloud-security/amazon/services/prerequisites/dependencies.rst
+++ b/source/cloud-security/amazon/services/prerequisites/dependencies.rst
@@ -39,13 +39,13 @@ To install the dependencies, execute the following command:
 
       .. code-block:: console
 
-         # pip3 install boto3==1.17.85 pyarrow==14.0.1 numpy==1.26.0
+         # pip3 install boto3==1.34.135 pyarrow==14.0.1 numpy==1.26.0
 
-   .. group-tab:: Python 3.11
+   .. group-tab:: Python 3.11-3.12
 
       .. code-block:: console
 
-         # pip3 install --break-system-packages boto3==1.17.85 pyarrow==14.0.1 numpy==1.26.0
+         # pip3 install --break-system-packages boto3==1.34.135 pyarrow==14.0.1 numpy==1.26.0
 
       .. note::
 

--- a/source/cloud-security/amazon/services/prerequisites/dependencies.rst
+++ b/source/cloud-security/amazon/services/prerequisites/dependencies.rst
@@ -41,7 +41,7 @@ To install the dependencies, execute the following command:
 
          # pip3 install boto3==1.34.135 pyarrow==14.0.1 numpy==1.26.0
 
-   .. group-tab:: Python 3.11-3.12
+   .. group-tab:: Python 3.11–3.12
 
       .. code-block:: console
 

--- a/source/cloud-security/azure/activity-services/prerequisites/dependencies.rst
+++ b/source/cloud-security/azure/activity-services/prerequisites/dependencies.rst
@@ -37,7 +37,7 @@ To install the dependencies, execute the following command:
 
          # pip3 install azure-storage-blob==12.20.0 azure-storage-common==2.1.0 azure-common==1.1.25 cryptography==3.3.2 cffi==1.14.4 pycparser==2.20 six==1.14.0 python-dateutil==2.8.1 requests==2.25.1 certifi==2022.12.07 chardet==3.0.4 idna==2.9 urllib3==1.26.18 SQLAlchemy==2.0.23 pytz==2020.1
 
-   .. group-tab:: Python 3.11
+   .. group-tab:: Python 3.11-3.12
 
       .. code-block:: console
 

--- a/source/cloud-security/azure/activity-services/prerequisites/dependencies.rst
+++ b/source/cloud-security/azure/activity-services/prerequisites/dependencies.rst
@@ -37,7 +37,7 @@ To install the dependencies, execute the following command:
 
          # pip3 install azure-storage-blob==12.20.0 azure-storage-common==2.1.0 azure-common==1.1.25 cryptography==3.3.2 cffi==1.14.4 pycparser==2.20 six==1.14.0 python-dateutil==2.8.1 requests==2.25.1 certifi==2022.12.07 chardet==3.0.4 idna==2.9 urllib3==1.26.18 SQLAlchemy==2.0.23 pytz==2020.1
 
-   .. group-tab:: Python 3.11-3.12
+   .. group-tab:: Python 3.11–3.12
 
       .. code-block:: console
 

--- a/source/cloud-security/gcp/prerequisites/dependencies.rst
+++ b/source/cloud-security/gcp/prerequisites/dependencies.rst
@@ -24,7 +24,7 @@ Python
 Google Cloud pip dependencies
 -----------------------------
 
-`google-cloud-pubsub <https://pypi.org/project/google-cloud-pubsub/>`__ and `google-cloud-storage <https://pypi.org/project/google-cloud-storage/>`__ are the official Python libraries supported by Google to manage Google Cloud Pub/Sub and Cloud Storage resources. 
+`google-cloud-pubsub <https://pypi.org/project/google-cloud-pubsub/>`__ and `google-cloud-storage <https://pypi.org/project/google-cloud-storage/>`__ are the official Python libraries supported by Google to manage Google Cloud Pub/Sub and Cloud Storage resources.
 
 Google Cloud Pub/Sub API is used to pull the log messages from the Pub/Sub queue, while Google Cloud Storage API is used to store and retrieve data.
 
@@ -37,13 +37,13 @@ Run the following command to install the dependencies depending on your Python v
       .. code-block:: console
 
          $ sudo pip3 install google-cloud-core==1.7.1 google-cloud-pubsub==2.7.1 google-cloud-storage==1.39.0 pytz==2020.1 setuptools==68.0.0
-   
-   .. group-tab:: Python 3.11
+
+   .. group-tab:: Python 3.11-3.12
 
       .. code-block:: console
 
          $ sudo pip3 install --break-system-packages google-cloud-core==1.7.1 google-cloud-pubsub==2.7.1 google-cloud-storage==1.39.0 pytz==2020.1 setuptools==68.0.0
 
       .. note::
-         
+
          If you're using a virtual environment, remove the ``--break-system-packages`` parameter from the command above.

--- a/source/cloud-security/gcp/prerequisites/dependencies.rst
+++ b/source/cloud-security/gcp/prerequisites/dependencies.rst
@@ -38,7 +38,7 @@ Run the following command to install the dependencies depending on your Python v
 
          $ sudo pip3 install google-cloud-core==1.7.1 google-cloud-pubsub==2.7.1 google-cloud-storage==1.39.0 pytz==2020.1 setuptools==68.0.0
 
-   .. group-tab:: Python 3.11-3.12
+   .. group-tab:: Python 3.11–3.12
 
       .. code-block:: console
 

--- a/source/proof-of-concept-guide/monitoring-docker.rst
+++ b/source/proof-of-concept-guide/monitoring-docker.rst
@@ -47,7 +47,7 @@ Perform the following steps to install Docker on the Ubuntu endpoint and configu
             $ curl -sSL https://get.docker.com/ | sh
             $ sudo pip3 install docker==7.1.0 urllib3==2.2.2 requests==2.32.2
 
-      .. group-tab:: Python 3.11-3.12
+      .. group-tab:: Python 3.11–3.12
 
          .. code-block:: console
 

--- a/source/proof-of-concept-guide/monitoring-docker.rst
+++ b/source/proof-of-concept-guide/monitoring-docker.rst
@@ -47,17 +47,17 @@ Perform the following steps to install Docker on the Ubuntu endpoint and configu
             $ curl -sSL https://get.docker.com/ | sh
             $ sudo pip3 install docker==7.1.0 urllib3==2.2.2 requests==2.32.2
 
-      .. group-tab:: Python 3.11
+      .. group-tab:: Python 3.11-3.12
 
          .. code-block:: console
 
             $ curl -sSL https://get.docker.com/ | sh
             $ sudo pip3 install docker==7.1.0 urllib3==2.2.2 requests==2.32.2 --break-system-packages
-      
+
          .. note::
 
             This command modifies the default externally managed Python environment. See the `PEP 668 <https://peps.python.org/pep-0668/>`__ description for more information.
-         
+
             To prevent the modification, you can run ``pip3 install --upgrade pip`` within a virtual environment. You must update the docker ``/var/ossec/wodles/docker/DockerListener`` script shebang with your virtual environment interpreter. For example: ``#!</path/to/your/virtual/environment>/bin/python3``.
 
 #. Edit the Wazuh agent configuration file ``/var/ossec/etc/ossec.conf`` and add this block to enable the ``docker-listener`` module:
@@ -107,7 +107,7 @@ Visualize the alerts
 You can visualize the alert data in the Wazuh dashboard. To do this, go to **Docker**.
 
    .. thumbnail:: /images/poc/docker-alerts.png
-      :title: Visualize Docker alerts 
+      :title: Visualize Docker alerts
       :align: center
       :width: 80%
 
@@ -120,7 +120,7 @@ Troubleshooting
    .. code-block:: none
 
       wazuh-modulesd:docker-listener: ERROR: /usr/bin/env: ‘python’: No such file or directory
-   
+
    **Location**: Wazuh agent log - ``/var/ossec/logs/ossec.log``
 
    **Resolution**: You can create a symbolic link to solve this:

--- a/source/user-manual/capabilities/container-security/monitoring-docker.rst
+++ b/source/user-manual/capabilities/container-security/monitoring-docker.rst
@@ -47,7 +47,7 @@ Docker library for Python
 
          $ pip3 install docker==7.1.0 urllib3==2.2.2 requests==2.32.2
 
-   .. group-tab:: Python 3.11-3.12
+   .. group-tab:: Python 3.11–3.12
 
       .. code-block:: console
 

--- a/source/user-manual/capabilities/container-security/monitoring-docker.rst
+++ b/source/user-manual/capabilities/container-security/monitoring-docker.rst
@@ -47,16 +47,16 @@ Docker library for Python
 
          $ pip3 install docker==7.1.0 urllib3==2.2.2 requests==2.32.2
 
-   .. group-tab:: Python 3.11
+   .. group-tab:: Python 3.11-3.12
 
       .. code-block:: console
 
          $ pip3 install docker==7.1.0 urllib3==2.2.2 requests==2.32.2 --break-system-packages
-      
+
       .. note::
 
          This command modifies the default externally managed Python environment. See the `PEP 668 <https://peps.python.org/pep-0668/>`__ description for more information.
-         
+
          To prevent the modification, you can run ``pip3 install --upgrade pip`` within a virtual environment. You must update the docker ``/var/ossec/wodles/docker/DockerListener`` script shebang with your virtual environment interpreter. For example: ``#!</path/to/your/virtual/environment>/bin/python3``.
 
 Configure the Wazuh agent


### PR DESCRIPTION
## Description

This PR closes wazuh/wazuh#25075. Add support to run the AWS wodle with Python 3.12

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
