### PR TITLE
Fix broken links

### DIFF
--- a/source/user-manual/capabilities/active-response/default-active-response-scripts.rst
+++ b/source/user-manual/capabilities/active-response/default-active-response-scripts.rst
@@ -32,10 +32,10 @@ Click on the name of each active response to open its source code.
 .. |npf| replace:: `npf <https://github.com/wazuh/wazuh/blob/v|WAZUH_CURRENT|/src/active-response/firewalls/npf.c>`__
 .. |wazuh-slack| replace:: `wazuh-slack <https://github.com/wazuh/wazuh/blob/v|WAZUH_CURRENT|/src/active-response/wazuh-slack.c>`__
 .. |pf| replace:: `pf <https://github.com/wazuh/wazuh/blob/v|WAZUH_CURRENT|/src/active-response/firewalls/pf.c>`__
-.. |restart.sh| replace:: `restart.sh <https://github.com/wazuh/wazuh/blob/master/src/active-response/restart.sh>`__
+.. |restart.sh| replace:: `restart.sh <https://github.com/wazuh/wazuh/blob/v|WAZUH_CURRENT|/src/active-response/restart.sh>`__
 .. |restart-wazuh| replace:: `restart-wazuh <https://github.com/wazuh/wazuh/blob/v|WAZUH_CURRENT|/src/active-response/restart-wazuh.c>`__
 .. |route-null| replace:: `route-null <https://github.com/wazuh/wazuh/blob/v|WAZUH_CURRENT|/src/active-response/route-null.c>`__
-.. |kaspersky| replace:: `kaspersky <https://github.com/wazuh/wazuh/blob/master/src/active-response/kaspersky.c>`__
+.. |kaspersky| replace:: `kaspersky <https://github.com/wazuh/wazuh/blob/v|WAZUH_CURRENT|/src/active-response/kaspersky.c>`__
 
 +---------------------------+-------------------------------------------------------------------------------------------------------------+
 | Name of script            | Description                                                                                                 |


### PR DESCRIPTION
## Description
This PR fixes two brokn links in this page:
- https://documentation.wazuh.com/current/user-manual/capabilities/active-response/default-active-response-scripts.html#linux-macos-and-unix-based-endpoints

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
