### PR TITLE
Add the step of restarting Wazuh-dashboard when modifying logos

### DIFF
--- a/source/user-manual/wazuh-dashboard/custom-branding.rst
+++ b/source/user-manual/wazuh-dashboard/custom-branding.rst
@@ -45,7 +45,7 @@ To customize the *global App loading* logo, do the following.
             defaultUrl: "https://domain.org/default-logo.png"
             darkModeUrl: "https://domain.org/dark-mode-logo.png"
    
-#. Restart the Wazuh dashboard service using this command:
+#. Restart the Wazuh dashboard service:
 
    .. code-block:: console
 
@@ -110,7 +110,7 @@ To customize the *Wazuh dashboard home* logo in the top header, do the following
             defaultUrl: "https://domain.org/default-logo.png"
             darkModeUrl: "https://domain.org/dark-mode-logo.png"
 
-#. Restart the Wazuh dashboard service using this command:
+#. Restart the Wazuh dashboard service:
 
    .. code-block:: console
 

--- a/source/user-manual/wazuh-dashboard/custom-branding.rst
+++ b/source/user-manual/wazuh-dashboard/custom-branding.rst
@@ -44,6 +44,12 @@ To customize the *global App loading* logo, do the following.
          loadingLogo:
             defaultUrl: "https://domain.org/default-logo.png"
             darkModeUrl: "https://domain.org/dark-mode-logo.png"
+   
+#. Restart the Wazuh dashboard service using this command:
+
+   .. code-block:: console
+
+      # systemctl restart wazuh-dashboard
 
 To customize the *Wazuh plugins loading* logo, do the following.
 
@@ -103,6 +109,12 @@ To customize the *Wazuh dashboard home* logo in the top header, do the following
          mark:
             defaultUrl: "https://domain.org/default-logo.png"
             darkModeUrl: "https://domain.org/dark-mode-logo.png"
+
+#. Restart the Wazuh dashboard service using this command:
+
+   .. code-block:: console
+
+      # systemctl restart wazuh-dashboard
 
 Once you are done setting your custom logo image, you can find it saved in ``/usr/share/wazuh-dashboard/plugins/wazuh/public/assets/custom/images/``.
 


### PR DESCRIPTION
## Description

Adds the step of restarting Wazuh-dashboard when modifying the custimized logos from `opensearch-dashboards.yml`

## Closes

- https://github.com/wazuh/wazuh-documentation/issues/7667

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
