### PR TITLE
Fix broken Alienvault IP address reputation database link

### DIFF
--- a/source/proof-of-concept-guide/block-malicious-actor-ip-reputation.rst
+++ b/source/proof-of-concept-guide/block-malicious-actor-ip-reputation.rst
@@ -139,7 +139,7 @@ Download the utilities and configure the CDB list
 
    .. code-block:: console
 
-      $ sudo wget https://raw.githubusercontent.com/firehol/blocklist-ipsets/master/alienvault_reputation.ipset -O /var/ossec/etc/lists/alienvault_reputation.ipset
+      $ sudo wget https://iplists.firehol.org/files/alienvault_reputation.ipset -O /var/ossec/etc/lists/alienvault_reputation.ipset
 
 #. Append the IP address of the attacker endpoint to the IP reputation database. Replace ``<ATTACKER_IP>`` with the RHEL IP address in the command below:
 


### PR DESCRIPTION
## Description
This PR updates the broken `alienvault_reputation.ipset` link.

## Documentation compilation
- [ ] Verified that documentation compiles without warnings.

## Changelog
- [ ] Updated `CHANGELOG.md`.

## Code formatting & web optimization
- [ ] Added or updated meta descriptions.
- [ ] Updated `redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
- [ ] Used three-space indentation in `.rst` files.

## Writing style
- [ ] Used **bold** for UI elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Followed present tense, active voice, and a semi-formal tone.
- [ ] Wrote short, clear, and concise sentences.
