### PR TITLE
Update Architecture Component Communication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - **Post-release**: Fixed the *User manual* index page so it shows the full page list for the *Wazuh dashboard* and *Data analysis* subsections. ([#9992](https://github.com/wazuh/wazuh-documentation/pull/9992))
 - **Post-release**: Fixed the *Deployment with Puppet* index page so the *Wazuh Puppet module* reference pages are listed. ([#9992](https://github.com/wazuh/wazuh-documentation/pull/9992))
 - **Post-release**: Added guidance about matching the Wazuh manager version to the existing cluster nodes in the *Adding new Wazuh server nodes* documentation. ([#10007](https://github.com/wazuh/wazuh-documentation/pull/10007))
+- **Post-release**: Fixed a duplicate heading in the *Architecture* documentation's component communication section, separating the Wazuh dashboard's connections to the Wazuh server and Wazuh indexer. ([#10038](https://github.com/wazuh/wazuh-documentation/pull/10038))
 
 ## [v4.14.6]
 

--- a/source/getting-started/architecture.rst
+++ b/source/getting-started/architecture.rst
@@ -47,12 +47,15 @@ Wazuh server - Wazuh indexer
 
 The Wazuh server uses Filebeat to send alert and event data to the Wazuh indexer, using TLS encryption. Filebeat reads the Wazuh server output data and sends it to the Wazuh indexer (by default listening on port 9200/TCP). Once the data is indexed by the Wazuh indexer, the Wazuh dashboard is used to query and visualize the security information.
 
-Wazuh dashboard - Wazuh dashboard/Wazuh indexer
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Wazuh dashboard - Wazuh server
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The Wazuh dashboard queries the Wazuh server API (by default listening on port 55000/TCP on the Wazuh server) to display configuration and status-related information of the :doc:`Wazuh server <components/wazuh-server>` and :doc:`agents <components/wazuh-agent>`. This communication is encrypted with TLS and authenticated with a username and password.
+The Wazuh dashboard queries the Wazuh server API (by default listening on TCP port ``55000``) to display configuration and status-related information of the :doc:`Wazuh server <components/wazuh-server>` and :doc:`Wazuh agents <components/wazuh-agent>`. This communication is encrypted with SSL certificates and authenticated with a username and password.
 
-The Wazuh dashboard visualizes and queries the information indexed on the Wazuh indexer.
+Wazuh dashboard - Wazuh indexer
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The Wazuh dashboard communicates with the :doc:`Wazuh indexer <components/wazuh-indexer>` to query and retrieve indexed security data for visualization and analysis. It uses secure HTTPS connections to interact with the Wazuh indexer RESTful API, sending search, aggregation, and management queries. The Wazuh indexer processes these requests and returns the relevant data, which the dashboard then reports.
 
 .. _default_ports:
 


### PR DESCRIPTION
## Description
Fixes a duplicate "Wazuh dashboard" heading in the *Architecture* documentation's component communication section by splitting it into separate "Wazuh dashboard - Wazuh server" and "Wazuh dashboard - Wazuh indexer" sections, matching the naming pattern used by the other component-communication subsections.

## Documentation compilation
- [x] Verify that documentation compiles without warnings.

## Changelog
- [x] Update `CHANGELOG.md`.

## Web optimization & code formatting
- Page references
  - [x] Update `/_static/js/redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
  - [x] Update `/llms.txt` if necessary.
- [x] Add or update meta descriptions.
- [x] Use three-space indentation in `.rst` files.

## Writing style
- [ ] Use **bold** for UI elements, _italics_ for key terms and emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Follow present tense, active voice, and a semi-formal tone.
- [ ] Write short, clear, and concise sentences.
