### PR TITLE
Fix re-indexing documentation page

### DIFF
--- a/source/user-manual/wazuh-indexer/re-indexing.rst
+++ b/source/user-manual/wazuh-indexer/re-indexing.rst
@@ -13,7 +13,7 @@ To re-index an existing index, perform the following steps on either the Wazuh d
 Wazuh dashboard
 ---------------
 
-#. Click on the **upper left menu ☰** and go to **Server management** then **Dev Tools**.
+#. Click on the **upper left menu ☰** and go to **Indexer management** then **Dev Tools**.
 #. Enter the following API call, replacing ``my-source-index`` with the source index pattern and ``my-destination-index`` with the destination index pattern.
 
    .. code-block:: none


### PR DESCRIPTION
## Description
A mention to the dashboard's `Server Management` section has been changed to `Indexer Management` instead.

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
