### PR TITLE
Fix log sample in sibling decoders section

### DIFF
--- a/source/user-manual/ruleset/decoders/sibling-decoders.rst
+++ b/source/user-manual/ruleset/decoders/sibling-decoders.rst
@@ -47,7 +47,7 @@ We have a log source that provides the following log message:
 
 .. code-block:: none
 
-   2019/01/02 13:16:35 securityapp: INFO: srcuser="Bob" action="called" dstusr="Alice"
+   Apr 12 14:31:38 hostname1 securityapp: INFO: srcuser="Bob" action="called" dstusr="Alice"
 
 A simple decoder may be:
 


### PR DESCRIPTION
| Issue |
| --- |
| #7954 |

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
This PR fixes the log sample used in the siblings decoders section.

Previous log sample:
`2019/01/02 13:16:35 securityapp: INFO: srcuser="Bob" action="called" dstusr="Alice" `
New log sample:
`Apr 12 14:31:38 hostname1 securityapp: INFO: srcuser="Bob" action="called" dstusr="Alice"`

![image](https://github.com/user-attachments/assets/75a5b6fd-8eb6-4daa-9778-a481823c5eff)

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
