### PR TITLE
Revert changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ All notable changes to this project will be documented in this file.
 
 - Added architecture information to assistant pages. ([#7830](https://github.com/wazuh/wazuh-documentation/pull/7830))
 - Added CISA to the vulnerability source enumerations and compatibility matrix. ([#8201](https://github.com/wazuh/wazuh-documentation/pull/8201))
-- **Post-release**: Added an Anti-tampering section to User administration and a note about it in Uninstalling a Linux Wazuh agent. ([#8221](https://github.com/wazuh/wazuh-documentation/pull/8221))
 
 ### Changed
 


### PR DESCRIPTION
## Description
This PR removes the changelog entry for the Anti-tampering section since it wasn't introduced in 4.11 but in an earlier version.

## Documentation compilation
- [X] Verified that documentation compiles without warnings.

## Changelog
- [X] Updated `CHANGELOG.md`.

## Code formatting & web optimization
- [ ] Added or updated meta descriptions.
- [ ] Updated `redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
- [ ] Used three-space indentation in `.rst` files.

## Writing style
- [X] Used **bold** for UI elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [X] Followed present tense, active voice, and a semi-formal tone.
- [X] Wrote short, clear, and concise sentences.
