### PR TITLE
Added missing dependencies to the assisted offline installation

### DIFF
--- a/source/deployment-options/offline-installation/installation-assistant.rst
+++ b/source/deployment-options/offline-installation/installation-assistant.rst
@@ -27,6 +27,7 @@ Install and configure the Wazuh indexer nodes.
       -  debconf
       -  adduser
       -  procps
+      -  apt-transport-https
 
 #. Run the assistant with the ``--offline-installation`` to perform an offline installation. Use the option ``--wazuh-indexer`` and the node name to install and configure the Wazuh indexer. The node name must be the same one used in ``config.yml`` for the initial configuration, for example, ``node-1``.
 
@@ -89,6 +90,12 @@ Installing the Wazuh server
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. tabs::
+
+   .. group-tab:: RPM
+
+      On systems with *yum* as package manager, the following dependencies must be installed on the Wazuh server nodes.
+
+      -  libcap
 
    .. group-tab:: DEB
 


### PR DESCRIPTION
Related issue: https://github.com/wazuh/wazuh-documentation/issues/7928
<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
<!--
Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->
This PR aims to add the missing dependencies of the Offline Installation Assistant to the documentation.

## Checks

![imagen](https://github.com/user-attachments/assets/cad29f08-fa1a-4b68-88fc-e2d01d9c3344)

![Captura desde 2024-10-24 17-41-17](https://github.com/user-attachments/assets/5dcb08c1-683f-4153-92fb-9994741771fc)
