### PR TITLE
Remove wrong 4.9.1 release notes entry

### DIFF
--- a/source/release-notes/release-4-9-1.rst
+++ b/source/release-notes/release-4-9-1.rst
@@ -48,7 +48,6 @@ Packages
 
 -  `#3111 <https://github.com/wazuh/wazuh-packages/pull/3111>`__ Added offline installation assistant import for the downloaded GPG Wazuh key.
 -  `#3098 <https://github.com/wazuh/wazuh-packages/pull/3098>`__ Changed version to tag reference in ``source_branch`` references.
--  `#3134 <https://github.com/wazuh/wazuh-packages/pull/3134>`__ Revert update source branch in unattended installer.
 -  `#3118 <https://github.com/wazuh/wazuh-packages/pull/3118>`__ Changed Filebeat passwords only when installing Wazuh Server or changing passwords.
 -  `#3119 <https://github.com/wazuh/wazuh-packages/pull/3119>`__ Updated ``SECURITY.md`` format.
 -  `#3121 <https://github.com/wazuh/wazuh-packages/pull/3121>`__ Added stage parameter in ``bump_version`` script.


### PR DESCRIPTION
## Description
This PR updates the 4.9.1 release notes by removing a wrong 4.9.1 release notes entry.

## Checks
### Docs building
- [ ] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
