### PR TITLE
[4.4] Revert the Microsoft Azure documentation page title update

### DIFF
--- a/source/cloud-security/azure/index.rst
+++ b/source/cloud-security/azure/index.rst
@@ -5,8 +5,8 @@
 
 .. _azure:
 
-Monitoring Microsoft Azure
-==========================
+Using Wazuh to monitor Microsoft Azure
+======================================
 
 This section provides instructions for monitoring `Microsoft Azure` infrastructures, such as:
 


### PR DESCRIPTION
## Description
Revert the Microsoft Azure documentation page title update, as the requested scope in wazuh/internal-documentation-requests#802 covers 4.9 and later versions only.

## Documentation compilation
- [x] Verify that documentation compiles without warnings.

## Changelog
- [ ] Update `CHANGELOG.md`.

## Web optimization & code formatting
- Page references
  - [ ] Update `/_static/js/redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
  - [ ] Update `/llms.txt` if necessary.
- [ ] Add or update meta descriptions.
- [x] Use three-space indentation in `.rst` files.

## Writing style
- [x] Use **bold** for UI elements, _italics_ for key terms and emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Follow present tense, active voice, and a semi-formal tone.
- [x] Write short, clear, and concise sentences.
