### PR TITLE
Fix Windows Apache log path in block malicious actor POC (4.3)

### DIFF
--- a/source/proof-of-concept-guide/block-malicious-actor-ip-reputation.rst
+++ b/source/proof-of-concept-guide/block-malicious-actor-ip-reputation.rst
@@ -112,7 +112,7 @@ Perform the steps below to configure the Wazuh agent to monitor Apache web serve
 
       <localfile>
         <log_format>syslog</log_format>
-        <location>C:\Apache24\logs\access.log</location>
+        <location>C:\Apache24\logs\access_log</location>
       </localfile>
 
 #. Restart the Wazuh agent in a PowerShell terminal with administrator privileges to apply the changes:


### PR DESCRIPTION
## Description

Backport of [#9530](https://github.com/wazuh/wazuh-documentation/pull/9530) to the 4.3 branch.

Fixes a typo in the **Windows endpoint** configuration of the *Blocking a known malicious actor* Proof of Concept guide. The `<localfile>` `location` referenced `C:\Apache24\logs\access.log`, but the file shipped in the suggested Apache2 archive is named `access_log` (no extension). Updated the snippet so the Wazuh agent monitors the correct path on Windows.

Related issue: wazuh/internal-documentation-requests#684

## Checks
### Docs building
- [ ] Compiles without warnings.
### Code formatting and web optimization
- [ ] Uses three spaces indentation.
- [ ] Adds or updates meta descriptions accordingly.
- [ ] Updates the `redirects.js` script if necessary (check [this guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
### Writing style
- [ ] Uses present tense, active voice, and semi-formal registry.
- [ ] Uses short, simple sentences.
- [ ] Uses **bold** for user interface elements, _italics_ for key terms or emphasis, and `code` font for Bash commands, file names, REST paths, and code.