### PR TITLE
Adapt not-latest notice wording for pre-release version folders

### DIFF
--- a/source/_themes/wazuh_doc_theme_v3/template-parts/no-latest-notice.html
+++ b/source/_themes/wazuh_doc_theme_v3/template-parts/no-latest-notice.html
@@ -7,7 +7,11 @@
 <div class="no-latest-notice-wrapper">
   <div class="no-latest-notice">
     <span class="no-latest-title">Attention</span>
+    {% if is_prerelease %}
+    <span class="no-latest-text-wrapper"> This documentation covers an upcoming release that is still under development. For the current stable documentation, check out <a class="link-latest" href="#">the latest version</a>.</span>
+    {% else %}
     <span class="no-latest-text-wrapper"> This documentation does not apply to the most recent version of Wazuh. Check out the docs for <a class="link-latest" href="#">the latest version</a>.</span>
+    {% endif %}
   </div>
 </div>
 {% endif %}

--- a/source/_themes/wazuh_doc_theme_v3/template-parts/no-latest-notice.html
+++ b/source/_themes/wazuh_doc_theme_v3/template-parts/no-latest-notice.html
@@ -4,13 +4,14 @@
   {%- set nav_version = current_version %}
 {% endif %}
 {% if nav_version and not is_latest_release %}
+{%- set latest_link_href = (theme_wazuh_doc_url + '/current/' + pagename + '.html') if pagename == 'index' else '#' -%}
 <div class="no-latest-notice-wrapper">
   <div class="no-latest-notice">
     <span class="no-latest-title">Attention</span>
     {% if is_prerelease %}
-    <span class="no-latest-text-wrapper"> This documentation covers an upcoming release that is still under development. For the current stable documentation, check out <a class="link-latest" href="#">the latest version</a>.</span>
+    <span class="no-latest-text-wrapper"> This documentation covers an upcoming release that is still under development. For the current stable documentation, check out <a class="link-latest" href="{{ latest_link_href }}">the latest version</a>.</span>
     {% else %}
-    <span class="no-latest-text-wrapper"> This documentation does not apply to the most recent version of Wazuh. Check out the docs for <a class="link-latest" href="#">the latest version</a>.</span>
+    <span class="no-latest-text-wrapper"> This documentation does not apply to the most recent version of Wazuh. Check out the docs for <a class="link-latest" href="{{ latest_link_href }}">the latest version</a>.</span>
     {% endif %}
   </div>
 </div>


### PR DESCRIPTION
## Description
Adapts the "not the most recent version" notice banner to branch its wording on the existing `is_prerelease` flag (added in IDR-833): pre-release/beta version folders now get "This documentation covers an upcoming release that is still under development..." instead of the archived-release wording. This is a no-op on `4.14` (the banner never renders here since `is_latest_release = True`); it lands the template logic so it flows forward through the normal merge chain.

## Documentation compilation
- [x] Verify that documentation compiles without warnings.

## Changelog
- [ ] Update `CHANGELOG.md`.

## Web optimization & code formatting
- Page references
  - [ ] Update `/_static/js/redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
  - [ ] Update `/llms.txt` if necessary.
- [ ] Add or update meta descriptions.
- [ ] Use three-space indentation in `.rst` files.

## Writing style
- [ ] Use **bold** for UI elements, _italics_ for key terms and emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Follow present tense, active voice, and a semi-formal tone.
- [ ] Write short, clear, and concise sentences.
