### PR TITLE
docs(poc/block-malicious-ip): fix Windows Apache log path (access.log -> access_log)

### DIFF
--- a/source/proof-of-concept-guide/block-malicious-actor-ip-reputation.rst
+++ b/source/proof-of-concept-guide/block-malicious-actor-ip-reputation.rst
@@ -112,7 +112,7 @@ Perform the steps below to configure the Wazuh agent to monitor Apache web serve
 
       <localfile>
         <log_format>syslog</log_format>
-        <location>C:\Apache24\logs\access.log</location>
+        <location>C:\Apache24\logs\access_log</location>
       </localfile>
 
 #. Restart the Wazuh agent in a PowerShell terminal with administrator privileges to apply the changes:


### PR DESCRIPTION
## Summary

Per #9479, the Windows Apache24 download ships the access log file as \`access_log\` (no dot); the POC guide told users to monitor \`C:\\Apache24\\logs\\access.log\`, so the Wazuh agent fails to open the file on Windows.

Fixed the Windows \`<location>\` entry in \`source/proof-of-concept-guide/block-malicious-actor-ip-reputation.rst:115\`. The Linux section (line 69, \`/var/log/apache2/access.log\`) is untouched — that filename is correct on Ubuntu/Debian Apache.

Closes #9479

## Testing

Docs-only change; one-line fix.