### PR TITLE
[Documentation]Internews feedback: Add clarity on required expertise for installation

### DIFF
--- a/source/getting-started/index.rst
+++ b/source/getting-started/index.rst
@@ -20,7 +20,7 @@ Community and support
 How to install Wazuh
 --------------------
 
-The Wazuh solution is composed of three :doc:`central platform components <components/index>` and a single universal :doc:`agent </installation-guide/wazuh-agent/index>`. For installing Wazuh in your infrastructure, you can check the following sections of our documentation:
+The Wazuh solution is composed of three :doc:`central platform components <components/index>` and a single universal :doc:`agent </installation-guide/wazuh-agent/index>`. For installing Wazuh in your infrastructure, intermediate Linux experience is required. You can check the following sections of our documentation:
 
 -  The :doc:`Quickstart </quickstart>` is an automated way of installing Wazuh in just a few minutes.
 -  The :doc:`Installation guide </installation-guide/index>` provides instructions on how to install each central component and how to deploy the Wazuh agents.

--- a/source/installation-guide/index.rst
+++ b/source/installation-guide/index.rst
@@ -9,6 +9,8 @@
 Installation guide
 ==================
 
+Before starting, please note: intermediate Linux experience is required.
+
 Wazuh is a security platform that provides unified XDR and SIEM protection for endpoints and cloud workloads. The solution is composed of a single universal agent and three central components: the Wazuh server, the Wazuh indexer, and the Wazuh dashboard. For more information, check the :doc:`Getting Started </getting-started/index>` documentation. 
 
 Wazuh is free and open source. Its components abide by the `GNU General Public License, version 2 <https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html>`_, and the `Apache License, Version 2.0 <https://www.apache.org/licenses/LICENSE-2.0>`_ (ALv2). 

--- a/source/quickstart.rst
+++ b/source/quickstart.rst
@@ -19,6 +19,8 @@ Below you can find a section about the requirements needed to install Wazuh. It 
 Requirements
 ------------
 
+Intermediate Linux experience is required.
+
 Hardware
 ^^^^^^^^
 


### PR DESCRIPTION
## Description
Feedback received through Internews highlighted the need to "Make it clear at the beginning of the documentation that intermediate Linux experience is required". This commit adds context on the Quickstart guide, the Installation guide, and the Getting started documentation.
## Checks
### Docs building
- [ ] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
