### PR TITLE
Revert changes applied to 4.11 branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 - **Post-release**: Fixed mispelled word "address" occurrences. ([#8421](https://github.com/wazuh/wazuh-documentation/pull/8421))
 - **Post-release**: Fixed `wazuh-certs-tool` download command from static version number to use `WAZUH_CURRENT_VERSION` ([#8473](https://github.com/wazuh/wazuh-documentation/pull/8473))
 - **Post-release**: Add missing changes in Download configuration files from remote location section. ([#8476](https://github.com/wazuh/wazuh-documentation/pull/8476))
+- **Post-release**: Reverted new configuration options added to the MS Graph integration documentation. ([#8495](https://github.com/wazuh/wazuh-documentation/pull/8495))
 
 ## [v4.11.1]
 
@@ -36,6 +37,7 @@ All notable changes to this project will be documented in this file.
 
 - Added architecture information to assistant pages. ([#7830](https://github.com/wazuh/wazuh-documentation/pull/7830))
 - Added CISA to the vulnerability source enumerations and compatibility matrix. ([#8201](https://github.com/wazuh/wazuh-documentation/pull/8201))
+- **Post-release**: Added new configuration options to the MS Graph integration documentation. ([#8226](https://github.com/wazuh/wazuh-documentation/pull/8226))
 - **Post-release**: Added Wazuh indexer API documentation. ([#8231](https://github.com/wazuh/wazuh-documentation/pull/8231))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,6 @@ All notable changes to this project will be documented in this file.
 
 - Added architecture information to assistant pages. ([#7830](https://github.com/wazuh/wazuh-documentation/pull/7830))
 - Added CISA to the vulnerability source enumerations and compatibility matrix. ([#8201](https://github.com/wazuh/wazuh-documentation/pull/8201))
-- **Post-release**: Added new configuration options to the MS Graph integration documentation. ([#8226](https://github.com/wazuh/wazuh-documentation/pull/8226))
 - **Post-release**: Added Wazuh indexer API documentation. ([#8231](https://github.com/wazuh/wazuh-documentation/pull/8231))
 
 ### Changed

--- a/source/cloud-security/azure/ms-graph-api-setup.rst
+++ b/source/cloud-security/azure/ms-graph-api-setup.rst
@@ -53,7 +53,7 @@ Certificates & secrets
 API permissions
 ---------------
 
-Your application needs specific API permissions to retrieve logs and events from the Microsoft Graph API. The specific API permission required depends on the resource to be accessed. The comprehensive list of permissions is documented in `Microsoft Graph permissions reference <https://learn.microsoft.com/en-us/graph/permissions-reference>`__.
+Your application needs specific API permissions to retrieve logs and events from the Microsoft Graph API, such as permissions related to the ``security`` and ``deviceManagement`` resources.
 
 To configure the application permissions, go to the **API permissions** page and choose **Add a permission**.
 

--- a/source/user-manual/reference/ossec-conf/ms-graph-module.rst
+++ b/source/user-manual/reference/ossec-conf/ms-graph-module.rst
@@ -29,8 +29,6 @@ Options
 - `only_future_events`_
 - `interval`_
 - `curl_max_size`_
-- `page_size`_
-- `time_delay`_
 - `run_on_start`_
 - `version`_
 - `api_auth`_
@@ -52,10 +50,6 @@ Options
 | `interval`_                            | A positive number + suffix      |
 +----------------------------------------+---------------------------------+
 | `curl_max_size`_                       | A positive number + suffix      |
-+----------------------------------------+---------------------------------+
-| `page_size`_                           | A positive number between 1–50  |
-+----------------------------------------+---------------------------------+
-| `time_delay`_                          | A positive number + suffix      |
 +----------------------------------------+---------------------------------+
 | `run_on_start`_                        | yes, no                         |
 +----------------------------------------+---------------------------------+
@@ -127,28 +121,6 @@ Specifies the maximum size allowed for the Microsoft Graph API response.
 +--------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | **Allowed values** | A positive number that should contain a suffix character indicating a size unit, such as b/B (bytes), k/K (kilobytes), m/M (megabytes), and g/G (gigabytes). Minimum value of 1M. |
 +--------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-
-page_size
-^^^^^^^^^
-
-Controls the page size by limiting the items returned per page on every API request.
-
-+--------------------+---------------------------------+
-| **Default value**  | 50                              |
-+--------------------+---------------------------------+
-| **Allowed values** | A positive number between 1–50. |
-+--------------------+---------------------------------+
-
-time_delay
-^^^^^^^^^^
-
-Adds ``time_delay`` setting. Its value must be greater than or equal to 0. By default, its value is ``30s``. This setting allows time suffixes ``s`` (seconds), ``m`` (minutes), ``h`` (hours), ``d`` (days), and ``w`` (weeks).
-
-+--------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| **Default value**  | 30s                                                                                                                                                                       |
-+--------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| **Allowed values** | A positive number that must contain a suffix character indicating a time unit, such as ``s`` (seconds), ``m`` (minutes), ``h`` (hours), ``d`` (days), and ``w`` (weeks).  |
-+--------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 run_on_start
 ^^^^^^^^^^^^
@@ -272,10 +244,6 @@ resource\\relationship
 
 This section configures the `relationships` content type from which to obtain logs.
 
-For the ``identityProtection`` resource, the configuration includes the following relationship:
-
--  riskDetections: Retrieves details of user risk, user and application sign-in risk detections from Microsoft Entra ID.
-
 For the ``security`` resource, the configuration includes the following relationships:
 
 - alerts: Legacy alert from supported Azure and Microsoft 365 Defender security providers.
@@ -328,9 +296,5 @@ Example of configuration
         <resource>
           <name>deviceManagement</name>
           <relationship>auditEvents</relationship>
-        </resource>
-        <resource>
-          <name>identityProtection</name>
-          <relationship>riskDetections</relationship>
         </resource>
     </ms-graph>


### PR DESCRIPTION
## Description
This PR reverts changes applied to 4.11 as requested here:
- https://github.com/wazuh/wazuh-documentation/issues/8218#issuecomment-2842358210

## Documentation compilation
- [x] Verified that documentation compiles without warnings.

## Changelog
- [x] Updated `CHANGELOG.md`.

## Code formatting & web optimization
- [x] Added or updated meta descriptions.
- [x] Updated `redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
- [x] Used three-space indentation in `.rst` files.

## Writing style
- [ ] Used **bold** for UI elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Followed present tense, active voice, and a semi-formal tone.
- [ ] Wrote short, clear, and concise sentences.
