### PR TITLE
Add warning about downgrading from 4.12+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Added Ubuntu 24.04 SCA to the list of available SCAs. ([#8021](https://github.com/wazuh/wazuh-documentation/pull/8021))
 - Added the `<aws_profile>` authentication parameter to the Amazon Security Lake documentation. ([#8199](https://github.com/wazuh/wazuh-documentation/pull/8199))
 - Added ARM64 to the central components architecture references. ([#8173](https://github.com/wazuh/wazuh-documentation/pull/8173))
+- Added a note warning that downgrades to 4.11 and earlier versions from 4.12 and later are not possible. ([#8425](https://github.com/wazuh/wazuh-documentation/pull/8425))
 
 ### Changed
 

--- a/source/upgrade-guide/upgrading-central-components.rst
+++ b/source/upgrade-guide/upgrading-central-components.rst
@@ -11,6 +11,14 @@ This section guides you through the upgrade process of the Wazuh indexer, the Wa
 -  **All-in-one deployments:** Execute all commands and configuration actions on the same node since all components run on a single system.
 -  **Multi-node cluster deployments:** Run commands and apply configurations on the respective node where the component being upgraded is located.
 
+.. warning::
+
+   Downgrading to version 4.11 and earlier is not possible. Since version 4.12.0, Wazuh uses a newer version of Apache Lucene.
+
+   Apache Lucene does not support downgrades, meaning once you upgrade to Wazuh 4.12.0 or later, you cannot roll back to 4.11 and earlier versions without a fresh installation of the indexer.
+
+   To avoid data loss, create an :ref:`index snapshot <migrating_indices_take_snapshots>` before upgrading. For more details, refer to the `Opensearch documentation <https://opensearch.org/docs/latest/install-and-configure/upgrade-opensearch/rolling-upgrade/#:~:text=Important%3A%20OpenSearch%20nodes%20cannot%20be,before%20beginning%20the%20upgrade%20procedure.>`__.
+
 Preparing the upgrade
 ---------------------
 

--- a/source/user-manual/wazuh-indexer/migrating-wazuh-indices.rst
+++ b/source/user-manual/wazuh-indexer/migrating-wazuh-indices.rst
@@ -183,6 +183,8 @@ On the Wazuh dashboard, perform the following steps:
 
 Repeat the above steps on the destination Wazuh cluster to set up a similar snapshot repository.
 
+.. _migrating_indices_take_snapshots:
+
 Take snapshots
 --------------
 


### PR DESCRIPTION
## Description
This PR adds a note warning that downgrades to 4.11 and earlier versions from 4.12+ are not possible.

## Documentation compilation
- [X] Verified that documentation compiles without warnings.

## Changelog
- [x] Updated `CHANGELOG.md`.

## Code formatting & web optimization
- [ ] Added or updated meta descriptions.
- [ ] Updated `redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
- [x] Used three-space indentation in `.rst` files.

## Writing style
- [x] Used **bold** for UI elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Followed present tense, active voice, and a semi-formal tone.
- [x] Wrote short, clear, and concise sentences.
