### PR TITLE
Add Version Matching Guidance To The Upscaling Docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 - **Post-release**: Obscured the sample private key values in the GCP credentials documentation. ([#9971](https://github.com/wazuh/wazuh-documentation/pull/9971))
 - **Post-release**: Fixed the *User manual* index page so it shows the full page list for the *Wazuh dashboard* and *Data analysis* subsections. ([#9992](https://github.com/wazuh/wazuh-documentation/pull/9992))
 - **Post-release**: Fixed the *Deployment with Puppet* index page so the *Wazuh Puppet module* reference pages are listed. ([#9992](https://github.com/wazuh/wazuh-documentation/pull/9992))
+- **Post-release**: Added guidance about matching the Wazuh manager version to the existing cluster nodes in the *Adding new Wazuh server nodes* documentation. ([#10007](https://github.com/wazuh/wazuh-documentation/pull/10007))
 
 ## [v4.14.6]
 

--- a/source/user-manual/wazuh-server-cluster/adding-new-server-nodes/all-in-one-deployment.rst
+++ b/source/user-manual/wazuh-server-cluster/adding-new-server-nodes/all-in-one-deployment.rst
@@ -338,7 +338,7 @@ This step ensures that the new Wazuh server node can download and install the re
 Installing the Wazuh manager
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This step installs the Wazuh manager on the node, which enables it to function as part of the cluster and manage alerts,Wazuh  agents, and internal communication.
+This step installs the Wazuh manager on the node, which enables it to function as part of the cluster and manage alerts, Wazuh agents, and internal communication.
 
 #. Install the Wazuh manager package.
 
@@ -355,6 +355,26 @@ This step installs the Wazuh manager on the node, which enables it to function a
          .. code-block:: console
 
             # apt-get -y install wazuh-manager
+
+   .. note::
+
+      The commands above install the latest version of the Wazuh manager. All nodes in a Wazuh server cluster must run the same version. If your existing node runs an earlier Wazuh server version, install that specific version instead, for example:
+
+      .. tabs::
+
+         .. group-tab:: YUM
+
+            .. code-block:: console
+
+               # yum -y install wazuh-manager-4.14.4-1
+
+         .. group-tab:: APT
+
+            .. code-block:: console
+
+               # apt-get -y install wazuh-manager=4.14.4-1
+
+      Alternatively, upgrade the existing Wazuh server to the latest version before adding the new node.
 
 #. Enable and start the Wazuh manager service.
 

--- a/source/user-manual/wazuh-server-cluster/adding-new-server-nodes/distributed-deployment.rst
+++ b/source/user-manual/wazuh-server-cluster/adding-new-server-nodes/distributed-deployment.rst
@@ -456,6 +456,26 @@ This step installs the Wazuh manager on the node, which enables it to function a
 
             # apt-get -y install wazuh-manager
 
+   .. note::
+
+      The commands above install the latest version of the Wazuh manager. All nodes in a Wazuh server cluster must run the same version. If your existing node runs an earlier Wazuh server version, install that specific version instead, for example:
+
+      .. tabs::
+
+         .. group-tab:: YUM
+
+            .. code-block:: console
+
+               # yum -y install wazuh-manager-4.14.4-1
+
+         .. group-tab:: APT
+
+            .. code-block:: console
+
+               # apt-get -y install wazuh-manager=4.14.4-1
+
+      Alternatively, upgrade the existing Wazuh server to the latest version before adding the new node.
+
 #. Enable and start the Wazuh manager service.
 
    .. tabs::


### PR DESCRIPTION
## Description

Adds guidance to the *Installing the Wazuh manager* step of the *Adding new Wazuh server nodes* documentation (all-in-one and distributed deployment) about matching the new node's Wazuh manager version to the version already running on the cluster.

## Documentation compilation
- [x] Verify that documentation compiles without warnings.

## Changelog
- [x] Update `CHANGELOG.md`.

## Web optimization & code formatting
- Page references
  - [x] Update `/_static/js/redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
  - [x] Update `/llms.txt` if necessary.
- [x] Add or update meta descriptions.
- [x] Use three-space indentation in `.rst` files.

## Writing style
- [ ] Use **bold** for UI elements, _italics_ for key terms and emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Follow present tense, active voice, and a semi-formal tone.
- [ ] Write short, clear, and concise sentences.
