### PR TITLE
Fix is_latest_release and version selector order for 5.0

### DIFF
--- a/source/_static/js/redirects.js
+++ b/source/_static/js/redirects.js
@@ -40,7 +40,7 @@ const versions = [
 
 betaVersions.push(
   /* [ LABEL , BETA_FOLDER, FILE_PATH ] */
-  ['5.0 (Beta 4)', '5.0-beta', '/index.html']
+  ['5.0 (Beta 4)', '5.0-beta', '/getting-started/index.html']
 );
 
 /* Data structure for every release

--- a/source/_static/js/redirects.js
+++ b/source/_static/js/redirects.js
@@ -5,8 +5,8 @@ const betaVersions = []; // Important: betaVersions won't redirect between simil
 
 /* Note: new release versions must always be inserted in the first position of the array "versions" */
 const versions = [
-  '5.0',
   '4.14',
+  '5.0',
   '4.13',
   '4.12',
   '4.11',

--- a/source/_variables/settings.py
+++ b/source/_variables/settings.py
@@ -16,7 +16,7 @@
 
 # The short X.Y version
 version = '5.0'
-is_latest_release = True
+is_latest_release = False
 
 # The full version, including alpha/beta/rc tags
 # Important: use a valid branch (4.0) or, preferably, tag name (v4.0.0)


### PR DESCRIPTION
## Description
Fixes the 5.0 line still marking itself as the latest release (`is_latest_release = True`) while 4.14 is the actual current/stable version. This caused `5.0-beta1` pages to be served with `robots: index` and a `canonical` tag pointing at `/current/...`, which now resolves to unrelated 4.14 content. Also reorders `versions` in `redirects.js` so `4.14` is first, keeping the version-selector's notion of "current" consistent with `is_latest_release` (this exact mismatch caused a prior fix for the same issue to be reverted under idr9660).

## Documentation compilation
- [x] Verify that documentation compiles without warnings.

## Changelog
- [ ] Update `CHANGELOG.md`.

## Web optimization & code formatting
- Page references
  - [x] Update `/_static/js/redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
  - [ ] Update `/llms.txt` if necessary.
- [ ] Add or update meta descriptions.
- [ ] Use three-space indentation in `.rst` files.

## Writing style
- [ ] Use **bold** for UI elements, _italics_ for key terms and emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Follow present tense, active voice, and a semi-formal tone.
- [ ] Write short, clear, and concise sentences.
