### PR TITLE
Add curl prerequisite (Fixes #7801)

### DIFF
--- a/source/quickstart.rst
+++ b/source/quickstart.rst
@@ -73,7 +73,7 @@ Other Chromium-based browsers might also work. Internet Explorer 11 is not suppo
 Installing Wazuh
 ----------------
 
-#.  Download and run the Wazuh installation assistant.
+#.  Download and run the Wazuh installation assistant. If ``curl`` is not installed on your computer, install it using your operating system's package manager.
 
     .. code-block:: console
 


### PR DESCRIPTION
## Description
On some operating system's `curl` is not installed by default. 

Closes #7801 

## Checks
### Docs building
- [ x] Compiles without warnings.
### Code formatting and web optimization
- [ x] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ x] Uses present tense, active voice, and semi-formal registry.
- [ x] Uses short, simple sentences.
- [ x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
