### PR TITLE
Changed frequency default value tfrom n/a to 360

### DIFF
--- a/source/user-manual/reference/ossec-conf/localfile.rst
+++ b/source/user-manual/reference/ossec-conf/localfile.rst
@@ -142,7 +142,7 @@ frequency
 Prevents a command from being executed in less time than the specified time (in seconds). This options can be used with *command* and *full_command*.
 
 +--------------------+--------------------------------+
-| **Default value**  | n/a                            |
+| **Default value**  | 360                            |
 +--------------------+--------------------------------+
 | **Allowed values** | any positive number of seconds |
 +--------------------+--------------------------------+


### PR DESCRIPTION
Contribution
## Description
Resolves #7805 , changing the wrong defalut value to 'frequency', previously n/a, now corrected to 360.
## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
