### PR TITLE
Fix typo: GCP -> GPG

### DIFF
--- a/source/_templates/installations/wazuh/deb/add_repository.rst
+++ b/source/_templates/installations/wazuh/deb/add_repository.rst
@@ -20,7 +20,7 @@
 
 .. note::
 
-   For Debian 7, 8, and Ubuntu 14 systems import the GCP key and add the Wazuh repository (steps 1 and 2) using the following commands.
+   For Debian 7, 8, and Ubuntu 14 systems import the GPG key and add the Wazuh repository (steps 1 and 2) using the following commands.
 
    .. code-block:: console
 


### PR DESCRIPTION
Small typo, probably an autocorrect induced error. The text says "GCP" but the steps reference importing a GPG key.

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
<!--
Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->
## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
