### PR TITLE
Update Deployment On Kubernetes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project will be documented in this file.
 - Updated the *Security configuration assessment* capability documentation. ([#9834](https://github.com/wazuh/wazuh-documentation/pull/9834)) ([#9849](https://github.com/wazuh/wazuh-documentation/pull/9849))
 - Updated the *Vulnerability detection* capability documentation. ([#9835](https://github.com/wazuh/wazuh-documentation/pull/9835)) ([#9841](https://github.com/wazuh/wazuh-documentation/pull/9841))
 - Updated the *Command monitoring* capability documentation. ([#9883](https://github.com/wazuh/wazuh-documentation/pull/9883)) ([#9915](https://github.com/wazuh/wazuh-documentation/pull/9915))
+- Updated the minimum required password length for Wazuh API users to 12 characters in the *Deploying with Kubernetes* documentation. ([#9941](https://github.com/wazuh/wazuh-documentation/pull/9941))
 
 ### Removed
 

--- a/source/deployment-options/deploying-with-kubernetes/kubernetes-password.rst
+++ b/source/deployment-options/deploying-with-kubernetes/kubernetes-password.rst
@@ -184,7 +184,7 @@ The ``wazuh-wui`` user is the default account for connecting to the Wazuh manage
 
 .. note::
 
-   The password for Wazuh API users must be between 8 and 64 characters long. It must contain at least one uppercase and one lowercase letter, a number, and a symbol.
+   The password for Wazuh API users must be between 12 and 64 characters long. It must contain at least one uppercase and one lowercase letter, a number, and a symbol.
 
 #. Encode your new password in base64 format. Use the ``-n`` option with the echo command as follows to avoid inserting a trailing newline character to maintain the hash value:
 


### PR DESCRIPTION
## Description
Updates the Kubernetes deployment documentation to raise the minimum required length for Wazuh API user passwords from 8 to 12 characters.

## Documentation compilation
- [x] Verify that documentation compiles without warnings.

## Changelog
- [x] Update `CHANGELOG.md`.

## Web optimization & code formatting
- Page references
  - [x] Update `/_static/js/redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
  - [x] Update `/llms.txt` if necessary.
- [x] Add or update meta descriptions.
- [x] Use three-space indentation in `.rst` files.

## Writing style
- [x] Use **bold** for UI elements, _italics_ for key terms and emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Follow present tense, active voice, and a semi-formal tone.
- [ ] Write short, clear, and concise sentences.
