### PR TITLE
Add `sudo` to macOS agent installation commands

### DIFF
--- a/source/installation-guide/wazuh-agent/wazuh-agent-package-macos.rst
+++ b/source/installation-guide/wazuh-agent/wazuh-agent-package-macos.rst
@@ -25,29 +25,27 @@ The agent runs on the endpoint you want to monitor and communicates with the Waz
    .. tabs::
 
       .. group-tab:: CLI
-      
+
          #. To deploy the Wazuh agent on your endpoint, choose your architecture, edit the ``WAZUH_MANAGER`` variable to contain your Wazuh manager IP address or hostname, and run the following command. 
 
             .. tabs::
-            
+
                .. group-tab:: Intel
 
                   .. code-block:: console
-                  
-                     # echo "WAZUH_MANAGER='10.0.0.2'" > /tmp/wazuh_envs && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.intel64.pkg -target /
-   
+
+                     # echo "WAZUH_MANAGER='10.0.0.2'" > /tmp/wazuh_envs && sudo installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.intel64.pkg -target /
 
                .. group-tab:: Apple silicon
 
                   .. versionadded:: 4.5.1
 
                   .. code-block:: console
-                  
-                     # echo "WAZUH_MANAGER='10.0.0.2'" > /tmp/wazuh_envs && installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.arm64.pkg -target /
 
+                     # echo "WAZUH_MANAGER='10.0.0.2'" > /tmp/wazuh_envs && sudo installer -pkg wazuh-agent-|WAZUH_CURRENT_OSX|-|WAZUH_REVISION_OSX|.arm64.pkg -target /
 
                For additional deployment options such as agent name, agent group, and registration password, see the :doc:`Deployment variables for macOS </user-manual/agent/agent-enrollment/deployment-variables/deployment-variables-macos>` section.
-               
+
                .. note:: Alternatively, if you want to install an agent without registering it, omit the deployment variables. To learn more about the different registration methods, see the :doc:`Wazuh agent enrollment </user-manual/agent/agent-enrollment/index>` section.
 
          #. To complete the installation process, start the Wazuh agent.
@@ -59,7 +57,7 @@ The agent runs on the endpoint you want to monitor and communicates with the Waz
 
          The installation process is now complete, and the Wazuh agent is successfully deployed and running on your macOS endpoint.
 
-      
+
       .. group-tab:: GUI
 
          #. To install the Wazuh agent on your system, run the downloaded file and follow the steps in the installation wizard. If you are not sure how to answer some of the prompts, use the default answers.
@@ -68,7 +66,7 @@ The agent runs on the endpoint you want to monitor and communicates with the Waz
                :align: center
                :title: macOS agent installer
                :alt: macOS agent installer
-               
+
          #. To complete the installation process, start the Wazuh agent.
 
             .. code-block:: console


### PR DESCRIPTION
## Description
This PR modifies the commands in https://documentation.wazuh.com/current/installation-guide/wazuh-agent/wazuh-agent-package-macos.html by prepending `sudo` to the `installer` command.

## Checks
### Docs building
- [ ] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
