### PR TITLE
Exclude getting started use cases from building

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -97,6 +97,7 @@ language = 'en-US'
 # This pattern also affects html_static_path and html_extra_path .
 exclude_patterns = [
     'redirects.js',
+    'getting-started/use-cases/**',
     'deployment-options/**',
     'user-manual/**',
     'cloud-security/**',


### PR DESCRIPTION
## Description
This PR ignores the Getting started use case documents when building documenattion preventing the compilation time warnings

## Documentation compilation
- [ ] Verify that documentation compiles without warnings.

## Changelog
- [ ] Update `CHANGELOG.md`.

## Web optimization & code formatting
- Page references
  - [ ] Update `/_static/js/redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
  - [ ] Update `/llms.txt` if necessary.
- [ ] Add or update meta descriptions.
- [ ] Use three-space indentation in `.rst` files.

## Writing style
- [ ] Use **bold** for UI elements, _italics_ for key terms and emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Follow present tense, active voice, and a semi-formal tone.
- [ ] Write short, clear, and concise sentences.
