### PR TITLE
Render real landing page for pre-release version folders 5.0.0

### DIFF
--- a/source/_static/js/redirects.js
+++ b/source/_static/js/redirects.js
@@ -40,7 +40,7 @@ const versions = [
 
 betaVersions.push(
   /* [ LABEL , BETA_FOLDER, FILE_PATH ] */
-  ['5.0 (Beta 4)', '5.0-beta', '/getting-started/index.html']
+  ['5.0 (Beta 4)', '5.0-beta', '/index.html']
 );
 
 /* Data structure for every release

--- a/source/_themes/wazuh_doc_theme_v3/index.html
+++ b/source/_themes/wazuh_doc_theme_v3/index.html
@@ -6,7 +6,7 @@
     
 -#}
 
-{% if is_latest_release and theme_breadcrumb_root_title == 'Documentation' %}
+{% if (is_latest_release or is_prerelease) and theme_breadcrumb_root_title == 'Documentation' %}
 
   {%- extends "!wazuh_doc_theme_v3/template-parts/body.html" -%}
   

--- a/source/_variables/settings.py
+++ b/source/_variables/settings.py
@@ -7,6 +7,9 @@
 #
 # * is_latest_release: this variable must be set to False except for the
 #     latest release, where it must set to True.
+# * is_prerelease: set to True only on a branch that previews an upcoming
+#     release under a beta/RC URL folder; leave False everywhere else
+#     (including the latest release and all archived releases).
 # * version: short X.Y version
 # * release: long X.Y.z version
 # * apiURL: URL of the Wazuh API reference spec in the Wazih repository (public)
@@ -17,6 +20,7 @@
 # The short X.Y version
 version = '5.0'
 is_latest_release = False
+is_prerelease = True
 
 # The full version, including alpha/beta/rc tags
 # Important: use a valid branch (4.0) or, preferably, tag name (v4.0.0)

--- a/source/conf.py
+++ b/source/conf.py
@@ -25,7 +25,7 @@ except ImportError:
     sys.exit()
 from requests.utils import requote_uri
 sys.path.append(os.path.abspath("_variables"))
-from settings import version, is_latest_release, release, api_tag, apiURL, apiURL_indexer, apiURL_server
+from settings import version, is_latest_release, is_prerelease, release, api_tag, apiURL, apiURL_indexer, apiURL_server
 from replacements import custom_replacements
 from empty_toc_nodes import emptyTocNodes
 from redirect_same_release import redirectSameRelease
@@ -900,6 +900,7 @@ html_context = {
     "compilation_ts": compilation_time,
     "empty_toc_nodes": emptyTocNodes,
     "redirectSameRelease": redirectSameRelease,
-    "is_latest_release": is_latest_release
+    "is_latest_release": is_latest_release,
+    "is_prerelease": is_prerelease
 }
 sphinx_tabs_nowarn = True


### PR DESCRIPTION
## Description
Fixes the broken `5.0-beta` home page: `index.html` was JS-redirected by `index-redirect.js` to `/5.0/getting-started/index.html`, which doesn't exist. Sets `is_prerelease = True` on this branch (which deploys under the `5.0-beta` URL folder) so `index.html` renders its own real landing page directly instead of redirecting, matching the same `is_prerelease` mechanism added on `4.14`.

## Documentation compilation
- [x] Verify that documentation compiles without warnings.

## Changelog
- [ ] Update `CHANGELOG.md`.

## Web optimization & code formatting
- Page references
  - [ ] Update `/_static/js/redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
  - [ ] Update `/llms.txt` if necessary.
- [ ] Add or update meta descriptions.
- [ ] Use three-space indentation in `.rst` files.

## Writing style
- [ ] Use **bold** for UI elements, _italics_ for key terms and emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Follow present tense, active voice, and a semi-formal tone.
- [ ] Write short, clear, and concise sentences.
