### PR TITLE
Fix compilation warnings

### DIFF
--- a/source/installation-guide/index.rst
+++ b/source/installation-guide/index.rst
@@ -13,7 +13,7 @@ Wazuh is a security platform that provides unified XDR and SIEM protection for e
 
 Wazuh is a free and open source platform. Its components abide by the `GNU General Public License, version 2 <https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html>`_, and the `GNU Affero General Public License version 3 <https://www.gnu.org/licenses/agpl-3.0.en.html>`_ (AGPLv3).
 
-In this installation guide, you will learn how to install Wazuh in your infrastructure. We also offer `Wazuh Cloud <https://wazuh.com/cloud/>`_, our software as a service (SaaS) solution. Wazuh Cloud is ready to use, with no additional hardware or software required, reducing the cost and complexity. Check the :doc:`Wazuh Cloud service </cloud-service/index>` documentation for more information and take advantage of the `Wazuh Cloud trial <https://console.cloud.wazuh.com/sign-up?landing=trial>`_ to explore this service.
+In this installation guide, you will learn how to install Wazuh in your infrastructure. We also offer `Wazuh Cloud <https://wazuh.com/cloud/>`_, our software as a service (SaaS) solution. Wazuh Cloud is ready to use, with no additional hardware or software required, reducing the cost and complexity. Check the `Wazuh Cloud service </cloud-service/index>`__ documentation for more information and take advantage of the `Wazuh Cloud trial <https://console.cloud.wazuh.com/sign-up?landing=trial>`_ to explore this service.
 
 
 Installing the Wazuh central components

--- a/source/installation-guide/wazuh-agent/index.rst
+++ b/source/installation-guide/wazuh-agent/index.rst
@@ -68,7 +68,7 @@ To install a Wazuh agent, select your operating system and follow the instructio
   </div>
 
 
-If you are deploying Wazuh in a large environment, with a high number of servers or endpoints, keep in mind that this deployment might be easier using automation tools such as :doc:`Puppet </deployment-options/deploying-with-puppet/index>`, `Chef <https://github.com/wazuh/wazuh-chef>`_, SCCM, or :doc:`Ansible </deployment-options/deploying-with-ansible/guide/index>`.
+If you are deploying Wazuh in a large environment, with a high number of servers or endpoints, keep in mind that this deployment might be easier using automation tools such as `Puppet </deployment-options/deploying-with-puppet/index>`__, `Chef <https://github.com/wazuh/wazuh-chef>`_, SCCM, or `Ansible </deployment-options/deploying-with-ansible/guide/index>`__.
 
 .. note:: Compatibility between the Wazuh agent and the Wazuh manager is guaranteed when the Wazuh manager version is later than or equal to that of the Wazuh agent.
 

--- a/source/installation-guide/wazuh-agent/wazuh-agent-package-macos.rst
+++ b/source/installation-guide/wazuh-agent/wazuh-agent-package-macos.rst
@@ -41,11 +41,11 @@ The Wazuh agent runs on the endpoint you want to monitor and communicates with t
 
                      # echo "WAZUH_MANAGER='10.0.0.2'" > /tmp/wazuh_envs && sudo installer -pkg wazuh-agent-5.0.0-beta1.arm64.pkg -target /
 
-            For additional deployment options such as agent name, agent group, and enrollment password, see the :doc:`Deployment variables for macOS </user-manual/agent/agent-enrollment/deployment-variables/deployment-variables-macos>` section.
+            For additional deployment options such as agent name, agent group, and enrollment password, see the `Deployment variables for macOS </user-manual/agent/agent-enrollment/deployment-variables/deployment-variables-macos>`__ section.
 
             .. note::
 
-               Alternatively, if you want to install an agent without enrolling it, omit the deployment variables. To learn more about the different enrollment methods, see the :doc:`Wazuh agent enrollment </user-manual/agent/agent-enrollment/index>` section.
+               Alternatively, if you want to install an agent without enrolling it, omit the deployment variables. To learn more about the different enrollment methods, see the `Wazuh agent enrollment </user-manual/agent/agent-enrollment/index>`__ section.
 
          #. Start the Wazuh agent to complete the installation process:
 
@@ -70,6 +70,6 @@ The Wazuh agent runs on the endpoint you want to monitor and communicates with t
 
                # launchctl bootstrap system /Library/LaunchDaemons/com.wazuh.agent.plist
 
-         The installation process is now complete, and the Wazuh agent is successfully installed on your macOS endpoint. The next step is to enroll and configure the Wazuh agent to communicate with the Wazuh manager. To perform this action, see the :doc:`Wazuh agent enrollment </user-manual/agent/agent-enrollment/index>` section.  
+         The installation process is now complete, and the Wazuh agent is successfully installed on your macOS endpoint. The next step is to enroll and configure the Wazuh agent to communicate with the Wazuh manager. To perform this action, see the `Wazuh agent enrollment </user-manual/agent/agent-enrollment/index>`__ section.
 
 By default, all agent files are stored in ``/Library/Ossec/`` after the installation.

--- a/source/installation-guide/wazuh-agent/wazuh-agent-package-windows.rst
+++ b/source/installation-guide/wazuh-agent/wazuh-agent-package-windows.rst
@@ -32,7 +32,7 @@ The Wazuh agent runs on the endpoint you want to monitor and communicates with t
 
                   > .\wazuh-agent-5.0.0-beta1.msi /q WAZUH_MANAGER="10.0.0.2"
 
-            For additional deployment options such as agent name, agent group, and enrollment password, see the :doc:`Deployment variables for Windows </user-manual/agent/agent-enrollment/deployment-variables/deployment-variables-windows>` section.
+            For additional deployment options such as agent name, agent group, and enrollment password, see the `Deployment variables for Windows </user-manual/agent/agent-enrollment/deployment-variables/deployment-variables-windows>`__ section.
 
          #. Start the Wazuh agent from the GUI or by running:
 
@@ -52,7 +52,7 @@ The Wazuh agent runs on the endpoint you want to monitor and communicates with t
 
             .. note::
 
-               Alternatively, if you want to install an agent without enrolling it, omit the deployment variables. To learn more about the different enrollment methods, see the :doc:`Wazuh agent enrollment </user-manual/agent/agent-enrollment/index>` section.
+               Alternatively, if you want to install an agent without enrolling it, omit the deployment variables. To learn more about the different enrollment methods, see the `Wazuh agent enrollment </user-manual/agent/agent-enrollment/index>`__ section.
 
       .. group-tab:: GUI
 
@@ -64,6 +64,6 @@ The Wazuh agent runs on the endpoint you want to monitor and communicates with t
                :title: Windows agent manager
                :alt: Windows agent manager
 
-         The installation process is now complete, and the Wazuh agent is successfully installed on your Windows endpoint. The next step is to enroll and configure the Wazuh agent to communicate with the Wazuh manager. To perform this action, see the :doc:`Wazuh agent enrollment </user-manual/agent/agent-enrollment/index>` section.
+         The installation process is now complete, and the Wazuh agent is successfully installed on your Windows endpoint. The next step is to enroll and configure the Wazuh agent to communicate with the Wazuh manager. To perform this action, see the `Wazuh agent enrollment </user-manual/agent/agent-enrollment/index>`__ section.
 
 By default, all agent files are stored in ``C:\Program Files (x86)\ossec-agent`` after the installation.

--- a/source/installation-guide/wazuh-indexer/step-by-step.rst
+++ b/source/installation-guide/wazuh-indexer/step-by-step.rst
@@ -78,7 +78,7 @@ Generating the SSL certificates
           #  dns: "<dashboard-node-dns>"
 
 
-   To learn more about how to create and configure the certificates, see the :doc:`/user-manual/wazuh-indexer-cluster/certificate-deployment` section.
+   To learn more about how to create and configure the certificates, see the `Certificates deployment </user-manual/wazuh-indexer-cluster/certificate-deployment>`__ section.
 
 #. Run ``./wazuh-certs-tool-5.0.0-beta1.sh`` to create the certificates. For a multi-node cluster, these certificates need to be later deployed to all Wazuh instances in your cluster:
 

--- a/source/under-construction.rst
+++ b/source/under-construction.rst
@@ -1,0 +1,17 @@
+:orphan:
+
+.. We place the missing labels here so :ref: calls find them
+.. _cluster_name:
+.. _cluster_node_name:
+.. _cluster_node_type:
+.. _cluster_key:
+.. _cluster_port:
+.. _cluster_bind_addr:
+.. _cluster_nodes:
+.. _cluster_hidden:
+.. _cluster_disabled:
+
+Under Construction
+==================
+
+This section of the Wazuh documentation is currently being updated.


### PR DESCRIPTION
## Description
This PR fixes compilation warnings by:
- Modifying `:doc:` references to excluded documents with the external link format
- Creating missing `:ref:` references in an "Under construction" temporary page

## Documentation compilation
- [ ] Verify that documentation compiles without warnings.

## Changelog
- [ ] Update `CHANGELOG.md`.

## Web optimization & code formatting
- Page references
  - [ ] Update `/_static/js/redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
  - [ ] Update `/llms.txt` if necessary.
- [ ] Add or update meta descriptions.
- [ ] Use three-space indentation in `.rst` files.

## Writing style
- [ ] Use **bold** for UI elements, _italics_ for key terms and emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Follow present tense, active voice, and a semi-formal tone.
- [ ] Write short, clear, and concise sentences.
