### PR TITLE
Fix missing slash in localfile block at Logcollector reference

### DIFF
--- a/source/user-manual/reference/ossec-conf/localfile.rst
+++ b/source/user-manual/reference/ossec-conf/localfile.rst
@@ -718,7 +718,7 @@ In the following configuration example Wazuh collects the ``journald`` logs if a
       <location>journald</location>
       <log_format>journald</log_format>
       <filter field="_SYSTEMD_UNIT">^ssh.service$</filter>
-    <localfile>
+    </localfile>
 
     <localfile>
       <location>journald</location>


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
<!--
Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->

This PR closes issue #7754.

It aims to fix a missing slash in a `<localfile>` block closing at the Logcollector reference:
```xml
<localfile>
  <!-- ... -->
<localfile> <!-- Missing slash -->
```

## Checks
### Docs building
- [ ] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
