### PR TITLE
[4.14] Fix for sphinx-tabs when compiling markdown first

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,12 +66,14 @@ search-index:
 	npx -y pagefind@v1.1.0 --site $(BUILDDIR)/html --force-language en
 
 html-production:
+	rm -rf $(BUILDDIR)/doctrees/*
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html -t production
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html. (production mode)"
 	@echo
 
 html-development:
+	rm -rf $(BUILDDIR)/doctrees/*
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html -t dev
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html. (dev mode)"


### PR DESCRIPTION
<!--
## Pull Request guidelines
This template outlines essential sections for new pull requests.

We greatly appreciate community contributions! If this is a community PR, please add the "contribution" label for proper tracking.

### Community contributions advice
We recommend making PRs from the current branch. For example, if Wazuh 4.10.1 is the latest release, use the `4.10` branch.
-->

## Description
<!--
Provide a clear and concise description of how this PR addresses the problem.
If this PR resolves an issue, use the `closes` keyword followed by the issue number (e.g., "closes #123").
-->

This PR cleans the doctrees folder to make sure that sphinx-tabs are correctly built.

## Documentation compilation
- [x] Verified that documentation compiles without warnings.

## Changelog
- [ ] Updated `CHANGELOG.md`.

## Code formatting & web optimization
- [ ] Added or updated meta descriptions.
- [ ] Updated `redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
- [ ] Used three-space indentation in `.rst` files.

## Writing style
- [ ] Used **bold** for UI elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Followed present tense, active voice, and a semi-formal tone.
- [ ] Wrote short, clear, and concise sentences.
