### PR TITLE
Add ARM to 64-bit architecture references for central components

### DIFF
--- a/source/deployment-options/docker/docker-installation.rst
+++ b/source/deployment-options/docker/docker-installation.rst
@@ -53,7 +53,7 @@ Wazuh indexer creates many memory-mapped areas. So you need to set the kernel to
 Docker engine
 -------------
 
-For Linux/Unix machines, Docker requires an amd64 architecture system running kernel version 3.10 or later.
+For Linux/Unix machines, Docker requires an AMD64 or ARM64 architecture system running kernel version 3.10 or later.
 
 #. Open a terminal and use ``uname -r`` to display and check your kernel version:
 

--- a/source/deployment-options/offline-installation/index.rst
+++ b/source/deployment-options/offline-installation/index.rst
@@ -6,7 +6,7 @@
 Offline installation
 ====================
 
-You can install Wazuh even when there is no connection to the Internet. Installing the solution offline involves downloading the Wazuh central components to later install them on a system with no Internet connection. The Wazuh server, the Wazuh indexer, and the Wazuh dashboard can be installed and configured on the same host in an all-in-one deployment, or each component can be installed on a separate host as a distributed deployment, depending on your environment needs. The supported architecture is 64-bit (x86_64/AMD64).
+You can install Wazuh even when there is no connection to the Internet. Installing the solution offline involves downloading the Wazuh central components later to install them on a system with no Internet connection. The Wazuh server, the Wazuh indexer, and the Wazuh dashboard can be installed and configured on the same host in an all-in-one deployment, or each component can be installed on a separate host as a distributed deployment, depending on your environment's needs. The supported architecture is 64-bit (x86_64/AMD64 or AARCH64/ARM64).
 
 For more information about the hardware requirements and the recommended operating systems, check the :ref:`Requirements <installation_requirements>` section.
 
@@ -22,26 +22,38 @@ Prerequisites
 Download the packages and configuration files
 ---------------------------------------------
 
-#. Run the following commands from any Linux system with Internet connection. This action executes a script that downloads all required files for the offline installation on x86_64 architectures. Select the package format to download.
-    
+#. Run the following commands from any Linux system with Internet connection. This action executes a script that downloads all required files for the offline installation (on x86_64/AMD64 and AARCH64/ARM64 architectures). Select the package format to download.
+
    .. tabs::
 
-        .. group-tab:: RPM
+      .. group-tab:: RPM
 
-            .. code-block:: console
-        
-               # curl -sO https://packages.wazuh.com/|WAZUH_CURRENT_MINOR|/wazuh-install.sh
-               # chmod 744 wazuh-install.sh
-               # ./wazuh-install.sh -dw rpm
+         .. code-block:: console
 
-        .. group-tab:: DEB
+            # curl -sO https://packages.wazuh.com/|WAZUH_CURRENT_MINOR|/wazuh-install.sh
+            # chmod 744 wazuh-install.sh
+            # ./wazuh-install.sh -dw rpm -da x86_64
 
-            .. code-block:: console
-        
-               # curl -sO https://packages.wazuh.com/|WAZUH_CURRENT_MINOR|/wazuh-install.sh
-               # chmod 744 wazuh-install.sh
-               # ./wazuh-install.sh -dw deb
-          
+         .. code-block:: console
+
+            # curl -sO https://packages.wazuh.com/|WAZUH_CURRENT_MINOR|/wazuh-install.sh
+            # chmod 744 wazuh-install.sh
+            # ./wazuh-install.sh -dw rpm -da aarch64
+
+      .. group-tab:: DEB
+
+         .. code-block:: console
+
+            # curl -sO https://packages.wazuh.com/|WAZUH_CURRENT_MINOR|/wazuh-install.sh
+            # chmod 744 wazuh-install.sh
+            # ./wazuh-install.sh -dw deb -da amd64
+
+         .. code-block:: console
+
+            # curl -sO https://packages.wazuh.com/|WAZUH_CURRENT_MINOR|/wazuh-install.sh
+            # chmod 744 wazuh-install.sh
+            # ./wazuh-install.sh -dw deb -da arm64
+
 #. Download the certificates configuration file.
 
       .. code-block:: console

--- a/source/deployment-options/offline-installation/installation-assistant.rst
+++ b/source/deployment-options/offline-installation/installation-assistant.rst
@@ -1,7 +1,7 @@
 Install Wazuh components using the assistant
 --------------------------------------------
 
-Install and configure the different Wazuh components on a 64-bit (x86_64/AMD64) architecture with the aid of the Wazuh installation assistant.
+Install and configure the different Wazuh components on a 64-bit (x86_64/AMD64 or AARCH64/ARM64) architecture with the aid of the Wazuh installation assistant.
 
 .. note:: You need root user privileges to run all the commands described below.
 

--- a/source/deployment-options/virtual-machine/virtual-machine.rst
+++ b/source/deployment-options/virtual-machine/virtual-machine.rst
@@ -36,9 +36,9 @@ Hardware requirements
 
 The following requirements have to be in place before the Wazuh VM can be imported into a host operating system:
 
-- The host operating system has to be a 64-bit system with x86_64/AMD64 architecture.
-- Hardware virtualization has to be enabled on the firmware of the host.
-- A virtualization platform, such as VirtualBox, should be installed on the host system.
+-  The host operating system has to be a 64-bit system with x86_64/AMD64 or AARCH64/ARM64 architecture.
+-  Hardware virtualization has to be enabled on the firmware of the host.
+-  A virtualization platform, such as VirtualBox, should be installed on the host system.
 
 Out of the box, the Wazuh VM is configured with the following specifications:
 

--- a/source/installation-guide/wazuh-dashboard/index.rst
+++ b/source/installation-guide/wazuh-dashboard/index.rst
@@ -74,7 +74,7 @@ Check the supported operating systems and the recommended hardware requirements 
 Recommended operating systems
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The Wazuh dashboard requires a 64-bit Intel or AMD Linux processor (x86_64/AMD64 architecture) to run. Wazuh supports the following operating system versions:
+The Wazuh dashboard requires a 64-bit Intel, AMD, or ARM Linux processor (x86_64/AMD64 or AARCH64/ARM64 architecture). Wazuh supports the following operating system versions:
 
 .. list-table::
    :width: 100%

--- a/source/installation-guide/wazuh-dashboard/installation-assistant.rst
+++ b/source/installation-guide/wazuh-dashboard/installation-assistant.rst
@@ -6,7 +6,7 @@
 Installing the Wazuh dashboard using the assisted installation method
 =====================================================================
 
-Install and configure the Wazuh dashboard on a 64-bit (x86_64/AMD64) architecture using the assisted installation method. Wazuh dashboard is a flexible and intuitive web interface for mining and visualizing security events and archives.
+Install and configure the Wazuh dashboard on a 64-bit (x86_64/AMD64 or AARCH64/ARM64) architecture using the assisted installation method. Wazuh dashboard is a flexible and intuitive web interface for mining and visualizing security events and archives.
 
 Wazuh dashboard installation
 -----------------------------

--- a/source/installation-guide/wazuh-indexer/index.rst
+++ b/source/installation-guide/wazuh-indexer/index.rst
@@ -73,7 +73,7 @@ Check the supported operating systems and the recommended hardware requirements 
 Recommended operating systems
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The Wazuh indexer requires a 64-bit Intel or AMD Linux processor (x86_64/AMD64 architecture) to run. Wazuh supports the following operating system versions:
+The Wazuh indexer requires a 64-bit Intel, AMD, or ARM Linux processor (x86_64/AMD64 or AARCH64/ARM64 architecture) to run. Wazuh supports the following operating system versions:
 
 .. list-table::
    :width: 100%

--- a/source/installation-guide/wazuh-indexer/installation-assistant.rst
+++ b/source/installation-guide/wazuh-indexer/installation-assistant.rst
@@ -6,7 +6,7 @@
 Installing the Wazuh indexer using the assisted installation method
 ===================================================================
 
-Install and configure the Wazuh indexer as a single-node or multi-node cluster on a 64-bit (x86_64/AMD64) architecture using the assisted installation method. The Wazuh indexer is a highly scalable full-text search engine. It offers advanced security, alerting, index management, deep performance analysis, and several other features.
+Install and configure the Wazuh indexer as a single-node or multi-node cluster on a 64-bit (x86_64/AMD64 or AARCH64/ARM64) architecture using the assisted installation method. The Wazuh indexer is a highly scalable full-text search engine. It offers advanced security, alerting, index management, deep performance analysis, and several other features.
 
 Wazuh indexer cluster installation
 ----------------------------------

--- a/source/installation-guide/wazuh-server/index.rst
+++ b/source/installation-guide/wazuh-server/index.rst
@@ -74,7 +74,7 @@ Check the supported operating systems and the recommended hardware requirements 
 Recommended operating systems
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The Wazuh server requires a 64-bit Intel or AMD Linux processor (x86_64/AMD64 architecture) to run. Wazuh supports the following operating system versions:
+The Wazuh server requires a 64-bit Intel, AMD, or ARM Linux processor (x86_64/AMD64 or AARCH64/ARM64 architecture). Wazuh supports the following operating system versions:
 
 .. list-table::
    :width: 100%

--- a/source/installation-guide/wazuh-server/installation-assistant.rst
+++ b/source/installation-guide/wazuh-server/installation-assistant.rst
@@ -6,7 +6,7 @@
 Installing the Wazuh server using the assisted installation method
 ==================================================================
 
-Install the Wazuh server as a single-node or multi-node cluster on a 64-bit (x86_64/AMD64) architecture using the assisted installation method. The Wazuh server analyzes the data received from the agents triggering alerts when it detects threats and anomalies. This central component includes the Wazuh manager and Filebeat.
+Install the Wazuh server as a single-node or multi-node cluster on a 64-bit (x86_64/AMD64 or AARCH64/ARM64) architecture using the assisted installation method. The Wazuh server analyzes the data received from the agents, triggering alerts when it detects threats and anomalies. This central component includes the Wazuh manager and Filebeat.
 
 Wazuh server cluster installation
 ---------------------------------

--- a/source/quickstart.rst
+++ b/source/quickstart.rst
@@ -45,7 +45,7 @@ For larger environments we recommend a distributed deployment. Multi-node cluste
 Operating system
 ^^^^^^^^^^^^^^^^
 
-The Wazuh central components require a 64-bit Intel or AMD Linux processor (x86_64/AMD64 architecture) to run. Wazuh recommends any of the following operating system versions:
+The Wazuh central components require a 64-bit Intel, AMD, or ARM Linux processor (x86_64/AMD64 or AARCH64/ARM64 architecture) to run. Wazuh recommends any of the following operating system versions:
 
 .. list-table::
    :width: 100%


### PR DESCRIPTION
## Description
This PR adds the ARM architecture to references about 64-bit processors for the central components.

## Checks
### Docs building
- [x] Compiles without warnings.
### Code formatting and web optimization
- [x] Uses three spaces indentation.
- [x] Adds or updates meta descriptions accordingly.
- [x] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
