### PR TITLE
Fix Windows Apache access log path

### DIFF
--- a/source/proof-of-concept-guide/block-malicious-actor-ip-reputation.rst
+++ b/source/proof-of-concept-guide/block-malicious-actor-ip-reputation.rst
@@ -112,7 +112,7 @@ Perform the steps below to configure the Wazuh agent to monitor Apache web serve
 
       <localfile>
         <log_format>syslog</log_format>
-        <location>C:\Apache24\logs\access.log</location>
+        <location>C:\Apache24\logs\access_log</location>
       </localfile>
 
 #. Restart the Wazuh agent in a PowerShell terminal with administrator privileges to apply the changes:


### PR DESCRIPTION
## Description

Updates the Windows Apache log path in the block malicious actor IP reputation proof-of-concept guide from `access.log` to `access_log`, matching the file name provided by the Apache for Windows ZIP package.

Fixes #9479.

## Verification

- `git diff --check`