### PR TITLE
Add function to convert .html links to .md in Markdown generated files 4.7

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -373,6 +373,87 @@ epub_exclude_files = ['search.html', 'not_found.html']
 
 # -- Options for Markdown output --------------------------------------------
 
+def fix_markdown_links(app, exception):
+    """
+    Post-process markdown files to replace .html extensions with .md extensions.
+
+    This function runs after the markdown build completes and converts all
+    relative .html links to .md links while preserving absolute URLs.
+
+    Features:
+    - Converts href="file.html" to href="file.md"
+    - Converts href="file.html#anchor" to href="file.md#anchor"
+    - Handles both single and double quotes
+    - Handles markdown-style links [text](file.html)
+    - Preserves absolute URLs (http://, https://, //, etc.)
+
+    Args:
+        app: Sphinx application object
+        exception: Exception raised during build (None if successful)
+    """
+    if app.builder.name == 'markdown' and not exception:
+        from pathlib import Path
+
+        build_dir = Path(app.outdir)
+        modified_count = 0
+        total_count = 0
+
+        print("\n" + "="*70)
+        print("Post-processing markdown files: Converting .html links to .md")
+        print("="*70)
+
+        # Process all markdown files recursively
+        for md_file in build_dir.rglob('*.md'):
+            total_count += 1
+
+            try:
+                with open(md_file, 'r', encoding='utf-8') as f:
+                    content = f.read()
+
+                original_content = content
+
+                # Pattern 1: href="...html" (but not absolute URLs)
+                # Matches: href="path/to/file.html"
+                # Skips: href="https://example.com/file.html"
+                content = re.sub(
+                    r'href="(?!(?:[a-zA-Z][a-zA-Z0-9+.-]*:)?//)([^"]*?)\.html"',
+                    r'href="\1.md"',
+                    content
+                )
+
+                # Pattern 2: href='...html' (single quotes, not absolute URLs)
+                # Matches: href='path/to/file.html'
+                content = re.sub(
+                    r"href='(?!(?:[a-zA-Z][a-zA-Z0-9+.-]*:)?//)([^']*?)\.html'",
+                    r"href='\1.md'",
+                    content
+                )
+
+                # Pattern 3: [text](link.html) markdown links (not absolute URLs)
+                # Matches: [Link](path/to/file.html) and [Link](file.html#anchor)
+                content = re.sub(
+                    r'\[([^\]]+)\]\((?!(?:[a-zA-Z][a-zA-Z0-9+.-]*:)?//)([^\)]*?)\.html((?:#[^\)]+)?)\)',
+                    r'[\1](\2.md\3)',
+                    content
+                )
+
+                # Only write if changes were made
+                if content != original_content:
+                    with open(md_file, 'w', encoding='utf-8') as f:
+                        f.write(content)
+                    modified_count += 1
+                    print(f"  ✓ Fixed links in: {md_file.relative_to(build_dir)}")
+
+            except Exception as e:
+                print(f"  ✗ Error processing {md_file.relative_to(build_dir)}: {e}")
+
+        print("-"*70)
+        print(f"Processing complete!")
+        print(f"  Total files: {total_count}")
+        print(f"  Modified files: {modified_count}")
+        print(f"  Unchanged files: {total_count - modified_count}")
+        print("="*70 + "\n")
+
 # Options for sphinx-markdown-builder
 markdown_http_base = '' # Use relative links
 
@@ -489,6 +570,8 @@ def setup(app):
         app.connect('html-page-context', insert_inline_js)
         app.connect('html-page-context', manage_assets)
     app.connect('build-finished', finish_and_clean)
+
+    app.connect('build-finished', fix_markdown_links) # Connect the markdown link fixer to post-process generated markdown files
 
     app.connect('html-page-context', pagefind_custom_weights)
 


### PR DESCRIPTION
## Description
This PR adds a post-process function to convert .html links that the sphinx-markdown-builder plugin don't convert into .md links.

## Documentation compilation
- [ ] Verify that documentation compiles without warnings.

## Changelog
- [ ] Update `CHANGELOG.md`.

## Web optimization & code formatting
- Page references
  - [ ] Update `/_static/js/redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
  - [ ] Update `/llms.txt` if necessary.
- [ ] Add or update meta descriptions.
- [ ] Use three-space indentation in `.rst` files.

## Writing style
- [ ] Use **bold** for UI elements, _italics_ for key terms and emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Follow present tense, active voice, and a semi-formal tone.
- [ ] Write short, clear, and concise sentences.
