### PR TITLE
Fix OS name mistype

### DIFF
--- a/source/user-manual/capabilities/sec-config-assessment/use-cases.rst
+++ b/source/user-manual/capabilities/sec-config-assessment/use-cases.rst
@@ -130,7 +130,7 @@ Take the following steps on your Ubuntu endpoint to create the file ``/usr/share
 Windows endpoint
 ^^^^^^^^^^^^^^^^
 
-Take the following steps on your Ubuntu endpoint to create the file ``C:\Program Files\testfile.txt`` and monitor it with the Wazuh SCA module:
+Take the following steps on your Windows endpoint to create the file ``C:\Program Files\testfile.txt`` and monitor it with the Wazuh SCA module:
 
 #. Run PowerShell as an administrator and create the test file and add some text to it, including the keyword ``password_enabled: yes``:
 


### PR DESCRIPTION
Copy-paste mistype.

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
<!--
Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->
## Checks
### Docs building
- [ ] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
