### PR TITLE
docs: warn that wazuh-agent conflicts with wazuh-manager on same host

### DIFF
--- a/source/installation-guide/wazuh-agent/wazuh-agent-package-linux.rst
+++ b/source/installation-guide/wazuh-agent/wazuh-agent-package-linux.rst
@@ -12,6 +12,12 @@ The deployment of a Wazuh agent on a Linux endpoint uses deployment variables th
 
 .. note:: You need root user privileges to run all the commands described below.
 
+.. warning::
+
+   Do not install the Wazuh agent on a host that already runs the Wazuh manager. The ``wazuh-agent`` and ``wazuh-manager`` packages share the ``/var/ossec/`` directory and provide conflicting files, so installing one silently removes the other through the package manager's ``Conflicts`` / ``Replaces`` metadata. On a manager host, running ``apt-get install wazuh-agent`` (or the DNF/Yum/ZYpp equivalent) results in ``wazuh-manager`` being uninstalled without any explicit warning, which takes the manager offline along with every agent that depends on it.
+
+   If you deploy agents with configuration management (Ansible, Puppet, Chef, Salt, etc.), make sure the manager host is **explicitly excluded** from the agent-install target — both in the ``hosts:`` pattern *and* in any ``--limit``/equivalent override.
+
 .. _agent-installation-add-wazuh-repository:
 
 Add the Wazuh repository


### PR DESCRIPTION
## What this PR does

Adds a `.. warning::` admonition to [Deploying Wazuh agents on Linux endpoints](https://documentation.wazuh.com/current/installation-guide/wazuh-agent/wazuh-agent-package-linux.html) explaining that installing the Wazuh agent on a host that already runs the Wazuh manager is destructive.

## Why

The `wazuh-agent` and `wazuh-manager` Debian/RPM packages share `/var/ossec/` and carry a mutual `Conflicts`/`Replaces` relationship. When an operator — often through configuration management — runs `apt-get install wazuh-agent` on the manager host, the manager is uninstalled silently (exit code 0, no stderr) and the SIEM goes offline along with all the agents connected to it.

The current install page makes no mention of this. New operators (especially those who use Ansible `deploy_wazuh_agents` playbooks and forget to exclude the manager from the target pattern) discover the problem only once alerts stop flowing, sometimes many hours later.

## Real-world context

This happened in a production-adjacent homelab earlier today: an Ansible run without the proper `!manager` exclusion installed `wazuh-agent=4.14.4-1` on the manager host at 00:38, which triggered `Remove: wazuh-manager:amd64 (4.14.4-1)`. The SIEM was silently offline for ~17 hours before detection. The manager's `/var/ossec/etc/ossec.conf` and `client.keys` were preserved by the postrm as `.save` files, but the `/var/ossec/` runtime was wiped. Recovery required reinstalling the manager package and restoring the `.save` files by hand.

A single warning on this install page would have made this failure mode visible to anyone reading the guide before running `apt-get install wazuh-agent` in their automation.

## Change

One `.. warning::` admonition inserted right after the existing root-privileges `.. note::`, before the "Add the Wazuh repository" section. It:

- Explains the `Conflicts`/`Replaces` behavior.
- Warns that the manager gets silently removed.
- Points out the configuration-management-specific pitfall (exclude the manager host explicitly in `hosts:` and `--limit`).

## Checklist

- [x] Follows the existing admonition style (`.. warning::` / `.. note::`).
- [x] Applies to `main` (5.x docs branch).
- [x] Signed-off-by line included (DCO).
- [ ] macOS and Windows agent pages are not affected (single-manager-package-per-OS, no conflict).
