### PR TITLE
Change wazuh-packages to wazuh-virtual-machines refs in ova generation

### DIFF
--- a/source/development/packaging/generate-ova.rst
+++ b/source/development/packaging/generate-ova.rst
@@ -29,11 +29,11 @@ Creating the Wazuh VM
 
 To create the virtual machine follow these steps:
 
-#. Download our *wazuh-packages* repository from GitHub and navigate to the ``ova/`` directory. Select the version, for example, ``v|WAZUH_CURRENT_OVA|``.
+#. Download our *wazuh-virtual-machines* repository from GitHub and navigate to the ``ova/`` directory. Select the version, for example, ``v|WAZUH_CURRENT_OVA|``.
 
    .. code-block:: console
 
-      $ git clone https://github.com/wazuh/wazuh-packages && cd wazuh-packages/ova && git checkout v|WAZUH_CURRENT_OVA|
+      $ git clone https://github.com/wazuh/wazuh-virtual-machines && cd wazuh-virtual-machines/ova/ && git checkout v|WAZUH_CURRENT_OVA|
 
 #. Execute the ``generate_ova.sh`` script.
 


### PR DESCRIPTION
# Description

When the` wazuh-virtual-machines` repository was created to host everything related to the OVA generation from version `4.10.0`, the `wazuh-packages` repository will no longer have these files. Therefore, in the OVA generation section we have to change the references from `wazuh-packages` to `wazuh-virtual-machines`.

## Changes

![Screenshot_20241024_120219](https://github.com/user-attachments/assets/4f545078-d87d-4d6a-84d8-30590987da05)
