### PR TITLE
Revert prompt symbol addition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ All notable changes to this project will be documented in this file.
 
 - Removed note about plugins and upgrading Wazuh central components. ([#8020](https://github.com/wazuh/wazuh-documentation/pull/8020))
 
+### Fixed
+
+- **Post-release**: Removed prompt symbol from code block. ([#8211](https://github.com/wazuh/wazuh-documentation/pull/8211))
+
 # [v4.10.2]
 
 - Support for Wazuh 4.10.2

--- a/source/upgrade-guide/upgrading-central-components.rst
+++ b/source/upgrade-guide/upgrading-central-components.rst
@@ -188,7 +188,7 @@ Perform the following steps on any of the Wazuh indexer nodes replacing ``<WAZUH
 
    .. code-block:: bash
 
-      # curl -X PUT "https://<WAZUH_INDEXER_IP_ADDRESS>:9200/_cluster/settings" \
+      curl -X PUT "https://<WAZUH_INDEXER_IP_ADDRESS>:9200/_cluster/settings" \
       -u <USERNAME>:<PASSWORD> -k -H "Content-Type: application/json" -d '
       {
          "persistent": {


### PR DESCRIPTION
## Description
This PR reverts the addition of the command line prompt symbol from the following code-blocK
- https://github.com/wazuh/wazuh-documentation/blob/4.11/source/upgrade-guide/upgrading-central-components.rst?plain=1#L189-L198

## Documentation compilation
- [ ] Verified that documentation compiles without warnings.

## Changelog
- [ ] Updated `CHANGELOG.md`.

## Code formatting & web optimization
- [ ] Added or updated meta descriptions.
- [ ] Updated `redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
- [ ] Used three-space indentation in `.rst` files.

## Writing style
- [ ] Used **bold** for UI elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Followed present tense, active voice, and a semi-formal tone.
- [ ] Wrote short, clear, and concise sentences.
