### PR TITLE
Remove step to delete ss4o index templates before a wazuh-indexer upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ source/_themes/wazuh_doc_theme_v3/static/js/min/*.js.map
 source/_themes/wazuh_doc_theme_v3/static/js/min/redirects.min.js
 source/_static/css/*.min.css
 source/_static/js/*.min.js
+.venv

--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,3 @@ source/_themes/wazuh_doc_theme_v3/static/js/min/*.js.map
 source/_themes/wazuh_doc_theme_v3/static/js/min/redirects.min.js
 source/_static/css/*.min.css
 source/_static/js/*.min.js
-.venv

--- a/source/upgrade-guide/upgrading-central-components.rst
+++ b/source/upgrade-guide/upgrading-central-components.rst
@@ -64,9 +64,7 @@ Upgrading the Wazuh indexer
 
 The cluster remains available throughout the upgrading process in a Wazuh indexer cluster with multiple nodes. This rolling upgrade allows for the shutting down of one Wazuh indexer node at a time for minimal disruption of service.
 
-Replace ``<WAZUH_INDEXER_IP_ADDRESS>``, ``<USERNAME>``, and ``<PASSWORD>`` before running any command below.
-
-Repeat the following steps for every Wazuh indexer node.
+Repeat the following steps for every Wazuh indexer node replacing ``<WAZUH_INDEXER_IP_ADDRESS>``, ``<USERNAME>``, and ``<PASSWORD>``.
 
 #. Disable shard allocation.
 

--- a/source/upgrade-guide/upgrading-central-components.rst
+++ b/source/upgrade-guide/upgrading-central-components.rst
@@ -64,13 +64,7 @@ Upgrading the Wazuh indexer
 
 The cluster remains available throughout the upgrading process in a Wazuh indexer cluster with multiple nodes. This rolling upgrade allows for the shutting down of one Wazuh indexer node at a time for minimal disruption of service.
 
-As a first step, remove the *ss4o* index templates. Replace ``<WAZUH_INDEXER_IP_ADDRESS>``, ``<USERNAME>``, and ``<PASSWORD>`` before running any command below.
-
-.. code-block:: bash
-
-   curl -X DELETE "https://<WAZUH_INDEXER_IP_ADDRESS>:9200/_index_template/ss4o_*_template" -u <USERNAME>:<PASSWORD> -k
-
-Then, repeat the following steps for every Wazuh indexer node.
+Repeat the following steps for every Wazuh indexer node.
 
 #. Disable shard allocation.
 

--- a/source/upgrade-guide/upgrading-central-components.rst
+++ b/source/upgrade-guide/upgrading-central-components.rst
@@ -64,6 +64,8 @@ Upgrading the Wazuh indexer
 
 The cluster remains available throughout the upgrading process in a Wazuh indexer cluster with multiple nodes. This rolling upgrade allows for the shutting down of one Wazuh indexer node at a time for minimal disruption of service.
 
+Replace ``<WAZUH_INDEXER_IP_ADDRESS>``, ``<USERNAME>``, and ``<PASSWORD>`` before running any command below.
+
 Repeat the following steps for every Wazuh indexer node.
 
 #. Disable shard allocation.


### PR DESCRIPTION
## Description
This PR remove the step to delete the `ss4o` index templates before a `wazuh-indexer` upgrade.

Closes https://github.com/wazuh/wazuh/issues/25971


## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
