### PR TITLE
Set 4.14.5 documentation for release

### DIFF
--- a/source/_variables/settings.py
+++ b/source/_variables/settings.py
@@ -22,7 +22,7 @@ is_latest_release = True
 # Important: use a valid branch (4.0) or, preferably, tag name (v4.0.0)
 
 release = '4.14.5'
-api_tag = '4.14.5'
+api_tag = 'v4.14.5'
 
 apiURL = 'https://raw.githubusercontent.com/wazuh/wazuh/'+api_tag+'/api/api/spec/spec.yaml'
 apiURL_server = '../../_static/server-api-spec/spec-'+api_tag+'.yaml'

--- a/source/release-notes/index-4x.rst
+++ b/source/release-notes/index-4x.rst
@@ -11,7 +11,7 @@ This section summarizes the most important features of each Wazuh 4.x release.
 =============================================  ====================
 Wazuh version                                  Release date
 =============================================  ====================
-:doc:`4.14.5 </release-notes/release-4-14-5>`  TBD
+:doc:`4.14.5 </release-notes/release-4-14-5>`  23 April 2026
 :doc:`4.14.4 </release-notes/release-4-14-4>`  17 March 2026
 :doc:`4.14.3 </release-notes/release-4-14-3>`  11 February 2026
 :doc:`4.14.2 </release-notes/release-4-14-2>`  14 January 2026

--- a/source/release-notes/index.rst
+++ b/source/release-notes/index.rst
@@ -11,7 +11,7 @@ This section summarizes the most important features of each Wazuh release.
 ==============================================   ====================
 Wazuh version                                    Release date
 ==============================================   ====================
-:doc:`4.14.5 </release-notes/release-4-14-5>`    TBD
+:doc:`4.14.5 </release-notes/release-4-14-5>`    23 April 2026
 :doc:`4.14.4 </release-notes/release-4-14-4>`    17 March 2026
 :doc:`4.14.3 </release-notes/release-4-14-3>`    11 February 2026
 :doc:`4.14.2 </release-notes/release-4-14-2>`    14 January 2026


### PR DESCRIPTION
Closes wazuh/internal-documentation-requests#682

## Summary
Final pre-publish documentation adjustments for 4.14.5.

## Changes
- `source/release-notes/index.rst` — set the release date for 4.14.5 to **23 April 2026** (was `TBD`).
- `source/release-notes/index-4x.rst` — set the release date for 4.14.5 to **23 April 2026** (was `TBD`).
- `source/_variables/settings.py` — change `api_tag` from `'4.14.5'` (branch) to `'v4.14.5'` (tag) so API spec URLs resolve against the released tag.

## Test plan
- [ ] Confirm the release notes index and 4.x index render with the correct date.
- [ ] Verify API reference pages load using the `v4.14.5` tag URL.