### PR TITLE
Removed 4.13.0 release notes entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ All notable changes to this project will be documented in this file.
 - Replaced version references with replacement variables in Wazuh package generation. ([#8906](https://github.com/wazuh/wazuh-documentation/pull/8906))
 - Updated System inventory documentation. ([#8910](https://github.com/wazuh/wazuh-documentation/pull/8910))
 
+### Removed
+
+- **Post-release**: Removed 4.13.0 release notes entry. ([#8923](https://github.com/wazuh/wazuh-documentation/pull/8923))
+
 ## [v4.12.0]
 
 ### Added

--- a/source/release-notes/release-4-13-0.rst
+++ b/source/release-notes/release-4-13-0.rst
@@ -39,7 +39,6 @@ Wazuh manager
 - `#30851 <https://github.com/wazuh/wazuh/pull/30851>`__ Improved exception handling in the ``run_local`` SDK function.
 - `#29135 <https://github.com/wazuh/wazuh/pull/29135>`__ Improved Authd connection management using epoll to handle concurrent agent registration requests more efficiently.
 - `#31114 <https://github.com/wazuh/wazuh/pull/31114>`__ Added a single writer buffer manager instance for each indexer connector instance.
-- `#31856 <https://github.com/wazuh/wazuh/pull/31856>`__ Disabled FIM Global Queries.
 
 Wazuh agent
 ^^^^^^^^^^^


### PR DESCRIPTION
## Description
This PR removes the following release notes entry to prevent user's confusion about global queries in this version.

## Documentation compilation
- [x] Verified that documentation compiles without warnings.

## Changelog
- [x] Updated `CHANGELOG.md`.

## Code formatting & web optimization
- [x] Added or updated meta descriptions.
- [x] Updated `redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
- [x] Used three-space indentation in `.rst` files.

## Writing style
- [x] Used **bold** for UI elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Followed present tense, active voice, and a semi-formal tone.
- [x] Wrote short, clear, and concise sentences.
