### PR TITLE
update docs to reflect new minimum API password length (12 instead of 8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ All notable changes to this project will be documented in this file.
 - Updated the minimum required password length for Wazuh API users to 12 characters in the *Deploying with Kubernetes* documentation. ([#9941](https://github.com/wazuh/wazuh-documentation/pull/9941))
 - Updated the *Using Wazuh for GDPR compliance* documentation in *Regulatory compliance* to Wazuh 5.0. ([#9944](https://github.com/wazuh/wazuh-documentation/pull/9944))
 
+### Fixed
+- Corrected instances of the outdated API password minimum (8 characters) to reflect the new minimum of 12 characters in 5.0.0 ([#9970](https://github.com/wazuh/wazuh-documentation/pull/9970))
+
 ### Removed
 
 - Removed all `agent-auth` references as this tool is now deprecated. ([#8718](https://github.com/wazuh/wazuh/pull/8718))

--- a/source/user-manual/api/api-examples.rst
+++ b/source/user-manual/api/api-examples.rst
@@ -43,11 +43,11 @@ The command returns output similar to the following example:
 POST
 ^^^^
 
-The following POST request to the Wazuh server API creates a new user on the Wazuh server by specifying the username ``test_user`` and password ``Test_user1`` in the request body.
+The following POST request to the Wazuh server API creates a new user on the Wazuh server by specifying the username ``test_user`` and password ``Test_user_1!`` in the request body.
 
 .. code-block:: console
 
-   # curl -k -X POST "https://localhost:55000/security/users" -H  "Authorization: Bearer $TOKEN" -H  "Content-Type: application/json" -d "{\"username\":\"test_user\",\"password\":\"Test_user1\"}"
+   # curl -k -X POST "https://localhost:55000/security/users" -H  "Authorization: Bearer $TOKEN" -H  "Content-Type: application/json" -d "{\"username\":\"test_user\",\"password\":\"Test_user_1!\"}"
 
 .. code-block:: none
    :class: output

--- a/source/user-manual/api/securing-api.rst
+++ b/source/user-manual/api/securing-api.rst
@@ -61,7 +61,7 @@ You can change the default password for the administrative users ``wazuh`` and `
 
 .. note::
 
-   The password for users must be between 8 and 64 characters long. It should contain at least one uppercase, lowercase letter, number, and symbol.
+   The password for users must be between 12 and 64 characters long. It should contain at least one uppercase, lowercase letter, number, and symbol.
 
 **We show an example of changing the password using curl below:**
 


### PR DESCRIPTION
closes #9938

Updated instances of the old password policy minimum (8 characters) to the new 12 character minimum in the 5.0.0 docs. This consisted of making the following changes to these files: 

source/user-manual/api/securing-api.rst
     -changed "8" to "12" on line 64 

source/user-manual/api/api-examples.rst. 
     -Updated the api password example from a 10 character password to a 12 character password ("Test_user1" turned into "Test_user_1!") on lines 46 and 50

I verified that the documentation compiled following the instructions in CONTRIBUTING.md and will be adding to the changelog with my changes and the PR number. 

Note: 
Upon checking the page linked in the second instance listed in the issue, I noticed that this had already been updated accordingly, so no changes were necessary there. I also parsed through the docs to see if there were any other instances of this and was unable to find anything else. 