### PR TITLE
Fix typos in word "address"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - **Post-release**: Added missing Oracle Linux to the vulnerability detection compatibility matrix and fixed heading level. ([#8391](https://github.com/wazuh/wazuh-documentation/pull/8391))
+- **Post-release**: Fixed mispelled word "address" occurrences. ([#8421](https://github.com/wazuh/wazuh-documentation/pull/8421))
 
 ## [v4.11.1]
 

--- a/source/installation-guide/wazuh-indexer/step-by-step.rst
+++ b/source/installation-guide/wazuh-indexer/step-by-step.rst
@@ -189,7 +189,7 @@ Testing the cluster installation
 
    .. code-block:: console
 
-      # curl -k -u admin:admin https://<WAZUH_INDEXER_IP_ADRESS>:9200
+      # curl -k -u admin:admin https://<WAZUH_INDEXER_IP_ADDRESS>:9200
 
    .. code-block:: none
       :class: output accordion-output

--- a/source/user-manual/capabilities/agentless-monitoring/agentless-configuration.rst
+++ b/source/user-manual/capabilities/agentless-monitoring/agentless-configuration.rst
@@ -172,5 +172,5 @@ When Wazuh has connected to the monitored endpoint, you should see a message sim
 
 .. code-block:: console
 
-   wazuh-agentlessd: INFO: ssh_integrity_check_linux: user@example_adress.com: Starting.
-   wazuh-agentlessd: INFO: ssh_integrity_check_linux: user@example_adress.com: Finished.
+   wazuh-agentlessd: INFO: ssh_integrity_check_linux: user@example_address.com: Starting.
+   wazuh-agentlessd: INFO: ssh_integrity_check_linux: user@example_address.com: Finished.


### PR DESCRIPTION
## Description
This PR fixes the occurrences of mispelled word "address"

## Documentation compilation
- [X] Verified that documentation compiles without warnings.

## Changelog
- [x] Updated `CHANGELOG.md`.

## Code formatting & web optimization
- [ ] Added or updated meta descriptions.
- [ ] Updated `redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
- [ ] Used three-space indentation in `.rst` files.

## Writing style
- [x] Used **bold** for UI elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Followed present tense, active voice, and a semi-formal tone.
- [x] Wrote short, clear, and concise sentences.
