### PR TITLE
Add verification step after docker compose startup

### DIFF
--- a/source/deployment-options/docker/wazuh-container.rst
+++ b/source/deployment-options/docker/wazuh-container.rst
@@ -248,6 +248,13 @@ Start the Wazuh Docker deployment using the ``docker compose`` command:
       .. code-block:: console
 
          # docker compose up -d
+#. Verify that all containers are running correctly:
+
+   .. code-block:: console
+
+      # docker compose ps
+
+   Ensure all Wazuh services show the ``Up`` status before accessing the Wazuh dashboard.
 
    .. group-tab:: Foreground
 


### PR DESCRIPTION
## Description

Adds a verification step after starting the Wazuh Docker deployment to ensure all containers are running correctly before accessing the dashboard.

## Documentation

- Added `docker compose ps` verification command
- Added note to verify all services show the `Up` status