### PR TITLE
Fix the Download configuration files from remote location section

### DIFF
--- a/source/user-manual/reference/centralized-configuration.rst
+++ b/source/user-manual/reference/centralized-configuration.rst
@@ -322,7 +322,7 @@ Whether for any reason you don't want to apply the shared configuration in a spe
 Download configuration files from remote location
 -------------------------------------------------
 
-The Wazuh manager has the capability to download configuration files like ``merged.mg`` as well as other files to be merged for the groups that you want.
+The Wazuh manager can download configuration files such as ``merged.mg`` and other files to be merged for selected groups.
 
 To use this feature, we need to put a yaml file named ``files.yml`` under the directory ``/var/ossec/etc/shared/``. When the **manager** starts, it will read and parse the file.
 
@@ -343,15 +343,7 @@ The ``files.yml`` has the following structure as shown in the following example:
                 agent.conf: https://example.com/agent.conf
             poll: 200
 
-    agents:
-        001: my_group_1
-        002: my_group_2
-        003: another_group
-
-Here we can distinguish the two main blocks: ``groups`` and ``agents``.
-
-
-1. In the ``groups`` block we define the group name from which we want to download the files.
+The ``groups`` block defines the group name from which to download the files.
 
     - If the group doesn't exist, it will be created.
     - If a file has the name ``merged.mg``, only this file will be downloaded. Then it will be validated.


### PR DESCRIPTION
## Description
This PR fix missing changes in the following section:

- https://documentation.wazuh.com/4.6/user-manual/reference/centralized-configuration.html#download-configuration-files-from-remote-location

## Documentation compilation
- [ ] Verified that documentation compiles without warnings.

## Changelog
- [ ] Updated `CHANGELOG.md`.

## Code formatting & web optimization
- [ ] Added or updated meta descriptions.
- [ ] Updated `redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
- [ ] Used three-space indentation in `.rst` files.

## Writing style
- [ ] Used **bold** for UI elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Followed present tense, active voice, and a semi-formal tone.
- [ ] Wrote short, clear, and concise sentences.
