### PR TITLE
Add note about Linux and macOS WPK ARM packages 4.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 - **Post-release**: Added Wazuh Docker support for Windows. ([#8852](https://github.com/wazuh/wazuh-documentation/pull/8852))
 - **Post-release**: Added new steps and images to the API Permission section of the *Wazuh Microsoft Graph API* setup documentation. ([#8898](https://github.com/wazuh/wazuh-documentation/pull/8898))
 - **Post-release**: Added LLMs-ready documentation. ([#9219](https://github.com/wazuh/wazuh-documentation/pull/9219))
+- **Post-release**: Added note about Linux and macOS WPK ARM packages in 4.12 and earlier versions. ([#9308](https://github.com/wazuh/wazuh-documentation/pull/9308))
 
 ### Changed
 

--- a/source/user-manual/agent/agent-management/remote-upgrading/wpk-files/wpk-list.rst
+++ b/source/user-manual/agent/agent-management/remote-upgrading/wpk-files/wpk-list.rst
@@ -21,6 +21,10 @@ Linux
 |  Linux (rpm) | |WAZUH_CUR_VER| |    x86_64/AMD64     | |WPK_Linux_RPM|               |
 +--------------+-----------------+---------------------+-------------------------------+
 
+.. note::
+
+   In Wazuh |WAZUH_CURRENT_MINOR| and earlier, official WPKs for Linux are available only for x86_64/AMD64 architectures. These versions do not provide Linux ARM WPKs, and the remote upgrade process is not architecture-aware. Use Linux WPK packages only on x86_64-based systems.
+
 Windows
 -------
 
@@ -44,3 +48,7 @@ macOS
 +==============+=====================+==============+=============================================+
 |    macOS     | |WAZUH_CUR_OSX|     |  Intel 64    | |WPK_macOS|                                 |
 +--------------+---------------------+--------------+---------------------------------------------+
+
+.. note::
+
+   In Wazuh |WAZUH_CURRENT_MINOR| and earlier, official WPKs for macOS are available only for Intel-based architectures. These versions do not provide Apple Silicon (ARM) WPKs, and the remote upgrade process is not architecture-aware. Use WPK packages only on Intel-based systems.


### PR DESCRIPTION
## Description

Add notes to the WPK list page clarifying that official WPKs for Linux and macOS are only available for x86_64/AMD64 and Intel-based architectures respectively in Wazuh 4.12 and earlier versions. This matches the changes already applied to the 4.13 and 4.14 branches in PRs #9293, #9304, #9224, and #9225.

Closes https://github.com/wazuh/internal-documentation-requests/issues/571 (4.12 portion)

## Documentation compilation
- [x] Verify that documentation compiles without warnings.

## Changelog
- [x] Update `CHANGELOG.md`.

## Web optimization & code formatting
- Page references
  - [x] Update `/_static/js/redirects.js` if necessary — N/A, no page additions or removals.
  - [x] Update `/llms.txt` if necessary — N/A.
- [x] Add or update meta descriptions — N/A, existing page.
- [x] Use three-space indentation in `.rst` files.

## Writing style
- [x] Use **bold** for UI elements, _italics_ for key terms and emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Follow present tense, active voice, and a semi-formal tone.
- [x] Write short, clear, and concise sentences.
