### PR TITLE
Updating SSH key path for agentless connection 

### DIFF
--- a/source/user-manual/capabilities/agentless-monitoring/connection.rst
+++ b/source/user-manual/capabilities/agentless-monitoring/connection.rst
@@ -18,13 +18,11 @@ Endpoints with public key authentication
 
 To add agentless endpoints that use public key authentication, perform the following steps on the Wazuh server.
 
-#. Generate a public key with the following command:
+#. Generate a public key with the following command. It saves the public key in ``/var/ossec/.ssh/id_rsa.pub`` by default.
 
    .. code-block:: console
 
       sudo -u wazuh ssh-keygen
-
-   By default, the public key will be saved to ``/var/ossec/.ssh/id_rsa.pub`` because ``/var/ossec/`` is the home directory of the Wazuh user.
 
 #. Run the following command to copy the public key to the monitored endpoint. Replace ``user@test.com`` with the username and the hostname or IP address of the agentless endpoint.
 

--- a/source/user-manual/capabilities/agentless-monitoring/connection.rst
+++ b/source/user-manual/capabilities/agentless-monitoring/connection.rst
@@ -1,8 +1,8 @@
 .. Copyright (C) 2015, Wazuh, Inc.
 
 .. meta::
-  :description: Wazuh provides a script to connect the agentless endpoint to the Wazuh server using SSH authentication. Learn more about it in this section. 
-  
+  :description: Wazuh provides a script to connect the agentless endpoint to the Wazuh server using SSH authentication. Learn more about it in this section.
+
 Connection
 ==========
 
@@ -11,7 +11,7 @@ Wazuh provides a ``register_host.sh`` script to connect the agentless endpoint t
 Add an endpoint
 ---------------
 
-The ``add`` option of the ``register_host.sh`` script adds an agentless endpoint to the Wazuh server. Specify the ``NOPASS`` option to use public key authentication rather than using a password. 
+The ``add`` option of the ``register_host.sh`` script adds an agentless endpoint to the Wazuh server. Specify the ``NOPASS`` option to use public key authentication rather than using a password.
 
 Endpoints with public key authentication
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -24,11 +24,13 @@ To add agentless endpoints that use public key authentication, perform the follo
 
       sudo -u wazuh ssh-keygen
 
+   By default, the public key will be saved to ``/var/ossec/.ssh/id_rsa.pub`` because ``/var/ossec/`` is the home directory of the Wazuh user.
+
 #. Run the following command to copy the public key to the monitored endpoint. Replace ``user@test.com`` with the username and the hostname or IP address of the agentless endpoint.
 
    .. code-block:: console
 
-      ssh-copy-id -i ~/.ssh/id_rsa.pub user@test.com
+      ssh-copy-id -i /var/ossec/.ssh/id_rsa.pub user@test.com
 
 #. Add the endpoint by running the following command on the Wazuh server:
 
@@ -40,7 +42,7 @@ To add agentless endpoints that use public key authentication, perform the follo
 
    .. code-block:: console
       :class: output
-      
+
       *Host user@test.com added.
 
 Endpoints with password authentication
@@ -62,7 +64,7 @@ The command output must be similar to the following:
 Cisco PIX
 ^^^^^^^^^
 
-For Cisco devices, such as routers or firewalls, use ``enablepass`` to specify the enable password. 
+For Cisco devices, such as routers or firewalls, use ``enablepass`` to specify the enable password.
 
 Add a Cisco device using the configuration command example below:
 
@@ -80,7 +82,7 @@ The command output must be similar to the following:
 List connected endpoints
 ------------------------
 
-The ``list`` option of the ``register_host.sh`` script displays all agentless endpoints connected to the Wazuh server. 
+The ``list`` option of the ``register_host.sh`` script displays all agentless endpoints connected to the Wazuh server.
 
 Use the following command to display the connected endpoints:
 
@@ -92,15 +94,15 @@ The command output must be similar to the following:
 
    .. code-block:: console
       :class: output
-      
-      *Available hosts: 
+
+      *Available hosts:
       user@example_address.com
-      pix@example_address.com 
+      pix@example_address.com
 
 Remove agentless configuration
 ------------------------------
 
-Agentless endpoint credentials are stored in the ``/var/ossec/agentless/.passlist`` file on the Wazuh server. This file must be deleted to remove all agentless configurations, as it is currently not possible to remove the configuration of only one endpoint. 
+Agentless endpoint credentials are stored in the ``/var/ossec/agentless/.passlist`` file on the Wazuh server. This file must be deleted to remove all agentless configurations, as it is currently not possible to remove the configuration of only one endpoint.
 
 Perform the following steps on the Wazuh server to remove your agentless configuration and passwords.
 
@@ -108,10 +110,8 @@ Perform the following steps on the Wazuh server to remove your agentless configu
 
 #. Delete the ``/var/ossec/agentless/.passlist`` file.
 
-#. Restart the Wazuh manager to apply the changes: 
+#. Restart the Wazuh manager to apply the changes:
 
    .. code-block:: console
 
       systemctl restart wazuh-manager
-
-


### PR DESCRIPTION
| Related issue |
|--------|
| Closes #7666  |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
<!--
Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->

This PR makes the suggested change and specifies the right path for the SSH key generated by the Wazuh user.

![2024-08-21_16-14](https://github.com/user-attachments/assets/d3b09366-4b05-45b3-855d-2f294eb075f6)


## Checks
### Docs building
- [x] Compiles without warnings.

### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
