### PR TITLE
Add OVA troubleshooting section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Added ARM64 to the central components architecture references. ([#8173](https://github.com/wazuh/wazuh-documentation/pull/8173))
 - Added a note warning that downgrades to 4.11 and earlier versions from 4.12 and later are not possible. ([#8425](https://github.com/wazuh/wazuh-documentation/pull/8425))
 - Added new configuration options to the MS Graph integration documentation. ([#8226](https://github.com/wazuh/wazuh-documentation/pull/8226)) ([#8495](https://github.com/wazuh/wazuh-documentation/pull/8495)) ([#8496](https://github.com/wazuh/wazuh-documentation/pull/8496))
+- **Post-release**: Added troubleshooting steps to the *Virtual Machine (OVA)* installation guide. ([#8562](https://github.com/wazuh/wazuh-documentation/pull/8562))
 
 ### Changed
 

--- a/source/deployment-options/virtual-machine/virtual-machine.rst
+++ b/source/deployment-options/virtual-machine/virtual-machine.rst
@@ -1,15 +1,12 @@
 .. Copyright (C) 2015, Wazuh, Inc.
 
 .. meta::
-  :description: The pre-built Wazuh Virtual Machine includes all Wazuh components ready-to-use. Test all Wazuh capabilities with our OVA.  
-
-.. _virtual_machine:
+   :description: The pre-built Wazuh Virtual Machine includes all Wazuh components ready-to-use. Test all Wazuh capabilities with our OVA.  
 
 Virtual Machine (OVA)
 =====================
 
 Wazuh provides a pre-built virtual machine image in Open Virtual Appliance (OVA) format. This can be directly imported to VirtualBox or other OVA compatible virtualization systems. Take into account that this VM only runs on 64-bit systems with x86_64/AMD64 architecture. It does not provide high availability and scalability out of the box. However, these can be implemented by using :doc:`distributed deployment </installation-guide/index>`.
-
 
 Download the `virtual appliance (OVA) <https://packages.wazuh.com/|WAZUH_CURRENT_MAJOR_OVA|/vm/wazuh-|WAZUH_CURRENT_OVA|.ova>`_, which includes Amazon Linux 2023 and the Wazuh central components.
 
@@ -64,7 +61,7 @@ Import and access the virtual machine
 
 #. Start the machine.
 #. Access the virtual machine using the following user and password. You can use the virtualization platform or access it via SSH.
- 
+
    .. code-block:: none
 
       user: wazuh-user
@@ -103,9 +100,9 @@ All components included in this virtual image are configured to work out-of-the-
   - Wazuh manager: ``/var/ossec/etc/ossec.conf``
 
   - Wazuh indexer: ``/etc/wazuh-indexer/opensearch.yml``
-  
+
   - Filebeat-OSS: ``/etc/filebeat/filebeat.yml``
-  
+
   - Wazuh dashboard: 
 
      - ``/etc/wazuh-dashboard/opensearch_dashboards.yml``
@@ -123,6 +120,38 @@ In case of using VirtualBox, once the virtual machine is imported it may run int
 
 Once the virtual machine is imported and running, the next step is to :doc:`deploy the Wazuh agents </installation-guide/wazuh-agent/index>` on the systems to be monitored.
 
+Troubleshooting
+---------------
+
+VM fails to start on AMD processors with VMware
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Issue**:
+
+-  After importing the Wazuh OVA into VMware Workstation on a host with an AMD processor, the VM fails to start with the error:
+
+   .. code-block:: none
+
+      The CPU has been disabled by the guest operating system. Power off or reset the virtual machine.
+
+**Workaround**:
+
+#. Locate and edit the VM’s ``.vmx`` file after importing the OVA.
+#. Add the following lines to the end of the file to resolve compatibility issues between the VM and AMD processors.
+
+   .. code-block:: ini
+
+      cpuid.0.eax = "0000:0000:0000:0000:0000:0000:0000:1011"
+      cpuid.0.ebx = "0111:0101:0110:1110:0110:0101:0100:0111"
+      cpuid.0.ecx = "0110:1100:0110:0101:0111:0100:0110:1110"
+      cpuid.0.edx = "0100:1001:0110:0101:0110:1110:0110:1001"
+      cpuid.1.eax = "0000:0000:0000:0001:0000:0110:0111:0001"
+      cpuid.1.ebx = "0000:0010:0000:0001:0000:1000:0000:0000"
+      cpuid.1.ecx = "1000:0010:1001:1000:0010:0010:0000:0011"
+      cpuid.1.edx = "0000:0111:1000:1011:1111:1011:1111:1111"
+      featureCompat.enable = "FALSE"
+
+#. Save the file and power on the VM.
 
 Upgrading the VM
 ----------------


### PR DESCRIPTION
## Description
This PR adds a troubleshooting section to the Virtual Machine (OVA) installation guide. It includes steps to solve the "CPU has been disabled by the guest operating system" error message.

## Checks
### Docs building
- [ ] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
