### PR TITLE
Add new FIM and Inventory settings for states persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Added documentation for the reporting plugin in the Wazuh dashboard package generation guide. ([#8682](https://github.com/wazuh/wazuh-documentation/pull/8682))
+- Added references for FIM (Syscheck) and inventory (Syscollector) state persistence settings. ([#8801](https://github.com/wazuh/wazuh-documentation/pull/8801))
 
 ### Changed
 

--- a/source/deployment-options/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-agent-class.rst
+++ b/source/deployment-options/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-agent-class.rst
@@ -649,9 +649,16 @@ $ossec_syscheck_process_priority
   `Type String`
 
 $ossec_syscheck_max_eps
-  Sets the maximum event reporting throughput. Events are messages that will produce an alert.
+  Sets the maximum throughput for reporting events. Events are messages that trigger alerts.
 
   `Default 50`
+
+  `Type String`
+
+$ossec_syscheck_notify_first_scan
+  Specifies whether the first Syscheck (FIM) scan reports stateless events.
+
+  `Default no`
 
   `Type String`
 
@@ -670,7 +677,7 @@ $ossec_syscheck_synchronization_interval
   `Type String`
 
 $ossec_syscheck_synchronization_response_timeout
-  Waiting time in seconds since a sync message is sent or received for the next synchronization activity.
+  Waiting time in seconds between a sync message and the next synchronization.
 
   `Default 30`
 
@@ -680,13 +687,6 @@ $ossec_syscheck_synchronization_max_eps
   Sets the maximum synchronization message throughput.
 
   `Default 10`
-
-  `Type String`
-
-$ossec_syscheck_notify_first_scan
-  Specifies if the first syscheck (FIM) scan reports stateless events or not.
-
-  `Default no`
 
   `Type String`
 
@@ -813,44 +813,44 @@ $wodle_syscollector_processes
   `Type String`
 
 $wodle_syscollector_max_eps
-  Sets the maximum event reporting throughput. Events are messages that will produce an alert.
+  Sets the maximum throughput for reporting events. Events are messages that trigger alerts.
 
   `Default 50`
 
   `Type String`
 
+$wodle_syscollector_notify_first_scan
+  Specifies whether the first scan reports stateless events.
+
+  `Default no`
+
+  `Type String`
+
 $wodle_syscollector_synchronization_enabled
-  Specifies performing periodic inventory synchronizations.
+  Specifies whether to perform periodic inventory synchronizations.
 
   `Default yes`
 
   `Type String`
 
 $wodle_syscollector_synchronization_interval
-  Specifies the initial time interval between every inventory synchronization.
+  Specifies the initial interval between inventory synchronizations.
 
   `Default 5m`
 
   `Type String`
 
 $wodle_syscollector_synchronization_response_timeout
-  Waiting time in seconds since a sync message is sent or received for the next synchronization activity.
+  Waiting time in seconds between a sync message and the next synchronization.
 
   `Default 30`
 
   `Type String`
 
 $wodle_syscollector_synchronization_max_eps
-  Sets the maximum synchronization message throughput.
+  Sets the maximum throughput for synchronization messages.
 
   `Default 10`
-
-  `Type String`
-
-$wodle_syscollector_notify_first_scan
-  Specifies if the first scan reports stateless events or not.
-
-  `Default no`
 
   `Type String`
 

--- a/source/deployment-options/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-agent-class.rst
+++ b/source/deployment-options/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-agent-class.rst
@@ -648,6 +648,13 @@ $ossec_syscheck_process_priority
 
   `Type String`
 
+$ossec_syscheck_max_eps
+  Sets the maximum event reporting throughput. Events are messages that will produce an alert.
+
+  `Default 50`
+
+  `Type String`
+
 $ossec_syscheck_synchronization_enabled
   Specifies whether there will be periodic inventory synchronizations or not.
 
@@ -662,6 +669,13 @@ $ossec_syscheck_synchronization_interval
 
   `Type String`
 
+$ossec_syscheck_synchronization_response_timeout
+  Waiting time in seconds since a sync message is sent or received for the next synchronization activity.
+
+  `Default 30`
+
+  `Type String`
+
 $ossec_syscheck_synchronization_max_eps
   Sets the maximum synchronization message throughput.
 
@@ -669,10 +683,10 @@ $ossec_syscheck_synchronization_max_eps
 
   `Type String`
 
-$ossec_syscheck_synchronization_max_interval
-  Specifies the maximum number of seconds between every inventory synchronization.
+$ossec_syscheck_notify_first_scan
+  Specifies if the first syscheck (FIM) scan reports stateless events or not.
 
-  `Default 1h`
+  `Default no`
 
   `Type String`
 
@@ -795,6 +809,48 @@ $wodle_syscollector_processes
   Enables the scan of the processes.
 
   `Default yes`
+
+  `Type String`
+
+$wodle_syscollector_max_eps
+  Sets the maximum event reporting throughput. Events are messages that will produce an alert.
+
+  `Default 50`
+
+  `Type String`
+
+$wodle_syscollector_synchronization_enabled
+  Specifies performing periodic inventory synchronizations.
+
+  `Default yes`
+
+  `Type String`
+
+$wodle_syscollector_synchronization_interval
+  Specifies the initial time interval between every inventory synchronization.
+
+  `Default 5m`
+
+  `Type String`
+
+$wodle_syscollector_synchronization_response_timeout
+  Waiting time in seconds since a sync message is sent or received for the next synchronization activity.
+
+  `Default 30`
+
+  `Type String`
+
+$wodle_syscollector_synchronization_max_eps
+  Sets the maximum synchronization message throughput.
+
+  `Default 10`
+
+  `Type String`
+
+$wodle_syscollector_notify_first_scan
+  Specifies if the first scan reports stateless events or not.
+
+  `Default no`
 
   `Type String`
 

--- a/source/deployment-options/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-manager-class.rst
+++ b/source/deployment-options/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-manager-class.rst
@@ -550,6 +550,13 @@ $ossec_syscheck_synchronization_interval
 
   `Type String`
 
+$ossec_syscheck_synchronization_response_timeout
+  Waiting time in seconds since a sync message is sent or received for the next synchronization activity.
+
+  `Default 30`
+
+  `Type String`
+
 $ossec_syscheck_synchronization_max_eps
   Sets the maximum synchronization message throughput.
 
@@ -557,10 +564,10 @@ $ossec_syscheck_synchronization_max_eps
 
   `Type String`
 
-$ossec_syscheck_synchronization_max_interval
-  Specifies the maximum number of seconds between every inventory synchronization.
+$ossec_syscheck_notify_first_scan
+  Specifies if the first syscheck (FIM) scan reports stateless events or not.
 
-  `Default 1h`
+  `Default no`
 
   `Type String`
 
@@ -998,6 +1005,48 @@ $wodle_syscollector_processes
   Enables the scan of the processes.
 
   `Default yes`
+
+  `Type String`
+
+$wodle_syscollector_max_eps
+  Sets the maximum event reporting throughput. Events are messages that will produce an alert.
+
+  `Default 50`
+
+  `Type String`
+
+$wodle_syscollector_synchronization_enabled
+  Specifies performing periodic inventory synchronizations.
+
+  `Default yes`
+
+  `Type String`
+
+$wodle_syscollector_synchronization_interval
+  Specifies the initial time interval between every inventory synchronization.
+
+  `Default 5m`
+
+  `Type String`
+
+$wodle_syscollector_synchronization_response_timeout
+  Waiting time in seconds since a sync message is sent or received for the next synchronization activity.
+
+  `Default 30`
+
+  `Type String`
+
+$wodle_syscollector_synchronization_max_eps
+  Sets the maximum synchronization message throughput.
+
+  `Default 10`
+
+  `Type String`
+
+$wodle_syscollector_notify_first_scan
+  Specifies if the first scan reports stateless events or not.
+
+  `Default no`
 
   `Type String`
 

--- a/source/deployment-options/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-manager-class.rst
+++ b/source/deployment-options/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-manager-class.rst
@@ -536,6 +536,13 @@ $ossec_syscheck_process_priority
 
   `Type String`
 
+$ossec_syscheck_notify_first_scan
+  Specifies whether the first Syscheck (FIM) scan reports stateless events.
+
+  `Default no`
+
+  `Type String`
+
 $ossec_syscheck_synchronization_enabled
   Specifies whether there will be periodic inventory synchronizations or not.
 
@@ -551,7 +558,7 @@ $ossec_syscheck_synchronization_interval
   `Type String`
 
 $ossec_syscheck_synchronization_response_timeout
-  Waiting time in seconds since a sync message is sent or received for the next synchronization activity.
+  Waiting time in seconds between a sync message and the next synchronization.
 
   `Default 30`
 
@@ -561,13 +568,6 @@ $ossec_syscheck_synchronization_max_eps
   Sets the maximum synchronization message throughput.
 
   `Default 10`
-
-  `Type String`
-
-$ossec_syscheck_notify_first_scan
-  Specifies if the first syscheck (FIM) scan reports stateless events or not.
-
-  `Default no`
 
   `Type String`
 
@@ -1009,47 +1009,46 @@ $wodle_syscollector_processes
   `Type String`
 
 $wodle_syscollector_max_eps
-  Sets the maximum event reporting throughput. Events are messages that will produce an alert.
+  Sets the maximum throughput for reporting events. Events are messages that trigger alerts.
 
   `Default 50`
 
   `Type String`
 
+$wodle_syscollector_notify_first_scan
+  Specifies whether the first scan reports stateless events.
+
+  `Default no`
+
+  `Type String`
+
 $wodle_syscollector_synchronization_enabled
-  Specifies performing periodic inventory synchronizations.
+  Specifies whether to perform periodic inventory synchronizations.
 
   `Default yes`
 
   `Type String`
 
 $wodle_syscollector_synchronization_interval
-  Specifies the initial time interval between every inventory synchronization.
+  Specifies the initial interval between inventory synchronizations.
 
   `Default 5m`
 
   `Type String`
 
 $wodle_syscollector_synchronization_response_timeout
-  Waiting time in seconds since a sync message is sent or received for the next synchronization activity.
+  Waiting time in seconds between a sync message and the next synchronization.
 
   `Default 30`
 
   `Type String`
 
 $wodle_syscollector_synchronization_max_eps
-  Sets the maximum synchronization message throughput.
+  Sets the maximum throughput for synchronization messages.
 
   `Default 10`
 
   `Type String`
-
-$wodle_syscollector_notify_first_scan
-  Specifies if the first scan reports stateless events or not.
-
-  `Default no`
-
-  `Type String`
-
 
 .. _ref_server_vars_misc:
 

--- a/source/user-manual/reference/ossec-conf/syscheck.rst
+++ b/source/user-manual/reference/ossec-conf/syscheck.rst
@@ -29,6 +29,7 @@ Configuration options for file integrity monitoring:
 - `ignore`_
 - `max_eps`_
 - `max_files_per_second`_
+- `notify_first_scan`_
 - `prefilter_cmd`_
 - `process_priority`_
 - `registry_ignore`_
@@ -762,6 +763,25 @@ Sets the maximum synchronization message throughput.
 +--------------------+---------------------------------------------------------+
 | **Allowed values** | Integer number between 0 and 1000000. 0 means disabled. |
 +--------------------+---------------------------------------------------------+
+
+.. _reference_ossec_syscheck_notify_first_scan:
+
+notify_first_scan
+------------------
+
+Specifies if the first scan reports stateless events or not.
+
++--------------------+----------+
+| **Default value**  | no       |
++--------------------+----------+
+| **Allowed values** | yes, no  |
++--------------------+----------+
+
+Example:
+
+.. code-block:: xml
+
+ <notify_first_scan>no</notify_first_scan>
 
 .. _reference_ossec_syscheck_diff:
 

--- a/source/user-manual/reference/ossec-conf/syscheck.rst
+++ b/source/user-manual/reference/ossec-conf/syscheck.rst
@@ -405,6 +405,25 @@ Example:
  <max_files_per_second>100</max_files_per_second>
 
 
+.. _reference_ossec_syscheck_notify_first_scan:
+
+notify_first_scan
+------------------
+
+Specifies whether the first scan reports stateless events.
+
++--------------------+----------+
+| **Default value**  | no       |
++--------------------+----------+
+| **Allowed values** | yes, no  |
++--------------------+----------+
+
+Example:
+
+.. code-block:: xml
+
+   <notify_first_scan>no</notify_first_scan>
+
 .. _reference_ossec_syscheck_prefilter_cmd:
 
 prefilter_cmd
@@ -763,25 +782,6 @@ Sets the maximum synchronization message throughput.
 +--------------------+---------------------------------------------------------+
 | **Allowed values** | Integer number between 0 and 1000000. 0 means disabled. |
 +--------------------+---------------------------------------------------------+
-
-.. _reference_ossec_syscheck_notify_first_scan:
-
-notify_first_scan
-------------------
-
-Specifies if the first scan reports stateless events or not.
-
-+--------------------+----------+
-| **Default value**  | no       |
-+--------------------+----------+
-| **Allowed values** | yes, no  |
-+--------------------+----------+
-
-Example:
-
-.. code-block:: xml
-
- <notify_first_scan>no</notify_first_scan>
 
 .. _reference_ossec_syscheck_diff:
 

--- a/source/user-manual/reference/ossec-conf/wodle-syscollector.rst
+++ b/source/user-manual/reference/ossec-conf/wodle-syscollector.rst
@@ -20,49 +20,38 @@ Configuration options of the Syscollector wodle for :ref:`system inventory <syst
 Options
 -------
 
-- `disabled`_
-- `wodle_syscollector_interval`_
-- `scan_on_start`_
-- `hardware`_
-- `os`_
-- `network`_
-- `packages`_
-- `ports`_
-- `hotfixes`_
-- `wodle_syscollector_max_eps`_
-- `notify_first_scan`_
-- `synchronization`_
+.. contents::
+   :local:
+   :depth: 2
+   :backlinks: none
 
-
-+----------------------------------+-----------------------------+
-| Options                          | Allowed values              |
-+==================================+=============================+
-| `disabled`_                      | yes, no                     |
-+----------------------------------+-----------------------------+
-| `wodle_syscollector_interval`_   | A positive number (seconds) |
-+----------------------------------+-----------------------------+
-| `scan_on_start`_                 | yes, no                     |
-+----------------------------------+-----------------------------+
-| `hardware`_                      | yes, no                     |
-+----------------------------------+-----------------------------+
-| `os`_                            | yes, no                     |
-+----------------------------------+-----------------------------+
-| `network`_                       | yes, no                     |
-+----------------------------------+-----------------------------+
-| `packages`_                      | yes, no                     |
-+----------------------------------+-----------------------------+
-| `ports`_                         | yes, no                     |
-+----------------------------------+-----------------------------+
-| `processes`_                     | yes, no                     |
-+----------------------------------+-----------------------------+
-| `hotfixes`_                      | yes, no                     |
-+----------------------------------+-----------------------------+
-| `wodle_syscollector_max_eps`_    | Integer (0-1000000)         |
-+----------------------------------+-----------------------------+
-| `notify_first_scan`_             | yes, no                     |
-+----------------------------------+-----------------------------+
-
-
++-------------------------------------------------+-----------------------------+
+| Options                                         | Allowed values              |
++=================================================+=============================+
+| `disabled`_                                     | yes, no                     |
++-------------------------------------------------+-----------------------------+
+| :ref:`interval <wodle_syscollector_interval>`   | A positive number (seconds) |
++-------------------------------------------------+-----------------------------+
+| `scan_on_start`_                                | yes, no                     |
++-------------------------------------------------+-----------------------------+
+| `hardware`_                                     | yes, no                     |
++-------------------------------------------------+-----------------------------+
+| `os`_                                           | yes, no                     |
++-------------------------------------------------+-----------------------------+
+| `network`_                                      | yes, no                     |
++-------------------------------------------------+-----------------------------+
+| `packages`_                                     | yes, no                     |
++-------------------------------------------------+-----------------------------+
+| `ports`_                                        | yes, no                     |
++-------------------------------------------------+-----------------------------+
+| `processes`_                                    | yes, no                     |
++-------------------------------------------------+-----------------------------+
+| `hotfixes`_                                     | yes, no                     |
++-------------------------------------------------+-----------------------------+
+| :ref:`max_eps <wodle_syscollector_max_eps>`     | Integer (0-1000000)         |
++-------------------------------------------------+-----------------------------+
+| `notify_first_scan`_                            | yes, no                     |
++-------------------------------------------------+-----------------------------+
 
 disabled
 ^^^^^^^^
@@ -196,7 +185,7 @@ Enables the hotfixes scan. It reports the Windows updates installed.
 max_eps
 ^^^^^^^
 
-Sets the maximum event reporting throughput. Events are messages that will produce an alert.
+Sets the maximum throughput for reporting events. Events are messages that trigger alerts.
 
 +--------------------+---------------------------------------------------------+
 | **Default value**  | 50                                                      |
@@ -208,12 +197,12 @@ Example:
 
 .. code-block:: xml
 
- <max_eps>50</max_eps>
+   <max_eps>50</max_eps>
 
 notify_first_scan
 ^^^^^^^^^^^^^^^^^
 
-Specifies if the first scan reports stateless events or not.
+Specifies whether the first scan reports stateless events.
 
 +--------------------+----------+
 | **Default value**  | no       |
@@ -225,7 +214,7 @@ Example:
 
 .. code-block:: xml
 
- <notify_first_scan>no</notify_first_scan>
+   <notify_first_scan>no</notify_first_scan>
 
 synchronization
 ^^^^^^^^^^^^^^^
@@ -246,22 +235,22 @@ The database synchronization settings are configured inside this tag.
 .. _wodle_syscollector_synchronization_enabled:
 
 enabled
-^^^^^^^
+~~~~~~~
 
-Specifies performing periodic inventory synchronizations.
+Specifies whether to perform periodic inventory synchronizations.
 
-+--------------------+---------------------------------------+
-| **Default value**  | yes                                   |
-+--------------------+---------------------------------------+
-| **Allowed values** | yes/no                                |
-+--------------------+---------------------------------------+
++--------------------+--------------+
+| **Default value**  | yes          |
++--------------------+--------------+
+| **Allowed values** | yes, no      |
++--------------------+--------------+
 
 .. _wodle_syscollector_synchronization_interval:
 
 interval
-^^^^^^^^
+~~~~~~~~
 
-Specifies the initial time interval between every inventory synchronization.
+Specifies the initial interval between inventory synchronizations.
 
 +--------------------+-----------------------------------------------------------------------+
 | **Default value**  | 5 m                                                                   |
@@ -272,9 +261,9 @@ Specifies the initial time interval between every inventory synchronization.
 .. _wodle_syscollector_synchronization_response_timeout:
 
 response_timeout
-^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~
 
-Waiting time in seconds since a sync message is sent or received for the next synchronization activity.
+Waiting time in seconds between a sync message and the next synchronization.
 
 +--------------------+----------------------------------------------------------------------+
 | **Default value**  | 30                                                                   |
@@ -285,9 +274,9 @@ Waiting time in seconds since a sync message is sent or received for the next sy
 .. _wodle_syscollector_synchronization_max_eps:
 
 max_eps
-^^^^^^^
+~~~~~~~
 
-Sets the maximum synchronization message throughput.
+Sets the maximum throughput for synchronization messages.
 
 +--------------------+--------------------------------------------------------------+
 | **Default value**  | 10                                                           |

--- a/source/user-manual/reference/ossec-conf/wodle-syscollector.rst
+++ b/source/user-manual/reference/ossec-conf/wodle-syscollector.rst
@@ -21,7 +21,7 @@ Options
 -------
 
 - `disabled`_
-- `interval`_
+- `wodle_syscollector_interval`_
 - `scan_on_start`_
 - `hardware`_
 - `os`_
@@ -29,32 +29,38 @@ Options
 - `packages`_
 - `ports`_
 - `hotfixes`_
+- `wodle_syscollector_max_eps`_
+- `notify_first_scan`_
 - `synchronization`_
 
 
-+----------------------+-----------------------------+
-| Options              | Allowed values              |
-+======================+=============================+
-| `disabled`_          | yes, no                     |
-+----------------------+-----------------------------+
-| `interval`_          | A positive number (seconds) |
-+----------------------+-----------------------------+
-| `scan_on_start`_     | yes, no                     |
-+----------------------+-----------------------------+
-| `hardware`_          | yes, no                     |
-+----------------------+-----------------------------+
-| `os`_                | yes, no                     |
-+----------------------+-----------------------------+
-| `network`_           | yes, no                     |
-+----------------------+-----------------------------+
-| `packages`_          | yes, no                     |
-+----------------------+-----------------------------+
-| `ports`_             | yes, no                     |
-+----------------------+-----------------------------+
-| `processes`_         | yes, no                     |
-+----------------------+-----------------------------+
-| `hotfixes`_          | yes, no                     |
-+----------------------+-----------------------------+
++----------------------------------+-----------------------------+
+| Options                          | Allowed values              |
++==================================+=============================+
+| `disabled`_                      | yes, no                     |
++----------------------------------+-----------------------------+
+| `wodle_syscollector_interval`_   | A positive number (seconds) |
++----------------------------------+-----------------------------+
+| `scan_on_start`_                 | yes, no                     |
++----------------------------------+-----------------------------+
+| `hardware`_                      | yes, no                     |
++----------------------------------+-----------------------------+
+| `os`_                            | yes, no                     |
++----------------------------------+-----------------------------+
+| `network`_                       | yes, no                     |
++----------------------------------+-----------------------------+
+| `packages`_                      | yes, no                     |
++----------------------------------+-----------------------------+
+| `ports`_                         | yes, no                     |
++----------------------------------+-----------------------------+
+| `processes`_                     | yes, no                     |
++----------------------------------+-----------------------------+
+| `hotfixes`_                      | yes, no                     |
++----------------------------------+-----------------------------+
+| `wodle_syscollector_max_eps`_    | Integer (0-1000000)         |
++----------------------------------+-----------------------------+
+| `notify_first_scan`_             | yes, no                     |
++----------------------------------+-----------------------------+
 
 
 
@@ -69,7 +75,7 @@ Disable the Syscollector wodle.
 | **Allowed values** | yes, no                     |
 +--------------------+-----------------------------+
 
-.. _syscollector_interval:
+.. _wodle_syscollector_interval:
 
 interval
 ^^^^^^^^
@@ -185,6 +191,42 @@ Enables the hotfixes scan. It reports the Windows updates installed.
   This option is enabled by default but not included in the initial configuration.
 
 
+.. _wodle_syscollector_max_eps:
+
+max_eps
+^^^^^^^
+
+Sets the maximum event reporting throughput. Events are messages that will produce an alert.
+
++--------------------+---------------------------------------------------------+
+| **Default value**  | 50                                                      |
++--------------------+---------------------------------------------------------+
+| **Allowed values** | Integer number between 0 and 1000000. 0 means disabled. |
++--------------------+---------------------------------------------------------+
+
+Example:
+
+.. code-block:: xml
+
+ <max_eps>50</max_eps>
+
+notify_first_scan
+^^^^^^^^^^^^^^^^^
+
+Specifies if the first scan reports stateless events or not.
+
++--------------------+----------+
+| **Default value**  | no       |
++--------------------+----------+
+| **Allowed values** | yes, no  |
++--------------------+----------+
+
+Example:
+
+.. code-block:: xml
+
+ <notify_first_scan>no</notify_first_scan>
+
 synchronization
 ^^^^^^^^^^^^^^^
 
@@ -194,14 +236,58 @@ The database synchronization settings are configured inside this tag.
 
 	<wodle name="syscollector">
 	  <synchronization>
+	    <enabled>yes</enabled>
+	    <interval>5m</interval>
+	    <response_timeout>30</response_timeout>
 	    <max_eps>10</max_eps>
 	  </synchronization>
 	</wodle>
 
+.. _wodle_syscollector_synchronization_enabled:
+
+enabled
+^^^^^^^
+
+Specifies performing periodic inventory synchronizations.
+
++--------------------+---------------------------------------+
+| **Default value**  | yes                                   |
++--------------------+---------------------------------------+
+| **Allowed values** | yes/no                                |
++--------------------+---------------------------------------+
+
+.. _wodle_syscollector_synchronization_interval:
+
+interval
+^^^^^^^^
+
+Specifies the initial time interval between every inventory synchronization.
+
++--------------------+-----------------------------------------------------------------------+
+| **Default value**  | 5 m                                                                   |
++--------------------+-----------------------------------------------------------------------+
+| **Allowed values** | Any number greater than or equal to 0. Allowed suffixes (s, m, h, d). |
++--------------------+-----------------------------------------------------------------------+
+
+.. _wodle_syscollector_synchronization_response_timeout:
+
+response_timeout
+^^^^^^^^^^^^^^^^
+
+Waiting time in seconds since a sync message is sent or received for the next synchronization activity.
+
++--------------------+----------------------------------------------------------------------+
+| **Default value**  | 30                                                                   |
++--------------------+----------------------------------------------------------------------+
+| **Allowed values** | Any number between 0 and ``interval``.                               |
++--------------------+----------------------------------------------------------------------+
+
+.. _wodle_syscollector_synchronization_max_eps:
+
 max_eps
 ^^^^^^^
 
-Sets the maximum event reporting throughput.
+Sets the maximum synchronization message throughput.
 
 +--------------------+--------------------------------------------------------------+
 | **Default value**  | 10                                                           |
@@ -225,9 +311,14 @@ Example of configuration
 	  <packages>yes</packages>
 	  <ports all="no">yes</ports>
 	  <processes>yes</processes>
+	  <max_eps>50</max_eps>
+	  <notify_first_scan>no</notify_first_scan>
 
 	  <!-- Database synchronization settings -->
 	  <synchronization>
+	    <enabled>yes</enabled>
+	    <interval>5m</interval>
+	    <response_timeout>30</response_timeout>
 	    <max_eps>10</max_eps>
 	  </synchronization>
 	</wodle>


### PR DESCRIPTION
## Description

This PR adds the following FIM settings:
- `notify_first_scan`

Also, this PR adds the following Inventory settings:
- `max_eps`
- `notify_first_scan`
- `synchronization.enabled`
- `synchronization.interval`
- `synchronization.response_timeout`

## Documentation compilation
- [x] Verified that documentation compiles without warnings.
