### PR TITLE
Fix file permissions output

### DIFF
--- a/source/user-manual/agent/agent-enrollment/security-options/using-password-authentication.rst
+++ b/source/user-manual/agent/agent-enrollment/security-options/using-password-authentication.rst
@@ -101,7 +101,7 @@ Follow these steps to enroll a Linux/Unix endpoint with password authentication:
 
       .. code-block:: none
 
-         -rw-r--r-- 1 root wazuh 18 Jan 11 13:03 /var/ossec/etc/authd.pass
+         -rw-r----- 1 root wazuh 18 Jan 11 13:03 /var/ossec/etc/authd.pass
 
 #. (Optional) To ensure the Wazuh agent can locate your password file if it is not in the default location (``/var/ossec/etc/authd.pass``), include the ``authorization_pass_path`` setting in the Wazuh agent configuration. Replace ``<PATH_TO_PASSWORD_FILE>`` with the filepath of the password file.
 


### PR DESCRIPTION
## Description
This PR fixes the file permissions displayed in the the output of step 1.b

- https://documentation.wazuh.com/current/user-manual/agent/agent-enrollment/security-options/using-password-authentication.html#linux-unix

## Checks
### Docs building
- [X] Compiles without warnings.
### Code formatting and web optimization
- [X] Uses three spaces indentation.
- [X] Adds or updates meta descriptions accordingly.
- [X] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
