### PR TITLE
Fix versioning on generate-indexer-package guide

### DIFF
--- a/source/development/packaging/generate-indexer-package.rst
+++ b/source/development/packaging/generate-indexer-package.rst
@@ -31,7 +31,7 @@ Build stage
 Docker environment
 ^^^^^^^^^^^^^^^^^^
 
-Using the provided `Docker environment <https://www.github.com/wazuh/wazuh-indexer/tree/master/docker>`__:
+Using the provided `Docker environment <https://www.github.com/wazuh/wazuh-indexer/tree/v|WAZUH_CURRENT|/docker>`__:
 
 .. tabs::
 
@@ -78,7 +78,7 @@ Pre-requisites:
 
 -  Current directory: ``wazuh-indexer/``
 -  Existing package in ``wazuh-indexer/artifacts/dist/{rpm|deb}``, as a result of the *Build* stage.
--  Using the `Docker environment <https://www.github.com/wazuh/wazuh-indexer/tree/master/docker>`__:
+-  Using the `Docker environment <https://www.github.com/wazuh/wazuh-indexer/tree/v|WAZUH_CURRENT|/docker>`__:
 
    .. tabs::
 


### PR DESCRIPTION
## Description

This PR fixes all links pointing to wazuh-indexer's master branch by using the appropriate Wazuh version.

![image](https://github.com/user-attachments/assets/6ec26687-c9c3-41d1-9b99-42e0f62ee587)

Closes https://github.com/wazuh/wazuh-indexer/issues/418

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
