### PR TITLE
Remove the Wazuh version from the Proof of Concept guide title

### DIFF
--- a/source/proof-of-concept-guide/index.rst
+++ b/source/proof-of-concept-guide/index.rst
@@ -3,8 +3,8 @@
 .. meta::
    :description: The Proof of Concept guide explains how to set up the Wazuh environment to test the different product capabilities. Learn more about it in our documentation.
 
-Wazuh |WAZUH_CURRENT_MINOR| Proof of Concept guide
-==================================================
+Proof of Concept guide
+======================
 
 In this section of the documentation, we provide a set of use cases to explore different Wazuh capabilities. We describe how Wazuh can be configured for threat prevention, detection, and response. Each use case represents a real-world scenario that users can deploy using specific configurations.
 


### PR DESCRIPTION
## Description
Remove the Wazuh version prefix from the *Proof of Concept guide* page title so the homepage card matches the other section titles.

## Documentation compilation
- [x] Verify that documentation compiles without warnings.

## Changelog
- [ ] Update `CHANGELOG.md`.

## Web optimization & code formatting
- Page references
  - [ ] Update `/_static/js/redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
  - [ ] Update `/llms.txt` if necessary.
- [x] Add or update meta descriptions.
- [x] Use three-space indentation in `.rst` files.

## Writing style
- [x] Use **bold** for UI elements, _italics_ for key terms and emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Follow present tense, active voice, and a semi-formal tone.
- [x] Write short, clear, and concise sentences.
