### PR TITLE
Fix mention to the Wazuh agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ All notable changes to this project will be documented in this file.
 - **Post-release**: Changed the warning note on using the `$` and `&` characters when changing passwords in Docker deployments. ([#8694](https://github.com/wazuh/wazuh-documentation/pull/8694))
 - **Post-release**: Changed Windows commands in the backup guide to PowerShell. ([#8761](https://github.com/wazuh/wazuh-documentation/pull/8761))
 - **Post-release**: Updated 4.12.0 command output examples. ([#8779](https://github.com/wazuh/wazuh-documentation/pull/8779)) ([#8780](https://github.com/wazuh/wazuh-documentation/pull/8780))
-- **Post-release**: Updated the *Deployment on Docker* documentation. ([#8793](https://github.com/wazuh/wazuh-documentation/pull/8793)) ([#8839](https://github.com/wazuh/wazuh-documentation/pull/8839))
+- **Post-release**: Updated the *Deployment on Docker* documentation. ([#8793](https://github.com/wazuh/wazuh-documentation/pull/8793)) ([#8839](https://github.com/wazuh/wazuh-documentation/pull/8839)) ([#8843](https://github.com/wazuh/wazuh-documentation/pull/8843))
 - **Post-release**: Updated the Windows logo in the documentation. ([#8804](https://github.com/wazuh/wazuh-documentation/pull/8804))
 - **Post-release**: Updated the offline installation guide. ([#8803](https://github.com/wazuh/wazuh-documentation/pull/8803))
 - **Post-release**: Updated the instruction and images in Wazuh server API getting started documentation to reflect the new navigation path (**Server management** > **Dev Tools**). ([#8811](https://github.com/wazuh/wazuh-documentation/pull/8811))

--- a/source/deployment-options/docker/wazuh-container.rst
+++ b/source/deployment-options/docker/wazuh-container.rst
@@ -11,7 +11,7 @@ Wazuh consists of a multi-platform Wazuh agent and three central components: the
 Deployment options
 ------------------
 
-Wazuh supports the deployment of its central components and agent on Docker.
+Wazuh supports the deployment of its central components on Docker.
 
 -  :ref:`Single-node stack <single-node-stack>`: This stack deploys one of each Wazuh central component as a separate container. It includes:
 


### PR DESCRIPTION
## Description
This PR removes a mention of the Wazuh agent in the deployment on docker documentation for 4.12.x

## Documentation compilation
- [x] Verified that documentation compiles without warnings.

## Changelog
- [x] Updated `CHANGELOG.md`.

## Code formatting & web optimization
- [x] Added or updated meta descriptions.
- [x] Updated `redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
- [x] Used three-space indentation in `.rst` files.

## Writing style
- [ ] Used **bold** for UI elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Followed present tense, active voice, and a semi-formal tone.
- [ ] Wrote short, clear, and concise sentences.
