### PR TITLE
Update macOS agent launchctl load and unload commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 - Updated the available SCA policies table. ([#8500](https://github.com/wazuh/wazuh-documentation/pull/8500))
 - **Post-release**: Updated the 4.12.0 release notes highlights text. ([#8510](https://github.com/wazuh/wazuh-documentation/pull/8510))
 - **Post-release**: Changed the *Packages list* title to *Open Virtual Appliances* in the *Virtual Machine (OVA)* section. ([#8514](https://github.com/wazuh/wazuh-documentation/pull/8514))
+- **Post-release**: Updated the launchctl `unload` and `load` commands with `launchctl bootout system` and `launchctl bootstrap system`. ([#8591](https://github.com/wazuh/wazuh-documentation/pull/8591))
 
 ### Fixed
 

--- a/source/installation-guide/uninstalling-wazuh/agent.rst
+++ b/source/installation-guide/uninstalling-wazuh/agent.rst
@@ -73,7 +73,7 @@ Follow these steps to uninstall the Wazuh agent from your macOS endpoint.
 
     .. code-block:: console
 
-      # launchctl unload /Library/LaunchDaemons/com.wazuh.agent.plist
+      # launchctl bootout system /Library/LaunchDaemons/com.wazuh.agent.plist
 
 #. Remove the ``/Library/Ossec/`` folder.
 

--- a/source/installation-guide/wazuh-agent/wazuh-agent-package-macos.rst
+++ b/source/installation-guide/wazuh-agent/wazuh-agent-package-macos.rst
@@ -50,7 +50,7 @@ The agent runs on the endpoint you want to monitor and communicates with the Waz
 
             .. code-block:: console
 
-               # launchctl load /Library/LaunchDaemons/com.wazuh.agent.plist
+               # launchctl bootstrap system /Library/LaunchDaemons/com.wazuh.agent.plist
 
 
          The installation process is now complete, and the Wazuh agent is successfully deployed and running on your macOS endpoint.
@@ -69,7 +69,7 @@ The agent runs on the endpoint you want to monitor and communicates with the Waz
 
             .. code-block:: console
 
-               # launchctl load /Library/LaunchDaemons/com.wazuh.agent.plist
+               # launchctl bootstrap system /Library/LaunchDaemons/com.wazuh.agent.plist
 
          The installation process is now complete, and the Wazuh agent is successfully installed on your macOS endpoint. The next step is to register and configure the agent to communicate with the Wazuh server. To perform this action, see the :doc:`Wazuh agent enrollment </user-manual/agent/agent-enrollment/index>` section.  
 

--- a/source/migration-guide/restoring/wazuh-agent.rst
+++ b/source/migration-guide/restoring/wazuh-agent.rst
@@ -178,7 +178,7 @@ Perform the steps below to restore Wazuh agent files on a macOS endpoint.
 
    .. code-block:: console
 
-      # launchctl unload /Library/LaunchDaemons/com.wazuh.agent.plist
+      # launchctl bootout system /Library/LaunchDaemons/com.wazuh.agent.plist
 
 #. Restore Wazuh agent data, certificates, and configuration files:
 
@@ -204,7 +204,7 @@ Perform the steps below to restore Wazuh agent files on a macOS endpoint.
 
    .. code-block:: console
 
-      # launchctl load /Library/LaunchDaemons/com.wazuh.agent.plist
+      # launchctl bootstrap system /Library/LaunchDaemons/com.wazuh.agent.plist
 
 Verifying data restoration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Description
This PR replaces the `launchctl unload` and `launchctl load` commands with `launchctl bootout system` and `launchctl bootstrap system`.

## Documentation compilation
- [x] Verified that documentation compiles without warnings.

## Changelog
- [x] Updated `CHANGELOG.md`.

## Code formatting & web optimization
- [x] Added or updated meta descriptions.
- [x] Updated `redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
- [ ] Used three-space indentation in `.rst` files.

## Writing style
- [x] Used **bold** for UI elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Followed present tense, active voice, and a semi-formal tone.
- [x] Wrote short, clear, and concise sentences.
