### PR TITLE
Update default chunck size to update agent via wpk

### DIFF
--- a/source/user-manual/reference/ossec-conf/agent-upgrade.rst
+++ b/source/user-manual/reference/ossec-conf/agent-upgrade.rst
@@ -52,9 +52,9 @@ chunk_size
 Size in KB of the chunk that will be used to send the WPK file.
 
 +--------------------+----------------------------------+
-| **Default value**  | 512                              |
+| **Default value**  | 32768                            |
 +--------------------+----------------------------------+
-| **Allowed values** | Any number between 64 and 32768  |
+| **Allowed values** | Any number between 64 and 60000  |
 +--------------------+----------------------------------+
 | **Required**       | no                               |
 +--------------------+----------------------------------+


### PR DESCRIPTION
|Wazuh version|
|---|
| 4.10.0 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
<!--
Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->
The purpose of this PR is to increase the size of the chunk size that is used when updating an agent via wpk. [Definition](https://github.com/wazuh/wazuh/issues/14856#issuecomment-1564297940)

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
