### PR TITLE
Set 4.11.1 for release

### DIFF
--- a/source/_variables/settings.py
+++ b/source/_variables/settings.py
@@ -22,6 +22,6 @@ is_latest_release = True
 # Important: use a valid branch (4.0) or, preferably, tag name (v4.0.0)
 
 release = '4.11.1'
-api_tag = '4.11.1'
+api_tag = 'v4.11.1'
 
 apiURL = 'https://raw.githubusercontent.com/wazuh/wazuh/'+api_tag+'/api/api/spec/spec.yaml'

--- a/source/release-notes/index-4x.rst
+++ b/source/release-notes/index-4x.rst
@@ -11,7 +11,7 @@ This section summarizes the most important features of each Wazuh 4.x release.
 =============================================  ====================
 Wazuh version                                  Release date
 =============================================  ====================
-:doc:`4.11.1 </release-notes/release-4-11-1>`  TBD
+:doc:`4.11.1 </release-notes/release-4-11-1>`  12 March 2025
 :doc:`4.11.0 </release-notes/release-4-11-0>`  20 February 2025
 :doc:`4.10.1 </release-notes/release-4-10-1>`  16 January 2025
 :doc:`4.10.0 </release-notes/release-4-10-0>`  9 January 2025

--- a/source/release-notes/index.rst
+++ b/source/release-notes/index.rst
@@ -11,7 +11,7 @@ This section summarizes the most important features of each Wazuh release.
 ==============================================   ====================
 Wazuh version                                    Release date
 ==============================================   ====================
-:doc:`4.11.1 </release-notes/release-4-11-1>`    TBD
+:doc:`4.11.1 </release-notes/release-4-11-1>`    12 March 2025
 :doc:`4.11.0 </release-notes/release-4-11-0>`    20 February 2025
 :doc:`4.10.1 </release-notes/release-4-10-1>`    16 January 2025
 :doc:`4.10.0 </release-notes/release-4-10-0>`    9 January 2025

--- a/source/release-notes/release-4-11-1.rst
+++ b/source/release-notes/release-4-11-1.rst
@@ -3,8 +3,8 @@
 .. meta::
    :description: Wazuh 4.11.1 has been released. Check out our release notes to discover the changes and additions of this release.
 
-4.11.1 Release notes - TBD
-==========================
+4.11.1 Release notes - 12 March 2025
+====================================
 
 This section lists the changes in version 4.11.1. Every update of the Wazuh solution is cumulative and includes all enhancements and fixes from previous releases.
 


### PR DESCRIPTION
## Description
This PR does the following to prepare for the 4.11.1 release:
- (1) set the release date in release notes documents
- (2) change api_tag value from 4.11.1 to v4.11.1.

## Documentation compilation
- [x] Verified that documentation compiles without warnings.

## Changelog
- [ ] Updated `CHANGELOG.md`.

## Code formatting & web optimization
- [ ] Added or updated meta descriptions.
- [ ] Updated `redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
- [x] Used three-space indentation in `.rst` files.

## Writing style
- [x] Used **bold** for UI elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Followed present tense, active voice, and a semi-formal tone.
- [x] Wrote short, clear, and concise sentences.
