### PR TITLE
Change the Python version and `urllib3` to `1.26.20`

### DIFF
--- a/source/proof-of-concept-guide/monitoring-docker.rst
+++ b/source/proof-of-concept-guide/monitoring-docker.rst
@@ -40,19 +40,19 @@ Perform the following steps to install Docker on the Ubuntu endpoint and configu
 
    .. tabs::
 
-      .. group-tab:: Python 3.7–3.10
+      .. group-tab:: Python 3.8–3.10
 
          .. code-block:: console
 
             $ curl -sSL https://get.docker.com/ | sh
-            $ sudo pip3 install docker==7.1.0 urllib3==2.2.2 requests==2.32.2
+            $ sudo pip3 install docker==7.1.0 urllib3==1.26.20 requests==2.32.2
 
       .. group-tab:: Python 3.11–3.12
 
          .. code-block:: console
 
             $ curl -sSL https://get.docker.com/ | sh
-            $ sudo pip3 install docker==7.1.0 urllib3==2.2.2 requests==2.32.2 --break-system-packages
+            $ sudo pip3 install docker==7.1.0 urllib3==1.26.20 requests==2.32.2 --break-system-packages
 
          .. note::
 

--- a/source/user-manual/capabilities/container-security/monitoring-docker.rst
+++ b/source/user-manual/capabilities/container-security/monitoring-docker.rst
@@ -41,17 +41,17 @@ Docker library for Python
 
 .. tabs::
 
-   .. group-tab:: Python 3.7–3.10
+   .. group-tab:: Python 3.8–3.10
 
       .. code-block:: console
 
-         $ pip3 install docker==7.1.0 urllib3==2.2.2 requests==2.32.2
+         $ pip3 install docker==7.1.0 urllib3==1.26.20 requests==2.32.2
 
    .. group-tab:: Python 3.11–3.12
 
       .. code-block:: console
 
-         $ pip3 install docker==7.1.0 urllib3==2.2.2 requests==2.32.2 --break-system-packages
+         $ pip3 install docker==7.1.0 urllib3==1.26.20 requests==2.32.2 --break-system-packages
 
       .. note::
 


### PR DESCRIPTION
This PR closes https://github.com/wazuh/wazuh/issues/26695, by modifying the Python version to `3.8` and changing the `urllib3` dependency version to `1.26.20`

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.