### PR TITLE
Remove wazuh-packages repository reference

### DIFF
--- a/source/release-notes/release-4-10-0.rst
+++ b/source/release-notes/release-4-10-0.rst
@@ -131,7 +131,6 @@ Product repositories
 
 -  `wazuh/wazuh <https://github.com/wazuh/wazuh/blob/v4.10.0/CHANGELOG.md>`__
 -  `wazuh/wazuh-dashboard-plugins <https://github.com/wazuh/wazuh-dashboard-plugins/blob/v4.10.0/CHANGELOG.md>`__
--  `wazuh/wazuh-packages <https://github.com/wazuh/wazuh-packages/blob/v4.10.0/CHANGELOG.md>`__
 
 Auxiliary repositories
 ^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Description
This PR removes the `wazuh-packages` repository reference from the release notes.

## Checks
### Docs building
- [ ] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
