### PR TITLE
`Securing your Wazuh installation` API section is changing every password

### DIFF
--- a/source/user-manual/user-administration/password-management.rst
+++ b/source/user-manual/user-administration/password-management.rst
@@ -35,63 +35,67 @@ The passwords tool is embedded in the Wazuh indexer under ``/usr/share/wazuh-ind
 
 All the available options to run the script are:
 
-+------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
-| Options                                              | Purpose                                                                                                     |
-+======================================================+=============================================================================================================+
-| ``-a`` / ``--change-all``                            | Changes all the Wazuh indexer and Wazuh API user passwords and prints them on screen.                       |
-|                                                      | To change API passwords ``-au|--admin-user`` and ``-ap|--admin-password`` are required.                     |
-+------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
-| ``-A`` /  ``--api``                                  | Change the Wazuh API password given the current password.                                                   |
-|                                                      | Requires ``-u|--user``, and ``-p|--password``, ``-au|--admin-user`` and ``-ap|--admin-password``.           |
-+------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
-| ``-au`` / ``--admin-user <adminUser>``               | Admin user for the Wazuh API. Required for changing the Wazuh API passwords.                                |
-|                                                      | Requires ``-A|--api``.                                                                                      |
-+------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
-| ``-ap`` / ``--admin-password <adminPassword>``       | Password for the Wazuh API admin user. Required for changing the Wazuh API passwords.                       |
-|                                                      | Requires ``-A|--api``.                                                                                      |
-+------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
-| ``-u`` / ``--user <user>``                           | Indicates the name of the user whose password will be changed.                                              |
-|                                                      | If no password is specified, it will generate a random one.                                                 |
-+------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
-| ``-p`` / ``--password <password>``                   | Indicates the new password. Must be used with option ``-u``.                                                |
-+------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
-| ``-c`` / ``--cert <route-admin-certificate>``        | Indicates route to the admin certificate.                                                                   |
-+------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
-| ``-k`` / ``--certkey <route-admin-certificate-key>`` | Indicates route to the admin certificate key.                                                               |
-+------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
-| ``-v`` / ``--verbose``                               | Shows the complete script execution output.                                                                 |
-+------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
-| ``-f`` / ``--file <password_file.yml>``              | Changes the passwords for the ones given in the file.                                                       |
-|                                                      |                                                                                                             |
-|                                                      | Wazuh indexer users must have this format:                                                                  |
-|                                                      |                                                                                                             |
-|                                                      |    # Description                                                                                            |
-|                                                      |      indexer_username: ``<user>``                                                                           |
-|                                                      |                                                                                                             |
-|                                                      |      indexer_password: ``<password>``                                                                       |
-|                                                      |                                                                                                             |
-|                                                      | Wazuh API users must have this format:                                                                      |
-|                                                      |                                                                                                             |
-|                                                      |    # Description                                                                                            |
-|                                                      |      api_username: ``<user>``                                                                               |
-|                                                      |                                                                                                             |
-|                                                      |      api_password: ``<password>``                                                                           |
-+------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
-| ``-gf`` / ``--generate-file <passwords.wazuh>``      | Generate password file with random passwords for standard users.                                            |
-+------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
-| ``-h`` / ``--help``                                  | Shows help.                                                                                                 |
-+------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
++--------------------------------------------------+--------------------------------------------------------------------------------------------------------------------+
+| Options                                          | Purpose                                                                                                            |
++==================================================+====================================================================================================================+
+| ``-a|--change-all``                              | Changes all the Wazuh indexer and Wazuh API user passwords and prints them on screen.                              |
+|                                                  | Changing API passwords requires ``-au|--admin-user <ADMIN_USER>`` and ``-ap|--admin-password <ADMIN_PASSWORD>``.   |
++--------------------------------------------------+--------------------------------------------------------------------------------------------------------------------+
+| ``-A|--api``                                     | Change the Wazuh API password given the current password.                                                          |
+|                                                  | Requires ``-u|--user <USER>``, ``-p|--password <PASSWORD>``, ``-au|--admin-user <ADMIN_USER>``, and                |
+|                                                  | ``-ap|--admin-password <ADMIN_PASSWORD>``.                                                                         |
++--------------------------------------------------+--------------------------------------------------------------------------------------------------------------------+
+| ``-au|--admin-user <ADMIN_USER>``                | Admin user for the Wazuh API. Required for changing the Wazuh API passwords.                                       |
+|                                                  | Requires ``-A|--api``.                                                                                             |
++--------------------------------------------------+--------------------------------------------------------------------------------------------------------------------+
+| ``-ap|--admin-password <ADMIN_PASSWORD>``        | Password for the Wazuh API admin user. Required for changing the Wazuh API passwords.                              |
+|                                                  | Requires ``-A|--api``.                                                                                             |
++--------------------------------------------------+--------------------------------------------------------------------------------------------------------------------+
+| ``-u|--user <USER>``                             | Indicates the name of the user whose password will be changed.                                                     |
+|                                                  | If no password is specified, it will generate a random one.                                                        |
++--------------------------------------------------+--------------------------------------------------------------------------------------------------------------------+
+| ``-p|--password <PASSWORD>``                     | Indicates the new password. Must be used with option ``-u|--user <USER>``.                                         |
++--------------------------------------------------+--------------------------------------------------------------------------------------------------------------------+
+| ``-c|--cert <ROUTE_ADMIN_CERTIFICATE>``          | Indicates route to the admin certificate.                                                                          |
++--------------------------------------------------+--------------------------------------------------------------------------------------------------------------------+
+| ``-k|--certkey <ROUTE_ADMIN_CERTIFICATE_KEY>``   | Indicates route to the admin certificate key.                                                                      |
++--------------------------------------------------+--------------------------------------------------------------------------------------------------------------------+
+| ``-v|--verbose``                                 | Shows the complete script execution output.                                                                        |
++--------------------------------------------------+--------------------------------------------------------------------------------------------------------------------+
+| ``-f|--file <PASSWORD_FILE.yml>``                | Changes the passwords for the ones given in the file.                                                              |
+|                                                  |                                                                                                                    |
+|                                                  | Wazuh indexer users must have this format:                                                                         |
+|                                                  |                                                                                                                    |
+|                                                  | .. code-block:: yaml                                                                                               |
+|                                                  |                                                                                                                    |
+|                                                  |    # Description                                                                                                   |
+|                                                  |      indexer_username: <USER>                                                                                      |
+|                                                  |                                                                                                                    |
+|                                                  |      indexer_password: <PASSWORD>                                                                                  |
+|                                                  |                                                                                                                    |
+|                                                  | Wazuh API users must have this format:                                                                             |
+|                                                  |                                                                                                                    |
+|                                                  | .. code-block:: yaml                                                                                               |
+|                                                  |                                                                                                                    |
+|                                                  |    # Description                                                                                                   |
+|                                                  |      api_username: <USER>                                                                                          |
+|                                                  |                                                                                                                    |
+|                                                  |      api_password: <PASSWORD>                                                                                      |
++--------------------------------------------------+--------------------------------------------------------------------------------------------------------------------+
+| ``-gf|--generate-file <passwords.wazuh>``        | Generate password file with random passwords for standard users.                                                   |
++--------------------------------------------------+--------------------------------------------------------------------------------------------------------------------+
+| ``-h|--help``                                    | Shows help.                                                                                                        |
++--------------------------------------------------+--------------------------------------------------------------------------------------------------------------------+
 
 Changing the password for single user
 -------------------------------------
 
-To change the password for a single Wazuh indexer user, run the script with the ``-u`` option and indicate the new password with the option ``-p``. The password must have a length between 8 and 64 characters and contain at least one upper case letter, one lower case letter, a number and one of the following symbols: ``.*+?-``. If no password is specified, the script will generate a random one.
+To change the password for a single Wazuh indexer user, run the script with the ``-u|--user <USER>`` option and indicate the new password with the option ``-p|--password <PASSWORD>``. The password must have a length between 8 and 64 characters and contain at least one upper case letter, one lower case letter, a number and one of the following symbols: ``.*+?-``. If no password is specified, the script will generate a random one.
 
 
    .. code-block:: console
 
       # bash wazuh-passwords-tool.sh -u admin -p Secr3tP4ssw*rd
-
 
    .. code-block:: console
       :class: output
@@ -107,7 +111,7 @@ If you want to change the password for a Wazuh manager API user, run the script 
 Changing the passwords for all users
 ------------------------------------
 
-To generate and change passwords for all the Wazuh indexer users, run the script with the ``-a`` option:
+To generate and change passwords for all the Wazuh indexer users, run the script with the ``-a|--change-all`` option:
 
   .. code-block:: console
 
@@ -128,7 +132,7 @@ To generate and change passwords for all the Wazuh indexer users, run the script
 
 If you use the tool in an all-in-one deployment, it automatically updates the passwords where necessary. If you use it in a distributed environment, you have to update the password on other components. See :ref:`Changing the passwords in a distributed environment <passwords_distributed>` for more details.
 
-On an all-in-one deployment, use options ``-a``, ``-au`` and ``-ap`` to also change the passwords for all the Wazuh indexer and the Wazuh manager API users.
+On an all-in-one deployment, use options ``-a|--change-all``, ``-au|--admin-user <ADMIN_USER>``, and ``-ap|--admin-password <ADMIN_PASSWORD>`` to also change the passwords for all the Wazuh indexer and the Wazuh manager API users.
 
    .. code-block:: console
 
@@ -150,33 +154,30 @@ On an all-in-one deployment, use options ``-a``, ``-au`` and ``-ap`` to also cha
       INFO: The password for Wazuh API user wazuh-wui is JmKiaCBQo?4Ne0yrM4+n7kGdXGfCmVjO
       INFO: Updated wazuh-wui user password in wazuh dashboard. Remember to restart the service.
 
-
-
-
 Changing the passwords using a formatted file
 ---------------------------------------------
 
-Use a formatted file to indicate the passwords and run the script with the ``-f`` option followed by the file path. Use the following pattern to indicate the users and passwords in the formatted file.
+Use a formatted file to indicate the passwords and run the script with the ``-f|--file <PASSWORD_FILE.yml>`` option followed by the file path. Use the following pattern to indicate the users and passwords in the formatted file.
 
 For Wazuh indexer users:
 
-  .. code-block:: none
+.. code-block:: none
 
-    # Description
-      indexer_username: <user>
-      indexer_password: <password>
+   # Description
+     indexer_username: <USER>
+     indexer_password: <PASSWORD>
 
 For Wazuh manager API users:
 
-  .. code-block:: none
+.. code-block:: none
 
-    # Description
-      api_username: <user>
-      api_password: <password>
+   # Description
+     api_username: <USER>
+     api_password: <PASSWORD>
 
-If the ``-a`` option is used in combination with the ``-f`` option, all users not included in the file are given a random password.
+If the ``-a|--change-all`` option is used in combination with the ``-f|--file <PASSWORD_FILE.yml>`` option, all users not included in the file are given a random password.
 
-The options ``-au`` and ``-ap`` are necessary to change the passwords for the API users.
+The options ``-au|--admin-user <ADMIN_USER>`` and ``-ap|--admin-password <ADMIN_PASSWORD>`` are necessary to change the passwords for the API users.
 
 .. _passwords_distributed:
 

--- a/source/user-manual/user-administration/password-management.rst
+++ b/source/user-manual/user-administration/password-management.rst
@@ -209,7 +209,7 @@ Follow the instructions below to change the passwords for all the Wazuh indexer 
    .. code-block:: console
 
       # curl -sO https://packages.wazuh.com/|WAZUH_CURRENT_MINOR|/wazuh-passwords-tool.sh
-      # bash wazuh-passwords-tool.sh --api --change-all --admin-user wazuh --admin-password <WAZUH_PASSWORD>
+      # bash wazuh-passwords-tool.sh --api --admin-user wazuh --admin-password <WAZUH_PASSWORD>
   
    .. code-block:: console
       :class: output

--- a/source/user-manual/user-administration/password-management.rst
+++ b/source/user-manual/user-administration/password-management.rst
@@ -204,13 +204,13 @@ Follow the instructions below to change the passwords for all the Wazuh indexer 
       INFO: The password for user snapshotrestore is Mb2EHw8SIc1d.oz.nM?dHiPBGk7s?UZB
       WARNING: Wazuh indexer passwords changed. Remember to update the password in the Wazuh dashboard, Wazuh server, and Filebeat nodes if necessary, and restart the services.
 
-#. On your `Wazuh server master node`, download the Wazuh passwords tool and use it to change the passwords of the Wazuh API users. Replace ``<WAZUH_PASSWORD>`` with the *wazuh* user password. 
+#. On your `Wazuh server master node`, download the Wazuh passwords tool and use it to change the passwords of the Wazuh API users. Replace ``<WAZUH_PASSWORD>`` with the *wazuh* user password.
 
    .. code-block:: console
 
       # curl -sO https://packages.wazuh.com/|WAZUH_CURRENT_MINOR|/wazuh-passwords-tool.sh
       # bash wazuh-passwords-tool.sh --api --admin-user wazuh --admin-password <WAZUH_PASSWORD>
-  
+
    .. code-block:: console
       :class: output
 
@@ -223,11 +223,11 @@ Follow the instructions below to change the passwords for all the Wazuh indexer 
 
       # echo <CUSTOM_USERNAME> | filebeat keystore add username --stdin --force
       # echo <CUSTOM_PASSWORD> | filebeat keystore add password --stdin --force
-         
+
    Restart Filebeat to apply the changes.
 
    .. include:: /_templates/common/restart_filebeat.rst
-       
+
 #. On your `Wazuh dashboard node`, run the following command to update the `kibanaserver` password in the Wazuh dashboard keystore. Replace ``<KIBANASERVER_PASSWORD>`` with the random password generated in the first step.
 
    .. code-block:: console

--- a/source/user-manual/user-administration/password-management.rst
+++ b/source/user-manual/user-administration/password-management.rst
@@ -101,7 +101,7 @@ To change the password for a single Wazuh indexer user, run the script with the 
 
 If you use the tool in an all-in-one deployment, it automatically updates the passwords where necessary.  If you use it in a distributed environment, depending on the user whose password you change, you may have to update the password on other components. See :ref:`Changing the passwords in a distributed environment <passwords_distributed>` for more details.
 
-If you want to change the password for a Wazuh manager API user, run the script on a Wazuh server node and use option ``-A, --api``. Alternatively, you can change the Wazuh manager API passwords following the instructions in the :doc:`Securing the Wazuh API </user-manual/api/securing-api>` documentation.
+If you want to change the password for a Wazuh manager API user, run the script on a Wazuh server node and use option ``-A|--api``. Alternatively, you can change the Wazuh manager API passwords following the instructions in the :doc:`Securing the Wazuh API </user-manual/api/securing-api>` documentation.
 
 
 Changing the passwords for all users

--- a/source/user-manual/user-administration/password-management.rst
+++ b/source/user-manual/user-administration/password-management.rst
@@ -35,50 +35,52 @@ The passwords tool is embedded in the Wazuh indexer under ``/usr/share/wazuh-ind
 
 All the available options to run the script are:
 
-+----------------------------------------------+-------------------------------------------------------------------------------------------------------------+
-| Options                                      | Purpose                                                                                                     |
-+==============================================+=============================================================================================================+
-| -a / --change-all                            | Changes all the Wazuh indexer and Wazuh API user passwords and prints them on screen.                       |
-|                                              | To change API passwords -au|--admin-user and -ap|--admin-password are required.                             |
-+----------------------------------------------+-------------------------------------------------------------------------------------------------------------+
-| -A,  --api                                   | Change the Wazuh API password given the current password.                                                   |
-|                                              | Requires -u|--user, and -p|--password, -au|--admin-user and -ap|--admin-password.                           |
-+----------------------------------------------+-------------------------------------------------------------------------------------------------------------+
-| -au,--admin-user <adminUser>                 | Admin user for the Wazuh API. Required for changing the Wazuh API passwords.                                |
-|                                              | Requires -A|--api.                                                                                          |               
-+----------------------------------------------+-------------------------------------------------------------------------------------------------------------+
-| -ap, --admin-password <adminPassword>        | Password for the Wazuh API admin user. Required for changing the Wazuh API passwords.                       |
-|                                              | Requires -A|--api.                                                                                          |      
-+----------------------------------------------+-------------------------------------------------------------------------------------------------------------+
-| -u / --user <user>                           | Indicates the name of the user whose password will be changed.                                              |
-|                                              | If no password is specified, it will generate a random one.                                                 |
-+----------------------------------------------+-------------------------------------------------------------------------------------------------------------+
-| -p / --password <password>                   | Indicates the new password. Must be used with option -u.                                                    |
-+----------------------------------------------+-------------------------------------------------------------------------------------------------------------+
-| -c / --cert <route-admin-certificate>        | Indicates route to the admin certificate.                                                                   |
-+----------------------------------------------+-------------------------------------------------------------------------------------------------------------+
-| -k / --certkey <route-admin-certificate-key> | Indicates route to the admin certificate key.                                                               |
-+----------------------------------------------+-------------------------------------------------------------------------------------------------------------+
-| -v / --verbose                               | Shows the complete script execution output.                                                                 |
-+----------------------------------------------+-------------------------------------------------------------------------------------------------------------+
-| -f / --file <password_file.yml>              | Changes the passwords for the ones given in the file.                                                       |
-|                                              |                                                                                                             |
-|                                              | Wazuh indexer users must have this format:                                                                  |
-|                                              |                                                                                                             |
-|                                              |    # Description                                                                                            |
-|                                              |      indexer_username: <user>                                                                               |
-|                                              |      indexer_password: <password>                                                                           |
-|                                              |                                                                                                             |
-|                                              | Wazuh API users must have this format:                                                                      |
-|                                              |                                                                                                             |
-|                                              |    # Description                                                                                            |
-|                                              |     api_username: <user>                                                                                    |
-|                                              |      api_password: <password>                                                                               |
-+----------------------------------------------+-------------------------------------------------------------------------------------------------------------+
-| -gf, --generate-file <passwords.wazuh>       | Generate password file with random passwords for standard users.                                            |
-+----------------------------------------------+-------------------------------------------------------------------------------------------------------------+
-| -h / --help                                  | Shows help.                                                                                                 |
-+----------------------------------------------+-------------------------------------------------------------------------------------------------------------+
++------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
+| Options                                              | Purpose                                                                                                     |
++======================================================+=============================================================================================================+
+| ``-a`` / ``--change-all``                            | Changes all the Wazuh indexer and Wazuh API user passwords and prints them on screen.                       |
+|                                                      | To change API passwords ``-au|--admin-user`` and ``-ap|--admin-password`` are required.                     |
++------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
+| ``-A`` /  ``--api``                                  | Change the Wazuh API password given the current password.                                                   |
+|                                                      | Requires ``-u|--user``, and ``-p|--password``, ``-au|--admin-user`` and ``-ap|--admin-password``.           |
++------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
+| ``-au`` / ``--admin-user <adminUser>``               | Admin user for the Wazuh API. Required for changing the Wazuh API passwords.                                |
+|                                                      | Requires ``-A|--api``.                                                                                      |
++------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
+| ``-ap`` / ``--admin-password <adminPassword>``       | Password for the Wazuh API admin user. Required for changing the Wazuh API passwords.                       |
+|                                                      | Requires ``-A|--api``.                                                                                      |
++------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
+| ``-u`` / ``--user <user>``                           | Indicates the name of the user whose password will be changed.                                              |
+|                                                      | If no password is specified, it will generate a random one.                                                 |
++------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
+| ``-p`` / ``--password <password>``                   | Indicates the new password. Must be used with option ``-u``.                                                |
++------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
+| ``-c`` / ``--cert <route-admin-certificate>``        | Indicates route to the admin certificate.                                                                   |
++------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
+| ``-k`` / ``--certkey <route-admin-certificate-key>`` | Indicates route to the admin certificate key.                                                               |
++------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
+| ``-v`` / ``--verbose``                               | Shows the complete script execution output.                                                                 |
++------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
+| ``-f`` / ``--file <password_file.yml>``              | Changes the passwords for the ones given in the file.                                                       |
+|                                                      |                                                                                                             |
+|                                                      | Wazuh indexer users must have this format:                                                                  |
+|                                                      |                                                                                                             |
+|                                                      |    # Description                                                                                            |
+|                                                      |      indexer_username: ``<user>``                                                                           |
+|                                                      |                                                                                                             |
+|                                                      |      indexer_password: ``<password>``                                                                       |
+|                                                      |                                                                                                             |
+|                                                      | Wazuh API users must have this format:                                                                      |
+|                                                      |                                                                                                             |
+|                                                      |    # Description                                                                                            |
+|                                                      |      api_username: ``<user>``                                                                               |
+|                                                      |                                                                                                             |
+|                                                      |      api_password: ``<password>``                                                                           |
++------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
+| ``-gf`` / ``--generate-file <passwords.wazuh>``      | Generate password file with random passwords for standard users.                                            |
++------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
+| ``-h`` / ``--help``                                  | Shows help.                                                                                                 |
++------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
 
 Changing the password for single user
 -------------------------------------


### PR DESCRIPTION
## Description
During https://github.com/wazuh/wazuh/issues/27183 it was found that https://documentation.wazuh.com/current/installation-guide/wazuh-dashboard/step-by-step.html#securing-your-wazuh-installation, in particular the Distributed Deployment tab, the following step is changing every password, while only should change API


![image](https://github.com/user-attachments/assets/16c9e87c-582e-45ef-8040-74c9c99cfda7)


This could be an issue if the Wazuh Manager co-exist with Wazuh Dashboard in the same host.

###  Current behavior when the Wazuh Master node and Wazuh Dashboard coexist on the same host

- Step 1
```console
root@host1:/home/vagrant# /usr/share/wazuh-indexer/plugins/opensearch-security/tools/wazuh-passwords-tool.sh --change-all
11/12/2024 14:40:07 INFO: Updating the internal users.
11/12/2024 14:40:11 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
11/12/2024 14:40:11 INFO: Wazuh API admin credentials not provided, Wazuh API passwords not changed.
11/12/2024 14:40:21 INFO: The filebeat.yml file has been updated to use the Filebeat Keystore username and password.
11/12/2024 14:40:49 INFO: The password for user admin is iEmuZf3ttp5ANFGyHzL?u?m68WO1d9Hp
11/12/2024 14:40:49 INFO: The password for user anomalyadmin is yxP0r4y2WNGCcwIkeI+.4Jd6Fma4zF0M
11/12/2024 14:40:49 INFO: The password for user kibanaserver is U9qWxUeT7YnPZOWdlksw5HEB+1.Jinvk
11/12/2024 14:40:49 INFO: The password for user kibanaro is LiDAb0nvRCnlOpj6EmH?2CCCo8EmU7gF
11/12/2024 14:40:49 INFO: The password for user logstash is LMpc3Isb98L*owj*c4n45JA3wqs?V?A2
11/12/2024 14:40:49 INFO: The password for user readall is B3pzRh.sY?YycQGj?Tld3CiT6bEL94rP
11/12/2024 14:40:49 INFO: The password for user snapshotrestore is QhN+yDiQc+q*Q1*7F88e.eEmUrOSfRgj
11/12/2024 14:40:49 WARNING: Wazuh indexer passwords changed. Remember to update the password in the Wazuh dashboard, Wazuh server, and Filebeat nodes if necessary, and restart the services.
```
- Step 2
``` console
root@host1:/home/vagrant# curl -sO https://packages.wazuh.com/4.9/wazuh-passwords-tool.sh
root@host1:/home/vagrant# bash wazuh-passwords-tool.sh --api --change-all --admin-user wazuh --admin-password wazuh
11/12/2024 14:41:05 INFO: Updating the internal users.
11/12/2024 14:41:09 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
11/12/2024 14:41:21 INFO: The filebeat.yml file has been updated to use the Filebeat Keystore username and password.
11/12/2024 14:41:45 INFO: The password for user admin is *ERWBUJYcoocwG?CRYfoHSnW7q0itdbh
11/12/2024 14:41:45 INFO: The password for user anomalyadmin is lhPFuWCjv*FlIMadgmNJo+7yYrV7f0vH
11/12/2024 14:41:45 INFO: The password for user kibanaserver is pSqT3?3eBspjKdBeQnSpCgsB.O?o9c8k
11/12/2024 14:41:45 INFO: The password for user kibanaro is tFS8z4ZnlKyc2c1w0G92IYrtySkqc+nX
11/12/2024 14:41:45 INFO: The password for user logstash is gmTiv5OKbx6GGJU2DQjdoTNltdAMMc?a
11/12/2024 14:41:45 INFO: The password for user readall is axSddng6vT7UzgIIv.Gq.PyTnq.8Z*LZ
11/12/2024 14:41:45 INFO: The password for user snapshotrestore is Et5vPBqXDJN72PHSB1paFMNgS+jhpyg+
11/12/2024 14:41:45 WARNING: Wazuh indexer passwords changed. Remember to update the password in the Wazuh dashboard, Wazuh server, and Filebeat nodes if necessary, and restart the services.
11/12/2024 14:41:47 INFO: The password for Wazuh API user wazuh is XFfgvv+Pm+olUvN3hRGSx*rIVQkVFQcE
11/12/2024 14:41:48 INFO: The password for Wazuh API user wazuh-wui is KcIFIovRmAeUho.+shLUs3FJMu*0Pvaa
```

###  Expected behavior when the Wazuh Master node and Wazuh Dashboard coexist on the same host

- Step 1
```console
root@host1:/home/vagrant# /usr/share/wazuh-indexer/plugins/opensearch-security/tools/wazuh-passwords-tool.sh --change-all
11/12/2024 14:40:07 INFO: Updating the internal users.
11/12/2024 14:40:11 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
11/12/2024 14:40:11 INFO: Wazuh API admin credentials not provided, Wazuh API passwords not changed.
11/12/2024 14:40:21 INFO: The filebeat.yml file has been updated to use the Filebeat Keystore username and password.
11/12/2024 14:40:49 INFO: The password for user admin is iEmuZf3ttp5ANFGyHzL?u?m68WO1d9Hp
11/12/2024 14:40:49 INFO: The password for user anomalyadmin is yxP0r4y2WNGCcwIkeI+.4Jd6Fma4zF0M
11/12/2024 14:40:49 INFO: The password for user kibanaserver is U9qWxUeT7YnPZOWdlksw5HEB+1.Jinvk
11/12/2024 14:40:49 INFO: The password for user kibanaro is LiDAb0nvRCnlOpj6EmH?2CCCo8EmU7gF
11/12/2024 14:40:49 INFO: The password for user logstash is LMpc3Isb98L*owj*c4n45JA3wqs?V?A2
11/12/2024 14:40:49 INFO: The password for user readall is B3pzRh.sY?YycQGj?Tld3CiT6bEL94rP
11/12/2024 14:40:49 INFO: The password for user snapshotrestore is QhN+yDiQc+q*Q1*7F88e.eEmUrOSfRgj
11/12/2024 14:40:49 WARNING: Wazuh indexer passwords changed. Remember to update the password in the Wazuh dashboard, Wazuh server, and Filebeat nodes if necessary, and restart the services.
```
- Step 2
``` console
root@host1:/home/vagrant# curl -sO https://packages.wazuh.com/4.9/wazuh-passwords-tool.sh
root@host1:/home/vagrant# bash wazuh-passwords-tool.sh --api --change-all --admin-user wazuh --admin-password wazuh
11/12/2024 14:41:47 INFO: The password for Wazuh API user wazuh is XFfgvv+Pm+olUvN3hRGSx*rIVQkVFQcE
11/12/2024 14:41:48 INFO: The password for Wazuh API user wazuh-wui is KcIFIovRmAeUho.+shLUs3FJMu*0Pvaa
```

### Conclusion

This could be the result of `--change-all` parameter at Step 2, but a propper RCA should be done

Closes https://github.com/wazuh/wazuh-documentation/issues/8025

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
