### PR TITLE
Add new SCA settings for states persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 
 - Added documentation for the reporting plugin in the Wazuh dashboard package generation guide. ([#8682](https://github.com/wazuh/wazuh-documentation/pull/8682))
 - Added references for FIM (Syscheck) and inventory (Syscollector) state persistence settings. ([#8801](https://github.com/wazuh/wazuh-documentation/pull/8801))
+- Added documentation for SCA state persistence settings. ([#8841](https://github.com/wazuh/wazuh-documentation/pull/8841))
 
 ### Changed
 

--- a/source/deployment-options/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-agent-class.rst
+++ b/source/deployment-options/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-agent-class.rst
@@ -531,7 +531,7 @@ $sca_else_policies
    Depends on **configure_sca and apply_template_os**
 
 $sca_max_eps
-  Sets the maximum event reporting throughput. Events are messages that will produce an alert.
+  Sets the maximum throughput for event reporting. Events are messages that generate alerts.
 
   `Default 50`
 
@@ -540,7 +540,7 @@ $sca_max_eps
    Depends on **configure_sca**
 
 $sca_synchronization_enabled
-  Specifies performing periodic inventory synchronizations.
+  Enables periodic inventory synchronization.
 
   `Default yes`
 
@@ -549,7 +549,7 @@ $sca_synchronization_enabled
    Depends on **configure_sca**
 
 $sca_synchronization_interval
-  Specifies the initial time interval between every inventory synchronization.
+  Specifies the initial time between inventory synchronizations.
 
   `Default 5m`
 
@@ -558,7 +558,7 @@ $sca_synchronization_interval
    Depends on **configure_sca**
 
 $sca_synchronization_response_timeout
-  Waiting time in seconds since a sync message is sent or received for the next synchronization activity.
+  Waiting time in seconds between a sync message and the next synchronization.
 
   `Default 30`
 
@@ -567,7 +567,7 @@ $sca_synchronization_response_timeout
    Depends on **configure_sca**
 
 $sca_synchronization_max_eps
-  Sets the maximum synchronization message throughput.
+  Sets the maximum throughput for synchronization messages.
 
   `Default 10`
 

--- a/source/deployment-options/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-manager-class.rst
+++ b/source/deployment-options/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-manager-class.rst
@@ -419,14 +419,14 @@ SCA variables
 -------------
 
 $configure_sca
-  Enables SCA section render on this host.
+  Enables rendering of the SCA section on this host.
 
   `Default true`
 
   `Type Boolean`
 
 $sca_enabled
-  Enable SCA on this host.
+  Enables SCA on this host.
 
   `Default yes`
 
@@ -435,7 +435,7 @@ $sca_enabled
    Depends on **configure_sca**
 
 $sca_scan_on_start
-  The SCA module will perform the scan immediately when started.
+  The SCA module performs a scan immediately on start.
 
   `Default yes`
 
@@ -444,7 +444,7 @@ $sca_scan_on_start
    Depends on **configure_sca**
 
 $sca_interval
-  The interval between module executions.
+  Sets the interval between module executions.
 
   `Default 12h`
 
@@ -453,7 +453,7 @@ $sca_interval
    Depends on **configure_sca**
 
 $sca_skip_nfs
-  Enable or disable the scanning of network mounted filesystems (Works on Linux and FreeBSD). Currently, skip_nfs will exclude checking files on CIFS or NFS mounts.
+  On Linux and FreeBSD, enables or disables scanning of network-mounted filesystems. This excludes CIFS and NFS mounts.
 
   `Default yes`
 
@@ -462,7 +462,7 @@ $sca_skip_nfs
    Depends on **configure_sca**
 
 $sca_policies
-  A list of policies to run assessments can be included in this section.
+  List of policies to run during assessments.
 
   `Default []`
 
@@ -471,7 +471,7 @@ $sca_policies
    Depends on **configure_sca**
 
 $sca_max_eps
-  Sets the maximum event reporting throughput. Events are messages that will produce an alert.
+  Sets the maximum throughput for event reporting. Events are messages that generate alerts.
 
   `Default 50`
 
@@ -480,7 +480,7 @@ $sca_max_eps
    Depends on **configure_sca**
 
 $sca_synchronization_enabled
-  Specifies performing periodic inventory synchronizations.
+  Enables periodic inventory synchronization.
 
   `Default yes`
 
@@ -489,7 +489,7 @@ $sca_synchronization_enabled
    Depends on **configure_sca**
 
 $sca_synchronization_interval
-  Specifies the initial time interval between every inventory synchronization.
+  Specifies the initial time between inventory synchronizations.
 
   `Default 5m`
 
@@ -498,7 +498,7 @@ $sca_synchronization_interval
    Depends on **configure_sca**
 
 $sca_synchronization_response_timeout
-  Waiting time in seconds since a sync message is sent or received for the next synchronization activity.
+  Waiting time in seconds between a sync message and the next synchronization.
 
   `Default 30`
 
@@ -507,7 +507,7 @@ $sca_synchronization_response_timeout
    Depends on **configure_sca**
 
 $sca_synchronization_max_eps
-  Sets the maximum synchronization message throughput.
+  Sets the maximum throughput for synchronization messages.
 
   `Default 10`
 

--- a/source/user-manual/reference/ossec-conf/sca.rst
+++ b/source/user-manual/reference/ossec-conf/sca.rst
@@ -41,7 +41,7 @@ Main options
 +----------------------+-----------------------------+
 | `policies`_          | N/A                         |
 +----------------------+-----------------------------+
-| `max_eps`_           | Integer (0-1000000)         |
+| `max_eps`_           | Integer (0-1,000,000)       |
 +----------------------+-----------------------------+
 | `synchronization`_   | N/A                         |
 +----------------------+-----------------------------+
@@ -147,12 +147,12 @@ Example
 max_eps
 ^^^^^^^
 
-Sets the maximum event reporting throughput. Events are messages that will produce an alert.
+Sets the maximum throughput for event reporting. Events are messages that generate alerts.
 
 +--------------------+---------------------------------------------------------+
 | **Default value**  | 50                                                      |
 +--------------------+---------------------------------------------------------+
-| **Allowed values** | Integer number between 0 and 1000000. 0 means disabled. |
+| **Allowed values** | Integer between 0 and 1,000,000. 0 disables it.         |
 +--------------------+---------------------------------------------------------+
 
 Example:
@@ -164,7 +164,7 @@ Example:
 synchronization
 ^^^^^^^^^^^^^^^
 
-The database synchronization settings are configured inside this tag.
+Database synchronization settings go inside this tag.
 
 .. code-block:: xml
 
@@ -178,7 +178,7 @@ The database synchronization settings are configured inside this tag.
 
 **enabled**
 
-Specifies performing periodic inventory synchronizations.
+Enables periodic inventory synchronization.
 
 +--------------------+---------------------------------------+
 | **Default value**  | yes                                   |
@@ -188,32 +188,32 @@ Specifies performing periodic inventory synchronizations.
 
 **interval**
 
-Specifies the initial time interval between every inventory synchronization.
+Specifies the initial time between inventory synchronizations.
 
 +--------------------+-----------------------------------------------------------------------+
 | **Default value**  | 5m                                                                    |
 +--------------------+-----------------------------------------------------------------------+
-| **Allowed values** | Any number greater than or equal to 0. Allowed suffixes (s, m, h, d). |
+| **Allowed values** | Any number greater than or equal to 0. Allowed suffixes: s, m, h, d.  |
 +--------------------+-----------------------------------------------------------------------+
 
 **response_timeout**
 
-Waiting time in seconds since a sync message is sent or received for the next synchronization activity.
+Waiting time in seconds between a sync message and the next synchronization.
 
 +--------------------+----------------------------------------------------------------------+
 | **Default value**  | 30                                                                   |
 +--------------------+----------------------------------------------------------------------+
-| **Allowed values** | Any number between 0 and ``interval``.                               |
+| **Allowed values** | Any number between 0 and the value of ``interval``.                  |
 +--------------------+----------------------------------------------------------------------+
 
 **max_eps**
 
-Sets the maximum synchronization message throughput.
+Sets the maximum throughput for synchronization messages.
 
 +--------------------+---------------------------------------------------------+
 | **Default value**  | 10                                                      |
 +--------------------+---------------------------------------------------------+
-| **Allowed values** | Integer number between 0 and 1000000. 0 means disabled. |
+| **Allowed values** | Integer between 0 and 1,000,000. 0 disables it.         |
 +--------------------+---------------------------------------------------------+
 
 scan_on_start


### PR DESCRIPTION
## Description

This PR adds the following SCA settings:
- `max_eps`
- `synchronization.enabled`
- `synchronization.interval`
- `synchronization.response_timeout`

This PR also adds a deprecation note related to the SCA `skip_nfs` setting.

## Documentation compilation
- [x] Verified that documentation compiles without warnings.
