### PR TITLE
Update Available SCA List in 4.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - Updated the *Profiles* section in *Configuring AWS credentials*. ([#8426](https://github.com/wazuh/wazuh-documentation/pull/8426)) ([#8429](https://github.com/wazuh/wazuh-documentation/pull/8429))
 - Updated the *Who-data monitoring on Linux* section. ([#8435](https://github.com/wazuh/wazuh-documentation/pull/8435)), ([#8492](https://github.com/wazuh/wazuh-documentation/pull/8492))
 - Updated the *Agents* sub-section in *Deployment on Kubernetes*. ([#8475](https://github.com/wazuh/wazuh-documentation/pull/8475))
+- Updated the available SCA policies table. ([#8500](https://github.com/wazuh/wazuh-documentation/pull/8500))
 
 ## [v4.11.2]
 

--- a/source/user-manual/capabilities/sec-config-assessment/available-sca-policies.rst
+++ b/source/user-manual/capabilities/sec-config-assessment/available-sca-policies.rst
@@ -161,5 +161,5 @@ The table below shows SCA policies pre-installed in Wazuh out-of-the-box. The Wa
     +-----------------------------+------------------------------------------------------------+-------------------------------+
     | cis_postgre-sql-13          |  CIS Checks for PostgreSQL 13                              | PostgreSQL 13                 |
     +-----------------------------+------------------------------------------------------------+-------------------------------+
-    | sca_distro_independent_linux|  CIS Checks for Independent Linux                          | PostgreSQL 13                 |
+    | sca_distro_independent_linux |  CIS Benchmark for Distribution Independent Linux   | Distribution Independent Linux  |
     +-----------------------------+------------------------------------------------------------+-------------------------------+

--- a/source/user-manual/capabilities/sec-config-assessment/available-sca-policies.rst
+++ b/source/user-manual/capabilities/sec-config-assessment/available-sca-policies.rst
@@ -111,8 +111,6 @@ The table below shows SCA policies pre-installed in Wazuh out-of-the-box. The Wa
     +-----------------------------+------------------------------------------------------------+-------------------------------+
     | cis_hpux_bastille           |  CIS Benchmark for HP-UX 11i using Bastille                | HPUX 11i                      |
     +-----------------------------+------------------------------------------------------------+-------------------------------+
-    | sca_unix_audit              |  Benchmark for Linux auditing                              | Unix based OS                 |
-    +-----------------------------+------------------------------------------------------------+-------------------------------+
     | cis_apple_macOS_10.11       |  CIS Apple macOS 10.11 Benchmark                           | macOS 10.11 (El Capitan)      |
     +-----------------------------+------------------------------------------------------------+-------------------------------+
     | cis_apple_macOS_10.12       |  CIS Apple macOS 10.12 Benchmark                           | macOS 10.12 (Sierra)          |
@@ -161,5 +159,5 @@ The table below shows SCA policies pre-installed in Wazuh out-of-the-box. The Wa
     +-----------------------------+------------------------------------------------------------+-------------------------------+
     | cis_postgre-sql-13          |  CIS Checks for PostgreSQL 13                              | PostgreSQL 13                 |
     +-----------------------------+------------------------------------------------------------+-------------------------------+
-    | sca_distro_independent_linux |  CIS Benchmark for Distribution Independent Linux   | Distribution Independent Linux  |
+    | sca_distro_independent_linux|  CIS Benchmark for Distribution Independent Linux          | Distribution Independent Linux|
     +-----------------------------+------------------------------------------------------------+-------------------------------+

--- a/source/user-manual/capabilities/sec-config-assessment/available-sca-policies.rst
+++ b/source/user-manual/capabilities/sec-config-assessment/available-sca-policies.rst
@@ -31,11 +31,15 @@ The table below shows SCA policies pre-installed in Wazuh out-of-the-box. The Wa
     +-----------------------------+------------------------------------------------------------+-------------------------------+
     | cis_win2022                 |  CIS Benchmark for Windows Server 2022                     | Windows Server 2022           |
     +-----------------------------+------------------------------------------------------------+-------------------------------+
+    | cis_win2025                 |  CIS Benchmark for Windows Server 2025                     | Windows Server 2025           |
+    +-----------------------------+------------------------------------------------------------+-------------------------------+
     | sca_win_audit               |  Benchmark for Windows auditing                            | Windows                       |
     +-----------------------------+------------------------------------------------------------+-------------------------------+
     | cis_alma_linux_8            |  CIS Benchmark for Alma Linux 8                            | Alma Linux 8                  |
     +-----------------------------+------------------------------------------------------------+-------------------------------+
     | cis_alma_linux_9            |  CIS Benchmark for Alma Linux 9                            | Alma Linux 9                  |
+    +-----------------------------+------------------------------------------------------------+-------------------------------+
+    | cis_alma_linux_10           |  CIS Benchmark for Alma Linux 10                           | Alma Linux 10                 |
     +-----------------------------+------------------------------------------------------------+-------------------------------+
     | cis_rocky_linux_8           |  CIS Benchmark for Rocky Linux 8                           | Rocky Linux 8                 |
     +-----------------------------+------------------------------------------------------------+-------------------------------+
@@ -49,6 +53,8 @@ The table below shows SCA policies pre-installed in Wazuh out-of-the-box. The Wa
     +-----------------------------+------------------------------------------------------------+-------------------------------+
     | cis_centos8_linux           |  CIS Benchmark for CentOS 8                                | CentOS 8                      |
     +-----------------------------+------------------------------------------------------------+-------------------------------+
+    | cis_centos10_linux          |  CIS Benchmark for CentOS 10                               | CentOS 10                     |
+    +-----------------------------+------------------------------------------------------------+-------------------------------+
     | cis_rhel5_linux             |  CIS Benchmark for Red Hat Enterprise Linux 5              | Red Hat Enterprise Linux 5    |
     +-----------------------------+------------------------------------------------------------+-------------------------------+
     | cis_rhel6_linux             |  CIS Benchmark for Red Hat Enterprise Linux 6              | Red Hat Enterprise Linux 6    |
@@ -58,6 +64,8 @@ The table below shows SCA policies pre-installed in Wazuh out-of-the-box. The Wa
     | cis_rhel8_linux             |  CIS Benchmark for Red Hat Enterprise Linux 8              | Red Hat Enterprise Linux 8    |
     +-----------------------------+------------------------------------------------------------+-------------------------------+
     | cis_rhel9_linux             |  CIS Benchmark for Red Hat Enterprise Linux 9              | Red Hat Enterprise Linux 9    |
+    +-----------------------------+------------------------------------------------------------+-------------------------------+
+    | cis_rhel10_linux            |  CIS Benchmark for Red Hat Enterprise Linux 10             | Red Hat Enterprise Linux 10   |
     +-----------------------------+------------------------------------------------------------+-------------------------------+
     | cis_debian7                 |  CIS Benchmark for Debian/Linux 7                          | Debian 7                      |
     +-----------------------------+------------------------------------------------------------+-------------------------------+
@@ -152,4 +160,6 @@ The table below shows SCA policies pre-installed in Wazuh out-of-the-box. The Wa
     | cis_oracle_database_19c     |  CIS Checks for Oracle Database 19c                        | Oracle Database 19c           |
     +-----------------------------+------------------------------------------------------------+-------------------------------+
     | cis_postgre-sql-13          |  CIS Checks for PostgreSQL 13                              | PostgreSQL 13                 |
+    +-----------------------------+------------------------------------------------------------+-------------------------------+
+    | sca_distro_independent_linux|  CIS Checks for Independent Linux                          | PostgreSQL 13                 |
     +-----------------------------+------------------------------------------------------------+-------------------------------+


### PR DESCRIPTION
The current documentation is missing support details for the following operating systems:

Support new OSs - Windows Server 2025 - Add SCA content	
 - PR - https://github.com/wazuh/wazuh/issues/26732

Create SCA policy for Distribution Independent Linux 	
 - PR - https://github.com/wazuh/wazuh/issues/26837

Preliminary support new OSs - CentOS Stream 10 - Add SCA content	
 - PR - https://github.com/wazuh/wazuh/issues/24495

Preliminary support new OSs - RHEL 10 - Add SCA content	
 - PR - https://github.com/wazuh/wazuh/issues/26934

Support new OSs - AlmaLinux 10 - Add SCA content	
 - PR - https://github.com/wazuh/wazuh/issues/27952


This PR aims to update the list of supported OS documentation to include these platforms.

