### PR TITLE
Fix line indentation in PoC script 4.7

### DIFF
--- a/source/proof-of-concept-guide/detect-remove-malware-virustotal.rst
+++ b/source/proof-of-concept-guide/detect-remove-malware-virustotal.rst
@@ -252,7 +252,7 @@ Perform the following steps to configure Wazuh to monitor near real-time changes
 
       # Copyright (C) 2015-2025, Wazuh Inc.
       # All rights reserved.
-      
+
       import os
       import sys
       import json
@@ -260,35 +260,35 @@ Perform the following steps to configure Wazuh to monitor near real-time changes
       import stat
       import tempfile
       import pathlib
-      
+
       if os.name == 'nt':
           LOG_FILE = "C:\\Program Files (x86)\\ossec-agent\\active-response\\active-responses.log"
       else:
           LOG_FILE = "/var/ossec/logs/active-responses.log"
-      
+
       ADD_COMMAND = 0
       DELETE_COMMAND = 1
       CONTINUE_COMMAND = 2
       ABORT_COMMAND = 3
-      
+
       OS_SUCCESS = 0
       OS_INVALID = -1
-      
+
       class message:
           def __init__(self):
               self.alert = ""
               self.command = 0
-      
+
       def write_debug_file(ar_name, msg):
           with open(LOG_FILE, mode="a") as log_file:
               log_file.write(str(datetime.datetime.now().strftime('%Y/%m/%d %H:%M:%S')) + " " + ar_name + ": " + msg +"\n")
-      
+
       def setup_and_check_message(argv):
           input_str = ""
           for line in sys.stdin:
               input_str = line
               break
-      
+
           msg_obj = message()
           try:
               data = json.loads(input_str)
@@ -296,10 +296,10 @@ Perform the following steps to configure Wazuh to monitor near real-time changes
               write_debug_file(argv[0], 'Decoding JSON has failed, invalid input format')
               msg_obj.command = OS_INVALID
               return msg_obj
-      
+
           msg_obj.alert = data
           command = data.get("command")
-      
+
           if command == "add":
               msg_obj.command = ADD_COMMAND
           elif command == "delete":
@@ -307,29 +307,29 @@ Perform the following steps to configure Wazuh to monitor near real-time changes
           else:
               msg_obj.command = OS_INVALID
               write_debug_file(argv[0], 'Not valid command: ' + command)
-      
+
           return msg_obj
-      
+
       def send_keys_and_check_message(argv, keys):
           keys_msg = json.dumps({"version": 1,"origin":{"name": argv[0],"module":"active-response"},"command":"check_keys","parameters":{"keys":keys}})
           write_debug_file(argv[0], keys_msg)
-      
+
           print(keys_msg)
           sys.stdout.flush()
-      
+
           input_str = ""
           while True:
               line = sys.stdin.readline()
               if line:
                   input_str = line
                   break
-      
+
           try:
               data = json.loads(input_str)
           except ValueError:
               write_debug_file(argv[0], 'Decoding JSON has failed, invalid input format')
               return OS_INVALID
-      
+
           action = data.get("command")
           if action == "continue":
               return CONTINUE_COMMAND
@@ -338,43 +338,43 @@ Perform the following steps to configure Wazuh to monitor near real-time changes
           else:
               write_debug_file(argv[0], "Invalid value of 'command'")
               return OS_INVALID
-      
+
       def secure_delete_file(filepath_str, ar_name):
           filepath = pathlib.Path(filepath_str)
-      
+
           # Reject NTFS alternate data streams
           if '::' in filepath_str:
               raise Exception(f"Refusing to delete ADS or NTFS stream: {filepath_str}")
-      
+
           # Reject symbolic links and reparse points
           if os.path.islink(filepath):
               raise Exception(f"Refusing to delete symbolic link: {filepath}")
-      
+
           attrs = os.lstat(filepath).st_file_attributes
           if attrs & stat.FILE_ATTRIBUTE_REPARSE_POINT:
               raise Exception(f"Refusing to delete reparse point: {filepath}")
-      
+
           resolved_filepath = filepath.resolve()
-      
+
           # Ensure it's a regular file
           if not resolved_filepath.is_file():
               raise Exception(f"Target is not a regular file: {resolved_filepath}")
-      	
+
       	# Perform deletion
           os.remove(resolved_filepath)
-      	
+
       def main(argv):
           write_debug_file(argv[0], "Started")
           msg = setup_and_check_message(argv)
-      
+
           if msg.command < 0:
               sys.exit(OS_INVALID)
-      
+
           if msg.command == ADD_COMMAND:
               alert = msg.alert["parameters"]["alert"]
               keys = [alert["rule"]["id"]]
               action = send_keys_and_check_message(argv, keys)
-      
+
               if action != CONTINUE_COMMAND:
                   if action == ABORT_COMMAND:
                       write_debug_file(argv[0], "Aborted")
@@ -382,7 +382,7 @@ Perform the following steps to configure Wazuh to monitor near real-time changes
                   else:
                       write_debug_file(argv[0], "Invalid command")
                       sys.exit(OS_INVALID)
-      
+
               try:
                   file_path = alert["data"]["virustotal"]["source"]["file"]
                   if os.path.exists(file_path):
@@ -392,14 +392,14 @@ Perform the following steps to configure Wazuh to monitor near real-time changes
                       write_debug_file(argv[0], f"File does not exist: {file_path}")
               except OSError as error:
                   write_debug_file(argv[0], json.dumps(msg.alert) + "Error removing threat")
-      		except Exception as e:
+              except Exception as e:
                   write_debug_file(argv[0], f"{json.dumps(msg.alert)}: Error removing threat: {str(e)}")
           else:
               write_debug_file(argv[0], "Invalid command")
-      
+
           write_debug_file(argv[0], "Ended")
           sys.exit(OS_SUCCESS)
-      
+
       if __name__ == "__main__":
           main(sys.argv)
 


### PR DESCRIPTION
## Description
This PR replaces tab characters with space characters in except Exception as e: line for proper indentation.

## Documentation compilation
- [ ] Verified that documentation compiles without warnings.

## Changelog
- [x] Updated `CHANGELOG.md`.

## Code formatting & web optimization
- [x] Added or updated meta descriptions.
- [x] Updated `redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
- [x] Used three-space indentation in `.rst` files.

## Writing style
- [x] Used **bold** for UI elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Followed present tense, active voice, and a semi-formal tone.
- [x] Wrote short, clear, and concise sentences.
