### PR TITLE
add an orientation to remove the `wazuh_indexer_ssl_certs/` directory in order to avoid errors during certificates creation.

### DIFF
--- a/source/deployment-options/docker/wazuh-container.rst
+++ b/source/deployment-options/docker/wazuh-container.rst
@@ -57,7 +57,7 @@ Single-node Deployment
              environment:
                - HTTP_PROXY=YOUR_PROXY_ADDRESS_OR_DNS
         
-      Execute the following command to get the desired certificates:
+      Make sure to remove the ``wazuh_indexer_ssl_certs/`` directory first, then execute the following command to get the desired certificates:
       
          .. code-block:: console
          


### PR DESCRIPTION


<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the "contribution" to properly track the Pull Request.
Please fill the table below. Feel free to extend it at your convenience.
-->
<!--
## Community contributions advice
We love our community contributions. We recommend making PRs from the current branch. For instance, if Wazuh 4.3.7 is the latest release, the branch to be used is 4.3.
Thanks!
-->
## Description

I've simply added an orientation to remove the certs directory, if they exist, before creating new ones.

## Checks
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [X] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
