### PR TITLE
Fix missing slash in localfile block at Logcollector reference

### DIFF
--- a/source/user-manual/reference/ossec-conf/localfile.rst
+++ b/source/user-manual/reference/ossec-conf/localfile.rst
@@ -718,7 +718,7 @@ In the following configuration example Wazuh collects the ``journald`` logs if a
       <location>journald</location>
       <log_format>journald</log_format>
       <filter field="_SYSTEMD_UNIT">^ssh.service$</filter>
-    <localfile>
+    </localfile>
 
     <localfile>
       <location>journald</location>

--- a/source/user-manual/reference/ossec-conf/localfile.rst
+++ b/source/user-manual/reference/ossec-conf/localfile.rst
@@ -725,7 +725,7 @@ In the following configuration example Wazuh collects the ``journald`` logs if a
       <log_format>journald</log_format>
       <filter field="_SYSTEMD_UNIT">^cron.service$</filter>
       <filter field="PRIORITY" ignore_if_missing="yes">[0-3]</filter>
-    <localfile>
+    </localfile>
 
 .. note::
 


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
<!--
Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->

This PR closes issue #7754.

It aims to fix a missing slash in a `<localfile>` block closing at the Logcollector reference:
```xml
<localfile>
  <!-- ... -->
<localfile> <!-- Missing slash -->
```

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
