### PR TITLE
Modify specific Solaris 11 minor version to delete group after uninstall agent

### DIFF
--- a/source/_templates/installations/wazuh/solaris/uninstall_wazuh_agent_s11.rst
+++ b/source/_templates/installations/wazuh/solaris/uninstall_wazuh_agent_s11.rst
@@ -7,8 +7,8 @@ Run the following command to uninstall the Wazuh agent in Solaris 11.
    # /var/ossec/bin/wazuh-control stop
    # pkg uninstall wazuh-agent
 
-.. note:: 
-  
-   If you uninstall the Wazuh agent in Solaris 11.4 or later, the Solaris 11 package manager does not remove the group ``wazuh`` from the system. Run the ``groupdel wazuh`` command to manually remove it.
+.. note::
+
+   Solaris 11 package manager does not remove the group ``wazuh`` from the system. Run the ``groupdel wazuh`` command to manually remove it.
 
 .. End of include file


### PR DESCRIPTION
Issue related: https://github.com/wazuh/wazuh-packages/issues/3053

## Description
Hello team, 
we have noticed that in the documentation about uninstalling the Wazuh agent for Solaris 11, it specifies the need to manually delete the wazuh group after uninstallation, however, it says that this only happens from Solaris 11.4+ onwards, however this is required for all Solaris 11 minor releases, as they share the same package manager.

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
