### PR TITLE
Remove us-gov-* AWS regions references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@ All notable changes to this project will be documented in this file.
 - **Post-release**: Fixed incorrect URL and filepaths in the YARA download steps of the *Leveraging LLMs for Alert Enrichment* PoC. ([#8686](https://github.com/wazuh/wazuh-documentation/pull/8686))
 - **Post-release**: Corrected inaccurate references to the Wazuh Syscollector module. ([#8713](https://github.com/wazuh/wazuh-documentation/pull/8713))
 
+### Removed
+
+- **Post-release**: Removed `us-gov-*` AWS regions references. ([#8791](https://github.com/wazuh/wazuh-documentation/pull/8791))
+
 ## [v4.11.2]
 
 ### Added

--- a/source/cloud-security/amazon/services/prerequisites/considerations.rst
+++ b/source/cloud-security/amazon/services/prerequisites/considerations.rst
@@ -23,7 +23,7 @@ If the S3 bucket contains a long history of logs and its directory structure is 
 
 -  ``only_logs_after``: Allows filtering logs produced after a given date. The date format must be ``YYYY-MMM-DD``. For example, ``2018-AUG-21`` would filter logs generated on or after the 21st of August 2018.
 -  ``aws_account_id``: This option will only work on CloudTrail, VPC, and Config buckets. If you have logs from multiple accounts, you can filter which ones will be read by Wazuh. You can specify multiple IDs separating them by commas.
--  ``regions``: This option will only work on CloudTrail, VPC, Config buckets, and Inspector service. If you have logs from multiple regions, you can filter which ones will be read by Wazuh. You can specify multiple regions separating them by commas. It is mandatory to specify the region when configuring an S3 bucket from an AWS GovCloud region (available GovCloud regions are ``us-gov-east-1`` and ``us-gov-west-1``).
+-  ``regions``: Works only with CloudTrail, VPC, Config buckets, and Inspector service. Use it to filter which regions Wazuh reads when you have logs from multiple regions. Separate multiple regions with commas.
 -  ``path``: If your logs are stored in a given path in an S3 bucket, this option can be specified. For example, to read logs stored in the directory ``vpclogs/``, it is necessary to specify the path ``vpclogs`` in the Wazuh module for AWS configuration. It can also be specified with ``/`` or ``\``.
 -  ``aws_organization_id``: This option will only work on CloudTrail buckets. If you have configured an organization, you need to specify the name of the AWS organization by using this parameter.
 
@@ -243,22 +243,6 @@ Below is an example of different AWS services configuration:
      <bucket type="cloudtrail">
        <name><WAZUH_CLOUDTRAIL></name>
        <aws_profile>default</aws_profile>
-     </bucket>
-
-     <!-- CloudTrail, 'gov1' profile, and 'us-gov-east-1' GovCloud region -->
-     <bucket type="cloudtrail">
-       <name><WAZUH_AWS_BUCKET></name>
-       <path>cloudtrail-govcloud</path>
-       <regions>us-gov-east-1</regions>
-       <aws_profile>gov1</aws_profile>
-     </bucket>
-
-     <!-- CloudTrail, 'gov2' profile, and 'us-gov-west-1' GovCloud region -->
-     <bucket type="cloudtrail">
-       <name><WAZUH_AWS_BUCKET></name>
-       <path>cloudtrail-govcloud</path>
-       <regions>us-gov-west-1</regions>
-       <aws_profile>gov2</aws_profile>
      </bucket>
 
    </wodle>

--- a/source/cloud-security/amazon/services/prerequisites/considerations.rst
+++ b/source/cloud-security/amazon/services/prerequisites/considerations.rst
@@ -245,6 +245,14 @@ Below is an example of different AWS services configuration:
        <aws_profile>default</aws_profile>
      </bucket>
 
+     <!-- CloudTrail, 'dev' profile, and 'us-east-1' region -->
+     <bucket type="cloudtrail">
+       <name><WAZUH_AWS_BUCKET></name>
+       <path>dev-cloudtrail</path>
+       <regions>us-east-1</regions>
+       <aws_profile>dev</aws_profile>
+     </bucket>
+
    </wodle>
 
 Where:


### PR DESCRIPTION
## Description
This PR removes `us-gov-*` regions references.

## Documentation compilation
- [ ] Verified that documentation compiles without warnings.

## Changelog
- [ ] Updated `CHANGELOG.md`.

## Code formatting & web optimization
- [ ] Added or updated meta descriptions.
- [ ] Updated `redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
- [ ] Used three-space indentation in `.rst` files.

## Writing style
- [ ] Used **bold** for UI elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Followed present tense, active voice, and a semi-formal tone.
- [ ] Wrote short, clear, and concise sentences.
