### PR TITLE
Remove the certificate blob copy instruction

### DIFF
--- a/source/user-manual/user-administration/single-sign-on/administrator/okta.rst
+++ b/source/user-manual/user-administration/single-sign-on/administrator/okta.rst
@@ -136,13 +136,6 @@ Okta Configuration
 
    Now, on the same page, click on  **View SAML setup instructions**. Copy the **Identity Provider Issuer URL**, it will be the ``idp.entity_id``.
 
-   Copy the blob of the **X.509 Certificate** excluding the ``-----BEGIN CERTIFICATE-----`` and ``-----END CERTIFICATE-----`` lines. This will be used as the ``exchange_key``:
-
-     .. thumbnail:: /images/single-sign-on/okta/14-navigate-to-applications.png
-        :title: Navigate to Applications - Applications - <YOUR_APP> - Sign On
-        :align: center
-        :width: 80%
-
    This information can also be found in the metadata XML file.
 
 Wazuh indexer configuration

--- a/source/user-manual/user-administration/single-sign-on/read-only/okta.rst
+++ b/source/user-manual/user-administration/single-sign-on/read-only/okta.rst
@@ -136,13 +136,6 @@ Okta Configuration
 
    Now, on the same page, click on  **View SAML setup instructions**. Copy the **Identity Provider Issuer URL**, it will be the ``idp.entity_id``.
 
-   Copy the blob of the **X.509 Certificate** excluding the ``-----BEGIN CERTIFICATE-----`` and ``-----END CERTIFICATE-----`` lines. This will be used as the ``exchange_key``:
-
-     .. thumbnail:: /images/single-sign-on/okta/read-only/14-navigate-to-applications-RO.png
-        :title: Navigate to Applications - Applications - <YOUR_APP> - Sign On
-        :align: center
-        :width: 80%
-
    This information can also be found in the metadata XML file.
 
 Wazuh indexer configuration


### PR DESCRIPTION
## Description
This pull request removes the "Copy certificate blob" instruction, because it's not correct.

## Checks
### Docs building
- [ ] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
