### PR TITLE
Add OpenSSL to offline installation prerequisites

### DIFF
--- a/source/deployment-options/offline-installation/index.rst
+++ b/source/deployment-options/offline-installation/index.rst
@@ -15,7 +15,7 @@ For more information about the hardware requirements and the recommended operati
 Prerequisites
 -------------
 
-- ``curl``, ``tar``, and ``setcap`` need to be installed in the target system where the offline installation will be carried out. ``gnupg`` might need to be installed as well for some Debian-based systems.
+- ``curl``, ``tar``, ``setcap``, and ``openssl`` need to be installed in the target system where the offline installation will be carried out. ``gnupg`` might need to be installed as well for some Debian-based systems.
 
 - In some systems, the command ``cp`` is an alias for ``cp -i`` — you can check this by running ``alias cp``. If this is your case, use ``unalias cp`` to avoid being asked for confirmation to overwrite files.
 


### PR DESCRIPTION
# Add OpenSSL to offline installation prerequisites

## Summary

- Add `openssl` to the prerequisite tools required for Wazuh offline installation.
- Address the missing dependency reported in #5900.

## Context

The offline installation flow requires certificate generation and related cryptographic operations. Issue #5900 reports failures when `openssl` is not installed on the target system, while the current prerequisites list only mentions `curl`, `tar`, `setcap`, and sometimes `gnupg`.

## Verification

- Documentation-only change.
- Checked the current `source/deployment-options/offline-installation/index.rst` prerequisite list on `main`.

Closes #5900.