### PR TITLE
Add missing entry to 4.11.1 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 # [v4.11.1]
 
-- Support for Wazuh 4.11.1
+- **Post-release**: Added missing entry to 4.11.1 release notes. ([#8280](https://github.com/wazuh/wazuh-documentation/pull/8280))
 
 ## [v4.11.0]
 

--- a/source/release-notes/release-4-11-1.rst
+++ b/source/release-notes/release-4-11-1.rst
@@ -41,6 +41,7 @@ Wazuh agent
 ^^^^^^^^^^^
 
 -  `#28339 <https://github.com/wazuh/wazuh/pull/28339>`__ Improved agent connectivity.
+-  `#28516 <https://github.com/wazuh/wazuh/pull/28516>`__ Applied the ``agent.recv_timeout`` timeout to the agent enrollment process to prevent it from waiting indefinitely for a response.
 
 Wazuh dashboard
 ^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Description
This PR updates the 4.11.1 release notes with a missing entry related to https://github.com/wazuh/wazuh/pull/28516

## Documentation compilation
- [X] Verified that documentation compiles without warnings.

## Changelog
- [x] Updated `CHANGELOG.md`.

## Code formatting & web optimization
- [ ] Added or updated meta descriptions.
- [ ] Updated `redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
- [X] Used three-space indentation in `.rst` files.

## Writing style
- [X] Used **bold** for UI elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [X] Followed present tense, active voice, and a semi-formal tone.
- [X] Wrote short, clear, and concise sentences.
