### PR TITLE
Change command to uninstall on Windows

### DIFF
--- a/source/installation-guide/uninstalling-wazuh/agent.rst
+++ b/source/installation-guide/uninstalling-wazuh/agent.rst
@@ -58,7 +58,7 @@ To uninstall the Wazuh agent, ensure the original Windows installer file is in y
 
 .. code-block:: doscon
 
-   > msiexec.exe /x wazuh-agent-|WAZUH_CURRENT_WINDOWS|-|WAZUH_REVISION_WINDOWS|.msi /qn
+   > Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* , HKLM:\Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\* | Where-Object { $_.DisplayName -like "*Wazuh Agent*" } | ForEach-Object { msiexec.exe /x $_.PSChildName /qn }
 
 The Wazuh agent is now completely removed from your Windows endpoint.
 


### PR DESCRIPTION
<!--
## Pull Request guidelines
This template outlines essential sections for new pull requests.

We greatly appreciate community contributions! If this is a community PR, please add the "contribution" label for proper tracking.

### Community contributions advice
We recommend making PRs from the current branch. For example, if Wazuh 4.10.1 is the latest release, use the `4.10` branch.
-->

## Description
<!--
Provide a clear and concise description of how this PR addresses the problem.
If this PR resolves an issue, use the `closes` keyword followed by the issue number (e.g., "closes #123").
-->
This PR addresses the issue of not being able to uninstall a Wazuh agent installation with the command currently stated in the documentation: 
`
msiexec.exe /x wazuh-agent-5.0.0.msi /qn
`

The problem with this command is two-fold.
1. The user does not always have the original .msi file from which the installation was done. In case of a remote upgrade, the .msi is actually deleted after the upgrade process finishes.
2. The uninstallation with .msi package actually fails in many cases.

This PR provides a way of uninstalling without the need of the original .msi file.

## Documentation compilation
- [ ] Verify that documentation compiles without warnings.

## Changelog
- [ ] Update `CHANGELOG.md`.

## Web optimization & code formatting
- Page references
  - [ ] Update `/_static/js/redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
  - [ ] Update `/llms.txt` if necessary.
- [ ] Add or update meta descriptions.
- [ ] Use three-space indentation in `.rst` files.

## Writing style
- [ ] Use **bold** for UI elements, _italics_ for key terms and emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Follow present tense, active voice, and a semi-formal tone.
- [ ] Write short, clear, and concise sentences.
