### PR TITLE
Remove the command to delete the opensearch_dashboard.yml file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ### Removed
 
-- Removed the command to delete opensearch_dashboard.yml([#7773](https://github.com/wazuh/wazuh-documentation/pull/7773)) 
+- Removed the command to delete opensearch_dashboard.yml([#7777](https://github.com/wazuh/wazuh-documentation/pull/7777)) 
 
 ## [v4.9.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 
 - Support for Wazuh 4.9.1
 
+### Removed
+
+- Removed the command to delete opensearch_dashboard.yml([#7773](https://github.com/wazuh/wazuh-documentation/pull/7773)) 
+
 ## [v4.9.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## [v4.9.1]
 
-- Support for Wazuh 4.9.1
-
 ### Removed
 
-- Removed the command to delete opensearch_dashboard.yml([#7777](https://github.com/wazuh/wazuh-documentation/pull/7777)) 
+- Removed the command to delete `opensearch_dashboards.yml` in the *Upgrading the Wazuh dashboard* section. ([#7777](https://github.com/wazuh/wazuh-documentation/pull/7777)) 
 
 ## [v4.9.0]
 

--- a/source/upgrade-guide/upgrading-central-components.rst
+++ b/source/upgrade-guide/upgrading-central-components.rst
@@ -255,7 +255,6 @@ Configuration options might differ across versions. Follow these steps to ensure
 
          .. code-block:: console
 
-            # rm /etc/wazuh-dashboard/opensearch_dashboards.yml
             # yum upgrade wazuh-dashboard|WAZUH_DASHBOARD_RPM_PKG_INSTALL|
 
       .. group-tab:: APT


### PR DESCRIPTION
## Description

This PR removes the instruction to delete the OpenSearch Dashboard configuration file manually. It only keeps the upgrade command

## Evidence

![image](https://github.com/user-attachments/assets/5f13926e-dc88-45f3-8d6c-28fdef26b5a8)


![image](https://github.com/user-attachments/assets/34006546-92e1-44a2-a1c0-649fbe4c9636)


## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
