### PR TITLE
Add note about Linux and macOS WPK ARM packages 4.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - **Post-release**: Changed Windows commands in the backup guide to PowerShell. ([#8764](https://github.com/wazuh/wazuh-documentation/pull/8764))
 - **Post-release**: Updated the offline installation guide. ([#8806](https://github.com/wazuh/wazuh-documentation/pull/8806))
 - **Post-release**: Added LLMs-ready documentation. ([#9223](https://github.com/wazuh/wazuh-documentation/pull/9223))
+- **Post-release**: Added note about Linux and macOS WPK ARM packages in 4.11 and earlier versions. ([#9309](https://github.com/wazuh/wazuh-documentation/pull/9309))
 
 ### Changed
 

--- a/source/user-manual/agent/agent-management/remote-upgrading/wpk-files/wpk-list.rst
+++ b/source/user-manual/agent/agent-management/remote-upgrading/wpk-files/wpk-list.rst
@@ -21,6 +21,10 @@ Linux
 |  Linux (rpm) | |WAZUH_CUR_VER| |    x86_64/AMD64     | |WPK_Linux_RPM|               |
 +--------------+-----------------+---------------------+-------------------------------+
 
+.. note::
+
+   In Wazuh |WAZUH_CURRENT_MINOR| and earlier, official WPKs for Linux are available only for x86_64/AMD64 architectures. These versions do not provide Linux ARM WPKs, and the remote upgrade process is not architecture-aware. Use Linux WPK packages only on x86_64-based systems.
+
 Windows
 -------
 
@@ -44,3 +48,7 @@ macOS
 +==============+=====================+==============+=============================================+
 |    macOS     | |WAZUH_CUR_OSX|     |  Intel 64    | |WPK_macOS|                                 |
 +--------------+---------------------+--------------+---------------------------------------------+
+
+.. note::
+
+   In Wazuh |WAZUH_CURRENT_MINOR| and earlier, official WPKs for macOS are available only for Intel-based architectures. These versions do not provide Apple Silicon (ARM) WPKs, and the remote upgrade process is not architecture-aware. Use WPK packages only on Intel-based systems.


### PR DESCRIPTION
## Description

Add notes to the WPK list page clarifying that official WPKs for Linux and macOS are only available for x86_64/AMD64 and Intel-based architectures respectively in Wazuh 4.11 and earlier versions.

Related: https://github.com/wazuh/internal-documentation-requests/issues/571

## Documentation compilation
- [x] Verify that documentation compiles without warnings.

## Changelog
- [x] Update `CHANGELOG.md`.

## Web optimization & code formatting
- Page references
  - [x] Update `/_static/js/redirects.js` if necessary — N/A, no page additions or removals.
  - [x] Update `/llms.txt` if necessary — N/A.
- [x] Add or update meta descriptions — N/A, existing page.
- [x] Use three-space indentation in `.rst` files.

## Writing style
- [x] Use **bold** for UI elements, _italics_ for key terms and emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Follow present tense, active voice, and a semi-formal tone.
- [x] Write short, clear, and concise sentences.

Made with [Cursor](https://cursor.com)