### PR TITLE
Missing steps building Wazuh dashboard from sources

### DIFF
--- a/source/_variables/replacements.py
+++ b/source/_variables/replacements.py
@@ -163,6 +163,9 @@ custom_replacements = {
     "|SPLUNK_LATEST_MINOR|" : "8.2",
     "|WAZUH_SPLUNK_REV_CURRENT_LATEST|" : "1", # 8.2
     "|WAZUH_SPLUNK_REV_CURRENT_8.1|" : "1",
+    #
+    # === Node.js
+    "|NODE_VERSION|": "18.19.0",
 }
 
 if is_latest_release:

--- a/source/_variables/replacements.py
+++ b/source/_variables/replacements.py
@@ -165,7 +165,7 @@ custom_replacements = {
     "|WAZUH_SPLUNK_REV_CURRENT_8.1|" : "1",
     #
     # === Node.js
-    "|NODE_VERSION|": "18.19.0",
+    "|WAZUH_DASHBOARD_NODE_VERSION|": "18.19.0",
 }
 
 if is_latest_release:

--- a/source/_variables/replacements.py
+++ b/source/_variables/replacements.py
@@ -166,6 +166,7 @@ custom_replacements = {
     #
     # === Node.js
     "|WAZUH_DASHBOARD_NODE_VERSION|": "18.19.0",
+    "|WAZUH_DASHBOARD_YARN_VERSION|": "1.22.22",
 }
 
 if is_latest_release:

--- a/source/_variables/replacements.py
+++ b/source/_variables/replacements.py
@@ -23,12 +23,15 @@ custom_replacements = {
     #
     "|CTI_URL|" : "https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0",
     #
+    # === Environment
+    "|PYTHON_CLOUD_CONTAINERS_MIN|": "3.8",
+    "|PYTHON_CLOUD_CONTAINERS_MAX|": "3.12",
+    "|WAZUH_DASHBOARD_YARN_VERSION|": "1.22.22",
+    #
     # === Global and Wazuh version (wazuh agent, manager, indexer, and dashboard)
     "|WAZUH_CURRENT_MAJOR|" : "4.x",
     "|WAZUH_CURRENT_MINOR|" : version,
     "|WAZUH_CURRENT|" : release,
-    "|PYTHON_CLOUD_CONTAINERS_MIN|": "3.8",
-    "|PYTHON_CLOUD_CONTAINERS_MAX|": "3.12",
 
     # --- Revision numbers for Wazuh agent and manager packages versions
     # Yum packages revisions
@@ -163,9 +166,6 @@ custom_replacements = {
     "|SPLUNK_LATEST_MINOR|" : "8.2",
     "|WAZUH_SPLUNK_REV_CURRENT_LATEST|" : "1", # 8.2
     "|WAZUH_SPLUNK_REV_CURRENT_8.1|" : "1",
-    #
-    # === Wazuh dashboard
-    "|WAZUH_DASHBOARD_YARN_VERSION|": "1.22.22",
 }
 
 if is_latest_release:

--- a/source/_variables/replacements.py
+++ b/source/_variables/replacements.py
@@ -164,7 +164,7 @@ custom_replacements = {
     "|WAZUH_SPLUNK_REV_CURRENT_LATEST|" : "1", # 8.2
     "|WAZUH_SPLUNK_REV_CURRENT_8.1|" : "1",
     #
-    # === Node.js
+    # === Wazuh dashboard
     "|WAZUH_DASHBOARD_YARN_VERSION|": "1.22.22",
 }
 

--- a/source/_variables/replacements.py
+++ b/source/_variables/replacements.py
@@ -165,7 +165,6 @@ custom_replacements = {
     "|WAZUH_SPLUNK_REV_CURRENT_8.1|" : "1",
     #
     # === Node.js
-    "|WAZUH_DASHBOARD_NODE_VERSION|": "18.19.0",
     "|WAZUH_DASHBOARD_YARN_VERSION|": "1.22.22",
 }
 

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -21,7 +21,6 @@ Build manually
 Requirements:
 
 -  Docker: see `Docker installation guide <https://docs.docker.com/engine/install/>`_
--  Docker Compose: see `Docker Compose installation guide <https://docs.docker.com/compose/install/>`_
 -  zip
 -  NVM (Node Version Manager): see `NVM installation guide <https://github.com/nvm-sh/nvm#installing-and-updating>`_
 -  Yarn v|WAZUH_DASHBOARD_YARN_VERSION| (Node Package Manager): see `Yarn installation guide <https://classic.yarnpkg.com/en/docs/install/>`_
@@ -207,6 +206,7 @@ Requirements
 ~~~~~~~~~~~~
 
 -  A system with Docker installed.
+-  Docker Compose: see `Docker Compose installation guide <https://docs.docker.com/compose/install/>`_
 -  Internet connection to download the Docker images for the first time.
 
 Building the packages

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -6,7 +6,7 @@
 Wazuh dashboard
 ===============
 
-The packages generation process is orchestrated by the ``build-packages.sh`` script, which is found within the ``dev-tools/build-packages/`` folder of the repository. This script is responsible for bundling plugins into one single application in tar, rpm and/or deb distributions. It takes the following parameters:
+The packages generation process is orchestrated by the ``build-packages.sh`` script, which is found within the ``dev-tools/build-packages/`` folder of the repository. This script is responsible for bundling plugins into one single application in ``tar``, ``rpm`` and/or ``deb`` distributions. It takes the following parameters:
 
 -  version
 -  revision

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -214,7 +214,7 @@ Building the packages
    .. code:: console
 
       $ git clone -b <BRANCH_OR_TAG> https://github.com/wazuh/wazuh-dashboard.git
-      $ cd wazuh-dashboard/dev-tools/build-packages/
+      $ cd wazuh-dashboard/dev-tools/build-packages/base-packages-to-base
 
    Example:
 

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -45,7 +45,7 @@ To build the packages, follow these steps:
       $ nvm install $(cat .nvmrc)
       $ nvm use $(cat .nvmrc)
       $ yarn osd bootstrap
-      $ yarn build <--linux | --linux-arm> --skip-os-packages --release
+      $ yarn build-platform <--linux | --linux-arm> --skip-os-packages --release
 
    Example:
 
@@ -56,7 +56,7 @@ To build the packages, follow these steps:
       $ nvm install $(cat .nvmrc)
       $ nvm use $(cat .nvmrc)
       $ yarn osd bootstrap
-      $ yarn build --linux --skip-os-packages --release
+      $ yarn build-platform --linux --skip-os-packages --release
 
    .. note::
 

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -21,7 +21,7 @@ Build manually
 Requirements:
 
 -  Docker: see `Docker installation guide <https://docs.docker.com/engine/install/>`_
--  zip: see `zip installation guide <https://www.tecmint.com/install-zip-and-unzip-in-linux/>`_
+-  zip
 -  NVM (Node Version Manager): see `NVM installation guide <https://github.com/nvm-sh/nvm#installing-and-updating>`_
 
    -  ``nvm install v|WAZUH_DASHBOARD_NODE_VERSION|``: installs Node.js version v|WAZUH_DASHBOARD_NODE_VERSION|

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -233,7 +233,7 @@ Building the packages
 
    .. code:: console
 
-      $ docker build \
+      $ bash run-docker-compose.sh \
       --node-version <NODE_VERSION> \
       --base <BRANCH_OF_wazuh-dashboard> \
       --app <BRANCH_OF_wazuh-dashboard-plugins> \

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -23,10 +23,6 @@ Requirements:
 -  Docker: see `Docker installation guide <https://docs.docker.com/engine/install/>`_
 -  zip
 -  NVM (Node Version Manager): see `NVM installation guide <https://github.com/nvm-sh/nvm#installing-and-updating>`_
-
-   -  ``nvm install v|WAZUH_DASHBOARD_NODE_VERSION|``: installs Node.js version v|WAZUH_DASHBOARD_NODE_VERSION|
-   -  ``nvm use v|WAZUH_DASHBOARD_NODE_VERSION|``: sets the current Node.js version to v|WAZUH_DASHBOARD_NODE_VERSION|
-
 -  Yarn v|WAZUH_DASHBOARD_YARN_VERSION| (Node Package Manager): see `Yarn installation guide <https://classic.yarnpkg.com/en/docs/install/>`_
 
 Generating zip packages
@@ -46,7 +42,8 @@ To build the packages, follow these steps:
 
       $ git clone -b <BRANCH_OR_TAG> https://github.com/wazuh/wazuh-dashboard.git
       $ cd wazuh-dashboard/
-      $ nvm use v|WAZUH_DASHBOARD_NODE_VERSION|
+      $ nvm install $(cat .nvmrc)
+      $ nvm use $(cat .nvmrc)
       $ yarn osd bootstrap
       $ yarn build <--linux | --linux-arm> --skip-os-packages --release
 
@@ -56,7 +53,8 @@ To build the packages, follow these steps:
 
       $ git clone -b v|WAZUH_CURRENT| https://github.com/wazuh/wazuh-dashboard.git
       $ cd wazuh-dashboard/
-      $ nvm use v|WAZUH_DASHBOARD_NODE_VERSION|
+      $ nvm install $(cat .nvmrc)
+      $ nvm use $(cat .nvmrc)
       $ yarn osd bootstrap
       $ yarn build --linux --skip-os-packages --release
 
@@ -71,7 +69,6 @@ To build the packages, follow these steps:
       $ cd plugins/
       $ git clone -b <BRANCH_OR_TAG> https://github.com/wazuh/wazuh-security-dashboards-plugin.git
       $ cd wazuh-security-dashboards-plugin/
-      $ nvm use v|WAZUH_DASHBOARD_NODE_VERSION|
       $ yarn
       $ yarn build
 
@@ -82,7 +79,6 @@ To build the packages, follow these steps:
       $ cd plugins/
       $ git clone -b v|WAZUH_CURRENT| https://github.com/wazuh/wazuh-security-dashboards-plugin.git
       $ cd wazuh-security-dashboards-plugin/
-      $ nvm use v|WAZUH_DASHBOARD_NODE_VERSION|
       $ yarn
       $ yarn build
 
@@ -97,7 +93,8 @@ To build the packages, follow these steps:
       $ cd ../
       $ git clone -b <BRANCH_OR_TAG> https://github.com/wazuh/wazuh-dashboard-plugins.git
       $ cd wazuh-dashboard-plugins/
-      $ nvm use v|WAZUH_DASHBOARD_NODE_VERSION|
+      $ nvm install $(cat .nvmrc)
+      $ nvm use $(cat .nvmrc)
       $ cp -r plugins/* ../
       $ cd ../main
       $ yarn
@@ -116,7 +113,8 @@ To build the packages, follow these steps:
       $ cd ../
       $ git clone -b v|WAZUH_CURRENT| https://github.com/wazuh/wazuh-dashboard-plugins.git
       $ cd wazuh-dashboard-plugins/
-      $ nvm use v|WAZUH_DASHBOARD_NODE_VERSION|
+      $ nvm install $(cat .nvmrc)
+      $ nvm use $(cat .nvmrc)
       $ cp -r plugins/* ../
       $ cd ../main
       $ yarn

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -23,7 +23,8 @@ Requirements:
 -  Docker
 -  NVM (Node Version Manager): see `NVM installation guide <https://github.com/nvm-sh/nvm#installing-and-updating>`_
 
-   -  ``nvm use`` command is used to switch Node.js version within the project
+   -  ``nvm install v|NODE_VERSION|``: installs Node.js version v|NODE_VERSION|
+   -  ``nvm use v|NODE_VERSION|``: sets the current Node.js version to v|NODE_VERSION|
 
 -  Yarn v1.22.22 (Node Package Manager): see `Yarn installation guide <https://classic.yarnpkg.com/en/docs/install/>`_
 
@@ -44,7 +45,7 @@ To build the packages, follow these steps:
 
       $ git clone -b <BRANCH_OR_TAG> https://github.com/wazuh/wazuh-dashboard.git
       $ cd wazuh-dashboard/
-      $ nvm use
+      $ nvm use v|NODE_VERSION|
       $ yarn osd bootstrap
       $ yarn build <--linux | --linux-arm> --skip-os-packages --release
 
@@ -54,7 +55,7 @@ To build the packages, follow these steps:
 
       $ git clone -b v|WAZUH_CURRENT| https://github.com/wazuh/wazuh-dashboard.git
       $ cd wazuh-dashboard/
-      $ nvm use
+      $ nvm use v|NODE_VERSION|
       $ yarn osd bootstrap
       $ yarn build --linux --skip-os-packages --release
 
@@ -69,7 +70,7 @@ To build the packages, follow these steps:
       $ cd plugins/
       $ git clone -b <BRANCH_OR_TAG> https://github.com/wazuh/wazuh-security-dashboards-plugin.git
       $ cd wazuh-security-dashboards-plugin/
-      $ nvm use
+      $ nvm use v|NODE_VERSION|
       $ yarn
       $ yarn build
 
@@ -80,7 +81,7 @@ To build the packages, follow these steps:
       $ cd plugins/
       $ git clone -b v|WAZUH_CURRENT| https://github.com/wazuh/wazuh-security-dashboards-plugin.git
       $ cd wazuh-security-dashboards-plugin/
-      $ nvm use
+      $ nvm use v|NODE_VERSION|
       $ yarn
       $ yarn build
 
@@ -95,7 +96,7 @@ To build the packages, follow these steps:
       $ cd ../
       $ git clone -b <BRANCH_OR_TAG> https://github.com/wazuh/wazuh-dashboard-plugins.git
       $ cd wazuh-dashboard-plugins/
-      $ nvm use
+      $ nvm use v|NODE_VERSION|
       $ cp -r plugins/* ../
       $ cd ../main
       $ yarn
@@ -114,7 +115,7 @@ To build the packages, follow these steps:
       $ cd ../
       $ git clone -b v|WAZUH_CURRENT| https://github.com/wazuh/wazuh-dashboard-plugins.git
       $ cd wazuh-dashboard-plugins/
-      $ nvm use
+      $ nvm use v|NODE_VERSION|
       $ cp -r plugins/* ../
       $ cd ../main
       $ yarn

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -40,21 +40,21 @@ To build the packages, follow these steps:
 
    .. code:: console
 
-      # git clone -b <BRANCH_OR_TAG> https://github.com/wazuh/wazuh-dashboard.git
-      # cd wazuh-dashboard/
-      # nvm use
-      # yarn osd bootstrap
-      # yarn build <--linux | --linux-arm> --skip-os-packages --release
+      $ git clone -b <BRANCH_OR_TAG> https://github.com/wazuh/wazuh-dashboard.git
+      $ cd wazuh-dashboard/
+      $ nvm use
+      $ yarn osd bootstrap
+      $ yarn build <--linux | --linux-arm> --skip-os-packages --release
 
    Example:
 
    .. code:: console
 
-      # git clone -b 4.10.2 https://github.com/wazuh/wazuh-dashboard.git
-      # cd wazuh-dashboard/
-      # nvm use
-      # yarn osd bootstrap
-      # yarn build --linux --skip-os-packages --release
+      $ git clone -b 4.10.2 https://github.com/wazuh/wazuh-dashboard.git
+      $ cd wazuh-dashboard/
+      $ nvm use
+      $ yarn osd bootstrap
+      $ yarn build --linux --skip-os-packages --release
 
    .. note::
 
@@ -64,23 +64,23 @@ To build the packages, follow these steps:
 
    .. code:: console
 
-      # cd plugins/
-      # git clone -b <BRANCH_OR_TAG> https://github.com/wazuh/wazuh-security-dashboards-plugin.git
-      # cd wazuh-security-dashboards-plugin/
-      # nvm use
-      # yarn
-      # yarn build
+      $ cd plugins/
+      $ git clone -b <BRANCH_OR_TAG> https://github.com/wazuh/wazuh-security-dashboards-plugin.git
+      $ cd wazuh-security-dashboards-plugin/
+      $ nvm use
+      $ yarn
+      $ yarn build
 
    Example:
 
    .. code:: console
 
-      # cd plugins/
-      # git clone -b 4.10.2 https://github.com/wazuh/wazuh-security-dashboards-plugin.git
-      # cd wazuh-security-dashboards-plugin/
-      # nvm use
-      # yarn
-      # yarn build
+      $ cd plugins/
+      $ git clone -b 4.10.2 https://github.com/wazuh/wazuh-security-dashboards-plugin.git
+      $ cd wazuh-security-dashboards-plugin/
+      $ nvm use
+      $ yarn
+      $ yarn build
 
 #. Clone the Wazuh dashboard plugins repository in the plugins folder, move the contents of the plugins folder to the folder where the repository was cloned and build the plugins.
 
@@ -90,61 +90,61 @@ To build the packages, follow these steps:
 
    .. code:: console
 
-      # cd ../
-      # git clone -b <BRANCH_OR_TAG> https://github.com/wazuh/wazuh-dashboard-plugins.git
-      # cd wazuh-dashboard-plugins/
-      # nvm use
-      # cp -r plugins/* ../
-      # cd ../main
-      # yarn
-      # yarn build
-      # cd ../wazuh-core/
-      # yarn
-      # yarn build
-      # cd ../wazuh-check-updates/
-      # yarn
-      # yarn build
+      $ cd ../
+      $ git clone -b <BRANCH_OR_TAG> https://github.com/wazuh/wazuh-dashboard-plugins.git
+      $ cd wazuh-dashboard-plugins/
+      $ nvm use
+      $ cp -r plugins/* ../
+      $ cd ../main
+      $ yarn
+      $ yarn build
+      $ cd ../wazuh-core/
+      $ yarn
+      $ yarn build
+      $ cd ../wazuh-check-updates/
+      $ yarn
+      $ yarn build
 
    Example:
 
    .. code:: console
 
-      # cd ../
-      # git clone -b 4.10.2 https://github.com/wazuh/wazuh-dashboard-plugins.git
-      # cd wazuh-dashboard-plugins/
-      # nvm use
-      # cp -r plugins/* ../
-      # cd ../main
-      # yarn
-      # yarn build
-      # cd ../wazuh-core/
-      # yarn
-      # yarn build
-      # cd ../wazuh-check-updates/
-      # yarn
-      # yarn build
+      $ cd ../
+      $ git clone -b 4.10.2 https://github.com/wazuh/wazuh-dashboard-plugins.git
+      $ cd wazuh-dashboard-plugins/
+      $ nvm use
+      $ cp -r plugins/* ../
+      $ cd ../main
+      $ yarn
+      $ yarn build
+      $ cd ../wazuh-core/
+      $ yarn
+      $ yarn build
+      $ cd ../wazuh-check-updates/
+      $ yarn
+      $ yarn build
 
 #. Zip the packages and move them to the packages folder
 
    .. code:: console
 
-      # cd ../../../
-      # mkdir packages
-      # cd packages
-      # zip -r -j ./dashboard-package.zip ../wazuh-dashboard/target/opensearch-dashboards-2.13.0-linux-x64.tar.gz
-      # zip -r -j ./security-package.zip ../wazuh-dashboard/plugins/wazuh-security-dashboards-plugin/build/security-dashboards-<OPENSEARCH_VERSION>.0.zip
-      # zip -r -j ./wazuh-package.zip ../wazuh-dashboard/plugins/wazuh-check-updates/build/wazuhCheckUpdates-<OPENSEARCH_VERSION>.zip ../wazuh-dashboard/plugins/main/build/wazuh-<OPENSEARCH_VERSION>.zip ../wazuh-dashboard/plugins/wazuh-core/build/wazuhCore-<OPENSEARCH_VERSION>.zip
+      $ cd ../../../
+      $ mkdir packages
+      $ cd packages
+      $ zip -r -j ./dashboard-package.zip ../wazuh-dashboard/target/opensearch-dashboards-2.13.0-linux-x64.tar.gz
+      $ zip -r -j ./security-package.zip ../wazuh-dashboard/plugins/wazuh-security-dashboards-plugin/build/security-dashboards-<OPENSEARCH_VERSION>.0.zip
+      $ zip -r -j ./wazuh-package.zip ../wazuh-dashboard/plugins/wazuh-check-updates/build/wazuhCheckUpdates-<OPENSEARCH_VERSION>.zip ../wazuh-dashboard/plugins/main/build/wazuh-<OPENSEARCH_VERSION>.zip ../wazuh-dashboard/plugins/wazuh-core/build/wazuhCore-<OPENSEARCH_VERSION>.zip
 
    Example:
 
    .. code:: console
 
-      # cd ../../../
-      # mkdir packages
-      # cd packages
-      # zip -r -j ./dashboard-package.zip ../wazuh-dashboard/target/opensearch-dashboards-2.13.0-linux-x64.tar.gz
-      # zip -r -j ./security-package.zip ../wazuh-dashboard/plugins/wazuh-security-dashboards-plugin/build/security-dashboards-2.13.0.0.zip
-      # zip -r -j ./wazuh-package.zip ../wazuh-dashboard/plugins/wazuh-check-updates/build/wazuhCheckUpdates-2.13.0.zip ../wazuh-dashboard/plugins/main/build/wazuh-2.13.0.zip ../wazuh-dashboard/plugins/wazuh-core/build/wazuhCore-2.13.0.zip
+      $ cd ../../../
+      $ mkdir packages
+      $ cd packages
+      $ zip -r -j ./dashboard-package.zip ../wazuh-dashboard/target/opensearch-dashboards-2.13.0-linux-x64.tar.gz
+      $ zip -r -j ./security-package.zip ../wazuh-dashboard/plugins/wazuh-security-dashboards-plugin/build/security-dashboards-2.13.0.0.zip
+      $ zip -r -j ./wazuh-package.zip ../wazuh-dashboard/plugins/wazuh-check-updates/build/wazuhCheckUpdates-2.13.0.zip ../wazuh-dashboard/plugins/main/build/wazuh-2.13.0.zip ../wazuh-dashboard/plugins/wazuh-core/build/wazuhCore-2.13.0.zip
 
 At this point you must have three packages in the ``packages`` folder:
 
@@ -173,8 +173,8 @@ Run the ``build-packages.sh`` script in the ``dev-tools/build-packages/`` folder
 
 .. code:: console
 
-   # cd ../wazuh-dashboard/dev-tools/build-packages/
-   # ./build-packages.sh -v <VERSION> -r <REVISION> --<DISTRIBUTION> -a file:///<PATH_TO_wazuh-package.zip> -s file:///<PATH_TO_security-package.zip> -b file:///<PATH_TO_dashboard-package.zip>
+   $ cd ../wazuh-dashboard/dev-tools/build-packages/
+   $ ./build-packages.sh -v <VERSION> -r <REVISION> --<DISTRIBUTION> -a file:///<PATH_TO_wazuh-package.zip> -s file:///<PATH_TO_security-package.zip> -b file:///<PATH_TO_dashboard-package.zip>
 
 Where ``--<DISTRIBUTION>`` is either ``--deb``, ``--rpm``,  ``--tar``, or ``--all-platforms``.
 
@@ -190,8 +190,8 @@ Example:
 
 .. code:: console
 
-   # cd ../wazuh-dashboard/dev-tools/build-packages/
-   # ./build-packages.sh -v 4.10.2 -r 1 --deb -a file:///packages/wazuh-package.zip -s file:///packages/security-package.zip -b file:///packages/dashboard-package.zip
+   $ cd ../wazuh-dashboard/dev-tools/build-packages/
+   $ ./build-packages.sh -v 4.10.2 -r 1 --deb -a file:///packages/wazuh-package.zip -s file:///packages/security-package.zip -b file:///packages/dashboard-package.zip
 
 The script generates the package in the ``output`` folder of the same directory where it is located.
 
@@ -213,15 +213,15 @@ Building the packages
 
    .. code:: console
 
-      # git clone -b <BRANCH_OR_TAG> https://github.com/wazuh/wazuh-dashboard.git
-      # cd wazuh-dashboard/dev-tools/build-packages/
+      $ git clone -b <BRANCH_OR_TAG> https://github.com/wazuh/wazuh-dashboard.git
+      $ cd wazuh-dashboard/dev-tools/build-packages/
 
    Example:
 
    .. code:: console
 
-      # git clone -b 4.10.2 https://github.com/wazuh/wazuh-dashboard.git
-      # cd wazuh-dashboard/dev-tools/build-packages/base-packages-to-base
+      $ git clone -b 4.10.2 https://github.com/wazuh/wazuh-dashboard.git
+      $ cd wazuh-dashboard/dev-tools/build-packages/base-packages-to-base
 
 #. Run the script ``run-docker-compose.sh`` with the following parameters:
 
@@ -233,7 +233,7 @@ Building the packages
 
    .. code:: console
 
-      # docker build \
+      $ docker build \
       --node-version <NODE_VERSION> \
       --base <BRANCH_OF_wazuh-dashboard> \
       --app <BRANCH_OF_wazuh-dashboard-plugins> \
@@ -243,7 +243,7 @@ Building the packages
 
    .. code:: console
 
-      # bash run-docker-compose.sh \
+      $ bash run-docker-compose.sh \
       --app 4.10.2 \
       --base 4.10.2 \
       --security 4.10.2 \
@@ -259,17 +259,17 @@ Building the packages
 
    .. code:: console
 
-      # cd ./packages
-      # zip -r -j ./dashboard-package.zip ./wazuh-dashboard/*.tar.gz
-      # zip -r -j ./security-package.zip ./wazuh-security-dashboards-plugin/*.zip
-      # zip -r -j ./wazuh-package.zip ./wazuh-dashboard-plugins/*.zip
+      $ cd ./packages
+      $ zip -r -j ./dashboard-package.zip ./wazuh-dashboard/*.tar.gz
+      $ zip -r -j ./security-package.zip ./wazuh-security-dashboards-plugin/*.zip
+      $ zip -r -j ./wazuh-package.zip ./wazuh-dashboard-plugins/*.zip
 
 #. Build deb, rpm, or tar.gz packages
 
    .. code:: console
 
-      # cd ../../
-      # ./build-packages.sh -v <VERSION> -r <REVISION> [--arm] --<DISTRIBUTION> -a file:///<PATH_TO_wazuh-package.zip> -s file:///<PATH_TO_security-package.zip> -b file:///<PATH_TO_dashboard-package.zip>
+      $ cd ../../
+      $ ./build-packages.sh -v <VERSION> -r <REVISION> [--arm] --<DISTRIBUTION> -a file:///<PATH_TO_wazuh-package.zip> -s file:///<PATH_TO_security-package.zip> -b file:///<PATH_TO_dashboard-package.zip>
 
    Where ``--<DISTRIBUTION>`` is either ``--deb``, ``--rpm``, ``--tar``, or ``--all-platforms``.
 
@@ -277,6 +277,6 @@ Building the packages
 
    .. code:: console
 
-      # ./build-packages.sh -v 4.10.2 -r 1 --deb -a file://$(pwd)/base-packages-to-base/packages/wazuh-package.zip -s file://$(pwd)/base-packages-to-base/packages/security-package.zip -b file://$(pwd)/base-packages-to-base/packages/dashboard-package.zip
+      $ ./build-packages.sh -v 4.10.2 -r 1 --deb -a file://$(pwd)/base-packages-to-base/packages/wazuh-package.zip -s file://$(pwd)/base-packages-to-base/packages/security-package.zip -b file://$(pwd)/base-packages-to-base/packages/dashboard-package.zip
 
    The script creates the package in the ``output`` folder within the same directory as the script.

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -21,6 +21,7 @@ Build manually
 Requirements:
 
 -  Docker: see `Docker installation guide <https://docs.docker.com/engine/install/>`_
+-  Docker Compose: see `Docker Compose installation guide <https://docs.docker.com/compose/install/>`_
 -  zip
 -  NVM (Node Version Manager): see `NVM installation guide <https://github.com/nvm-sh/nvm#installing-and-updating>`_
 -  Yarn v|WAZUH_DASHBOARD_YARN_VERSION| (Node Package Manager): see `Yarn installation guide <https://classic.yarnpkg.com/en/docs/install/>`_

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -277,6 +277,7 @@ Building the packages
 
    .. code:: console
 
+      $ cd ../../
       $ ./build-packages.sh -v 4.10.2 -r 1 --deb -a file://$(pwd)/base-packages-to-base/packages/wazuh-package.zip -s file://$(pwd)/base-packages-to-base/packages/security-package.zip -b file://$(pwd)/base-packages-to-base/packages/dashboard-package.zip
 
    The script creates the package in the ``output`` folder within the same directory as the script.

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -23,8 +23,8 @@ Requirements:
 -  Docker
 -  NVM (Node Version Manager): see `NVM installation guide <https://github.com/nvm-sh/nvm#installing-and-updating>`_
 
-   -  ``nvm install v|NODE_VERSION|``: installs Node.js version v|NODE_VERSION|
-   -  ``nvm use v|NODE_VERSION|``: sets the current Node.js version to v|NODE_VERSION|
+   -  ``nvm install v|WAZUH_DASHBOARD_NODE_VERSION|``: installs Node.js version v|WAZUH_DASHBOARD_NODE_VERSION|
+   -  ``nvm use v|WAZUH_DASHBOARD_NODE_VERSION|``: sets the current Node.js version to v|WAZUH_DASHBOARD_NODE_VERSION|
 
 -  Yarn v1.22.22 (Node Package Manager): see `Yarn installation guide <https://classic.yarnpkg.com/en/docs/install/>`_
 
@@ -45,7 +45,7 @@ To build the packages, follow these steps:
 
       $ git clone -b <BRANCH_OR_TAG> https://github.com/wazuh/wazuh-dashboard.git
       $ cd wazuh-dashboard/
-      $ nvm use v|NODE_VERSION|
+      $ nvm use v|WAZUH_DASHBOARD_NODE_VERSION|
       $ yarn osd bootstrap
       $ yarn build <--linux | --linux-arm> --skip-os-packages --release
 
@@ -55,7 +55,7 @@ To build the packages, follow these steps:
 
       $ git clone -b v|WAZUH_CURRENT| https://github.com/wazuh/wazuh-dashboard.git
       $ cd wazuh-dashboard/
-      $ nvm use v|NODE_VERSION|
+      $ nvm use v|WAZUH_DASHBOARD_NODE_VERSION|
       $ yarn osd bootstrap
       $ yarn build --linux --skip-os-packages --release
 
@@ -70,7 +70,7 @@ To build the packages, follow these steps:
       $ cd plugins/
       $ git clone -b <BRANCH_OR_TAG> https://github.com/wazuh/wazuh-security-dashboards-plugin.git
       $ cd wazuh-security-dashboards-plugin/
-      $ nvm use v|NODE_VERSION|
+      $ nvm use v|WAZUH_DASHBOARD_NODE_VERSION|
       $ yarn
       $ yarn build
 
@@ -81,7 +81,7 @@ To build the packages, follow these steps:
       $ cd plugins/
       $ git clone -b v|WAZUH_CURRENT| https://github.com/wazuh/wazuh-security-dashboards-plugin.git
       $ cd wazuh-security-dashboards-plugin/
-      $ nvm use v|NODE_VERSION|
+      $ nvm use v|WAZUH_DASHBOARD_NODE_VERSION|
       $ yarn
       $ yarn build
 
@@ -96,7 +96,7 @@ To build the packages, follow these steps:
       $ cd ../
       $ git clone -b <BRANCH_OR_TAG> https://github.com/wazuh/wazuh-dashboard-plugins.git
       $ cd wazuh-dashboard-plugins/
-      $ nvm use v|NODE_VERSION|
+      $ nvm use v|WAZUH_DASHBOARD_NODE_VERSION|
       $ cp -r plugins/* ../
       $ cd ../main
       $ yarn
@@ -115,7 +115,7 @@ To build the packages, follow these steps:
       $ cd ../
       $ git clone -b v|WAZUH_CURRENT| https://github.com/wazuh/wazuh-dashboard-plugins.git
       $ cd wazuh-dashboard-plugins/
-      $ nvm use v|NODE_VERSION|
+      $ nvm use v|WAZUH_DASHBOARD_NODE_VERSION|
       $ cp -r plugins/* ../
       $ cd ../main
       $ yarn

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -27,7 +27,7 @@ Requirements:
    -  ``nvm install v|WAZUH_DASHBOARD_NODE_VERSION|``: installs Node.js version v|WAZUH_DASHBOARD_NODE_VERSION|
    -  ``nvm use v|WAZUH_DASHBOARD_NODE_VERSION|``: sets the current Node.js version to v|WAZUH_DASHBOARD_NODE_VERSION|
 
--  Yarn v1.22.22 (Node Package Manager): see `Yarn installation guide <https://classic.yarnpkg.com/en/docs/install/>`_
+-  Yarn v|WAZUH_DASHBOARD_YARN_VERSION| (Node Package Manager): see `Yarn installation guide <https://classic.yarnpkg.com/en/docs/install/>`_
 
 Generating zip packages
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -244,10 +244,10 @@ Building the packages
    .. code:: console
 
       $ bash run-docker-compose.sh \
-      --app 4.10.2 \
+      --node-version $(cat ../../../.nvmrc) \
       --base 4.10.2 \
-      --security 4.10.2 \
-      --node-version $(cat ../../../.nvmrc)
+      --app 4.10.2 \
+      --security 4.10.2
 
    The script creates the packages in the ``packages`` directory within the ``base-packages-to-base`` folder.
 

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -247,7 +247,7 @@ Building the packages
       --app 4.10.2 \
       --base 4.10.2 \
       --security 4.10.2 \
-      --node-version $(cat .nvmrc)
+      --node-version $(cat ../../../.nvmrc)
 
    The script creates the packages in the ``packages`` directory within the ``base-packages-to-base`` folder.
 

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -131,7 +131,7 @@ To build the packages, follow these steps:
       $ cd ../../../
       $ mkdir packages
       $ cd packages
-      $ zip -r -j ./dashboard-package.zip ../wazuh-dashboard/target/opensearch-dashboards-2.13.0-linux-x64.tar.gz
+      $ zip -r -j ./dashboard-package.zip ../wazuh-dashboard/target/opensearch-dashboards-2.16.0-linux-x64.tar.gz
       $ zip -r -j ./security-package.zip ../wazuh-dashboard/plugins/wazuh-security-dashboards-plugin/build/security-dashboards-<OPENSEARCH_VERSION>.0.zip
       $ zip -r -j ./wazuh-package.zip ../wazuh-dashboard/plugins/wazuh-check-updates/build/wazuhCheckUpdates-<OPENSEARCH_VERSION>.zip ../wazuh-dashboard/plugins/main/build/wazuh-<OPENSEARCH_VERSION>.zip ../wazuh-dashboard/plugins/wazuh-core/build/wazuhCore-<OPENSEARCH_VERSION>.zip
 
@@ -142,9 +142,9 @@ To build the packages, follow these steps:
       $ cd ../../../
       $ mkdir packages
       $ cd packages
-      $ zip -r -j ./dashboard-package.zip ../wazuh-dashboard/target/opensearch-dashboards-2.13.0-linux-x64.tar.gz
-      $ zip -r -j ./security-package.zip ../wazuh-dashboard/plugins/wazuh-security-dashboards-plugin/build/security-dashboards-2.13.0.0.zip
-      $ zip -r -j ./wazuh-package.zip ../wazuh-dashboard/plugins/wazuh-check-updates/build/wazuhCheckUpdates-2.13.0.zip ../wazuh-dashboard/plugins/main/build/wazuh-2.13.0.zip ../wazuh-dashboard/plugins/wazuh-core/build/wazuhCore-2.13.0.zip
+      $ zip -r -j ./dashboard-package.zip ../wazuh-dashboard/target/opensearch-dashboards-2.16.0-linux-x64.tar.gz
+      $ zip -r -j ./security-package.zip ../wazuh-dashboard/plugins/wazuh-security-dashboards-plugin/build/security-dashboards-2.16.0.0.zip
+      $ zip -r -j ./wazuh-package.zip ../wazuh-dashboard/plugins/wazuh-check-updates/build/wazuhCheckUpdates-2.16.0.zip ../wazuh-dashboard/plugins/main/build/wazuh-2.16.0.zip ../wazuh-dashboard/plugins/wazuh-core/build/wazuhCore-2.16.0.zip
 
 At this point you must have three packages in the ``packages`` folder:
 

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -20,7 +20,8 @@ Build manually
 
 Requirements:
 
--  Docker
+-  Docker: see `Docker installation guide <https://docs.docker.com/engine/install/>`_
+-  zip: see `zip installation guide <https://www.tecmint.com/install-zip-and-unzip-in-linux/>`_
 -  NVM (Node Version Manager): see `NVM installation guide <https://github.com/nvm-sh/nvm#installing-and-updating>`_
 
    -  ``nvm install v|WAZUH_DASHBOARD_NODE_VERSION|``: installs Node.js version v|WAZUH_DASHBOARD_NODE_VERSION|

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -99,7 +99,6 @@ To build the packages, follow these steps:
       $ cd ../main
       $ yarn
       $ yarn build
-      $ # When prompted for the OpenSearch version, check the version specified in the package.json file.
       $ cd ../wazuh-core/
       $ yarn
       $ yarn build
@@ -120,7 +119,6 @@ To build the packages, follow these steps:
       $ cd ../main
       $ yarn
       $ yarn build
-      $ # When prompted for the OpenSearch version, check the version specified in the package.json file.
       $ cd ../wazuh-core/
       $ yarn
       $ yarn build

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -6,7 +6,7 @@
 Wazuh dashboard
 ===============
 
-The packages generation process is orchestrated by the ``build-packages.sh`` script, which is found within the ``dev-tools/build-packages/`` folder of the repository. This script is responsible for bundling plugins into one single application in ``tar``, ``rpm`` and/or ``deb`` distributions. It takes the following parameters:
+The ``build-packages.sh`` script, located in the ``dev-tools/build-packages/`` folder, orchestrates the package generation process. This script bundles plugins into a single application and supports ``tar``, ``rpm``, and ``deb`` distributions. It accepts the following parameters:
 
 -  version
 -  revision
@@ -20,10 +20,9 @@ Build manually
 
 Requirements:
 
--  Docker: see `Docker installation guide <https://docs.docker.com/engine/install/>`_
--  zip
--  NVM (Node Version Manager): see `NVM installation guide <https://github.com/nvm-sh/nvm#installing-and-updating>`_
--  Yarn v|WAZUH_DASHBOARD_YARN_VERSION| (Node Package Manager): see `Yarn installation guide <https://classic.yarnpkg.com/en/docs/install/>`_
+-  **NVM (Node Version Manager)**: Refer to `NVM installation guide <https://github.com/nvm-sh/nvm#installing-and-updating>`__.
+-  **Yarn v|WAZUH_DASHBOARD_YARN_VERSION| (Node Package Manager)**: Refer to `Yarn installation guide <https://classic.yarnpkg.com/en/docs/install/>`__.
+-  **zip**: Ensure the ``zip`` utility is available.
 
 Generating zip packages
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -205,9 +204,10 @@ This option allows you to create packages that include all necessary plugins req
 Requirements
 ~~~~~~~~~~~~
 
--  A system with Docker installed.
--  Docker Compose: see `Docker Compose installation guide <https://docs.docker.com/compose/install/>`_
--  Internet connection to download the Docker images for the first time.
+-  **Docker**: Refer to `Docker installation guide <https://docs.docker.com/engine/install/>`__.
+-  **Docker Compose**: Refer to `Docker Compose installation guide <https://docs.docker.com/compose/install/>`__.
+-  **Internet connection** to download the Docker images for the first time.
+-  **zip**: Ensure the ``zip`` utility is available.
 
 Building the packages
 ~~~~~~~~~~~~~~~~~~~~~

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -99,6 +99,7 @@ To build the packages, follow these steps:
       $ cd ../main
       $ yarn
       $ yarn build
+      $ # When prompted for the OpenSearch version, check the version specified in the package.json file.
       $ cd ../wazuh-core/
       $ yarn
       $ yarn build
@@ -119,6 +120,7 @@ To build the packages, follow these steps:
       $ cd ../main
       $ yarn
       $ yarn build
+      $ # When prompted for the OpenSearch version, check the version specified in the package.json file.
       $ cd ../wazuh-core/
       $ yarn
       $ yarn build

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -22,7 +22,9 @@ Requirements:
 
 -  Docker
 -  NVM (Node Version Manager): see `NVM installation guide <https://github.com/nvm-sh/nvm#installing-and-updating>`_
+
    -  ``nvm use`` command is used to switch Node.js version within the project
+
 -  Yarn v1.22.22 (Node Package Manager): see `Yarn installation guide <https://classic.yarnpkg.com/en/docs/install/>`_
 
 Generating zip packages

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -191,7 +191,7 @@ Example:
 .. code:: console
 
    $ cd ../wazuh-dashboard/dev-tools/build-packages/
-   $ ./build-packages.sh -v v|WAZUH_CURRENT| -r 1 --deb -a file:///packages/wazuh-package.zip -s file:///packages/security-package.zip -b file:///packages/dashboard-package.zip
+   $ ./build-packages.sh -v |WAZUH_CURRENT| -r 1 --deb -a file:///packages/wazuh-package.zip -s file:///packages/security-package.zip -b file:///packages/dashboard-package.zip
 
 The script generates the package in the ``output`` folder of the same directory where it is located.
 
@@ -278,6 +278,6 @@ Building the packages
    .. code:: console
 
       $ cd ../../
-      $ ./build-packages.sh -v v|WAZUH_CURRENT| -r 1 --deb -a file://$(pwd)/base-packages-to-base/packages/wazuh-package.zip -s file://$(pwd)/base-packages-to-base/packages/security-package.zip -b file://$(pwd)/base-packages-to-base/packages/dashboard-package.zip
+      $ ./build-packages.sh -v |WAZUH_CURRENT| -r 1 --deb -a file://$(pwd)/base-packages-to-base/packages/wazuh-package.zip -s file://$(pwd)/base-packages-to-base/packages/security-package.zip -b file://$(pwd)/base-packages-to-base/packages/dashboard-package.zip
 
    The script creates the package in the ``output`` folder within the same directory as the script.

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -11,7 +11,7 @@ The packages generation process is orchestrated by the ``build-packages.sh`` scr
 -  version
 -  revision
 -  distribution
--  wazuh-dashboard, wazuh-dashboard-plugins, and wazuh-security-dashboards-plugin package paths
+-  ``wazuh-dashboard``, ``wazuh-dashboard-plugins``, and ``wazuh-security-dashboards-plugin`` package paths
 
 Official packages are built through a GitHub Actions pipeline, however, the process is designed to be independent enough for maximum portability. The building process is self-contained in the application code.
 
@@ -21,6 +21,9 @@ Build manually
 Requirements:
 
 -  Docker
+-  NVM (Node Version Manager): see `NVM installation guide <https://github.com/nvm-sh/nvm#installing-and-updating>`_
+   -  ``nvm use`` command is used to switch Node.js version within the project
+-  Yarn v1.22.22 (Node Package Manager): see `Yarn installation guide <https://classic.yarnpkg.com/en/docs/install/>`_
 
 Generating zip packages
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -28,7 +31,7 @@ Generating zip packages
 To use the script you first need to generate the packages from these repositories:
 
 -  ``wazuh-dashboard``
--  ``wazuh-security-dashboards-plugin`` 
+-  ``wazuh-security-dashboards-plugin``
 -  ``wazuh-dashboard-plugins``
 
 To build the packages, follow these steps:
@@ -39,6 +42,7 @@ To build the packages, follow these steps:
 
       # git clone -b <BRANCH_OR_TAG> https://github.com/wazuh/wazuh-dashboard.git
       # cd wazuh-dashboard/
+      # nvm use
       # yarn osd bootstrap
       # yarn build <--linux | --linux-arm> --skip-os-packages --release
 
@@ -48,6 +52,7 @@ To build the packages, follow these steps:
 
       # git clone -b 4.10.2 https://github.com/wazuh/wazuh-dashboard.git
       # cd wazuh-dashboard/
+      # nvm use
       # yarn osd bootstrap
       # yarn build --linux --skip-os-packages --release
 
@@ -62,6 +67,7 @@ To build the packages, follow these steps:
       # cd plugins/
       # git clone -b <BRANCH_OR_TAG> https://github.com/wazuh/wazuh-security-dashboards-plugin.git
       # cd wazuh-security-dashboards-plugin/
+      # nvm use
       # yarn
       # yarn build
 
@@ -72,6 +78,7 @@ To build the packages, follow these steps:
       # cd plugins/
       # git clone -b 4.10.2 https://github.com/wazuh/wazuh-security-dashboards-plugin.git
       # cd wazuh-security-dashboards-plugin/
+      # nvm use
       # yarn
       # yarn build
 
@@ -86,6 +93,7 @@ To build the packages, follow these steps:
       # cd ../
       # git clone -b <BRANCH_OR_TAG> https://github.com/wazuh/wazuh-dashboard-plugins.git
       # cd wazuh-dashboard-plugins/
+      # nvm use
       # cp -r plugins/* ../
       # cd ../main
       # yarn
@@ -104,6 +112,7 @@ To build the packages, follow these steps:
       # cd ../
       # git clone -b 4.10.2 https://github.com/wazuh/wazuh-dashboard-plugins.git
       # cd wazuh-dashboard-plugins/
+      # nvm use
       # cp -r plugins/* ../
       # cd ../main
       # yarn

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -247,7 +247,7 @@ Building the packages
       --app 4.10.2 \
       --base 4.10.2 \
       --security 4.10.2 \
-      --node-version 18.19.0
+      --node-version $(cat .nvmrc)
 
    The script creates the packages in the ``packages`` directory within the ``base-packages-to-base`` folder.
 

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -50,7 +50,7 @@ To build the packages, follow these steps:
 
    .. code:: console
 
-      $ git clone -b 4.10.2 https://github.com/wazuh/wazuh-dashboard.git
+      $ git clone -b v|WAZUH_CURRENT| https://github.com/wazuh/wazuh-dashboard.git
       $ cd wazuh-dashboard/
       $ nvm use
       $ yarn osd bootstrap
@@ -76,7 +76,7 @@ To build the packages, follow these steps:
    .. code:: console
 
       $ cd plugins/
-      $ git clone -b 4.10.2 https://github.com/wazuh/wazuh-security-dashboards-plugin.git
+      $ git clone -b v|WAZUH_CURRENT| https://github.com/wazuh/wazuh-security-dashboards-plugin.git
       $ cd wazuh-security-dashboards-plugin/
       $ nvm use
       $ yarn
@@ -110,7 +110,7 @@ To build the packages, follow these steps:
    .. code:: console
 
       $ cd ../
-      $ git clone -b 4.10.2 https://github.com/wazuh/wazuh-dashboard-plugins.git
+      $ git clone -b v|WAZUH_CURRENT| https://github.com/wazuh/wazuh-dashboard-plugins.git
       $ cd wazuh-dashboard-plugins/
       $ nvm use
       $ cp -r plugins/* ../
@@ -191,7 +191,7 @@ Example:
 .. code:: console
 
    $ cd ../wazuh-dashboard/dev-tools/build-packages/
-   $ ./build-packages.sh -v 4.10.2 -r 1 --deb -a file:///packages/wazuh-package.zip -s file:///packages/security-package.zip -b file:///packages/dashboard-package.zip
+   $ ./build-packages.sh -v v|WAZUH_CURRENT| -r 1 --deb -a file:///packages/wazuh-package.zip -s file:///packages/security-package.zip -b file:///packages/dashboard-package.zip
 
 The script generates the package in the ``output`` folder of the same directory where it is located.
 
@@ -220,7 +220,7 @@ Building the packages
 
    .. code:: console
 
-      $ git clone -b 4.10.2 https://github.com/wazuh/wazuh-dashboard.git
+      $ git clone -b v|WAZUH_CURRENT| https://github.com/wazuh/wazuh-dashboard.git
       $ cd wazuh-dashboard/dev-tools/build-packages/base-packages-to-base
 
 #. Run the script ``run-docker-compose.sh`` with the following parameters:
@@ -245,9 +245,9 @@ Building the packages
 
       $ bash run-docker-compose.sh \
       --node-version $(cat ../../../.nvmrc) \
-      --base 4.10.2 \
-      --app 4.10.2 \
-      --security 4.10.2
+      --base v|WAZUH_CURRENT| \
+      --app v|WAZUH_CURRENT| \
+      --security v|WAZUH_CURRENT|
 
    The script creates the packages in the ``packages`` directory within the ``base-packages-to-base`` folder.
 
@@ -278,6 +278,6 @@ Building the packages
    .. code:: console
 
       $ cd ../../
-      $ ./build-packages.sh -v 4.10.2 -r 1 --deb -a file://$(pwd)/base-packages-to-base/packages/wazuh-package.zip -s file://$(pwd)/base-packages-to-base/packages/security-package.zip -b file://$(pwd)/base-packages-to-base/packages/dashboard-package.zip
+      $ ./build-packages.sh -v v|WAZUH_CURRENT| -r 1 --deb -a file://$(pwd)/base-packages-to-base/packages/wazuh-package.zip -s file://$(pwd)/base-packages-to-base/packages/security-package.zip -b file://$(pwd)/base-packages-to-base/packages/dashboard-package.zip
 
    The script creates the package in the ``output`` folder within the same directory as the script.


### PR DESCRIPTION
## Description
We detected there are missing steps in the documentation to build Wazuh dashboard from source code. Some of those steps involve installing NodeJS and Yarn.
We need to analyze which required steps are missing and add them to the documentation.

Closes https://github.com/wazuh/wazuh-documentation/issues/7998

## Checks
### Docs building
- [ ] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
