### PR TITLE
Change all references to `wazuh-packages` repository

### DIFF
--- a/source/upgrade-guide/upgrading-central-components.rst
+++ b/source/upgrade-guide/upgrading-central-components.rst
@@ -56,12 +56,6 @@ In the case Wazuh is installed in a multi-node cluster configuration, repeat the
 Upgrading the Wazuh indexer
 ---------------------------
 
-.. note::
-
-   Note that this upgrade process doesn't update plugins installed manually. Outdated plugins might cause the upgrade to fail.
-
-   To ensure compatibility with the latest Wazuh indexer and Wazuh dashboard, please update manually installed plugins accordingly. For additional information, check the `distribution matrix <https://github.com/wazuh/wazuh-packages/tree/v|WAZUH_CURRENT|#distribution-version-matrix>`__.
-
 The cluster remains available throughout the upgrading process in a Wazuh indexer cluster with multiple nodes. This rolling upgrade allows for the shutting down of one Wazuh indexer node at a time for minimal disruption of service.
 
 Repeat the following steps for every Wazuh indexer node replacing ``<WAZUH_INDEXER_IP_ADDRESS>``, ``<USERNAME>``, and ``<PASSWORD>``.
@@ -194,10 +188,10 @@ If upgrading from version 4.7 and earlier, edit ``/var/ossec/etc/ossec.conf`` to
 #. Save the Wazuh indexer username and password into the Wazuh manager keystore using the :doc:`Wazuh-keystore </user-manual/reference/tools/wazuh-keystore>` tool.
 
    .. code-block:: console
-  
+
       # echo '<INDEXER_USERNAME>' | /var/ossec/bin/wazuh-keystore -f indexer -k username
       # echo '<INDEXER_PASSWORD>' | /var/ossec/bin/wazuh-keystore -f indexer -k password
-   
+
    .. note::
 
       In case you've forgotten your Wazuh indexer password, follow the :doc:`password management </user-manual/user-administration/password-management>` guide to reset the password.
@@ -231,12 +225,6 @@ Configuring Filebeat
 
 Upgrading the Wazuh dashboard
 -----------------------------
-
-.. note::
-
-   Note that this upgrade process doesn't update plugins installed manually. Outdated plugins might cause the upgrade to fail.
-
-   To ensure compatibility with the latest Wazuh indexer and Wazuh dashboard, please update manually installed plugins accordingly. For additional information, check the `distribution matrix <https://github.com/wazuh/wazuh-packages/tree/v|WAZUH_CURRENT|#distribution-version-matrix>`__.
 
 Configuration options might differ across versions. Follow these steps to ensure a smooth upgrade.
 


### PR DESCRIPTION
## Description
Following the development carried out in [Wazuh packages redesign tier 2](https://github.com/wazuh/wazuh-packages/issues/2904), considering that the `wazuh-packages` repository is going to be deprecated, it is necessary to remove any existing reference to this repository in:

- https://documentation.wazuh.com/4.9/upgrade-guide/upgrading-central-components.html#upgrading-the-wazuh-dashboard
  - https://github.com/wazuh/wazuh-documentation/blob/4.10.0/source/upgrade-guide/upgrading-central-components.rst

<details><summary>References</summary>

```
source/upgrade-guide/upgrading-central-components.rst:   To ensure compatibility with the latest Wazuh indexer and Wazuh dashboard, please update manually installed plugins accordingly. For additional information, check the `distribution matrix <https://github.com/wazuh/wazuh-packages/tree/v|WAZUH_CURRENT|#distribution-version-matrix>`__.
source/upgrade-guide/upgrading-central-components.rst:   To ensure compatibility with the latest Wazuh indexer and Wazuh dashboard, please update manually installed plugins accordingly. For additional information, check the `distribution matrix <https://github.com/wazuh/wazuh-packages/tree/v|WAZUH_CURRENT|#distribution-version-matrix>`__.
```

</details>

Closes https://github.com/wazuh/wazuh-documentation/issues/7989

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
