### PR TITLE
Move OSQuery section to System inventory section

### DIFF
--- a/source/_static/js/redirects.js
+++ b/source/_static/js/redirects.js
@@ -175,6 +175,11 @@ redirections.push(
   },
   {
     'target': ['4.8=>4.9', '4.9=>4.8'],
+    '4.8': '/user-manual/capabilities/malware-detection/osquery.html',
+    '4.9': '/user-manual/capabilities/system-inventory/osquery.html',
+  },
+  {
+    'target': ['4.8=>4.9', '4.9=>4.8'],
     '4.8': '/user-manual/upscaling/adding-indexer-node.html',
     '4.9': '/user-manual/wazuh-indexer/wazuh-indexer-cluster.html#adding-wazuh-indexer-nodes',
   },
@@ -233,6 +238,7 @@ newUrls['4.9'] = [
   '/development/packaging/generate-indexer-package.html',
   '/development/packaging/generate-deb-rpm-package.html',
   '/user-manual/capabilities/log-data-collection/journald.html',
+  '/user-manual/capabilities/system-inventory/osquery.html',
   '/integrations-guide/amazon-security-lake/index.html',
   '/user-manual/agent/agent-enrollment/agent-life-cycle.html',
   '/user-manual/agent/agent-enrollment/deployment-variables/deployment-variables-aix.html',
@@ -290,6 +296,7 @@ removedUrls['4.9'] = [
   '/user-manual/capabilities/policy-monitoring/rootcheck/rootcheck-configuration.html',
   '/user-manual/capabilities/policy-monitoring/rootcheck/rootcheck-faq.html',
   '/user-manual/capabilities/policy-monitoring/ciscat/ciscat.html',
+  '/user-manual/capabilities/malware-detection/osquery.html',
   '/user-manual/upscaling/index.html',
   '/user-manual/upscaling/adding-indexer-node.html',
   '/user-manual/upscaling/adding-server-node.html',

--- a/source/release-notes/release-3-7-0.rst
+++ b/source/release-notes/release-3-7-0.rst
@@ -156,7 +156,7 @@ The Wazuh app for Kibana includes new features and interface redesigns to make u
   - Get the current manager/agent configuration on the redesigned tabs.
   - Added support for multiple groups feature.
   - The :doc:`Amazon AWS </cloud-security/amazon/index>` tab has been redesigned to include better visualizations and the module configuration.
-  - The new :ref:`Osquery <osquery>` extension shows scans results from this Wazuh module.
+  - The new :doc:`Osquery </user-manual/capabilities/system-inventory/osquery>` extension shows scans results from this Wazuh module.
   - Added a new selector to check the cluster nodes’ status and logs on the *Management > Status/Logs* tabs.
   - Several bugfixes, performance improvements, and compatibility with the latest Elastic Stack version.
 

--- a/source/user-manual/capabilities/malware-detection/index.rst
+++ b/source/user-manual/capabilities/malware-detection/index.rst
@@ -2,8 +2,6 @@
 
 .. meta::
   :description: Learn more about how you can detect anomalies and malware using Wazuh in this section of our documentation. 
-  
-.. _manual_anomaly_detection:
 
 Malware detection
 =================
@@ -29,4 +27,3 @@ Wazuh :doc:`log collection capability <../log-data-collection/index>` allows you
       clam-av-logs-collection
       win-defender-logs-collection
       custom-rules-malware-ioc
-      osquery

--- a/source/user-manual/capabilities/system-inventory/index.rst
+++ b/source/user-manual/capabilities/system-inventory/index.rst
@@ -17,13 +17,14 @@ Users can generate system inventory reports from the Wazuh dashboard, which can 
 
 .. topic:: Contents
 
-    .. toctree::
-        :maxdepth: 2
+   .. toctree::
+      :maxdepth: 2
 
-        how-it-works
-        configuration
-        viewing-system-inventory-data
-        generating-system-inventory-reports
-        available-inventory-fields
-        compatibility-matrix
-        using-syscollector-information-to-trigger-alerts
+      how-it-works
+      configuration
+      viewing-system-inventory-data
+      generating-system-inventory-reports
+      available-inventory-fields
+      compatibility-matrix
+      using-syscollector-information-to-trigger-alerts
+      osquery

--- a/source/user-manual/capabilities/system-inventory/osquery.rst
+++ b/source/user-manual/capabilities/system-inventory/osquery.rst
@@ -2,8 +2,6 @@
 
 .. meta::
   :description: Osquery exposes operating system data. Learn how to explore this data with Wazuh in this section of the Wazuh documentation.
-  
-.. _osquery:
 
 Osquery
 =======

--- a/source/user-manual/reference/daemons/wazuh-modulesd.rst
+++ b/source/user-manual/reference/daemons/wazuh-modulesd.rst
@@ -51,7 +51,7 @@ The wazuh-modulesd program manages the Wazuh modules described below.
 
 .. topic:: Osquery wodle
 
-  The Osquery wodle provides the user with an operating system instrumentation tool that makes low-level operating system analytics and monitoring both efficient and intuitive using SQL-based queries. For more information, read through the documentation for :doc:`osquery integration </user-manual/capabilities/malware-detection/osquery>`.
+  The Osquery wodle provides the user with an operating system instrumentation tool that makes low-level operating system analytics and monitoring both efficient and intuitive using SQL-based queries. For more information, read through the documentation for :doc:`osquery integration </user-manual/capabilities/system-inventory/osquery>`.
 
 .. topic:: SCA module
 


### PR DESCRIPTION
## Description
This PR moves the [OSQuery](https://documentation.wazuh.com/current/user-manual/capabilities/malware-detection/osquery.html) section to the [System inventory](https://documentation.wazuh.com/current/user-manual/capabilities/system-inventory/) capability section.

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
