### PR TITLE
Fix Noisy Warning During Make Markdown

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -471,6 +471,38 @@ def patch_markdown_translator_meta_nodes():
     MarkdownTranslator.visit_meta = lambda self, node: None
     MarkdownTranslator.depart_meta = lambda self, node: None
 
+def patch_markdown_translator_unhandled_nodes():
+    """
+    sphinx-markdown-builder's MarkdownTranslator doesn't handle a few more
+    node types found in this repo, each logging an "unknown node type"
+    warning during `make markdown` and silently dropping the node's content:
+
+    - `hlist`/`hlistcol` (from `.. hlist::`) are pure column-layout wrappers
+      around a bullet_list; treating them as pass-through (like `container`)
+      renders that list's content normally instead of dropping it — Markdown
+      has no column-layout equivalent to preserve anyway.
+    - `caption` (from a `:caption:` code-block option) has no handler at all,
+      silently discarding its text; render it as a bold label line instead.
+    - `toctree` only reaches the translator for `:hidden:` toctrees, which
+      Sphinx's own HTML5 translator also skips outright (`visit_toctree`
+      raises SkipNode there too), since they render via the sidebar/context,
+      not inline content.
+    """
+    from sphinx_markdown_builder.translator import MarkdownTranslator, PREDEFINED_ELEMENTS, SKIP
+
+    PREDEFINED_ELEMENTS["hlist"] = None
+    PREDEFINED_ELEMENTS["hlistcol"] = None
+    PREDEFINED_ELEMENTS["toctree"] = SKIP
+
+    def visit_caption(self, _node):
+        self.add("**", prefix_eol=2)
+
+    def depart_caption(self, _node):
+        self.add("**", suffix_eol=2)
+
+    MarkdownTranslator.visit_caption = visit_caption
+    MarkdownTranslator.depart_caption = depart_caption
+
 # -- Extension configuration -------------------------------------------------
 
 # -- Images extension -----------------------------------------------------
@@ -593,6 +625,7 @@ def setup(app):
     app.connect('build-finished', fix_markdown_links) # Connect the markdown link fixer to post-process generated markdown files
 
     patch_markdown_translator_meta_nodes()
+    patch_markdown_translator_unhandled_nodes()
 
     app.connect('html-page-context', pagefind_custom_weights)
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -458,6 +458,19 @@ def fix_markdown_links(app, exception):
 # Options for sphinx-markdown-builder
 markdown_http_base = '' # Use relative links
 
+def patch_markdown_translator_meta_nodes():
+    """
+    sphinx-markdown-builder's MarkdownTranslator has no visit_meta/depart_meta,
+    so every `.. meta::` directive (used site-wide for SEO descriptions) falls
+    through to unknown_visit and logs an "unknown node type" warning during
+    `make markdown`. Metadata isn't rendered in Markdown output, so skipping
+    the node is correct, not a workaround.
+    """
+    from sphinx_markdown_builder.translator import MarkdownTranslator
+
+    MarkdownTranslator.visit_meta = lambda self, node: None
+    MarkdownTranslator.depart_meta = lambda self, node: None
+
 # -- Extension configuration -------------------------------------------------
 
 # -- Images extension -----------------------------------------------------
@@ -578,6 +591,8 @@ def setup(app):
     app.connect('build-finished', finish_and_clean)
 
     app.connect('build-finished', fix_markdown_links) # Connect the markdown link fixer to post-process generated markdown files
+
+    patch_markdown_translator_meta_nodes()
 
     app.connect('html-page-context', pagefind_custom_weights)
 


### PR DESCRIPTION
## Description
Suppresses the noisy `unknown node type: <meta: >` warnings that `make markdown` logged for nearly every page by registering no-op `visit_meta`/`depart_meta` handlers on sphinx-markdown-builder's translator in `source/conf.py`.

## Documentation compilation
- [x] Verify that documentation compiles without warnings.

## Changelog
- [ ] Update `CHANGELOG.md`.

## Web optimization & code formatting
- Page references
  - [ ] Update `/_static/js/redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
  - [ ] Update `/llms.txt` if necessary.
- [ ] Add or update meta descriptions.
- [ ] Use three-space indentation in `.rst` files.

## Writing style
- [ ] Use **bold** for UI elements, _italics_ for key terms and emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Follow present tense, active voice, and a semi-formal tone.
- [ ] Write short, clear, and concise sentences.
