### PR TITLE
Change all migrated wazuh-packages references of agent packages

### DIFF
--- a/source/deployment-options/wazuh-from-sources/wazuh-agent/index.rst
+++ b/source/deployment-options/wazuh-from-sources/wazuh-agent/index.rst
@@ -422,7 +422,7 @@ The Wazuh agent is a single and lightweight monitoring software. It is a multi-p
 
                 .. code-block:: console
 
-                    # wget https://raw.githubusercontent.com/wazuh/wazuh-packages/|WAZUH_CURRENT_MINOR_FROM_SOURCES|/aix/generate_wazuh_packages.sh --no-check-certificate
+                    # wget https://raw.githubusercontent.com/wazuh/wazuh/v|WAZUH_CURRENT|/packages/aix/generate_wazuh_packages.sh --no-check-certificate
 
                 .. note::
 
@@ -555,7 +555,7 @@ The Wazuh agent is a single and lightweight monitoring software. It is a multi-p
 
                 .. code-block:: console
 
-                    # /usr/local/bin/wget https://github.com/wazuh/wazuh-packages/raw/master/hp-ux/depothelper-2.10-hppa_32-11.31.depot --no-check-certificate
+                    # /usr/local/bin/wget https://raw.githubusercontent.com/wazuh/wazuh/v|WAZUH_CURRENT|/packages/hp-ux/depothelper-2.20-ia64_64-11.31.depot --no-check-certificate
 
                 .. note::
 
@@ -577,7 +577,7 @@ The Wazuh agent is a single and lightweight monitoring software. It is a multi-p
 
                 .. code-block:: console
 
-                    # /usr/local/bin/wget https://raw.githubusercontent.com/wazuh/wazuh-packages/master/hp-ux/generate_wazuh_packages.sh --no-check-certificate
+                    # /usr/local/bin/wget https://raw.githubusercontent.com/wazuh/wazuh/v|WAZUH_CURRENT|/packages/hp-ux/generate_wazuh_packages.sh --no-check-certificate
 
                 .. note::
 

--- a/source/development/packaging/generate-aix-package.rst
+++ b/source/development/packaging/generate-aix-package.rst
@@ -17,13 +17,13 @@ Requirements
 
  * curl
 
-Download our wazuh-packages repository from GitHub and go to the aix directory.
+Download our wazuh repository from GitHub and go to the aix directory.
 
 .. code-block:: console
 
- $ curl -L https://github.com/wazuh/wazuh-packages/tarball/v|WAZUH_CURRENT| | tar zx
- $ cd wazuh-wazuh-packages-*
- $ cd aix
+ $ curl -L https://github.com/wazuh/wazuh/tarball/v|WAZUH_CURRENT| | tar zx
+ $ cd wazuh-wazuh-*
+ $ cd packages/aix
 
 Execute the ``generate_wazuh_packages.sh`` script, with the different options you desire.
 

--- a/source/development/packaging/generate-hpux-package.rst
+++ b/source/development/packaging/generate-hpux-package.rst
@@ -18,13 +18,13 @@ Requirements
  * GCC: download.
  * depothelper: download.
 
-Download our wazuh-packages repository from GitHub and go to the ``hpux`` directory.
+Download our wazuh repository from GitHub and go to the ``hp-ux`` directory.
 
 .. code-block:: console
 
- $ curl -L https://github.com/wazuh/wazuh-packages/tarball/v|WAZUH_CURRENT| | tar zx
- $ cd wazuh-wazuh-packages-*
- $ cd hp-ux
+ $ curl -L https://github.com/wazuh/wazuh/tarball/v|WAZUH_CURRENT| | tar zx
+ $ cd wazuh-wazuh-*
+ $ cd packages/hp-ux
 
 Execute the ``generate_wazuh_packages.sh`` script, with the different options you desire.
 

--- a/source/development/packaging/generate-osx-package.rst
+++ b/source/development/packaging/generate-osx-package.rst
@@ -21,7 +21,7 @@ Requirements
 
 If ``Packages`` and ``Brew`` are not already installed in your system, they can be installed using the generate_wazuh_packages.sh script
 
-Download our wazuh-packages repository from GitHub and go to the macos directory.
+Download our wazuh repository from GitHub and go to the macos directory.
 
 .. code-block:: console
 
@@ -108,7 +108,7 @@ Once you have set up the environment, you can build and notarize the package as 
 
 The script will automatically sign the code and enable the hardened runtime, build the package and sign it, upload the package for its notarization and once it is notarized, the script will staple the notarization ticket to the package. Thanks to this, the package will be able to be installed in those hosts without an internet connection.
 
-The result of the notarization will be stored in wazuh-packages/macos/request_result.txt.
+The result of the notarization will be stored in wazuh/packages/macos/request_result.txt.
 
 Common issues
 ^^^^^^^^^^^^^^

--- a/source/development/packaging/generate-sol-package.rst
+++ b/source/development/packaging/generate-sol-package.rst
@@ -17,11 +17,11 @@ Requirements
 
  * Git
 
-Download our wazuh-packages repository from GitHub and go to the ``solaris`` directory.
+Download our wazuh repository from GitHub and go to the ``solaris`` directory.
 
 .. code-block:: console
 
-  $ git clone https://github.com/wazuh/wazuh-packages && cd wazuh-packages/solaris && git checkout v|WAZUH_CURRENT_SOLARIS|
+  $ git clone https://github.com/wazuh/wazuh && cd wazuh/packages/solaris && git checkout v|WAZUH_CURRENT_SOLARIS|
 
 Choose the version of solaris you want to build the package for and go to that directory.
 
@@ -105,7 +105,7 @@ Bring the machine up ``vagrant [OPTION] ... up solaris10/solaris11/both``:
       -v, --version                    Print the version and exit.
       -h, --help                       Print this help.
 
-Clone our wazuh-packages repository from GitHub and switch to your target branch. Copy the source files for your Solaris 10 or Solaris 11 target system into ``wazuh-packages/solaris/package_generation/src``. Change to the ``wazuh-packages/solaris/package_generation`` directory before building the package.
+Clone our wazuh repository from GitHub and switch to your target branch. Copy the source files for your Solaris 10 or Solaris 11 target system into ``wazuh/packages/solaris/package_generation/src``. Change to the ``wazuh/packages/solaris/package_generation`` directory before building the package.
 
 .. tabs::
 
@@ -113,7 +113,7 @@ Clone our wazuh-packages repository from GitHub and switch to your target branch
 
     .. code-block:: console
 
-      $ git clone https://github.com/wazuh/wazuh-packages && cd wazuh-packages/solaris && git checkout v|WAZUH_CURRENT_SOLARIS10|
+      $ git clone https://github.com/wazuh/wazuh && cd wazuh/packages/solaris && git checkout v|WAZUH_CURRENT_SOLARIS10|
       $ cp solaris10 package_generation/src/
       $ cd package_generation
 
@@ -121,7 +121,7 @@ Clone our wazuh-packages repository from GitHub and switch to your target branch
 
     .. code-block:: console
 
-      $ git clone https://github.com/wazuh/wazuh-packages && cd wazuh-packages/solaris && git checkout v|WAZUH_CURRENT_SOLARIS11|
+      $ git clone https://github.com/wazuh/wazuh && cd wazuh/packages/solaris && git checkout v|WAZUH_CURRENT_SOLARIS11|
       $ cp solaris11 package_generation/src/
       $ cd package_generation
 

--- a/source/user-manual/agent/agent-management/remote-upgrading/wpk-files/create-custom-wpk.rst
+++ b/source/user-manual/agent/agent-management/remote-upgrading/wpk-files/create-custom-wpk.rst
@@ -63,11 +63,11 @@ Requirements
 -  Docker
 -  Git
 
-#. Download the ``wazuh-packages`` repository from GitHub and navigate to the WPK directory:
+#. Download the ``wazuh`` repository from GitHub and navigate to the WPK directory:
 
    .. code-block:: console
 
-      $ git clone https://github.com/wazuh/wazuh-packages && cd wazuh-packages/wpk && git checkout v|WAZUH_CURRENT|
+      $ git clone https://github.com/wazuh/wazuh && cd wazuh/packages/wpk && git checkout v|WAZUH_CURRENT|
 
 #. Execute the ``generate_wpk_package.sh`` script with the different options you desire. This script will build a Docker image with all the necessary tools to create the WPK and run a container that will build it:
 


### PR DESCRIPTION
**Related issue:** https://github.com/wazuh/wazuh/issues/27059

## Description

With this PR we have fixed the wazuh-packages references, adapting them to the new package references found in the wazuh/wazuh repository:

- https://github.com/wazuh/wazuh-documentation/blob/4.10.0/source/user-manual/agent/agent-management/remote-upgrading/wpk-files/create-custom-wpk.rst
- https://github.com/wazuh/wazuh-documentation/blob/4.10.0/source/development/packaging/generate-osx-package.rst
- https://github.com/wazuh/wazuh-documentation/blob/4.10.0/source/development/packaging/generate-hpux-package.rst
- https://github.com/wazuh/wazuh-documentation/blob/4.10.0/source/development/packaging/generate-sol-package.rst
- https://github.com/wazuh/wazuh-documentation/blob/4.10.0/source/development/packaging/generate-aix-package.rst
- https://github.com/wazuh/wazuh-documentation/blob/4.10.0/source/deployment-options/wazuh-from-sources/wazuh-agent/index.rst

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
