### PR TITLE
Update documentation to match new playbook variable assignment

### DIFF
--- a/source/deployment-options/deploying-with-ansible/guide/install-wazuh-cluster.rst
+++ b/source/deployment-options/deploying-with-ansible/guide/install-wazuh-cluster.rst
@@ -196,10 +196,10 @@ Let’s see below, the content of the YAML file ``/etc/ansible/roles/wazuh-ansib
        roles:
          - role: "../roles/wazuh/ansible-wazuh-manager"
          - role: "../roles/wazuh/ansible-filebeat-oss"
-           filebeat_node_name: node-4
        become: yes
        become_user: root
        vars:
+         filebeat_node_name: node-4
          wazuh_manager_config:
            connection:
                - type: 'secure'
@@ -228,10 +228,10 @@ Let’s see below, the content of the YAML file ``/etc/ansible/roles/wazuh-ansib
        roles:
          - role: "../roles/wazuh/ansible-wazuh-manager"
          - role: "../roles/wazuh/ansible-filebeat-oss"
-           filebeat_node_name: node-5
        become: yes
        become_user: root
        vars:
+         filebeat_node_name: node-5
          wazuh_manager_config:
            connection:
                - type: 'secure'


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
<!--
Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->
This PR updates the `install-wazuh-cluster.rst` file to modify the position of the `filebeat_node_name` variable in the Ansible role definitions. This ensures that the node name for Filebeat is correctly configured.

More information can be found in the related issue: https://github.com/wazuh/wazuh-ansible/issues/1384

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
