### PR TITLE
[4.12] Add version matching guidance and move root-privileges note for adding new server nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
 - **Post-release**: Added LLMs-ready documentation. ([#9219](https://github.com/wazuh/wazuh-documentation/pull/9219))
 - **Post-release**: Added note about Linux and macOS WPK ARM packages in 4.12 and earlier versions. ([#9308](https://github.com/wazuh/wazuh-documentation/pull/9308))
 - **Post-release**: Backport: Added the *System requirements* section to the *Wazuh server cluster* documentation. ([#9673](https://github.com/wazuh/wazuh-documentation/pull/9673))
+- **Post-release**: Added guidance about matching the Wazuh manager version in the *Adding new Wazuh server nodes* documentation. ([#10013](https://github.com/wazuh/wazuh-documentation/pull/10013))
 
 ### Changed
 
@@ -76,7 +77,7 @@ All notable changes to this project will be documented in this file.
 - **Post-release**: Updated `offline-url` setting reference in the vulnerability detection capability section. ([#9199](https://github.com/wazuh/wazuh-documentation/pull/9199))
 - **Post-release**: Updated the *Monitoring Microsoft Azure* documentation page title. ([#9925](https://github.com/wazuh/wazuh-documentation/pull/9925))
 - **Post-release**: Obscured the sample private key values in the GCP credentials documentation. ([#9973](https://github.com/wazuh/wazuh-documentation/pull/9973))
-- **Post-release**: Added guidance about matching the Wazuh manager version and moved the root user privileges note into each step of the *Adding new Wazuh server nodes* documentation. ([#10013](https://github.com/wazuh/wazuh-documentation/pull/10013))
+- **Post-release**: Moved the root user privileges note into each step of the *Adding new Wazuh server nodes* documentation. ([#10013](https://github.com/wazuh/wazuh-documentation/pull/10013))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ All notable changes to this project will be documented in this file.
 - **Post-release**: Updated `offline-url` setting reference in the vulnerability detection capability section. ([#9199](https://github.com/wazuh/wazuh-documentation/pull/9199))
 - **Post-release**: Updated the *Monitoring Microsoft Azure* documentation page title. ([#9925](https://github.com/wazuh/wazuh-documentation/pull/9925))
 - **Post-release**: Obscured the sample private key values in the GCP credentials documentation. ([#9973](https://github.com/wazuh/wazuh-documentation/pull/9973))
+- **Post-release**: Added guidance about matching the Wazuh manager version and moved the root user privileges note into each step of the *Adding new Wazuh server nodes* documentation. ([#10013](https://github.com/wazuh/wazuh-documentation/pull/10013))
 
 ### Fixed
 

--- a/source/user-manual/wazuh-server-cluster/adding-new-server-nodes/certificates-creation.rst
+++ b/source/user-manual/wazuh-server-cluster/adding-new-server-nodes/certificates-creation.rst
@@ -10,6 +10,10 @@ Wazuh uses certificates to establish trust and confidentiality between its compo
 
 Perform the following steps on your existing Wazuh server node to generate the certificates required for secure communication among the Wazuh central components.
 
+.. note::
+
+   You need root user privileges to execute the commands below.
+
 All-in-one deployment
 ---------------------
 

--- a/source/user-manual/wazuh-server-cluster/adding-new-server-nodes/configuration-to-connect-with-new-node.rst
+++ b/source/user-manual/wazuh-server-cluster/adding-new-server-nodes/configuration-to-connect-with-new-node.rst
@@ -6,6 +6,10 @@
 Configuring existing components to connect with the new node
 ============================================================
 
+.. note::
+
+   You need root user privileges to execute the commands below.
+
 All-in-one deployment
 ---------------------
 

--- a/source/user-manual/wazuh-server-cluster/adding-new-server-nodes/index.rst
+++ b/source/user-manual/wazuh-server-cluster/adding-new-server-nodes/index.rst
@@ -22,10 +22,6 @@ We have organized the steps for upscaling the Wazuh server into two subsections:
 
 Ensure you select the appropriate sub-section based on your existing deployment. If you are unsure which method aligns with your infrastructure, consider reviewing your deployment architecture before proceeding.
 
-.. note::
-
-   You need root user privileges to execute the commands in the next sub-sections.
-
 .. toctree::
    :titlesonly:
 

--- a/source/user-manual/wazuh-server-cluster/adding-new-server-nodes/server-nodes-installation.rst
+++ b/source/user-manual/wazuh-server-cluster/adding-new-server-nodes/server-nodes-installation.rst
@@ -8,6 +8,10 @@ Wazuh server node(s) installation
 
 Once the certificates have been created and copied to the new node(s), you can now proceed with installing and configuring the new Wazuh server as a worker node.
 
+.. note::
+
+   You need root user privileges to execute the commands below.
+
 Adding the Wazuh repository
 ---------------------------
 
@@ -79,6 +83,26 @@ Installing the Wazuh manager
          .. code-block:: console
 
             # apt-get -y install wazuh-manager
+
+   .. note::
+
+      The commands above install the latest version of the Wazuh manager. All nodes in a Wazuh server cluster must run the same version. If your existing node runs an earlier Wazuh server version, install that specific version instead, for example:
+
+      .. tabs::
+
+         .. group-tab:: YUM
+
+            .. code-block:: console
+
+               # yum -y install wazuh-manager-4.11.2-1
+
+         .. group-tab:: APT
+
+            .. code-block:: console
+
+               # apt-get -y install wazuh-manager=4.11.2-1
+
+      Alternatively, upgrade the existing Wazuh server to the latest version before adding the new node.
 
 #. Enable and start the Wazuh manager service.
 

--- a/source/user-manual/wazuh-server-cluster/adding-new-server-nodes/testing-the-cluster.rst
+++ b/source/user-manual/wazuh-server-cluster/adding-new-server-nodes/testing-the-cluster.rst
@@ -11,6 +11,10 @@ Now that the installation and configuration are completed, you can proceed with 
 -  `Using the cluster control tool`_
 -  `Using the Wazuh API console`_
 
+.. note::
+
+   You need root user privileges to execute the commands below.
+
 Using the cluster control tool
 ------------------------------
 


### PR DESCRIPTION
## Description

Backports two fixes already applied to the `4.14` branch's *Adding new Wazuh server nodes* documentation, adapted to this branch's pre-rework page structure (`certificates-creation.rst`, `configuration-to-connect-with-new-node.rst`, `server-nodes-installation.rst`, `testing-the-cluster.rst`):

- Adds guidance about matching the new node's Wazuh manager version to the version already running on the cluster (see [#10007](https://github.com/wazuh/wazuh-documentation/pull/10007)).
- Moves the "root user privileges" note off the shared `index.rst` and onto each of the four instructional pages, so a reader landing directly on one via search or a deep link doesn't miss it (see [#9937](https://github.com/wazuh/wazuh-documentation/pull/9937)).

## Documentation compilation
- [x] Verify that documentation compiles without warnings.

## Changelog
- [x] Update `CHANGELOG.md`.

## Web optimization & code formatting
- Page references
  - [x] Update `/_static/js/redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
  - [x] Update `/llms.txt` if necessary.
- [x] Add or update meta descriptions.
- [x] Use three-space indentation in `.rst` files.

## Writing style
- [x] Use **bold** for UI elements, _italics_ for key terms and emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Follow present tense, active voice, and a semi-formal tone.
- [x] Write short, clear, and concise sentences.
