### PR TITLE
Fix dashboard package generation commands 4.10

### DIFF
--- a/source/_variables/replacements.py
+++ b/source/_variables/replacements.py
@@ -147,7 +147,7 @@ custom_replacements = {
     "|WAZUH_REVISION_HPUX|" : "1",
     #
     # === OpenSearch
-    "|OPENSEARCH_DASHBOARDS_VERSION|": "2.13.0",
+    "|OPENSEARCH_DASHBOARDS_VERSION|": "2.16.0",
     #
     # === Elastic
     # --- Filebeat

--- a/source/development/packaging/generate-dashboard-package.rst
+++ b/source/development/packaging/generate-dashboard-package.rst
@@ -180,7 +180,7 @@ Example:
 .. code:: console
 
    $ cd ../wazuh-dashboard/dev-tools/build-packages/
-   $ ./build-packages.sh -v v|WAZUH_CURRENT| -r 1 --deb -a file:///packages/wazuh-package.zip -s file:///packages/security-package.zip -b file:///packages/dashboard-package.zip
+   $ ./build-packages.sh -v |WAZUH_CURRENT| -r 1 --deb -a file:///packages/wazuh-package.zip -s file:///packages/security-package.zip -b file:///packages/dashboard-package.zip
 
 The package will be generated in the ``output`` folder of the same directory where the script is located.
 


### PR DESCRIPTION
## Description
This PR fixes the following problems:

- Script argument in the Wazuh dashboard package generation command.
- The Opensearch Dashboards version reference.

## Documentation compilation
- [X] Verified that documentation compiles without warnings.

## Changelog
- [ ] Updated `CHANGELOG.md`.

## Code formatting & web optimization
- [ ] Added or updated meta descriptions.
- [ ] Updated `redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
- [x] Used three-space indentation in `.rst` files.

## Writing style
- [x] Used **bold** for UI elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Followed present tense, active voice, and a semi-formal tone.
- [x] Wrote short, clear, and concise sentences.
