### PR TITLE
Capitalize Active Response module references

### DIFF
--- a/source/compliance/gdpr/gdpr-IV.rst
+++ b/source/compliance/gdpr/gdpr-IV.rst
@@ -364,5 +364,5 @@ Wazuh helps meet this article of the GDPR by providing security measures such as
 -  :doc:`Integrating with VirusTotal to detect and remove malware </proof-of-concept-guide/detect-remove-malware-virustotal>`.
 -  :doc:`Integrating with YARA to detect malware </proof-of-concept-guide/detect-malware-yara-integration>`.
 -  `Using constant database (CDB) lists to detect and remove malicious files <https://wazuh.com/blog/detecting-and-responding-to-malicious-files-using-cdb-lists-and-active-response/>`__.
--  :doc:`Active response </getting-started/use-cases/incident-response>`.
+-  :doc:`Active Response </getting-started/use-cases/incident-response>`.
 -  :doc:`Vulnerability detection </getting-started/use-cases/vulnerability-detection>`.

--- a/source/compliance/hipaa/active-response.rst
+++ b/source/compliance/hipaa/active-response.rst
@@ -3,7 +3,7 @@
 .. meta::
   :description: The Active Response module assists in meeting HIPAA compliance. Learn more about it in this section of the Wazuh documentation.
 
-Active response
+Active Response
 ===============
 
 The Wazuh Active Response module is configured to automatically execute scripts when events match specified rules in the Wazuh ruleset. These scripts may perform a firewall block or drop, traffic shaping or throttling, account lockout, or any other user defined action.

--- a/source/compliance/nist/active-response.rst
+++ b/source/compliance/nist/active-response.rst
@@ -3,7 +3,7 @@
 .. meta::
   :description: The Active Response module performs autonomous actions on endpoints to mitigate security threats. Learn more about it in this section of the documentation.
 
-Active response
+Active Response
 ===============
 
 The Wazuh Active Response module performs autonomous actions on endpoints to mitigate security threats. You can  configure the module to automatically execute scripts when specific alerts trigger. These scripts execute actions, such as a firewall block or drop, traffic shaping or throttling, and account lockout.

--- a/source/deployment-options/deploying-with-puppet/wazuh-puppet-module/index.rst
+++ b/source/deployment-options/deploying-with-puppet/wazuh-puppet-module/index.rst
@@ -383,7 +383,7 @@ Reference Wazuh puppet
 |                                                                 |                                                                 |                                             |
 |                                                                 | :ref:`Misc <ref_server_vars_misc>`                              |                                             |
 +-----------------------------------------------------------------+-----------------------------------------------------------------+---------------------------------------------+
-| :ref:`Wazuh agent class <reference_wazuh_agent_class>`          | :ref:`Active response <ref_agent_vars_ar>`                      |                                             |
+| :ref:`Wazuh agent class <reference_wazuh_agent_class>`          | :ref:`Active Response <ref_agent_vars_ar>`                      |                                             |
 |                                                                 |                                                                 |                                             |
 |                                                                 | :ref:`Agent enrollment <ref_agent_vars_enroll>`                 |                                             |
 |                                                                 |                                                                 |                                             |

--- a/source/getting-started/components/wazuh-agent.rst
+++ b/source/getting-started/components/wazuh-agent.rst
@@ -40,7 +40,7 @@ All agent modules are configurable and perform different security tasks. This mo
 
 -  **Malware detection:** Using a non-signature-based approach, this component is capable of detecting anomalies and the possible presence of rootkits. Also, it looks for hidden processes, hidden files, and hidden ports while monitoring system calls. 
 
--  **Active response:** This module runs automatic actions when threats are detected, triggering responses to block a network connection, stop a running process, or delete a malicious file. Users can also create custom responses when necessary and customize, for example, responses for running a binary in a sandbox, capturing network traffic, and scanning a file with an antivirus.
+-  **Active Response:** This module runs automatic actions when threats are detected, triggering responses to block a network connection, stop a running process, or delete a malicious file. Users can also create custom responses when necessary and customize, for example, responses for running a binary in a sandbox, capturing network traffic, and scanning a file with an antivirus.
 
 -  **Container security monitoring:** This agent module is integrated with the Docker Engine API to monitor changes in a containerized environment. For example, it detects changes to container images, network configuration, or data volumes. Besides, it alerts about containers running in privileged mode and about users executing commands in a running container.
 

--- a/source/installation-guide/wazuh-agent/index.rst
+++ b/source/installation-guide/wazuh-agent/index.rst
@@ -24,7 +24,7 @@ The Wazuh agent provides :ref:`key features <agents_modules>` to enhance your sy
      - Security configuration assessment (SCA)
    * - System inventory 
      - Malware detection
-   * - Active response
+   * - Active Response
      - Container security
    * - Cloud security
      -

--- a/source/proof-of-concept-guide/leveraging-llms-for-alert-enrichment.rst
+++ b/source/proof-of-concept-guide/leveraging-llms-for-alert-enrichment.rst
@@ -646,8 +646,8 @@ As seen in the image, ChatGPT provides more context to the malicious file detect
    :width: 80%
 
 .. thumbnail:: /images/poc/chatgpt-active-response-ubuntu-alert.png
-   :title: Active response
-   :alt: Active response
+   :title: Active Response
+   :alt: Active Response
    :align: center
    :width: 80%
 
@@ -683,8 +683,8 @@ As seen in the image, ChatGPT provides more context to the malicious file detect
    :width: 80%
 
 .. thumbnail:: /images/poc/chatgpt-active-response-windows-alert.png
-   :title: Active response
-   :alt: Active response
+   :title: Active Response
+   :alt: Active Response
    :align: center
    :width: 80%
 

--- a/source/user-manual/capabilities/active-response/ar-use-cases/blocking-ssh-brute-force.rst
+++ b/source/user-manual/capabilities/active-response/ar-use-cases/blocking-ssh-brute-force.rst
@@ -136,8 +136,8 @@ Monitored Linux/Unix endpoints have a log file at ``/var/ossec/logs/active-respo
 When the active response triggers, a corresponding alert appears on the Wazuh dashboard.
 
 .. thumbnail:: /images/manual/active-response/ar-alert-fired.png
-   :title: Active response alert: Host Blocked by firewall-drop
-   :alt: Active response alert: Host Blocked by firewall-drop
+   :title: Active Response alert: Host Blocked by firewall-drop
+   :alt: Active Response alert: Host Blocked by firewall-drop
    :align: center
    :width: 80%
 

--- a/source/user-manual/capabilities/active-response/ar-use-cases/disabling-user-account.rst
+++ b/source/user-manual/capabilities/active-response/ar-use-cases/disabling-user-account.rst
@@ -122,7 +122,7 @@ Visualize the alerts
 You can visualize the alert data on the Wazuh dashboard. In the image below, you can see that the active response triggers just after rule ID ``120100`` fires to disable the account. Then re-enables it again after 5 minutes.
 
 .. thumbnail:: /images/manual/active-response/ar-alert-fired3.png
-   :title: Active response alert: User account disabled
-   :alt: Active response alert: User account disabled
+   :title: Active Response alert: User account disabled
+   :alt: Active Response alert: User account disabled
    :align: center
    :width: 80%

--- a/source/user-manual/capabilities/active-response/ar-use-cases/index.rst
+++ b/source/user-manual/capabilities/active-response/ar-use-cases/index.rst
@@ -1,7 +1,7 @@
 .. Copyright (C) 2015, Wazuh, Inc.
 
 .. meta::
-  :description: Find out some Active response use cases in this section of the Wazuh documentation.
+  :description: Find out some Active Response use cases in this section of the Wazuh documentation.
 
 .. _active_response_use_cases:
 

--- a/source/user-manual/capabilities/active-response/ar-use-cases/restarting-wazuh-agent.rst
+++ b/source/user-manual/capabilities/active-response/ar-use-cases/restarting-wazuh-agent.rst
@@ -109,7 +109,7 @@ Visualize the alerts
 You can visualize the alert data on the Wazuh dashboard.
 
 .. thumbnail:: /images/manual/active-response/ar-alert-fired2.png
-   :title: Active response alert: The Wazuh agent was restarted
-   :alt: Active response alert: The Wazuh agent was restarted
+   :title: Active Response alert: The Wazuh agent was restarted
+   :alt: Active Response alert: The Wazuh agent was restarted
    :align: center
    :width: 80%

--- a/source/user-manual/capabilities/active-response/index.rst
+++ b/source/user-manual/capabilities/active-response/index.rst
@@ -1,9 +1,9 @@
 .. Copyright (C) 2015, Wazuh, Inc.
 
 .. meta::
-  :description: Active response executes scripts in response to specific alerts. Learn more about it here.
+  :description: Active Response executes scripts in response to specific alerts. Learn more about it here.
 
-Active response
+Active Response
 ===============
 
 Security teams often encounter problems in incident response such as addressing high severity events in a timely manner or providing complete mitigation actions. They might struggle to collect relevant information in real time, which makes it difficult to understand the full scope of an incident. These problems increase the difficulty to contain and mitigate the impact of a cyberattack.


### PR DESCRIPTION
## Description
This PR replaces `active response` with `Active Response` when referring to the Wazuh module or capability.

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
