### PR TITLE
Update version to Beta 5 in 5.0 documentation

### DIFF
--- a/source/_variables/replacements.py
+++ b/source/_variables/replacements.py
@@ -35,7 +35,7 @@ custom_replacements = {
 
     # --- Revision numbers for Wazuh manager package version
     # RPM and Deb manager package revisions
-    "|WAZUH_MANAGER_CURRENT_REV|" : "beta4", # RPM and Deb
+    "|WAZUH_MANAGER_CURRENT_REV|" : "beta5", # RPM and Deb
     # --- Architectures for Wazuh manager packages
     "|WAZUH_MANAGER_x64_RPM|" : "x86_64",
     "|WAZUH_MANAGER_x64_DEB|" : "amd64",
@@ -44,7 +44,7 @@ custom_replacements = {
 
     # --- Revision numbers for Wazuh agent package version
     # RPM and Deb agent package revisions
-    "|WAZUH_AGENT_CURRENT_REV|" : "beta4", # RPM and Deb
+    "|WAZUH_AGENT_CURRENT_REV|" : "beta5", # RPM and Deb
     # --- Architectures for Wazuh agent packages
     "|WAZUH_AGENT_x64_RPM|" : "x86_64",
     "|WAZUH_AGENT_x64_DEB|" : "amd64",
@@ -53,7 +53,7 @@ custom_replacements = {
 
     #
     # === Wazuh indexer version revisions
-    "|WAZUH_INDEXER_CURRENT_REV|" : "beta4", # RPM and Deb
+    "|WAZUH_INDEXER_CURRENT_REV|" : "beta5", # RPM and Deb
     #"|WAZUH_INDEXER_CURRENT_REV_DEB|" :
     # --- Architectures for Wazuh indexer packages
     "|WAZUH_INDEXER_x64_RPM|" : "x86_64",
@@ -62,7 +62,7 @@ custom_replacements = {
     "|WAZUH_INDEXER_ARM64_DEB|" : "arm64",
     #
     # === Wazuh dashboard version revisions
-    "|WAZUH_DASHBOARD_CURRENT_REV|" : "beta4", # RPM and Deb
+    "|WAZUH_DASHBOARD_CURRENT_REV|" : "beta5", # RPM and Deb
     # --- Architectures for Wazuh dashboard packages
     "|WAZUH_DASHBOARD_x64_RPM|" : "x86_64",
     "|WAZUH_DASHBOARD_x64_DEB|" : "amd64",
@@ -76,20 +76,20 @@ custom_replacements = {
     "|WAZUH_CURRENT_MAJOR_OVA|" : "5.x",
     #"|WAZUH_CURRENT_MINOR_OVA|" :
     "|WAZUH_CURRENT_OVA|" : release,
-    "|WAZUH_CURRENT_OVA_REV|" : "beta4",
+    "|WAZUH_CURRENT_OVA_REV|" : "beta5",
     #"|WAZUH_CURRENT_MAJOR_DOCKER|" :
     "|WAZUH_CURRENT_MINOR_DOCKER|" : version,
     "|WAZUH_CURRENT_DOCKER|" : release,
-    "|WAZUH_CURRENT_DOCKER_REV|" : "beta4",
-    "|WAZUH_CURRENT_OFFLINE_INSTALL_REV|" : "beta4",
+    "|WAZUH_CURRENT_DOCKER_REV|" : "beta5",
+    "|WAZUH_CURRENT_OFFLINE_INSTALL_REV|" : "beta5",
     #"|WAZUH_CURRENT_MAJOR_KUBERNETES|" :
     #"|WAZUH_CURRENT_MINOR_KUBERNETES|" :
     "|WAZUH_CURRENT_KUBERNETES|" : release,
-    "|WAZUH_CURRENT_KUBERNETES_REV|" : "beta4",
+    "|WAZUH_CURRENT_KUBERNETES_REV|" : "beta5",
     #"|WAZUH_CURRENT_MAJOR_ANSIBLE|" :
     "|WAZUH_CURRENT_MINOR_ANSIBLE|" : version,
     "|WAZUH_CURRENT_ANSIBLE|" : release,
-    "|WAZUH_CURRENT_ANSIBLE_REV|" : "beta4",
+    "|WAZUH_CURRENT_ANSIBLE_REV|" : "beta5",
     #"|WAZUH_CURRENT_MAJOR_PUPPET|" :
     #"|WAZUH_CURRENT_MINOR_PUPPET|" :
     "|WAZUH_CURRENT_PUPPET|" : release,
@@ -105,11 +105,11 @@ custom_replacements = {
     "|WAZUH_CURRENT_MAJOR_WINDOWS|" : "5.x",
     #"|WAZUH_CURRENT_MINOR_WINDOWS|" :
     "|WAZUH_CURRENT_WINDOWS|" : release,
-    "|WAZUH_REVISION_WINDOWS|" : "beta4",
+    "|WAZUH_REVISION_WINDOWS|" : "beta5",
     "|WAZUH_CURRENT_MAJOR_OSX|" : "5.x",
     #"|WAZUH_CURRENT_MINOR_OSX|" :
     "|WAZUH_CURRENT_OSX|" : release,
-    "|WAZUH_REVISION_OSX|" : "beta4",
+    "|WAZUH_REVISION_OSX|" : "beta5",
     "|WAZUH_CURRENT_MAJOR_SOLARIS|" : "5.x",
     #"|WAZUH_CURRENT_MINOR_SOLARIS|" :
     "|WAZUH_CURRENT_SOLARIS|" : release, # Set here the lesser of WAZUH_CURRENT_MAJOR_SOLARIS10 and 11 values

--- a/source/user-manual/agent/agent-management/upgrade-agents-remotely.rst
+++ b/source/user-manual/agent/agent-management/upgrade-agents-remotely.rst
@@ -144,5 +144,5 @@ Follow these steps to upgrade a Wazuh agent using a WPK file:
       :emphasize-lines: 1
 
       WAZUH_VERSION="v5.0.0"
-      WAZUH_REVISION="beta4"
+      WAZUH_REVISION="beta5"
       WAZUH_TYPE="agent"


### PR DESCRIPTION
## Description
This PR updates 5.0.0 revision references to Beta 5.

`/_static/js/redirects.js` is intentionally **not** touched on this branch: tracing `layout.html`'s script-tag logic and `conf.py`'s `local_redirects_file` formula shows a tagged/production build of `5.0.0` (`is_latest_release = False`) always defers to `../current/redirects.min.js` — i.e. the `4.14` branch's copy, since that's the only branch where `local_redirects_file` is unconditionally true. `5.0.0`'s own copy is only read by an untagged local preview build, never the deployed site, so it doesn't need bumping here (that's handled in the separate `4.14` PR).

🤖 Drafted by Claude

## Documentation compilation
- [x] Verify that documentation compiles without warnings.

## Changelog
- [ ] Update `CHANGELOG.md`.

## Web optimization & code formatting
- Page references
  - [ ] Update `/_static/js/redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
  - [ ] Update `/llms.txt` if necessary.
- [ ] Add or update meta descriptions.
- [x] Use three-space indentation in `.rst` files.

## Writing style
- [x] Use **bold** for UI elements, _italics_ for key terms and emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Follow present tense, active voice, and a semi-formal tone.
- [x] Write short, clear, and concise sentences.
