### PR TITLE
Change Opensearch Version minor in release notes for 4.9.0

### DIFF
--- a/source/release-notes/release-4-9-0.rst
+++ b/source/release-notes/release-4-9-0.rst
@@ -11,7 +11,7 @@ This section lists the changes in version 4.9.0. Every update of the Wazuh solut
 Highlights
 ----------
 
-This release introduces several significant updates aimed at enhancing functionality, compatibility, and user experience. Key updates include support for journald logs in Logcollector, improved compatibility with OpenSearch 2.11.0, and integration with AWS Security Hub. Additionally, there are improvements to WPK packages and enhancements in the Wazuh-API with Connexion 3.0 and Uvicorn support. The release also addresses numerous bugs, further stabilizing the platform and improving overall performance.
+This release introduces several significant updates aimed at enhancing functionality, compatibility, and user experience. Key updates include support for journald logs in Logcollector, improved compatibility with OpenSearch 2.13.0, and integration with AWS Security Hub. Additionally, there are improvements to WPK packages and enhancements in the Wazuh-API with Connexion 3.0 and Uvicorn support. The release also addresses numerous bugs, further stabilizing the platform and improving overall performance.
 
 -  `Journald support in Logcollector <https://github.com/wazuh/wazuh/issues/12862>`__: Systemd's journald logging is now supported, enabling Logcollector to monitor these logs, which can provide valuable information for users.
 -  `Integrate Wazuh with AWS Security Hub <https://github.com/wazuh/wazuh/issues/21209>`__: Wazuh now integrates with AWS Security Hub, enabling users to manage security and assess compliance with best practices directly within AWS.


### PR DESCRIPTION
## Description
This PR corrects the OpenSearch version number in the release notes for 4.9.0. It previously incorrectly quoted 4.9.0 as running Opensearch `2.11` when it should say `2.13`.

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
