### PR TITLE
Update references in 4.12.0 release notes

### DIFF
--- a/source/release-notes/release-4-12-0.rst
+++ b/source/release-notes/release-4-12-0.rst
@@ -38,7 +38,7 @@ Auxiliary repositories
 -  `wazuh/wazuh-puppet <https://github.com/wazuh/wazuh-puppet/blob/v4.12.0/CHANGELOG.md>`__
 -  `wazuh/wazuh-docker <https://github.com/wazuh/wazuh-docker/blob/v4.12.0/CHANGELOG.md>`__
 
--  `wazuh/wazuh-qa <https://github.com/wazuh/wazuh-qa/blob/v4.12.0/CHANGELOG.md>`__
+-  wazuh/wazuh-qa-automation
 -  `wazuh/qa-integration-framework <https://github.com/wazuh/qa-integration-framework/blob/v4.12.0/CHANGELOG.md>`__
 
 -  `wazuh/wazuh-documentation <https://github.com/wazuh/wazuh-documentation/blob/v4.12.0/CHANGELOG.md>`__


### PR DESCRIPTION
## Description
This PR updates auxiliary Wazuh repositories references for version 4.12.0.

## Checks
### Docs building
- [ ] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
