### PR TITLE
Add note about Linux and macOS WPK ARM packages 4.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ All notable changes to this project will be documented in this file.
 ## [v4.10.3]
 
 - Support for Wazuh 4.10.3
-- Added note about Linux and macOS WPK ARM packages in 4.10 and earlier versions. ([#9310](https://github.com/wazuh/wazuh-documentation/pull/9310))
 
 ## [v4.10.2]
 


### PR DESCRIPTION
## Description

Add notes to the WPK list page clarifying that official WPKs for Linux and macOS are only available for x86_64/AMD64 and Intel-based architectures respectively in Wazuh 4.10 and earlier versions.

Related: https://github.com/wazuh/internal-documentation-requests/issues/571

## Documentation compilation
- [x] Verify that documentation compiles without warnings.

## Changelog
- [x] Update `CHANGELOG.md`.

## Web optimization & code formatting
- Page references
  - [x] Update `/_static/js/redirects.js` if necessary — N/A, no page additions or removals.
  - [x] Update `/llms.txt` if necessary — N/A.
- [x] Add or update meta descriptions — N/A, existing page.
- [x] Use three-space indentation in `.rst` files.

## Writing style
- [x] Use **bold** for UI elements, _italics_ for key terms and emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Follow present tense, active voice, and a semi-formal tone.
- [x] Write short, clear, and concise sentences.

Made with [Cursor](https://cursor.com)