### PR TITLE
Update Available SCA policies section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Added the *Wazuh indexer configuration on hardened endpoints* section. ([#8437](https://github.com/wazuh/wazuh-documentation/pull/8437))
+- Added the CentOS Stream 9 SCA policy reference to the Available SCA policies section. ([#8602](https://github.com/wazuh/wazuh-documentation/pull/8602))
+
+### Changed
+
+- Updated the Available SCA policies section. ([#8602](https://github.com/wazuh/wazuh-documentation/pull/8602))
 
 ## [v4.12.0]
 

--- a/source/user-manual/capabilities/sec-config-assessment/available-sca-policies.rst
+++ b/source/user-manual/capabilities/sec-config-assessment/available-sca-policies.rst
@@ -52,6 +52,7 @@ The table below shows SCA policies pre-installed in Wazuh out-of-the-box. The Wa
     | cis_centos7_linux           |  CIS Benchmark for CentOS Linux 7                          | CentOS Linux 7                |
     +-----------------------------+------------------------------------------------------------+-------------------------------+
     | cis_centos8_linux           |  CIS Benchmark for CentOS Linux 8                          | CentOS Linux 8                |
+    |                             |                                                            +-------------------------------+
     |                             |                                                            | CentOS Stream 8               |
     +-----------------------------+------------------------------------------------------------+-------------------------------+
     | cis_centos9_linux           |  CIS Benchmark for CentOS Stream 9                         | CentOS Stream 9               |

--- a/source/user-manual/capabilities/sec-config-assessment/available-sca-policies.rst
+++ b/source/user-manual/capabilities/sec-config-assessment/available-sca-policies.rst
@@ -15,7 +15,7 @@ The table below shows SCA policies pre-installed in Wazuh out-of-the-box. The Wa
     :name: available_sca_policies
 
     +-----------------------------+------------------------------------------------------------+-------------------------------+
-    | Policy                      | Name                                                       | Target                        |
+    | Reference                   | Policy                                                     | Target                        |
     +=============================+============================================================+===============================+
     | cis_win10_enterprise        |  CIS Benchmark for Windows 10 Enterprise                   | Windows 10                    |
     +-----------------------------+------------------------------------------------------------+-------------------------------+
@@ -47,13 +47,16 @@ The table below shows SCA policies pre-installed in Wazuh out-of-the-box. The Wa
     +-----------------------------+------------------------------------------------------------+-------------------------------+
     | cis_oracle_linux_9          |  CIS Benchmark for Oracle Linux 9                          | Oracle Linux 9                |
     +-----------------------------+------------------------------------------------------------+-------------------------------+
-    | cis_centos6_linux           |  CIS Benchmark for CentOS 6                                | CentOS 6                      |
+    | cis_centos6_linux           |  CIS Benchmark for CentOS Linux 6                          | CentOS Linux 6                |
     +-----------------------------+------------------------------------------------------------+-------------------------------+
-    | cis_centos7_linux           |  CIS Benchmark for CentOS 7                                | CentOS 7                      |
+    | cis_centos7_linux           |  CIS Benchmark for CentOS Linux 7                          | CentOS Linux 7                |
     +-----------------------------+------------------------------------------------------------+-------------------------------+
-    | cis_centos8_linux           |  CIS Benchmark for CentOS 8                                | CentOS 8                      |
+    | cis_centos8_linux           |  CIS Benchmark for CentOS Linux 8                          | CentOS Linux 8                |
+    |                             |                                                            | CentOS Stream 8               |
     +-----------------------------+------------------------------------------------------------+-------------------------------+
-    | cis_centos10_linux          |  CIS Benchmark for CentOS 10                               | CentOS 10                     |
+    | cis_centos9_linux           |  CIS Benchmark for CentOS Stream 9                         | CentOS Stream 9               |
+    +-----------------------------+------------------------------------------------------------+-------------------------------+
+    | cis_centos10_linux          |  CIS Benchmark for CentOS Stream 10                        | CentOS Stream 10              |
     +-----------------------------+------------------------------------------------------------+-------------------------------+
     | cis_rhel5_linux             |  CIS Benchmark for Red Hat Enterprise Linux 5              | Red Hat Enterprise Linux 5    |
     +-----------------------------+------------------------------------------------------------+-------------------------------+


### PR DESCRIPTION
## Description
This PR does the following in the Available SCA policies table:
- Updates the table header row since "Name" column is not exactly the `name` field in the policy YAML files.
- Updates CentOS naming references defining whether it's a CentOS Linux or a CentOS Stream release.
- Includes the table entry for the CentOS Stream 9 SCA policy coming out with 4.12.1.

## Documentation compilation
- [ ] Verified that documentation compiles without warnings.

## Changelog
- [ ] Updated `CHANGELOG.md`.

## Code formatting & web optimization
- [ ] Added or updated meta descriptions.
- [ ] Updated `redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
- [ ] Used three-space indentation in `.rst` files.

## Writing style
- [ ] Used **bold** for UI elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Followed present tense, active voice, and a semi-formal tone.
- [ ] Wrote short, clear, and concise sentences.
