### PR TITLE
Fix 5.0 beta version-selector link

### DIFF
--- a/source/_static/js/redirects.js
+++ b/source/_static/js/redirects.js
@@ -39,7 +39,7 @@ const versions = [
 
 betaVersions.push(
   /* [ LABEL , BETA_FOLDER, FILE_PATH ] */
-  ['5.0 (Beta 4)', '5.0-beta', '/index.html']
+  ['5.0 (Beta 4)', '5.0-beta', '/getting-started/index.html']
 );
 
 /* Data structure for every release


### PR DESCRIPTION
## Description
Fixes the version-selector's "5.0 (Beta 4)" link, which pointed at `/5.0-beta/index.html`. That page runs a client-side redirect keyed on the build's `version` setting (`5.0`), which does not match the folder it is actually published under (`5.0-beta`), so it bounced to a nonexistent `/5.0/getting-started/index.html`. Points the link at `/5.0-beta/getting-started/index.html` instead, a real page in the published beta folder. This file is loaded from `/current/` by every page on the site in production, so the fix belongs on this branch rather than on the 5.0 line.

## Documentation compilation
- [x] Verify that documentation compiles without warnings.

## Changelog
- [ ] Update `CHANGELOG.md`.

## Web optimization & code formatting
- Page references
  - [x] Update `/_static/js/redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
  - [ ] Update `/llms.txt` if necessary.
- [ ] Add or update meta descriptions.
- [ ] Use three-space indentation in `.rst` files.

## Writing style
- [ ] Use **bold** for UI elements, _italics_ for key terms and emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Follow present tense, active voice, and a semi-formal tone.
- [ ] Write short, clear, and concise sentences.
