### PR TITLE
Adding a note to update existing vulnerabilities indices mappings

### DIFF
--- a/source/upgrade-guide/upgrading-central-components.rst
+++ b/source/upgrade-guide/upgrading-central-components.rst
@@ -229,8 +229,7 @@ Configuring Filebeat
       # filebeat setup --pipelines
       # filebeat setup --index-management -E output.logstash.enabled=false
 
-
-   .. note:: When upgrading from v4.8.x or v4.9.x, the ``wazuh-states-vulnerabilities-*`` mappings need to be updated manually with the command that follows:
+#. If you are upgrading from versions v4.8.x or v4.9.x, manually update the ``wazuh-states-vulnerabilities-*`` mappings using the following command:
 
    .. code-block:: console
 

--- a/source/upgrade-guide/upgrading-central-components.rst
+++ b/source/upgrade-guide/upgrading-central-components.rst
@@ -230,7 +230,7 @@ Configuring Filebeat
       # filebeat setup --index-management -E output.logstash.enabled=false
 
 
-   .. note:: When upgrading from v4.9.x, the ``wazuh-states-vulnerabilities-*`` mappings need to be updated manually with the command that follows:
+   .. note:: When upgrading from v4.8.x or v4.9.x, the ``wazuh-states-vulnerabilities-*`` mappings need to be updated manually with the command that follows:
 
    .. code-block:: console
 

--- a/source/upgrade-guide/upgrading-central-components.rst
+++ b/source/upgrade-guide/upgrading-central-components.rst
@@ -229,6 +229,34 @@ Configuring Filebeat
       # filebeat setup --pipelines
       # filebeat setup --index-management -E output.logstash.enabled=false
 
+
+   .. note:: Due to additions of new fields in version v|WAZUH_CURRENT| the ``wazuh-states-vulnerabilities-*`` mappings need to be updated manually with the command that follows:
+
+   .. code-block:: console
+
+      curl -X PUT "https://<WAZUH_INDEXER_IP_ADDRESS>:9200/wazuh-states-vulnerabilities-*/_mapping"  -u <USERNAME>:<PASSWORD> -k -H 'Content-Type: application/json' -d'
+      {
+        "properties": {
+          "vulnerability": {
+            "properties": {
+              "under_evaluation": {
+                "type": "boolean"
+              },
+              "scanner": {
+                "properties": {
+                  "source": {
+                    "type": "keyword",
+                    "ignore_above": 1024
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      '
+
+
 Upgrading the Wazuh dashboard
 -----------------------------
 

--- a/source/upgrade-guide/upgrading-central-components.rst
+++ b/source/upgrade-guide/upgrading-central-components.rst
@@ -230,7 +230,7 @@ Configuring Filebeat
       # filebeat setup --index-management -E output.logstash.enabled=false
 
 
-   .. note:: Due to additions of new fields in version v|WAZUH_CURRENT| the ``wazuh-states-vulnerabilities-*`` mappings need to be updated manually with the command that follows:
+   .. note:: When upgrading from v4.9.x, the ``wazuh-states-vulnerabilities-*`` mappings need to be updated manually with the command that follows:
 
    .. code-block:: console
 


### PR DESCRIPTION
## Description
This PR adds a note to the upgrade guide with a curl command that updates existing vulnerabilities indices to include two new fields:
* `vulnerability.under_evaluation`
* `vulnerability.scanner.source`

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [x] Uses present tense, active voice, and semi-formal registry.
- [x] Uses short, simple sentences.
- [x] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
