### PR TITLE
Warn about installing a Wazuh agent on an endpoint that runs a Wazuh manager

### DIFF
--- a/source/installation-guide/wazuh-agent/wazuh-agent-package-linux.rst
+++ b/source/installation-guide/wazuh-agent/wazuh-agent-package-linux.rst
@@ -42,6 +42,10 @@ Deploy a Wazuh agent
 
 Follow these steps to deploy the Wazuh agent on your Linux endpoint.
 
+.. warning::
+
+   To monitor an endpoint that runs a Wazuh manager, install a Wazuh agent with the same major version as the Wazuh manager. Wazuh 4.x agent packages declare a conflict with the ``wazuh-manager`` package, so a Wazuh 4.x agent and a Wazuh 5.x manager cannot coexist on the same endpoint. Depending on the package manager, the installation fails or removes the Wazuh manager to resolve the conflict.
+
 #. Select your package manager and run the command below.
 
    Replace

--- a/source/user-manual/capabilities/file-integrity/basic-settings.rst
+++ b/source/user-manual/capabilities/file-integrity/basic-settings.rst
@@ -6,7 +6,7 @@
 Basic configuration options
 ============================
 
-Configure the FIM capability locally on each Wazuh agent or remotely through centralized configuration. Wazuh agents include a default FIM configuration you can modify as needed. To monitor file integrity on a Wazuh manager endpoint, install a Wazuh agent on the same host. Find all FIM configuration options in the ``syscheck`` section.
+Configure the FIM capability locally on each Wazuh agent or remotely through centralized configuration. Wazuh agents include a default FIM configuration you can modify as needed. To monitor file integrity on a Wazuh manager endpoint, install a Wazuh agent with the same major version as the Wazuh manager on the same host. Find all FIM configuration options in the ``syscheck`` section.
 
 This section covers the common FIM configuration options used for file integrity monitoring. For additional settings, see the :doc:`advanced configuration options </user-manual/capabilities/file-integrity/advanced-settings>`.
 


### PR DESCRIPTION
## Description

Wazuh 4.x agent packages declare an unversioned conflict with the `wazuh-manager` package (`Conflicts: ossec-hids-agent, wazuh-manager, ossec-hids, wazuh-api` in `packages/debs/SPECS/wazuh-agent/debian/control`, and the equivalent lines in `packages/rpms/SPECS/wazuh-agent.spec` and `packages/aix/SPECS/wazuh-agent-aix.spec` of the 4.14 branch). Because the conflict has no version restriction, it also matches the Wazuh 5.x manager, so a Wazuh 4.x agent and a Wazuh 5.x manager cannot coexist on the same endpoint. Depending on the package manager, the installation fails or the Wazuh manager is removed to resolve the conflict.

Wazuh 5.0.0 dropped the mutual agent/manager conflict from its own packages, so an agent and a manager can share an endpoint only when both are 5.x. The documentation does not mention this anywhere, and the FIM basic configuration page instructs users to install an agent on the Wazuh manager endpoint to monitor it, without stating the version requirement.

This PR adds a warning to the Linux agent deployment guide and clarifies the FIM sentence.

Reproduction on Ubuntu 22.04 with a Wazuh 5.0.0 manager installed, where APT resolves the conflict by removing the manager:

```
root@ubuntu22:/home/vagrant# /var/wazuh-manager/bin/wazuh-manager-control info
WAZUH_VERSION="v5.0.0"
WAZUH_REVISION="beta5"
WAZUH_TYPE="manager"

root@ubuntu22:/home/vagrant# WAZUH_MANAGER="192.168.56.34" WAZUH_REGISTRATION_PASSWORD="***" apt install ./wazuh-agent_4.14.7-1_amd64.deb
The following packages will be REMOVED:
  wazuh-manager
The following NEW packages will be installed:
  wazuh-agent
0 upgraded, 1 newly installed, 1 to remove and 280 not upgraded.
...
Removing wazuh-manager (5.0.0-latest) ...
Unpacking wazuh-agent (4.14.7-1) ...
Setting up wazuh-agent (4.14.7-1) ...

root@ubuntu22:/home/vagrant# /var/wazuh-manager/bin/wazuh-manager-control info
bash: /var/wazuh-manager/bin/wazuh-manager-control: No such file or directory
```

## Documentation compilation
- [ ] Verify that documentation compiles without warnings.

## Changelog
- [ ] Update `CHANGELOG.md`.

## Web optimization & code formatting
- Page references
  - [x] Update `/_static/js/redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
  - [x] Update `/llms.txt` if necessary.
- [x] Add or update meta descriptions.
- [x] Use three-space indentation in `.rst` files.

## Writing style
- [x] Use **bold** for UI elements, _italics_ for key terms and emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Follow present tense, active voice, and a semi-formal tone.
- [x] Write short, clear, and concise sentences.
