### PR TITLE
Remove the Example configuration section from the Container security documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ All notable changes to this project will be documented in this file.
 - Updated the *Wazuh server* documentation to the new *Wazuh manager* documentation in the *User manual*. ([#9728](https://github.com/wazuh/wazuh-documentation/pull/9728)) ([#9737](https://github.com/wazuh/wazuh-documentation/pull/9737))
 - Updated the *User administration* documentation. ([#9745](https://github.com/wazuh/wazuh-documentation/pull/9745)) ([#9758](https://github.com/wazuh/wazuh-documentation/pull/9758)) ([#9765](https://github.com/wazuh/wazuh-documentation/pull/9765)) ([#9766](https://github.com/wazuh/wazuh-documentation/pull/9766)) ([#9775](https://github.com/wazuh/wazuh-documentation/pull/9775))
 - Updated the *Proof of concept guide* use cases for File integrity monitoring, Vulnerability detection, Monitoring Docker events, Detecting an SQL injection attack, and Monitoring AWS infrastructure. ([#9777](https://github.com/wazuh/wazuh-documentation/pull/9777))
-- Updated the *Container security* documentation. ([#9816](https://github.com/wazuh/wazuh-documentation/pull/9816)) ([#9819](https://github.com/wazuh/wazuh-documentation/pull/9819))
+- Updated the *Container security* documentation. ([#9816](https://github.com/wazuh/wazuh-documentation/pull/9816)) ([#9819](https://github.com/wazuh/wazuh-documentation/pull/9819)) ([#9823](https://github.com/wazuh/wazuh-documentation/pull/9823))
 - Updated the *System inventory* documentation. ([#9820](https://github.com/wazuh/wazuh-documentation/pull/9820))
 
 ### Removed

--- a/source/user-manual/capabilities/container-security/monitoring-docker.rst
+++ b/source/user-manual/capabilities/container-security/monitoring-docker.rst
@@ -145,17 +145,3 @@ The scheduling options allow you to configure when the Wazuh Docker listener mod
 |                  | interval value must be a multiple of days or   |               |                                    |
 |                  | weeks. The default interval is set to a day.   |               |                                    |
 +------------------+------------------------------------------------+---------------+------------------------------------+
-
-Example configuration
----------------------
-
-The example configuration below shows an enabled Wazuh Docker listener module. The module attempts to execute five times at ten-minute intervals if it fails.
-
-.. code-block:: XML
-
-   <wodle name="docker-listener">
-     <interval>10m</interval>
-     <attempts>5</attempts>
-     <run_on_start>no</run_on_start>
-     <disabled>no</disabled>
-   </wodle>


### PR DESCRIPTION
## Description
Remove the legacy Example configuration section that is not part of the Container security source document for wazuh/internal-documentation-requests#778, following up on #9816 and #9819.

## Documentation compilation
- [x] Verify that documentation compiles without warnings.

## Changelog
- [x] Update `CHANGELOG.md`.

## Web optimization & code formatting
- Page references
  - [ ] Update `/_static/js/redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
  - [ ] Update `/llms.txt` if necessary.
- [x] Add or update meta descriptions.
- [x] Use three-space indentation in `.rst` files.

## Writing style
- [x] Use **bold** for UI elements, _italics_ for key terms and emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Follow present tense, active voice, and a semi-formal tone.
- [x] Write short, clear, and concise sentences.
