### PR TITLE
fix etc path

### DIFF
--- a/source/proof-of-concept-guide/audit-commands-run-by-user.rst
+++ b/source/proof-of-concept-guide/audit-commands-run-by-user.rst
@@ -105,7 +105,7 @@ Perform the following steps to create a CDB list of malicious programs and rules
 
    .. code-block:: xml
 
-      <list>etc/lists/suspicious-programs</list>
+      <list>/etc/lists/suspicious-programs</list>
 
 #. Create a high severity rule to fire when a "red" program is executed. Add this new rule to the ``/var/ossec/etc/rules/local_rules.xml`` file on the Wazuh server.
 
@@ -114,7 +114,7 @@ Perform the following steps to create a CDB list of malicious programs and rules
       <group name="audit">
         <rule id="100210" level="12">
             <if_sid>80792</if_sid>
-        <list field="audit.command" lookup="match_key_value" check_value="red">etc/lists/suspicious-programs</list>
+        <list field="audit.command" lookup="match_key_value" check_value="red">/etc/lists/suspicious-programs</list>
           <description>Audit: Highly Suspicious Command executed: $(audit.exe)</description>
             <group>audit_command,</group>
         </rule>


### PR DESCRIPTION
https://documentation.wazuh.com/current/proof-of-concept-guide/audit-commands-run-by-user.html 

the page containing two missing forward slashes "/"

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description
<!--
Add a clear description of how the problem has been solved.
If your PR closes an issue, please use the "closes" keyword indicating the issue.
-->
## Checks
### Docs building
- [ ] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
