### PR TITLE
Update pubsub.rst

### DIFF
--- a/source/cloud-security/gcp/supported-services/pubsub.rst
+++ b/source/cloud-security/gcp/supported-services/pubsub.rst
@@ -93,6 +93,7 @@ Follow the next steps to configure the Wazuh module for Google Cloud Pub/Sub on 
 
       <ossec_config>
         <gcp-pubsub>
+          <enabled>yes</enabled>
           <pull_on_start>yes</pull_on_start>
           <interval>1m</interval>
           <project_id><YOUR_PROJECT_ID></project_id>


### PR DESCRIPTION
## Description
Local configuration [references](https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/gcp-pubsub.html#gcp-pubsub) specifies the `enabled` tag, but it is not specified in GCP integration documentation [here](https://documentation.wazuh.com/current/cloud-security/gcp/supported-services/pubsub.html). Missing this detail was caused a lot of confusion, hence contributing for correction.
## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
