### PR TITLE
Fix User Manual Index Section Structure 4.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [v4.14.7]
 
 - **Post-release**: Obscured the sample private key values in the GCP credentials documentation. ([#9971](https://github.com/wazuh/wazuh-documentation/pull/9971))
+- **Post-release**: Fixed the *User manual* index page so it shows the full page list for the *Wazuh dashboard* and *Data analysis* subsections. ([#9992](https://github.com/wazuh/wazuh-documentation/pull/9992))
 
 ## [v4.14.6]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 - **Post-release**: Obscured the sample private key values in the GCP credentials documentation. ([#9971](https://github.com/wazuh/wazuh-documentation/pull/9971))
 - **Post-release**: Fixed the *User manual* index page so it shows the full page list for the *Wazuh dashboard* and *Data analysis* subsections. ([#9992](https://github.com/wazuh/wazuh-documentation/pull/9992))
+- **Post-release**: Fixed the *Deployment with Puppet* index page so the *Wazuh Puppet module* reference pages are listed. ([#9992](https://github.com/wazuh/wazuh-documentation/pull/9992))
 
 ## [v4.14.6]
 

--- a/source/deployment-options/deploying-with-puppet/index.rst
+++ b/source/deployment-options/deploying-with-puppet/index.rst
@@ -14,6 +14,7 @@ Puppet is an open source software that automatically inspects, delivers, operate
 
     .. toctree::
         :maxdepth: 2
+        :titlesonly:
 
         setup-puppet/index
         wazuh-puppet-module/index

--- a/source/user-manual/index.rst
+++ b/source/user-manual/index.rst
@@ -12,6 +12,7 @@ Welcome to the Wazuh user manual. Use it as your reference library once your bas
 
    .. toctree::
       :maxdepth: 2
+      :titlesonly:
 
       manager/index
       wazuh-server-cluster/index


### PR DESCRIPTION
## Description

Adds `:titlesonly:` to two parent toctrees so they fully resolve their child pages instead of stopping at an intervening in-page heading: the *User manual* index page (its *Wazuh dashboard* and *Data analysis* subsections) and the *Deployment with Puppet* index page (its *Wazuh Puppet module* reference pages), matching the section structure already shown by the rest of the docs.

## Documentation compilation
- [x] Verify that documentation compiles without warnings.

## Changelog
- [x] Update `CHANGELOG.md`.

## Web optimization & code formatting
- Page references
  - [x] Update `/_static/js/redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
  - [x] Update `/llms.txt` if necessary.
- [x] Add or update meta descriptions.
- [x] Use three-space indentation in `.rst` files.

## Writing style
- [x] Use **bold** for UI elements, _italics_ for key terms and emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Follow present tense, active voice, and a semi-formal tone.
- [x] Write short, clear, and concise sentences.
