### PR TITLE
feat(#25587): add CephFS type to skip_nfs flag

### DIFF
--- a/source/deployment-options/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-agent-class.rst
+++ b/source/deployment-options/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-agent-class.rst
@@ -378,7 +378,7 @@ $ossec_rootcheck_rootkit_trojans
   `Type String`
 
 $ossec_rootcheck_skip_nfs
-  Enable or disable the scanning of network mounted filesystems (Works on Linux and FreeBSD). Currently, skip_nfs will exclude checking files on CIFS or NFS mounts.
+  Enable or disable the scanning of network mounted filesystems (Works on Linux and FreeBSD). Currently, skip_nfs will exclude checking files on CephFS, CIFS or NFS mounts.
 
   `Default yes`
 
@@ -445,7 +445,7 @@ $sca_amazon_interval
    Depends on **configure_sca and apply_template_os**
 
 $sca_amazon_skip_nfs
-  Enable or disable the scanning of network mounted filesystems (Works on Linux and FreeBSD). Currently, skip_nfs will exclude checking files on CIFS or NFS mounts.
+  Enable or disable the scanning of network mounted filesystems (Works on Linux and FreeBSD). Currently, skip_nfs will exclude checking files on CephFS, CIFS or NFS mounts.
 
   `Default yes`
 
@@ -484,7 +484,7 @@ $sca_rhel_interval
    Depends on **configure_sca and apply_template_os**
 
 $sca_rhel_skip_nfs
-  Enable or disable the scanning of network mounted filesystems (Works on Linux and FreeBSD). Currently, skip_nfs will exclude checking files on CIFS or NFS mounts.
+  Enable or disable the scanning of network mounted filesystems (Works on Linux and FreeBSD). Currently, skip_nfs will exclude checking files on CephFS, CIFS or NFS mounts.
 
   `Default yes`
 
@@ -517,7 +517,7 @@ $sca_else_interval
    Depends on **configure_sca and apply_template_os**
 
 $sca_else_skip_nfs
-  Enable or disable the scanning of network mounted filesystems (Works on Linux and FreeBSD). Currently, `skip_nfs` will exclude checking files on CIFS or NFS mounts.
+  Enable or disable the scanning of network mounted filesystems (Works on Linux and FreeBSD). Currently, `skip_nfs` will exclude checking files on CephFS, CIFS or NFS mounts.
 
   `Default yes`
 
@@ -736,7 +736,7 @@ $ossec_syscheck_synchronization_max_eps
   `Type String`
 
 $ossec_syscheck_skip_nfs
-  Specifies if syscheck should scan network mounted filesystems. This option works on Linux and FreeBSD systems. Currently, `skip_nfs` will exclude checking files on CIFS or NFS mounts.
+  Specifies if syscheck should scan network mounted filesystems. This option works on Linux and FreeBSD systems. Currently, `skip_nfs` will exclude checking files on CephFS, CIFS or NFS mounts.
 
   `Default yes`
 

--- a/source/deployment-options/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-manager-class.rst
+++ b/source/deployment-options/deploying-with-puppet/wazuh-puppet-module/reference-wazuh-puppet/wazuh-manager-class.rst
@@ -400,7 +400,7 @@ $ossec_rootcheck_rootkit_trojans
   `Type String`
 
 $ossec_rootcheck_skip_nfs
-  Enable or disable the scanning of network mounted filesystems (Works on Linux and FreeBSD). Currently, skip_nfs will exclude checking files on CIFS or NFS mounts.
+  Enable or disable the scanning of network mounted filesystems (Works on Linux and FreeBSD). Currently, skip_nfs will exclude checking files on CephFS, CIFS or NFS mounts.
 
   `Default yes`
 
@@ -453,7 +453,7 @@ $sca_interval
    Depends on **configure_sca**
 
 $sca_skip_nfs
-  On Linux and FreeBSD, enables or disables scanning of network-mounted filesystems. This excludes CIFS and NFS mounts.
+  On Linux and FreeBSD, enables or disables scanning of network-mounted filesystems. This excludes CephFS, CIFS and NFS mounts.
 
   `Default yes`
 
@@ -673,7 +673,7 @@ $ossec_syscheck_synchronization_max_eps
   `Type String`
 
 $ossec_syscheck_skip_nfs
-  Specifies if syscheck should scan network mounted filesystems. This option works on Linux and FreeBSD systems. Currently, `skip_nfs` will exclude checking files on CIFS or NFS mounts.
+  Specifies if syscheck should scan network mounted filesystems. This option works on Linux and FreeBSD systems. Currently, `skip_nfs` will exclude checking files on CephFS, CIFS or NFS mounts.
 
   `Default yes`
 

--- a/source/user-manual/reference/ossec-conf/rootcheck.rst
+++ b/source/user-manual/reference/ossec-conf/rootcheck.rst
@@ -176,7 +176,7 @@ skip_nfs
 ^^^^^^^^
 
 Enable or disable the scanning of network mounted filesystems (Works on Linux and FreeBSD).
-Currently, skip_nfs will exclude checking files on CIFS or NFS mounts.
+Currently, skip_nfs will exclude checking files on CephFS, CIFS or NFS mounts.
 
 +--------------------+---------+
 | **Default value**  | yes     |

--- a/source/user-manual/reference/ossec-conf/sca.rst
+++ b/source/user-manual/reference/ossec-conf/sca.rst
@@ -104,7 +104,7 @@ skip_nfs
 .. deprecated:: 5.0.0
 
 Enable or disable the scanning of network mounted filesystems (Works on Linux and FreeBSD).
-Currently, ``skip_nfs`` will exclude checking files on CIFS or NFS mounts.
+Currently, ``skip_nfs`` will exclude checking files on CephFS, CIFS or NFS mounts.
 
 +--------------------+---------+
 | **Default value**  | yes     |

--- a/source/user-manual/reference/ossec-conf/syscheck.rst
+++ b/source/user-manual/reference/ossec-conf/syscheck.rst
@@ -540,7 +540,7 @@ Example:
 skip_nfs
 --------
 
-Specifies if syscheck should scan network mounted filesystems. This option works on Linux and FreeBSD systems. Currently, ``skip_nfs`` will exclude checking files on CIFS or NFS mounts.
+Specifies if syscheck should scan network mounted filesystems. This option works on Linux and FreeBSD systems. Currently, ``skip_nfs`` will exclude checking files on CephFS, CIFS or NFS mounts.
 
 +--------------------+----------+
 | **Default value**  | yes      |


### PR DESCRIPTION
[ceph-csi](https://github.com/ceph/ceph-csi) for Kubernetes mounts CephFS filesystems under /var/lib/kubelet/plugins/kubernetes.io/csi/cephfs.csi.ceph.com/*/globalmount
 
Wazuh rootcheck scans include /var/lib by default
https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/rootcheck.html?utm_source=chatgpt.com#readall
 
As a result, Wazuh on Kubernetes hosts will recurse into those network filesystems, which is typically not desired, as they may be mounted by multiple hosts at the same time, as well as potentially causing performance issues.
 
I suggest that skip_nfs include CephFS (but not necessarily Ceph RBD) in addition to CIFS and NFS.
 
Closes https://github.com/wazuh/wazuh/issues/25587