### PR TITLE
Fix missing redirection entry for anti-tampering in 4.11

### DIFF
--- a/source/_static/js/redirects.js
+++ b/source/_static/js/redirects.js
@@ -226,6 +226,7 @@ newUrls['4.10'] = [
   '/user-manual/wazuh-server-cluster/adding-new-server-nodes/testing-the-cluster.html',
   '/user-manual/wazuh-server-cluster/agent-connections.html',
   '/user-manual/wazuh-server-cluster/load-balancers.html',
+  '/user-manual/agent/agent-management/anti-tampering.html',
 ]
 
 /* Pages no longer available in 4.10 */


### PR DESCRIPTION
## Description
This PR fixes the missing entry for the Anti-tampering section for 4.11 documentation.

## Documentation compilation
- [X] Verified that documentation compiles without warnings.

## Changelog
- [ ] Updated `CHANGELOG.md`.

## Code formatting & web optimization
- [ ] Added or updated meta descriptions.
- [X] Updated `redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
- [ ] Used three-space indentation in `.rst` files.

## Writing style
- [ ] Used **bold** for UI elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Followed present tense, active voice, and a semi-formal tone.
- [ ] Wrote short, clear, and concise sentences.
