### PR TITLE
`Securing your Wazuh installation` API section is changing every password

### DIFF
--- a/source/installation-guide/wazuh-dashboard/step-by-step.rst
+++ b/source/installation-guide/wazuh-dashboard/step-by-step.rst
@@ -1,7 +1,7 @@
 .. Copyright (C) 2015, Wazuh, Inc.
 
 .. meta::
-   :description: Learn how to install Wazuh dashboard, a flexible and intuitive web interface for mining and visualizing the events and archives. 
+   :description: Learn how to install Wazuh dashboard, a flexible and intuitive web interface for mining and visualizing the events and archives.
 
 .. _wazuh_dashboard_step_by_step:
 
@@ -27,21 +27,21 @@ Adding the Wazuh repository
     If you are installing the Wazuh dashboard on the same host as the Wazuh indexer or the Wazuh server, you may skip these steps as you may have added the Wazuh repository already.
 
   .. tabs::
-  
+
     .. group-tab:: Yum
-  
-  
+
+
       .. include:: /_templates/installations/common/yum/add-repository.rst
-  
-  
-  
+
+
+
     .. group-tab:: APT
-  
-  
+
+
       .. include:: /_templates/installations/common/deb/add-repository.rst
-  
-  
-  
+
+
+
 
 Installing the Wazuh dashboard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -59,7 +59,7 @@ Installing the Wazuh dashboard
       .. group-tab:: APT
 
          .. code-block:: console
-              
+
             # apt-get -y install wazuh-dashboard|WAZUH_DASHBOARD_DEB_PKG_INSTALL|
 
 Configuring the Wazuh dashboard
@@ -98,14 +98,14 @@ Starting the Wazuh dashboard service
 
       .. include:: /_templates/installations/dashboard/enable_dashboard.rst
 
-      
-      **Only for distributed deployments**  
-      
+
+      **Only for distributed deployments**
+
           Edit the ``/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml`` file and replace the ``url`` value with the IP address or hostname of the Wazuh server master node.
-          
+
             .. code-block:: yaml
                :emphasize-lines: 3
-            
+
                hosts:
                  - default:
                      url: https://localhost
@@ -121,14 +121,14 @@ Starting the Wazuh dashboard service
       - **Username**: *admin*
       - **Password**: *admin*
 
-    When you access the Wazuh dashboard for the first time, the browser shows a warning message stating that the certificate was not issued by a trusted authority. An exception can be added in the advanced options of the web browser. For increased security, the ``root-ca.pem``  file previously generated can be imported to the certificate manager of the browser. Alternatively, a certificate from a trusted authority can be configured. 
+    When you access the Wazuh dashboard for the first time, the browser shows a warning message stating that the certificate was not issued by a trusted authority. An exception can be added in the advanced options of the web browser. For increased security, the ``root-ca.pem``  file previously generated can be imported to the certificate manager of the browser. Alternatively, a certificate from a trusted authority can be configured.
 
 
 Securing your Wazuh installation
 --------------------------------
 
 
-You have now installed and configured all the Wazuh central components. We recommend changing the default credentials to protect your infrastructure from possible attacks. 
+You have now installed and configured all the Wazuh central components. We recommend changing the default credentials to protect your infrastructure from possible attacks.
 
 Select your deployment type and follow the instructions to change the default passwords for both the Wazuh API and the Wazuh indexer users.
 
@@ -138,14 +138,14 @@ Select your deployment type and follow the instructions to change the default pa
    .. group-tab:: All-in-one deployment
 
       #. Use the Wazuh passwords tool to change all the internal users' passwords.
-      
+
          .. code-block:: console
-         
+
             # /usr/share/wazuh-indexer/plugins/opensearch-security/tools/wazuh-passwords-tool.sh --change-all --admin-user wazuh --admin-password wazuh
-         
+
          .. code-block:: console
             :class: output
-       
+
             INFO: The password for user admin is yWOzmNA.?Aoc+rQfDBcF71KZp?1xd7IO
             INFO: The password for user kibanaserver is nUa+66zY.eDF*2rRl5GKdgLxvgYQA+wo
             INFO: The password for user kibanaro is 0jHq.4i*VAgclnqFiXvZ5gtQq1D5LCcL
@@ -156,16 +156,16 @@ Select your deployment type and follow the instructions to change the default pa
             INFO: The password for Wazuh API user wazuh is JYWz5Zdb3Yq+uOzOPyUU4oat0n60VmWI
             INFO: The password for Wazuh API user wazuh-wui is +fLddaCiZePxh24*?jC0nyNmgMGCKE+2
             INFO: Updated wazuh-wui user password in wazuh dashboard. Remember to restart the service.
-       
-    
+
+
    .. group-tab:: Distributed deployment
 
-      #. On `any Wazuh indexer node`, use the Wazuh passwords tool to change the passwords of the Wazuh indexer users. 
+      #. On `any Wazuh indexer node`, use the Wazuh passwords tool to change the passwords of the Wazuh indexer users.
 
          .. code-block:: console
-  
+
             # /usr/share/wazuh-indexer/plugins/opensearch-security/tools/wazuh-passwords-tool.sh --change-all
-  
+
          .. code-block:: console
             :class: output
 
@@ -181,7 +181,7 @@ Select your deployment type and follow the instructions to change the default pa
       #. On your `Wazuh server master node`, download the Wazuh passwords tool and use it to change the passwords of the Wazuh API users.
 
          .. code-block:: console
-  
+
             # curl -sO https://packages.wazuh.com/|WAZUH_CURRENT_MINOR|/wazuh-passwords-tool.sh
             # bash wazuh-passwords-tool.sh --admin-user wazuh --admin-password wazuh
 
@@ -192,7 +192,7 @@ Select your deployment type and follow the instructions to change the default pa
             INFO: The password for Wazuh API user wazuh-wui is fL+f?sFRPEv5pYRE559rqy9b6G4Z5pVi
 
       #. On `all your Wazuh server nodes`, run the following command to update the `admin` password in the Filebeat keystore. Replace ``<ADMIN_PASSWORD>`` with the random password generated in the first step.
-      
+
          .. code-block:: console
 
             # echo <ADMIN_PASSWORD> | filebeat keystore add password --stdin --force
@@ -202,7 +202,7 @@ Select your deployment type and follow the instructions to change the default pa
          .. include:: /_templates/common/restart_filebeat.rst
 
          .. note:: Repeat steps 3 and 4 on `every Wazuh server node`.
-       
+
       #. On your `Wazuh dashboard node`, run the following command to update the `kibanaserver` password in the Wazuh dashboard keystore. Replace ``<KIBANASERVER_PASSWORD>`` with the random password generated in the first step.
 
          .. code-block:: console
@@ -213,7 +213,7 @@ Select your deployment type and follow the instructions to change the default pa
 
          .. code-block:: yaml
             :emphasize-lines: 6
-           
+
             hosts:
               - default:
                   url: https://localhost
@@ -252,7 +252,7 @@ All the Wazuh central components are successfully installed and secured.
 
       </a>
     </div>
-  
+
     <div class="link-boxes-item past-step">
       <a class="link-boxes-link" href="../wazuh-server/index.html">
         <p class="link-boxes-label">Install the Wazuh server</p>
@@ -265,7 +265,7 @@ All the Wazuh central components are successfully installed and secured.
 
       </a>
     </div>
-  
+
     <div class="link-boxes-item past-step">
       <a class="link-boxes-link" href="index.html">
         <p class="link-boxes-label">Install the Wazuh dashboard</p>
@@ -273,7 +273,7 @@ All the Wazuh central components are successfully installed and secured.
 .. image:: ../../images/installation/Dashboard-Circle.png
      :align: center
      :height: 61px
-     
+
 .. raw:: html
 
       </a>

--- a/source/installation-guide/wazuh-dashboard/step-by-step.rst
+++ b/source/installation-guide/wazuh-dashboard/step-by-step.rst
@@ -183,8 +183,8 @@ Select your deployment type and follow the instructions to change the default pa
          .. code-block:: console
   
             # curl -sO https://packages.wazuh.com/|WAZUH_CURRENT_MINOR|/wazuh-passwords-tool.sh
-            # bash wazuh-passwords-tool.sh --change-all --admin-user wazuh --admin-password wazuh
-  
+            # bash wazuh-passwords-tool.sh --admin-user wazuh --admin-password wazuh
+
          .. code-block:: console
             :class: output
 


### PR DESCRIPTION
## Description
During https://github.com/wazuh/wazuh/issues/27183 it was found that https://documentation.wazuh.com/current/installation-guide/wazuh-dashboard/step-by-step.html#securing-your-wazuh-installation, in particular the Distributed Deployment tab, the following step is changing every password, while only should change API


![image](https://github.com/user-attachments/assets/16c9e87c-582e-45ef-8040-74c9c99cfda7)


This could be an issue if the Wazuh Manager co-exist with Wazuh Dashboard in the same host.

###  Current behavior when the Wazuh Master node and Wazuh Dashboard coexist on the same host

- Step 1
```console
root@host1:/home/vagrant# /usr/share/wazuh-indexer/plugins/opensearch-security/tools/wazuh-passwords-tool.sh --change-all
11/12/2024 14:40:07 INFO: Updating the internal users.
11/12/2024 14:40:11 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
11/12/2024 14:40:11 INFO: Wazuh API admin credentials not provided, Wazuh API passwords not changed.
11/12/2024 14:40:21 INFO: The filebeat.yml file has been updated to use the Filebeat Keystore username and password.
11/12/2024 14:40:49 INFO: The password for user admin is iEmuZf3ttp5ANFGyHzL?u?m68WO1d9Hp
11/12/2024 14:40:49 INFO: The password for user anomalyadmin is yxP0r4y2WNGCcwIkeI+.4Jd6Fma4zF0M
11/12/2024 14:40:49 INFO: The password for user kibanaserver is U9qWxUeT7YnPZOWdlksw5HEB+1.Jinvk
11/12/2024 14:40:49 INFO: The password for user kibanaro is LiDAb0nvRCnlOpj6EmH?2CCCo8EmU7gF
11/12/2024 14:40:49 INFO: The password for user logstash is LMpc3Isb98L*owj*c4n45JA3wqs?V?A2
11/12/2024 14:40:49 INFO: The password for user readall is B3pzRh.sY?YycQGj?Tld3CiT6bEL94rP
11/12/2024 14:40:49 INFO: The password for user snapshotrestore is QhN+yDiQc+q*Q1*7F88e.eEmUrOSfRgj
11/12/2024 14:40:49 WARNING: Wazuh indexer passwords changed. Remember to update the password in the Wazuh dashboard, Wazuh server, and Filebeat nodes if necessary, and restart the services.
```
- Step 2
``` console
root@host1:/home/vagrant# curl -sO https://packages.wazuh.com/4.9/wazuh-passwords-tool.sh
bash wazuh-passwords-tool.sh --api --change-all --admin-user wazuh --admin-password wazuh
11/12/2024 14:41:05 INFO: Updating the internal users.
11/12/2024 14:41:09 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
11/12/2024 14:41:21 INFO: The filebeat.yml file has been updated to use the Filebeat Keystore username and password.
11/12/2024 14:41:45 INFO: The password for user admin is *ERWBUJYcoocwG?CRYfoHSnW7q0itdbh
11/12/2024 14:41:45 INFO: The password for user anomalyadmin is lhPFuWCjv*FlIMadgmNJo+7yYrV7f0vH
11/12/2024 14:41:45 INFO: The password for user kibanaserver is pSqT3?3eBspjKdBeQnSpCgsB.O?o9c8k
11/12/2024 14:41:45 INFO: The password for user kibanaro is tFS8z4ZnlKyc2c1w0G92IYrtySkqc+nX
11/12/2024 14:41:45 INFO: The password for user logstash is gmTiv5OKbx6GGJU2DQjdoTNltdAMMc?a
11/12/2024 14:41:45 INFO: The password for user readall is axSddng6vT7UzgIIv.Gq.PyTnq.8Z*LZ
11/12/2024 14:41:45 INFO: The password for user snapshotrestore is Et5vPBqXDJN72PHSB1paFMNgS+jhpyg+
11/12/2024 14:41:45 WARNING: Wazuh indexer passwords changed. Remember to update the password in the Wazuh dashboard, Wazuh server, and Filebeat nodes if necessary, and restart the services.
11/12/2024 14:41:47 INFO: The password for Wazuh API user wazuh is XFfgvv+Pm+olUvN3hRGSx*rIVQkVFQcE
11/12/2024 14:41:48 INFO: The password for Wazuh API user wazuh-wui is KcIFIovRmAeUho.+shLUs3FJMu*0Pvaa
```

###  Expected behavior when the Wazuh Master node and Wazuh Dashboard coexist on the same host

- Step 1
```console
root@host1:/home/vagrant# /usr/share/wazuh-indexer/plugins/opensearch-security/tools/wazuh-passwords-tool.sh --change-all
11/12/2024 14:40:07 INFO: Updating the internal users.
11/12/2024 14:40:11 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
11/12/2024 14:40:11 INFO: Wazuh API admin credentials not provided, Wazuh API passwords not changed.
11/12/2024 14:40:21 INFO: The filebeat.yml file has been updated to use the Filebeat Keystore username and password.
11/12/2024 14:40:49 INFO: The password for user admin is iEmuZf3ttp5ANFGyHzL?u?m68WO1d9Hp
11/12/2024 14:40:49 INFO: The password for user anomalyadmin is yxP0r4y2WNGCcwIkeI+.4Jd6Fma4zF0M
11/12/2024 14:40:49 INFO: The password for user kibanaserver is U9qWxUeT7YnPZOWdlksw5HEB+1.Jinvk
11/12/2024 14:40:49 INFO: The password for user kibanaro is LiDAb0nvRCnlOpj6EmH?2CCCo8EmU7gF
11/12/2024 14:40:49 INFO: The password for user logstash is LMpc3Isb98L*owj*c4n45JA3wqs?V?A2
11/12/2024 14:40:49 INFO: The password for user readall is B3pzRh.sY?YycQGj?Tld3CiT6bEL94rP
11/12/2024 14:40:49 INFO: The password for user snapshotrestore is QhN+yDiQc+q*Q1*7F88e.eEmUrOSfRgj
11/12/2024 14:40:49 WARNING: Wazuh indexer passwords changed. Remember to update the password in the Wazuh dashboard, Wazuh server, and Filebeat nodes if necessary, and restart the services.
```
- Step 2
``` console
root@host1:/home/vagrant# curl -sO https://packages.wazuh.com/4.9/wazuh-passwords-tool.sh
bash wazuh-passwords-tool.sh --api --change-all --admin-user wazuh --admin-password wazuh
11/12/2024 14:41:47 INFO: The password for Wazuh API user wazuh is XFfgvv+Pm+olUvN3hRGSx*rIVQkVFQcE
11/12/2024 14:41:48 INFO: The password for Wazuh API user wazuh-wui is KcIFIovRmAeUho.+shLUs3FJMu*0Pvaa
```

## Checks
### Docs building
- [ ] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
