### PR TITLE
Fix: Code block type

### DIFF
--- a/source/upgrade-guide/upgrading-central-components.rst
+++ b/source/upgrade-guide/upgrading-central-components.rst
@@ -186,7 +186,7 @@ Perform the following steps on any of the Wazuh indexer nodes replacing ``<WAZUH
 
 #. Re-enable shard allocation.
 
-   .. code-block:: bash
+   .. code-block:: console
 
       # curl -X PUT "https://<WAZUH_INDEXER_IP_ADDRESS>:9200/_cluster/settings" \
       -u <USERNAME>:<PASSWORD> -k -H "Content-Type: application/json" -d '


### PR DESCRIPTION
## Description
Code-block should be of type "console" otherwise the first character (#) is interpreted as a comment instead of a console root prompt and is commented out when copied

## Documentation compilation
- [x] Verified that documentation compiles without warnings.

## Changelog
- [ ] Updated `CHANGELOG.md`.

## Code formatting & web optimization
- [ ] Added or updated meta descriptions.
- [ ] Updated `redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
- [ ] Used three-space indentation in `.rst` files.

## Writing style
- [ ] Used **bold** for UI elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Followed present tense, active voice, and a semi-formal tone.
- [ ] Wrote short, clear, and concise sentences.
