### PR TITLE
Fix the wazuh dashboard reference when cloning the repository

### DIFF
--- a/source/_variables/replacements.py
+++ b/source/_variables/replacements.py
@@ -163,6 +163,9 @@ custom_replacements = {
     "|SPLUNK_LATEST_MINOR|" : "8.2",
     "|WAZUH_SPLUNK_REV_CURRENT_LATEST|" : "1", # 8.2
     "|WAZUH_SPLUNK_REV_CURRENT_8.1|" : "1",
+    #
+    # === Node.js
+    "|NODE_VERSION|": "18.19.0",
 }
 
 if is_latest_release:

--- a/source/_variables/replacements.py
+++ b/source/_variables/replacements.py
@@ -164,8 +164,7 @@ custom_replacements = {
     "|WAZUH_SPLUNK_REV_CURRENT_LATEST|" : "1", # 8.2
     "|WAZUH_SPLUNK_REV_CURRENT_8.1|" : "1",
     #
-    # === Node.js
-    "|WAZUH_DASHBOARD_NODE_VERSION|": "18.19.0",
+    # === Wazuh dashboard
     "|WAZUH_DASHBOARD_YARN_VERSION|": "1.22.22",
 }
 

--- a/source/_variables/replacements.py
+++ b/source/_variables/replacements.py
@@ -165,7 +165,7 @@ custom_replacements = {
     "|WAZUH_SPLUNK_REV_CURRENT_8.1|" : "1",
     #
     # === Node.js
-    "|NODE_VERSION|": "18.19.0",
+    "|WAZUH_DASHBOARD_NODE_VERSION|": "18.19.0",
 }
 
 if is_latest_release:

--- a/source/_variables/replacements.py
+++ b/source/_variables/replacements.py
@@ -23,12 +23,15 @@ custom_replacements = {
     #
     "|CTI_URL|" : "https://cti.wazuh.com/api/v1/catalog/contexts/vd_1.0.0/consumers/vd_4.8.0",
     #
+    # === Environment
+    "|PYTHON_CLOUD_CONTAINERS_MIN|": "3.8",
+    "|PYTHON_CLOUD_CONTAINERS_MAX|": "3.12",
+    "|WAZUH_DASHBOARD_YARN_VERSION|": "1.22.22",
+    #
     # === Global and Wazuh version (wazuh agent, manager, indexer, and dashboard)
     "|WAZUH_CURRENT_MAJOR|" : "4.x",
     "|WAZUH_CURRENT_MINOR|" : version,
     "|WAZUH_CURRENT|" : release,
-    "|PYTHON_CLOUD_CONTAINERS_MIN|": "3.8",
-    "|PYTHON_CLOUD_CONTAINERS_MAX|": "3.12",
 
     # --- Revision numbers for Wazuh agent and manager packages versions
     # Yum packages revisions
@@ -143,6 +146,9 @@ custom_replacements = {
     "|WAZUH_CURRENT_HPUX|" : release,
     "|WAZUH_REVISION_HPUX|" : "1",
     #
+    # === OpenSearch
+    "|OPENSEARCH_DASHBOARDS_VERSION|": "2.13.0",
+    #
     # === Elastic
     # --- Filebeat
     "|FILEBEAT_LATEST|" : "7.10.2",
@@ -163,12 +169,6 @@ custom_replacements = {
     "|SPLUNK_LATEST_MINOR|" : "8.2",
     "|WAZUH_SPLUNK_REV_CURRENT_LATEST|" : "1", # 8.2
     "|WAZUH_SPLUNK_REV_CURRENT_8.1|" : "1",
-    #
-    # === Wazuh dashboard
-    "|WAZUH_DASHBOARD_YARN_VERSION|": "1.22.22",
-    #
-    # === OpenSearch Dashboard
-    "|OPENSEARCH_DASHBOARDS_VERSION|": "2.13.0",
 }
 
 if is_latest_release:

--- a/source/_variables/replacements.py
+++ b/source/_variables/replacements.py
@@ -166,6 +166,9 @@ custom_replacements = {
     #
     # === Wazuh dashboard
     "|WAZUH_DASHBOARD_YARN_VERSION|": "1.22.22",
+    #
+    # === OpenSearch Dashboard
+    "|OPENSEARCH_DASHBOARDS_VERSION|": "2.13.0",
 }
 
 if is_latest_release:

--- a/source/_variables/replacements.py
+++ b/source/_variables/replacements.py
@@ -166,6 +166,7 @@ custom_replacements = {
     #
     # === Node.js
     "|WAZUH_DASHBOARD_NODE_VERSION|": "18.19.0",
+    "|WAZUH_DASHBOARD_YARN_VERSION|": "1.22.22",
 }
 
 if is_latest_release:

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -257,6 +257,6 @@ With this option you can create an image that has the package in tar.gz format a
 
    .. code:: console
 
-      $ ./launcher.sh -v 4.9.0 -r 1 -p file:///wazuh-dashboard-4.9.0-1-linux-x64.tar.gz
+      $ ./launcher.sh -v |WAZUH_CURRENT| -r 1 -p file:///wazuh-dashboard-|WAZUH_CURRENT|-1-linux-x64.tar.gz
 
 The package will be generated in the ``output`` folder of the ``rpm`` or ``deb`` folder.

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -6,7 +6,7 @@
 Wazuh dashboard
 ===============
 
-The packages generation process is orchestrated by the ``build-packages.sh`` script, which is found within the ``dev-tools/build-packages/`` folder of the repository. This script is responsible for bundling plugins into one single application in tar, rpm and/or deb distributions. It takes the following parameters:
+The packages generation process is orchestrated by the ``build-packages.sh`` script, which is found within the ``dev-tools/build-packages/`` folder of the repository. This script is responsible for bundling plugins into one single application in ``tar``, ``rpm`` and/or ``deb`` distributions. It takes the following parameters:
 
 -  version
 -  revision

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -21,6 +21,12 @@ Build manually
 Requirements:
 
 -  Docker
+-  NVM (Node Version Manager): see `NVM installation guide <https://github.com/nvm-sh/nvm#installing-and-updating>`_
+
+   -  ``nvm install v|NODE_VERSION|``: installs Node.js version v|NODE_VERSION|
+   -  ``nvm use v|NODE_VERSION|``: sets the current Node.js version to v|NODE_VERSION|
+
+-  Yarn v1.22.22 (Node Package Manager): see `Yarn installation guide <https://classic.yarnpkg.com/en/docs/install/>`_
 
 Generating zip packages
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -39,6 +45,7 @@ To build the packages, follow these steps:
 
       $ git clone -b <BRANCH_OR_TAG> https://github.com/wazuh/wazuh-dashboard.git
       $ cd wazuh-dashboard/
+      $ nvm use v|NODE_VERSION|
       $ yarn osd bootstrap
       $ yarn build --linux --skip-os-packages --release
 
@@ -48,6 +55,7 @@ To build the packages, follow these steps:
 
       $ git clone -b v|WAZUH_CURRENT| https://github.com/wazuh/wazuh-dashboard.git
       $ cd wazuh-dashboard/
+      $ nvm use v|NODE_VERSION|
       $ yarn osd bootstrap
       $ yarn build --linux --skip-os-packages --release
 
@@ -58,6 +66,7 @@ To build the packages, follow these steps:
       $ cd plugins/
       $ git clone -b <BRANCH_OR_TAG> https://github.com/wazuh/wazuh-security-dashboards-plugin.git
       $ cd wazuh-security-dashboards-plugin/
+      $ nvm use v|NODE_VERSION|
       $ yarn
       $ yarn build
 
@@ -68,6 +77,7 @@ To build the packages, follow these steps:
       $ cd plugins/
       $ git clone -b v|WAZUH_CURRENT| https://github.com/wazuh/wazuh-security-dashboards-plugin.git
       $ cd wazuh-security-dashboards-plugin/
+      $ nvm use v|NODE_VERSION|
       $ yarn
       $ yarn build
 
@@ -82,6 +92,7 @@ To build the packages, follow these steps:
       $ cd ../
       $ git clone -b <BRANCH_OR_TAG> https://github.com/wazuh/wazuh-dashboard-plugins.git
       $ cd wazuh-dashboard-plugins/
+      $ nvm use v|NODE_VERSION|
       $ cp -r plugins/* ../
       $ cd ../main
       $ yarn
@@ -100,6 +111,7 @@ To build the packages, follow these steps:
       $ cd ../
       $ git clone -b v|WAZUH_CURRENT| https://github.com/wazuh/wazuh-dashboard-plugins.git
       $ cd wazuh-dashboard-plugins/
+      $ nvm use v|NODE_VERSION|
       $ cp -r plugins/* ../
       $ cd ../main
       $ yarn
@@ -209,7 +221,7 @@ With this option you can create an image that has the package in tar.gz format a
    .. code:: console
 
       $ docker build \
-      --build-arg NODE_VERSION=18.19.0 \
+      --build-arg NODE_VERSION=|NODE_VERSION| \
       --build-arg WAZUH_DASHBOARDS_BRANCH=v|WAZUH_CURRENT| \
       --build-arg WAZUH_DASHBOARDS_PLUGINS=v|WAZUH_CURRENT| \
       --build-arg WAZUH_SECURITY_DASHBOARDS_PLUGIN_BRANCH=v|WAZUH_CURRENT| \

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -21,7 +21,7 @@ Build manually
 Requirements:
 
 -  Docker: see `Docker installation guide <https://docs.docker.com/engine/install/>`_
--  zip: see `zip installation guide <https://www.tecmint.com/install-zip-and-unzip-in-linux/>`_
+-  zip
 -  NVM (Node Version Manager): see `NVM installation guide <https://github.com/nvm-sh/nvm#installing-and-updating>`_
 
    -  ``nvm install v|WAZUH_DASHBOARD_NODE_VERSION|``: installs Node.js version v|WAZUH_DASHBOARD_NODE_VERSION|

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -214,7 +214,7 @@ With this option you can create an image that has the package in tar.gz format a
       --build-arg WAZUH_DASHBOARDS_PLUGINS=4.9.0 \
       --build-arg WAZUH_SECURITY_DASHBOARDS_PLUGIN_BRANCH=4.9.0 \
       --build-arg OPENSEARCH_DASHBOARDS_VERSION=2.13.0 \
-      -t wzd:4.9.0 \
+      -t wzd:v|WAZUH_CURRENT| \
       -f wazuh-dashboard.Dockerfile .
 
 #. Run the Docker image:
@@ -227,7 +227,7 @@ With this option you can create an image that has the package in tar.gz format a
 
    .. code:: console
 
-      $ docker run -d --rm --name wazuh-dashboard-package wzd:4.9.0 tail -f /dev/null
+      $ docker run -d --rm --name wazuh-dashboard-package wzd:v|WAZUH_CURRENT| tail -f /dev/null
 
 #. Copy the package to the host:
 

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -129,7 +129,7 @@ To build the packages, follow these steps:
       $ cd ../../../
       $ mkdir packages
       $ cd packages
-      $ zip -r -j ./dashboard-package.zip ../wazuh-dashboard/target/opensearch-dashboards-2.13.0-linux-x64.tar.gz
+      $ zip -r -j ./dashboard-package.zip ../wazuh-dashboard/target/opensearch-dashboards-<OPENSEARCH_VERSION>-linux-x64.tar.gz
       $ zip -r -j ./security-package.zip ../wazuh-dashboard/plugins/wazuh-security-dashboards-plugin/build/security-dashboards-<OPENSEARCH_VERSION>.0.zip
       $ zip -r -j ./wazuh-package.zip ../wazuh-dashboard/plugins/wazuh-check-updates/build/wazuhCheckUpdates-<OPENSEARCH_VERSION>.zip ../wazuh-dashboard/plugins/main/build/wazuh-<OPENSEARCH_VERSION>.zip ../wazuh-dashboard/plugins/wazuh-core/build/wazuhCore-<OPENSEARCH_VERSION>.zip
 
@@ -140,9 +140,9 @@ To build the packages, follow these steps:
       $ cd ../../../
       $ mkdir packages
       $ cd packages
-      $ zip -r -j ./dashboard-package.zip ../wazuh-dashboard/target/opensearch-dashboards-2.13.0-linux-x64.tar.gz
-      $ zip -r -j ./security-package.zip ../wazuh-dashboard/plugins/wazuh-security-dashboards-plugin/build/security-dashboards-2.13.0.0.zip
-      $ zip -r -j ./wazuh-package.zip ../wazuh-dashboard/plugins/wazuh-check-updates/build/wazuhCheckUpdates-2.13.0.zip ../wazuh-dashboard/plugins/main/build/wazuh-2.13.0.zip ../wazuh-dashboard/plugins/wazuh-core/build/wazuhCore-2.13.0.zip
+      $ zip -r -j ./dashboard-package.zip ../wazuh-dashboard/target/opensearch-dashboards-|OPENSEARCH_DASHBOARDS_VERSION|-linux-x64.tar.gz
+      $ zip -r -j ./security-package.zip ../wazuh-dashboard/plugins/wazuh-security-dashboards-plugin/build/security-dashboards-|OPENSEARCH_DASHBOARDS_VERSION|.0.zip
+      $ zip -r -j ./wazuh-package.zip ../wazuh-dashboard/plugins/wazuh-check-updates/build/wazuhCheckUpdates-|OPENSEARCH_DASHBOARDS_VERSION|.zip ../wazuh-dashboard/plugins/main/build/wazuh-|OPENSEARCH_DASHBOARDS_VERSION|.zip ../wazuh-dashboard/plugins/wazuh-core/build/wazuhCore-|OPENSEARCH_DASHBOARDS_VERSION|.zip
 
 At this point you must have three packages in the ``packages`` folder:
 
@@ -224,7 +224,7 @@ With this option you can create an image that has the package in tar.gz format a
       --build-arg WAZUH_DASHBOARDS_BRANCH=v|WAZUH_CURRENT| \
       --build-arg WAZUH_DASHBOARDS_PLUGINS=v|WAZUH_CURRENT| \
       --build-arg WAZUH_SECURITY_DASHBOARDS_PLUGIN_BRANCH=v|WAZUH_CURRENT| \
-      --build-arg OPENSEARCH_DASHBOARDS_VERSION=2.13.0 \
+      --build-arg OPENSEARCH_DASHBOARDS_VERSION=|OPENSEARCH_DASHBOARDS_VERSION| \
       -t wzd:v|WAZUH_CURRENT| \
       -f wazuh-dashboard.Dockerfile .
 

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -210,9 +210,9 @@ With this option you can create an image that has the package in tar.gz format a
 
       $ docker build \
       --build-arg NODE_VERSION=18.19.0 \
-      --build-arg WAZUH_DASHBOARDS_BRANCH=4.9.0 \
-      --build-arg WAZUH_DASHBOARDS_PLUGINS=4.9.0 \
-      --build-arg WAZUH_SECURITY_DASHBOARDS_PLUGIN_BRANCH=4.9.0 \
+      --build-arg WAZUH_DASHBOARDS_BRANCH=v|WAZUH_CURRENT| \
+      --build-arg WAZUH_DASHBOARDS_PLUGINS=v|WAZUH_CURRENT| \
+      --build-arg WAZUH_SECURITY_DASHBOARDS_PLUGIN_BRANCH=v|WAZUH_CURRENT| \
       --build-arg OPENSEARCH_DASHBOARDS_VERSION=2.13.0 \
       -t wzd:v|WAZUH_CURRENT| \
       -f wazuh-dashboard.Dockerfile .

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -24,8 +24,8 @@ Requirements:
 -  zip: see `zip installation guide <https://www.tecmint.com/install-zip-and-unzip-in-linux/>`_
 -  NVM (Node Version Manager): see `NVM installation guide <https://github.com/nvm-sh/nvm#installing-and-updating>`_
 
-   -  ``nvm install v|NODE_VERSION|``: installs Node.js version v|NODE_VERSION|
-   -  ``nvm use v|NODE_VERSION|``: sets the current Node.js version to v|NODE_VERSION|
+   -  ``nvm install v|WAZUH_DASHBOARD_NODE_VERSION|``: installs Node.js version v|WAZUH_DASHBOARD_NODE_VERSION|
+   -  ``nvm use v|WAZUH_DASHBOARD_NODE_VERSION|``: sets the current Node.js version to v|WAZUH_DASHBOARD_NODE_VERSION|
 
 -  Yarn v1.22.22 (Node Package Manager): see `Yarn installation guide <https://classic.yarnpkg.com/en/docs/install/>`_
 
@@ -46,7 +46,7 @@ To build the packages, follow these steps:
 
       $ git clone -b <BRANCH_OR_TAG> https://github.com/wazuh/wazuh-dashboard.git
       $ cd wazuh-dashboard/
-      $ nvm use v|NODE_VERSION|
+      $ nvm use v|WAZUH_DASHBOARD_NODE_VERSION|
       $ yarn osd bootstrap
       $ yarn build --linux --skip-os-packages --release
 
@@ -56,7 +56,7 @@ To build the packages, follow these steps:
 
       $ git clone -b v|WAZUH_CURRENT| https://github.com/wazuh/wazuh-dashboard.git
       $ cd wazuh-dashboard/
-      $ nvm use v|NODE_VERSION|
+      $ nvm use v|WAZUH_DASHBOARD_NODE_VERSION|
       $ yarn osd bootstrap
       $ yarn build --linux --skip-os-packages --release
 
@@ -67,7 +67,7 @@ To build the packages, follow these steps:
       $ cd plugins/
       $ git clone -b <BRANCH_OR_TAG> https://github.com/wazuh/wazuh-security-dashboards-plugin.git
       $ cd wazuh-security-dashboards-plugin/
-      $ nvm use v|NODE_VERSION|
+      $ nvm use v|WAZUH_DASHBOARD_NODE_VERSION|
       $ yarn
       $ yarn build
 
@@ -78,7 +78,7 @@ To build the packages, follow these steps:
       $ cd plugins/
       $ git clone -b v|WAZUH_CURRENT| https://github.com/wazuh/wazuh-security-dashboards-plugin.git
       $ cd wazuh-security-dashboards-plugin/
-      $ nvm use v|NODE_VERSION|
+      $ nvm use v|WAZUH_DASHBOARD_NODE_VERSION|
       $ yarn
       $ yarn build
 
@@ -93,7 +93,7 @@ To build the packages, follow these steps:
       $ cd ../
       $ git clone -b <BRANCH_OR_TAG> https://github.com/wazuh/wazuh-dashboard-plugins.git
       $ cd wazuh-dashboard-plugins/
-      $ nvm use v|NODE_VERSION|
+      $ nvm use v|WAZUH_DASHBOARD_NODE_VERSION|
       $ cp -r plugins/* ../
       $ cd ../main
       $ yarn
@@ -112,7 +112,7 @@ To build the packages, follow these steps:
       $ cd ../
       $ git clone -b v|WAZUH_CURRENT| https://github.com/wazuh/wazuh-dashboard-plugins.git
       $ cd wazuh-dashboard-plugins/
-      $ nvm use v|NODE_VERSION|
+      $ nvm use v|WAZUH_DASHBOARD_NODE_VERSION|
       $ cp -r plugins/* ../
       $ cd ../main
       $ yarn
@@ -222,7 +222,7 @@ With this option you can create an image that has the package in tar.gz format a
    .. code:: console
 
       $ docker build \
-      --build-arg NODE_VERSION=|NODE_VERSION| \
+      --build-arg NODE_VERSION=|WAZUH_DASHBOARD_NODE_VERSION| \
       --build-arg WAZUH_DASHBOARDS_BRANCH=v|WAZUH_CURRENT| \
       --build-arg WAZUH_DASHBOARDS_PLUGINS=v|WAZUH_CURRENT| \
       --build-arg WAZUH_SECURITY_DASHBOARDS_PLUGIN_BRANCH=v|WAZUH_CURRENT| \

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -165,7 +165,7 @@ Run the ``build-packages.sh`` script in the ``dev-tools/build-packages/`` folder
 .. code:: console
 
    $ cd ../wazuh-dashboard/dev-tools/build-packages/
-   $ ./build-packages.sh -v <VERSION> -r <REVISION> --<DISTRIBUTION_(--deb_OR_--rpm)> -a file:///<PATH_TO_wazuh-package.zip> -s file:///<PATH_TO_security-package.zip> -b file:///<PATH_TO_dashboard-package.zip>
+   $ ./build-packages.sh -v <VERSION> -r <REVISION> (--deb|--rpm) -a file:///<PATH_TO_wazuh-package.zip> -s file:///<PATH_TO_security-package.zip> -b file:///<PATH_TO_dashboard-package.zip>
 
 Example:
 

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -95,6 +95,7 @@ To build the packages, follow these steps:
       $ cd ../main
       $ yarn
       $ yarn build
+      $ # When prompted for the OpenSearch version, check the version specified in the package.json file.
       $ cd ../wazuh-core/
       $ yarn
       $ yarn build
@@ -115,6 +116,7 @@ To build the packages, follow these steps:
       $ cd ../main
       $ yarn
       $ yarn build
+      $ # When prompted for the OpenSearch version, check the version specified in the package.json file.
       $ cd ../wazuh-core/
       $ yarn
       $ yarn build

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -28,7 +28,7 @@ Generating zip packages
 To use the script you first need to generate the packages from these repositories:
 
 -  ``wazuh-dashboard``
--  ``wazuh-security-dashboards-plugin`` 
+-  ``wazuh-security-dashboards-plugin``
 -  ``wazuh-dashboard-plugins``
 
 To build the packages, follow these steps:
@@ -37,39 +37,39 @@ To build the packages, follow these steps:
 
    .. code:: console
 
-      # git clone -b <BRANCH_OR_TAG> https://github.com/wazuh/wazuh-dashboard.git
-      # cd wazuh-dashboard/
-      # yarn osd bootstrap
-      # yarn build --linux --skip-os-packages --release
+      $ git clone -b <BRANCH_OR_TAG> https://github.com/wazuh/wazuh-dashboard.git
+      $ cd wazuh-dashboard/
+      $ yarn osd bootstrap
+      $ yarn build --linux --skip-os-packages --release
 
    Example:
 
    .. code:: console
 
-      # git clone -b 4.9.0 https://github.com/wazuh/wazuh-dashboard.git
-      # cd wazuh-dashboard/
-      # yarn osd bootstrap
-      # yarn build --linux --skip-os-packages --release
+      $ git clone -b 4.9.0 https://github.com/wazuh/wazuh-dashboard.git
+      $ cd wazuh-dashboard/
+      $ yarn osd bootstrap
+      $ yarn build --linux --skip-os-packages --release
 
 #. Clone the Wazuh Security Dashboards Plugin repository in the plugins folder and build the plugin.
 
    .. code:: console
 
-      # cd plugins/
-      # git clone -b <BRANCH_OR_TAG> https://github.com/wazuh/wazuh-security-dashboards-plugin.git
-      # cd wazuh-security-dashboards-plugin/
-      # yarn
-      # yarn build
+      $ cd plugins/
+      $ git clone -b <BRANCH_OR_TAG> https://github.com/wazuh/wazuh-security-dashboards-plugin.git
+      $ cd wazuh-security-dashboards-plugin/
+      $ yarn
+      $ yarn build
 
    Example:
 
    .. code:: console
 
-      # cd plugins/
-      # git clone -b 4.9.0 https://github.com/wazuh/wazuh-security-dashboards-plugin.git
-      # cd wazuh-security-dashboards-plugin/
-      # yarn
-      # yarn build
+      $ cd plugins/
+      $ git clone -b 4.9.0 https://github.com/wazuh/wazuh-security-dashboards-plugin.git
+      $ cd wazuh-security-dashboards-plugin/
+      $ yarn
+      $ yarn build
 
 #. Clone the Wazuh dashboard plugins repository in the plugins folder, move the contents of the plugins folder to the folder where the repository was cloned and build the plugins.
 
@@ -79,59 +79,59 @@ To build the packages, follow these steps:
 
    .. code:: console
 
-      # cd ../
-      # git clone -b <BRANCH_OR_TAG> https://github.com/wazuh/wazuh-dashboard-plugins.git
-      # cd wazuh-dashboard-plugins/
-      # cp -r plugins/* ../
-      # cd ../main
-      # yarn
-      # yarn build
-      # cd ../wazuh-core/
-      # yarn
-      # yarn build
-      # cd ../wazuh-check-updates/
-      # yarn
-      # yarn build
+      $ cd ../
+      $ git clone -b <BRANCH_OR_TAG> https://github.com/wazuh/wazuh-dashboard-plugins.git
+      $ cd wazuh-dashboard-plugins/
+      $ cp -r plugins/* ../
+      $ cd ../main
+      $ yarn
+      $ yarn build
+      $ cd ../wazuh-core/
+      $ yarn
+      $ yarn build
+      $ cd ../wazuh-check-updates/
+      $ yarn
+      $ yarn build
 
    Example:
 
    .. code:: console
 
-      # cd ../
-      # git clone -b 4.9.0 https://github.com/wazuh/wazuh-dashboard-plugins.git
-      # cd wazuh-dashboard-plugins/
-      # cp -r plugins/* ../
-      # cd ../main
-      # yarn
-      # yarn build
-      # cd ../wazuh-core/
-      # yarn
-      # yarn build
-      # cd ../wazuh-check-updates/
-      # yarn
-      # yarn build
+      $ cd ../
+      $ git clone -b 4.9.0 https://github.com/wazuh/wazuh-dashboard-plugins.git
+      $ cd wazuh-dashboard-plugins/
+      $ cp -r plugins/* ../
+      $ cd ../main
+      $ yarn
+      $ yarn build
+      $ cd ../wazuh-core/
+      $ yarn
+      $ yarn build
+      $ cd ../wazuh-check-updates/
+      $ yarn
+      $ yarn build
 
 #. Zip the packages and move them to the packages folder
 
    .. code:: console
 
-      # cd ../../../
-      # mkdir packages
-      # cd packages
-      # zip -r -j ./dashboard-package.zip ../wazuh-dashboard/target/opensearch-dashboards-2.13.0-linux-x64.tar.gz
-      # zip -r -j ./security-package.zip ../wazuh-dashboard/plugins/wazuh-security-dashboards-plugin/build/security-dashboards-<OPENSEARCH_VERSION>.0.zip
-      # zip -r -j ./wazuh-package.zip ../wazuh-dashboard/plugins/wazuh-check-updates/build/wazuhCheckUpdates-<OPENSEARCH_VERSION>.zip ../wazuh-dashboard/plugins/main/build/wazuh-<OPENSEARCH_VERSION>.zip ../wazuh-dashboard/plugins/wazuh-core/build/wazuhCore-<OPENSEARCH_VERSION>.zip
+      $ cd ../../../
+      $ mkdir packages
+      $ cd packages
+      $ zip -r -j ./dashboard-package.zip ../wazuh-dashboard/target/opensearch-dashboards-2.13.0-linux-x64.tar.gz
+      $ zip -r -j ./security-package.zip ../wazuh-dashboard/plugins/wazuh-security-dashboards-plugin/build/security-dashboards-<OPENSEARCH_VERSION>.0.zip
+      $ zip -r -j ./wazuh-package.zip ../wazuh-dashboard/plugins/wazuh-check-updates/build/wazuhCheckUpdates-<OPENSEARCH_VERSION>.zip ../wazuh-dashboard/plugins/main/build/wazuh-<OPENSEARCH_VERSION>.zip ../wazuh-dashboard/plugins/wazuh-core/build/wazuhCore-<OPENSEARCH_VERSION>.zip
 
    Example:
 
    .. code:: console
 
-      # cd ../../../
-      # mkdir packages
-      # cd packages
-      # zip -r -j ./dashboard-package.zip ../wazuh-dashboard/target/opensearch-dashboards-2.13.0-linux-x64.tar.gz
-      # zip -r -j ./security-package.zip ../wazuh-dashboard/plugins/wazuh-security-dashboards-plugin/build/security-dashboards-2.13.0.0.zip
-      # zip -r -j ./wazuh-package.zip ../wazuh-dashboard/plugins/wazuh-check-updates/build/wazuhCheckUpdates-2.13.0.zip ../wazuh-dashboard/plugins/main/build/wazuh-2.13.0.zip ../wazuh-dashboard/plugins/wazuh-core/build/wazuhCore-2.13.0.zip
+      $ cd ../../../
+      $ mkdir packages
+      $ cd packages
+      $ zip -r -j ./dashboard-package.zip ../wazuh-dashboard/target/opensearch-dashboards-2.13.0-linux-x64.tar.gz
+      $ zip -r -j ./security-package.zip ../wazuh-dashboard/plugins/wazuh-security-dashboards-plugin/build/security-dashboards-2.13.0.0.zip
+      $ zip -r -j ./wazuh-package.zip ../wazuh-dashboard/plugins/wazuh-check-updates/build/wazuhCheckUpdates-2.13.0.zip ../wazuh-dashboard/plugins/main/build/wazuh-2.13.0.zip ../wazuh-dashboard/plugins/wazuh-core/build/wazuhCore-2.13.0.zip
 
 At this point you must have three packages in the ``packages`` folder:
 
@@ -153,15 +153,15 @@ Run the ``build-packages.sh`` script in the ``dev-tools/build-packages/`` folder
 
 .. code:: console
 
-   # cd ../wazuh-dashboard/dev-tools/build-packages/
-   # ./build-packages.sh -v <VERSION> -r <REVISION> --<DISTRIBUTION_(--deb_OR_--rpm)> -a file:///<PATH_TO_wazuh-package.zip> -s file:///<PATH_TO_security-package.zip> -b file:///<PATH_TO_dashboard-package.zip>
+   $ cd ../wazuh-dashboard/dev-tools/build-packages/
+   $ ./build-packages.sh -v <VERSION> -r <REVISION> --<DISTRIBUTION_(--deb_OR_--rpm)> -a file:///<PATH_TO_wazuh-package.zip> -s file:///<PATH_TO_security-package.zip> -b file:///<PATH_TO_dashboard-package.zip>
 
 Example:
 
 .. code:: console
 
-   # cd ../wazuh-dashboard/dev-tools/build-packages/
-   # ./build-packages.sh -v 4.9.0 -r 1 --deb -a file:///packages/wazuh-package.zip -s file:///packages/security-package.zip -b file:///packages/dashboard-package.zip
+   $ cd ../wazuh-dashboard/dev-tools/build-packages/
+   $ ./build-packages.sh -v 4.9.0 -r 1 --deb -a file:///packages/wazuh-package.zip -s file:///packages/security-package.zip -b file:///packages/dashboard-package.zip
 
 The package will be generated in the ``output`` folder of the same directory where the script is located.
 
@@ -173,16 +173,16 @@ With this option you can create an image that has the package in tar.gz format a
 #. Clone the Wazuh dashboard repository.
 
    .. code:: console
-   
-      # git clone -b <BRANCH_OR_TAG> https://github.com/wazuh/wazuh-dashboard.git
-      # cd wazuh-dashboard/dev-tools/build-packages/
-   
+
+      $ git clone -b <BRANCH_OR_TAG> https://github.com/wazuh/wazuh-dashboard.git
+      $ cd wazuh-dashboard/dev-tools/build-packages/
+
    Example:
-   
+
    .. code:: console
-   
-      # git clone -b 4.9.0 https://github.com/wazuh/wazuh-dashboard.git
-      # cd wazuh-dashboard/dev-tools/build-packages/
+
+      $ git clone -b 4.9.0 https://github.com/wazuh/wazuh-dashboard.git
+      $ cd wazuh-dashboard/dev-tools/build-packages/
 
 #. Build the Docker image with the following parameters:
 
@@ -194,21 +194,21 @@ With this option you can create an image that has the package in tar.gz format a
    -  ``-t``: Tag of the image.
 
    .. code:: console
-   
-      # docker build \
+
+      $ docker build \
       --build-arg NODE_VERSION=<NODE_VERSION> \
       --build-arg WAZUH_DASHBOARDS_BRANCH=<BRANCH_OF_wazuh-dashboard> \
       --build-arg WAZUH_DASHBOARDS_PLUGINS=<BRANCH_OF_wazuh-dashboard-plugins> \
       --build-arg WAZUH_SECURITY_DASHBOARDS_PLUGIN_BRANCH=<BRANCH_OF_wazuh-security-dashboards-plugin> \
       --build-arg OPENSEARCH_DASHBOARDS_VERSION=<OPENSEARCH_DASHBOARDS_VERSION> \
-      -t <TAG_OF_IMAGE> \ 
+      -t <TAG_OF_IMAGE> \
       -f wazuh-dashboard.Dockerfile .
 
    Example:
-   
+
    .. code:: console
-   
-      # docker build \
+
+      $ docker build \
       --build-arg NODE_VERSION=18.19.0 \
       --build-arg WAZUH_DASHBOARDS_BRANCH=4.9.0 \
       --build-arg WAZUH_DASHBOARDS_PLUGINS=4.9.0 \
@@ -220,26 +220,26 @@ With this option you can create an image that has the package in tar.gz format a
 #. Run the Docker image:
 
    .. code:: console
-   
-      # docker run -d --rm --name wazuh-dashboard-package <TAG_OF_IMAGE> tail -f /dev/null
-   
+
+      $ docker run -d --rm --name wazuh-dashboard-package <TAG_OF_IMAGE> tail -f /dev/null
+
    Example:
-   
+
    .. code:: console
-   
-      # docker run -d --rm --name wazuh-dashboard-package wzd:4.9.0 tail -f /dev/null
+
+      $ docker run -d --rm --name wazuh-dashboard-package wzd:4.9.0 tail -f /dev/null
 
 #. Copy the package to the host:
 
    .. code:: console
-   
-      # docker cp wazuh-dashboard-package:/home/node/packages/. <PATH_TO_SAVE_THE_PACKAGE>
+
+      $ docker cp wazuh-dashboard-package:/home/node/packages/. <PATH_TO_SAVE_THE_PACKAGE>
 
    Example:
-   
+
    .. code:: console
-   
-      # docker cp wazuh-dashboard-package:/home/node/packages/. /
+
+      $ docker cp wazuh-dashboard-package:/home/node/packages/. /
 
    This copies the final package and the packages that were used to generate the final package.
 
@@ -248,15 +248,15 @@ With this option you can create an image that has the package in tar.gz format a
    -  ``-v``: Version of the package.
    -  ``-r``: Revision of the package.
    -  ``-p``: Path to the package in tar.gz format generated in the previous step
-   
+
    .. code:: console
-   
-      # ./launcher.sh -v <VERSION> -r <REVISION> -p <PATH_TO_PACKAGE>
-   
+
+      $ ./launcher.sh -v <VERSION> -r <REVISION> -p <PATH_TO_PACKAGE>
+
    Example:
-   
+
    .. code:: console
-   
-      # ./launcher.sh -v 4.9.0 -r 1 -p file:///wazuh-dashboard-4.9.0-1-linux-x64.tar.gz
+
+      $ ./launcher.sh -v 4.9.0 -r 1 -p file:///wazuh-dashboard-4.9.0-1-linux-x64.tar.gz
 
 The package will be generated in the ``output`` folder of the ``rpm`` or ``deb`` folder.

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -172,7 +172,7 @@ Example:
 .. code:: console
 
    $ cd ../wazuh-dashboard/dev-tools/build-packages/
-   $ ./build-packages.sh -v |WAZUH_CURRENT| -r 1 --deb -a file:///packages/wazuh-package.zip -s file:///packages/security-package.zip -b file:///packages/dashboard-package.zip
+   $ ./build-packages.sh -v v|WAZUH_CURRENT| -r 1 --deb -a file:///packages/wazuh-package.zip -s file:///packages/security-package.zip -b file:///packages/dashboard-package.zip
 
 The package will be generated in the ``output`` folder of the same directory where the script is located.
 

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -21,6 +21,7 @@ Build manually
 Requirements:
 
 -  Docker: see `Docker installation guide <https://docs.docker.com/engine/install/>`_
+-  Docker Compose: see `Docker Compose installation guide <https://docs.docker.com/compose/install/>`_
 -  zip
 -  NVM (Node Version Manager): see `NVM installation guide <https://github.com/nvm-sh/nvm#installing-and-updating>`_
 -  Yarn v|WAZUH_DASHBOARD_YARN_VERSION| (Node Package Manager): see `Yarn installation guide <https://classic.yarnpkg.com/en/docs/install/>`_

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -27,7 +27,7 @@ Requirements:
    -  ``nvm install v|WAZUH_DASHBOARD_NODE_VERSION|``: installs Node.js version v|WAZUH_DASHBOARD_NODE_VERSION|
    -  ``nvm use v|WAZUH_DASHBOARD_NODE_VERSION|``: sets the current Node.js version to v|WAZUH_DASHBOARD_NODE_VERSION|
 
--  Yarn v1.22.22 (Node Package Manager): see `Yarn installation guide <https://classic.yarnpkg.com/en/docs/install/>`_
+-  Yarn v|WAZUH_DASHBOARD_YARN_VERSION| (Node Package Manager): see `Yarn installation guide <https://classic.yarnpkg.com/en/docs/install/>`_
 
 Generating zip packages
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -45,7 +45,7 @@ To build the packages, follow these steps:
       $ nvm install $(cat .nvmrc)
       $ nvm use $(cat .nvmrc)
       $ yarn osd bootstrap
-      $ yarn build --linux --skip-os-packages --release
+      $ yarn build-platform --linux --skip-os-packages --release
 
    Example:
 
@@ -56,7 +56,7 @@ To build the packages, follow these steps:
       $ nvm install $(cat .nvmrc)
       $ nvm use $(cat .nvmrc)
       $ yarn osd bootstrap
-      $ yarn build --linux --skip-os-packages --release
+      $ yarn build-platform --linux --skip-os-packages --release
 
 #. Clone the Wazuh Security Dashboards Plugin repository in the plugins folder and build the plugin.
 

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -24,6 +24,10 @@ Requirements:
 -  **NVM (Node Version Manager)**: Refer to `NVM installation guide <https://github.com/nvm-sh/nvm#installing-and-updating>`__.
 -  **Yarn v|WAZUH_DASHBOARD_YARN_VERSION| (Node Package Manager)**: Refer to `Yarn installation guide <https://classic.yarnpkg.com/en/docs/install/>`__.
 -  **zip**: Ensure the ``zip`` utility is available.
+-  **unzip**: Ensure the ``unzip`` utility is available.
+-  **gzip**: Ensure the ``gzip`` utility is available.
+-  **brotli**: Ensure the ``brotli`` utility is available.
+-  **curl**: Ensure the ``curl`` utility is available.
 
 Generating zip packages
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -180,6 +184,14 @@ Build with Docker image
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 With this option you can create an image that has the package in tar.gz format and then if desired you can use the created package to generate the .deb or .rpm file.
+
+Requirements
+~~~~~~~~~~~~
+
+-  **Docker**: Refer to `Docker installation guide <https://docs.docker.com/engine/install/>`__.
+-  **Internet connection** to download the Docker images for the first time.
+-  **jq**: Ensure the ``jq`` utility is available.
+-  **curl**: Ensure the ``curl`` utility is available.
 
 #. Clone the Wazuh dashboard repository.
 

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -21,7 +21,6 @@ Build manually
 Requirements:
 
 -  Docker: see `Docker installation guide <https://docs.docker.com/engine/install/>`_
--  Docker Compose: see `Docker Compose installation guide <https://docs.docker.com/compose/install/>`_
 -  zip
 -  NVM (Node Version Manager): see `NVM installation guide <https://github.com/nvm-sh/nvm#installing-and-updating>`_
 -  Yarn v|WAZUH_DASHBOARD_YARN_VERSION| (Node Package Manager): see `Yarn installation guide <https://classic.yarnpkg.com/en/docs/install/>`_

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -20,7 +20,8 @@ Build manually
 
 Requirements:
 
--  Docker
+-  Docker: see `Docker installation guide <https://docs.docker.com/engine/install/>`_
+-  zip: see `zip installation guide <https://www.tecmint.com/install-zip-and-unzip-in-linux/>`_
 -  NVM (Node Version Manager): see `NVM installation guide <https://github.com/nvm-sh/nvm#installing-and-updating>`_
 
    -  ``nvm install v|NODE_VERSION|``: installs Node.js version v|NODE_VERSION|

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -20,10 +20,10 @@ Build manually
 
 Requirements:
 
--  Docker: see `Docker installation guide <https://docs.docker.com/engine/install/>`_
--  zip
--  NVM (Node Version Manager): see `NVM installation guide <https://github.com/nvm-sh/nvm#installing-and-updating>`_
--  Yarn v|WAZUH_DASHBOARD_YARN_VERSION| (Node Package Manager): see `Yarn installation guide <https://classic.yarnpkg.com/en/docs/install/>`_
+-  **Docker**: Refer to `Docker installation guide <https://docs.docker.com/engine/install/>`__.
+-  **NVM (Node Version Manager)**: Refer to `NVM installation guide <https://github.com/nvm-sh/nvm#installing-and-updating>`__.
+-  **Yarn v|WAZUH_DASHBOARD_YARN_VERSION| (Node Package Manager)**: Refer to `Yarn installation guide <https://classic.yarnpkg.com/en/docs/install/>`__.
+-  **zip**: Ensure the ``zip`` utility is available.
 
 Generating zip packages
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -95,7 +95,6 @@ To build the packages, follow these steps:
       $ cd ../main
       $ yarn
       $ yarn build
-      $ # When prompted for the OpenSearch version, check the version specified in the package.json file.
       $ cd ../wazuh-core/
       $ yarn
       $ yarn build
@@ -116,7 +115,6 @@ To build the packages, follow these steps:
       $ cd ../main
       $ yarn
       $ yarn build
-      $ # When prompted for the OpenSearch version, check the version specified in the package.json file.
       $ cd ../wazuh-core/
       $ yarn
       $ yarn build

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -171,7 +171,9 @@ Run the ``build-packages.sh`` script in the ``dev-tools/build-packages/`` folder
 .. code:: console
 
    $ cd ../wazuh-dashboard/dev-tools/build-packages/
-   $ ./build-packages.sh -v <VERSION> -r <REVISION> (--deb|--rpm) -a file:///<PATH_TO_wazuh-package.zip> -s file:///<PATH_TO_security-package.zip> -b file:///<PATH_TO_dashboard-package.zip>
+   $ ./build-packages.sh -v <VERSION> -r <REVISION> --<DISTRIBUTION> -a file:///<PATH_TO_wazuh-package.zip> -s file:///<PATH_TO_security-package.zip> -b file:///<PATH_TO_dashboard-package.zip>
+
+Where ``--<DISTRIBUTION>`` is either ``--deb`` or ``--rpm``.
 
 Example:
 

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -23,10 +23,6 @@ Requirements:
 -  Docker: see `Docker installation guide <https://docs.docker.com/engine/install/>`_
 -  zip
 -  NVM (Node Version Manager): see `NVM installation guide <https://github.com/nvm-sh/nvm#installing-and-updating>`_
-
-   -  ``nvm install v|WAZUH_DASHBOARD_NODE_VERSION|``: installs Node.js version v|WAZUH_DASHBOARD_NODE_VERSION|
-   -  ``nvm use v|WAZUH_DASHBOARD_NODE_VERSION|``: sets the current Node.js version to v|WAZUH_DASHBOARD_NODE_VERSION|
-
 -  Yarn v|WAZUH_DASHBOARD_YARN_VERSION| (Node Package Manager): see `Yarn installation guide <https://classic.yarnpkg.com/en/docs/install/>`_
 
 Generating zip packages
@@ -46,7 +42,8 @@ To build the packages, follow these steps:
 
       $ git clone -b <BRANCH_OR_TAG> https://github.com/wazuh/wazuh-dashboard.git
       $ cd wazuh-dashboard/
-      $ nvm use v|WAZUH_DASHBOARD_NODE_VERSION|
+      $ nvm install $(cat .nvmrc)
+      $ nvm use $(cat .nvmrc)
       $ yarn osd bootstrap
       $ yarn build --linux --skip-os-packages --release
 
@@ -56,7 +53,8 @@ To build the packages, follow these steps:
 
       $ git clone -b v|WAZUH_CURRENT| https://github.com/wazuh/wazuh-dashboard.git
       $ cd wazuh-dashboard/
-      $ nvm use v|WAZUH_DASHBOARD_NODE_VERSION|
+      $ nvm install $(cat .nvmrc)
+      $ nvm use $(cat .nvmrc)
       $ yarn osd bootstrap
       $ yarn build --linux --skip-os-packages --release
 
@@ -67,7 +65,6 @@ To build the packages, follow these steps:
       $ cd plugins/
       $ git clone -b <BRANCH_OR_TAG> https://github.com/wazuh/wazuh-security-dashboards-plugin.git
       $ cd wazuh-security-dashboards-plugin/
-      $ nvm use v|WAZUH_DASHBOARD_NODE_VERSION|
       $ yarn
       $ yarn build
 
@@ -78,7 +75,6 @@ To build the packages, follow these steps:
       $ cd plugins/
       $ git clone -b v|WAZUH_CURRENT| https://github.com/wazuh/wazuh-security-dashboards-plugin.git
       $ cd wazuh-security-dashboards-plugin/
-      $ nvm use v|WAZUH_DASHBOARD_NODE_VERSION|
       $ yarn
       $ yarn build
 
@@ -93,7 +89,8 @@ To build the packages, follow these steps:
       $ cd ../
       $ git clone -b <BRANCH_OR_TAG> https://github.com/wazuh/wazuh-dashboard-plugins.git
       $ cd wazuh-dashboard-plugins/
-      $ nvm use v|WAZUH_DASHBOARD_NODE_VERSION|
+      $ nvm install $(cat .nvmrc)
+      $ nvm use $(cat .nvmrc)
       $ cp -r plugins/* ../
       $ cd ../main
       $ yarn
@@ -112,7 +109,8 @@ To build the packages, follow these steps:
       $ cd ../
       $ git clone -b v|WAZUH_CURRENT| https://github.com/wazuh/wazuh-dashboard-plugins.git
       $ cd wazuh-dashboard-plugins/
-      $ nvm use v|WAZUH_DASHBOARD_NODE_VERSION|
+      $ nvm install $(cat .nvmrc)
+      $ nvm use $(cat .nvmrc)
       $ cp -r plugins/* ../
       $ cd ../main
       $ yarn
@@ -222,7 +220,7 @@ With this option you can create an image that has the package in tar.gz format a
    .. code:: console
 
       $ docker build \
-      --build-arg NODE_VERSION=|WAZUH_DASHBOARD_NODE_VERSION| \
+      --build-arg NODE_VERSION=$(cat ../../.nvmrc) \
       --build-arg WAZUH_DASHBOARDS_BRANCH=v|WAZUH_CURRENT| \
       --build-arg WAZUH_DASHBOARDS_PLUGINS=v|WAZUH_CURRENT| \
       --build-arg WAZUH_SECURITY_DASHBOARDS_PLUGIN_BRANCH=v|WAZUH_CURRENT| \

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -6,7 +6,7 @@
 Wazuh dashboard
 ===============
 
-The packages generation process is orchestrated by the ``build-packages.sh`` script, which is found within the ``dev-tools/build-packages/`` folder of the repository. This script is responsible for bundling plugins into one single application in ``tar``, ``rpm`` and/or ``deb`` distributions. It takes the following parameters:
+The ``build-packages.sh`` script, located in the ``dev-tools/build-packages/`` folder, orchestrates the package generation process. This script bundles plugins into a single application and supports ``tar``, ``rpm``, and ``deb`` distributions. It accepts the following parameters:
 
 -  version
 -  revision
@@ -23,11 +23,13 @@ Requirements:
 -  **Docker**: Refer to `Docker installation guide <https://docs.docker.com/engine/install/>`__.
 -  **NVM (Node Version Manager)**: Refer to `NVM installation guide <https://github.com/nvm-sh/nvm#installing-and-updating>`__.
 -  **Yarn v|WAZUH_DASHBOARD_YARN_VERSION| (Node Package Manager)**: Refer to `Yarn installation guide <https://classic.yarnpkg.com/en/docs/install/>`__.
--  **zip**: Ensure the ``zip`` utility is available.
--  **unzip**: Ensure the ``unzip`` utility is available.
--  **gzip**: Ensure the ``gzip`` utility is available.
--  **brotli**: Ensure the ``brotli`` utility is available.
--  **curl**: Ensure the ``curl`` utility is available.
+-  **Utilities**: Ensure the following are available:
+
+   -  ``zip``
+   -  ``unzip``
+   -  ``gzip``
+   -  ``brotli``
+   -  ``curl``
 
 Generating zip packages
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -190,8 +192,10 @@ Requirements
 
 -  **Docker**: Refer to `Docker installation guide <https://docs.docker.com/engine/install/>`__.
 -  **Internet connection** to download the Docker images for the first time.
--  **jq**: Ensure the ``jq`` utility is available.
--  **curl**: Ensure the ``curl`` utility is available.
+-  **Utilities**: Ensure the following are available:
+
+   -  ``jq``
+   -  ``curl``
 
 #. Clone the Wazuh dashboard repository.
 

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -46,7 +46,7 @@ To build the packages, follow these steps:
 
    .. code:: console
 
-      $ git clone -b 4.9.0 https://github.com/wazuh/wazuh-dashboard.git
+      $ git clone -b v|WAZUH_CURRENT| https://github.com/wazuh/wazuh-dashboard.git
       $ cd wazuh-dashboard/
       $ yarn osd bootstrap
       $ yarn build --linux --skip-os-packages --release
@@ -66,7 +66,7 @@ To build the packages, follow these steps:
    .. code:: console
 
       $ cd plugins/
-      $ git clone -b 4.9.0 https://github.com/wazuh/wazuh-security-dashboards-plugin.git
+      $ git clone -b v|WAZUH_CURRENT| https://github.com/wazuh/wazuh-security-dashboards-plugin.git
       $ cd wazuh-security-dashboards-plugin/
       $ yarn
       $ yarn build
@@ -98,7 +98,7 @@ To build the packages, follow these steps:
    .. code:: console
 
       $ cd ../
-      $ git clone -b 4.9.0 https://github.com/wazuh/wazuh-dashboard-plugins.git
+      $ git clone -b v|WAZUH_CURRENT| https://github.com/wazuh/wazuh-dashboard-plugins.git
       $ cd wazuh-dashboard-plugins/
       $ cp -r plugins/* ../
       $ cd ../main
@@ -181,7 +181,7 @@ With this option you can create an image that has the package in tar.gz format a
 
    .. code:: console
 
-      $ git clone -b 4.9.0 https://github.com/wazuh/wazuh-dashboard.git
+      $ git clone -b v|WAZUH_CURRENT| https://github.com/wazuh/wazuh-dashboard.git
       $ cd wazuh-dashboard/dev-tools/build-packages/
 
 #. Build the Docker image with the following parameters:

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -161,7 +161,7 @@ Example:
 .. code:: console
 
    $ cd ../wazuh-dashboard/dev-tools/build-packages/
-   $ ./build-packages.sh -v 4.9.0 -r 1 --deb -a file:///packages/wazuh-package.zip -s file:///packages/security-package.zip -b file:///packages/dashboard-package.zip
+   $ ./build-packages.sh -v |WAZUH_CURRENT| -r 1 --deb -a file:///packages/wazuh-package.zip -s file:///packages/security-package.zip -b file:///packages/dashboard-package.zip
 
 The package will be generated in the ``output`` folder of the same directory where the script is located.
 

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -268,6 +268,6 @@ With this option you can create an image that has the package in tar.gz format a
 
    .. code:: console
 
-      $ ./launcher.sh -v |WAZUH_CURRENT| -r 1 -p file:///wazuh-dashboard-|WAZUH_CURRENT|-1-linux-x64.tar.gz
+      $ ./launcher.sh -v v|WAZUH_CURRENT| -r 1 -p file:///wazuh-dashboard-|WAZUH_CURRENT|-1-linux-x64.tar.gz
 
 The package will be generated in the ``output`` folder of the ``rpm`` or ``deb`` folder.

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -11,7 +11,7 @@ The packages generation process is orchestrated by the ``build-packages.sh`` scr
 -  version
 -  revision
 -  distribution
--  wazuh-dashboard, wazuh-dashboard-plugins, and wazuh-security-dashboards-plugin package paths
+-  ``wazuh-dashboard``, ``wazuh-dashboard-plugins``, and ``wazuh-security-dashboards-plugin`` package paths
 
 Official packages are built through a GitHub Actions pipeline, however, the process is designed to be independent enough for maximum portability. The building process is self-contained in the application code.
 


### PR DESCRIPTION
## Description
Following the steps from Build manually in: https://documentation.wazuh.com/current/development/packaging/generate-dashboard-package.html, it has been found that the documentation has mistakes, because the current version of the documentation is 4.9.2, so the tag v4.9.2 should be used in all the steps

Closes https://github.com/wazuh/wazuh-documentation/issues/8003

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
