### PR TITLE
Fix image alt text across install and PoC pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - **Post-release**: Added guidance about matching the Wazuh manager version to the existing cluster nodes in the *Adding new Wazuh server nodes* documentation. ([#10007](https://github.com/wazuh/wazuh-documentation/pull/10007))
 - **Post-release**: Fixed a duplicate heading in the *Architecture* documentation's component communication section, separating the Wazuh dashboard's connections to the Wazuh server and Wazuh indexer. ([#10038](https://github.com/wazuh/wazuh-documentation/pull/10038))
 - **Post-release**: Clarified the LDAPS connection success step and updated its screenshot in the *Active Directory and LDAP integration* documentation. ([#10039](https://github.com/wazuh/wazuh-documentation/pull/10039))
+- **Post-release**: Fixed missing or non-descriptive image alt text in the *Installation guide*, *Deployment options*, *Quickstart*, and *Proof of concept guide* documentation. ([#10057](https://github.com/wazuh/wazuh-documentation/pull/10057))
 
 ## [v4.14.6]
 

--- a/source/deployment-options/index.rst
+++ b/source/deployment-options/index.rst
@@ -66,6 +66,7 @@ If the Wazuh central components are already installed in your environment, selec
         <p class="link-boxes-label">Linux</p>
 
 .. image:: /images/installation/linux.png
+      :alt: Linux Tux penguin logo
       :align: center
 
 .. raw:: html
@@ -77,6 +78,7 @@ If the Wazuh central components are already installed in your environment, selec
         <p class="link-boxes-label">Windows</p>
 
 .. image:: /images/installation/windows-logo.png
+      :alt: Windows logo
       :align: center
 
 .. raw:: html
@@ -88,6 +90,7 @@ If the Wazuh central components are already installed in your environment, selec
         <p class="link-boxes-label">macOS</p>
 
 .. image:: /images/installation/macOS-logo.png
+      :alt: Apple macOS logo
       :align: center
 
 .. raw:: html
@@ -99,6 +102,7 @@ If the Wazuh central components are already installed in your environment, selec
         <p class="link-boxes-label">Solaris</p>
 
 .. image:: /images/installation/solaris.png
+      :alt: Oracle Solaris logo
       :align: center
       :width: 150px
 
@@ -111,6 +115,7 @@ If the Wazuh central components are already installed in your environment, selec
         <p class="link-boxes-label">AIX</p>
 
 .. image:: /images/installation/AIX.png
+      :alt: AIX logo
       :align: center
 
 .. raw:: html
@@ -122,6 +127,7 @@ If the Wazuh central components are already installed in your environment, selec
         <p class="link-boxes-label">HP-UX</p>
 
 .. image:: /images/installation/hpux.png
+      :alt: HP-UX logo
       :align: center
 
 .. raw:: html

--- a/source/installation-guide/index.rst
+++ b/source/installation-guide/index.rst
@@ -40,6 +40,7 @@ Follow this installation workflow:
         <p class="link-boxes-label">Install the Wazuh indexer</p>
 
 .. image:: ../images/installation/Indexer-noBG.png
+     :alt: Wazuh indexer logo
      :align: center
      :height: 61px
 
@@ -53,6 +54,7 @@ Follow this installation workflow:
         <p class="link-boxes-label">Install the Wazuh server</p>
 
 .. image:: ../images/installation/Server-noBG.png
+     :alt: Wazuh server logo
      :align: center
      :height: 61px
 
@@ -66,6 +68,7 @@ Follow this installation workflow:
         <p class="link-boxes-label">Install the Wazuh dashboard</p>
 
 .. image:: ../images/installation/Dashboard-noBG.png
+     :alt: Wazuh dashboard logo
      :align: center
      :height: 61px
 
@@ -92,6 +95,7 @@ Select your endpoint operating system below and follow the installation steps to
         <p class="link-boxes-label">Linux</p>
 
 .. image:: /images/installation/linux.png
+      :alt: Linux penguin mascot logo
       :align: center
 
 .. raw:: html
@@ -103,6 +107,7 @@ Select your endpoint operating system below and follow the installation steps to
         <p class="link-boxes-label">Windows</p>
 
 .. image:: /images/installation/windows-logo.png
+      :alt: Windows logo
       :align: center
 
 .. raw:: html
@@ -114,6 +119,7 @@ Select your endpoint operating system below and follow the installation steps to
         <p class="link-boxes-label">macOS</p>
 
 .. image:: /images/installation/macOS-logo.png
+      :alt: macOS Apple logo
       :align: center
 
 .. raw:: html
@@ -125,6 +131,7 @@ Select your endpoint operating system below and follow the installation steps to
         <p class="link-boxes-label">Solaris</p>
 
 .. image:: /images/installation/solaris.png
+      :alt: Oracle Solaris logo
       :align: center
       :width: 150px
 
@@ -137,6 +144,7 @@ Select your endpoint operating system below and follow the installation steps to
         <p class="link-boxes-label">AIX</p>
 
 .. image:: /images/installation/AIX.png
+      :alt: IBM AIX logo
       :align: center
 
 .. raw:: html
@@ -148,6 +156,7 @@ Select your endpoint operating system below and follow the installation steps to
         <p class="link-boxes-label">HP-UX</p>
 
 .. image:: /images/installation/hpux.png
+      :alt: HP-UX logo
       :align: center
 
 .. raw:: html

--- a/source/proof-of-concept-guide/aws-infrastructure-monitoring.rst
+++ b/source/proof-of-concept-guide/aws-infrastructure-monitoring.rst
@@ -37,6 +37,7 @@ The image below shows how to create a new CloudTrail service and attach a new S3
 
 .. thumbnail:: /images/poc/cloudtrail.gif
    :title: Creating a Cloudtrail service
+   :alt: Animated walkthrough of creating a new AWS CloudTrail trail and attaching a new S3 bucket in the AWS console
    :align: center
    :width: 80%
 
@@ -81,6 +82,7 @@ Visualize the alerts
 You can visualize the alert data in the Wazuh dashboard. To do this, navigate through **Amazon Web Services** module.
 
 .. thumbnail:: /images/poc/AWS-alerts.png
-   :title: Visualize Amazon Web Services alerts 
+   :title: Visualize Amazon Web Services alerts
+   :alt: Wazuh dashboard Events view showing AWS CloudTrail alerts in the Amazon Web Services module
    :align: center
    :width: 80%

--- a/source/proof-of-concept-guide/block-malicious-actor-ip-reputation.rst
+++ b/source/proof-of-concept-guide/block-malicious-actor-ip-reputation.rst
@@ -271,6 +271,7 @@ You can visualize the alert data in the Wazuh dashboard. To do this, go to the *
 -  Ubuntu - ``rule.id:(651 OR 100100)``
 
    .. thumbnail:: /images/poc/block-malicious-actor-ubuntu-alerts.png
+         :alt: Wazuh dashboard Threat Hunting events for the Ubuntu22.04 agent, showing alerts for an IP address found in the AlienVault reputation database and a host blocked by the firewall-drop active response.
          :title: Visualize block malicious actor Ubuntu alerts 
          :align: center
          :width: 80%
@@ -278,6 +279,7 @@ You can visualize the alert data in the Wazuh dashboard. To do this, go to the *
 -  Windows - ``rule.id:(657 OR 100100)``
 
    .. thumbnail:: /images/poc/block-malicious-actor-windows-alerts.png
+         :alt: Wazuh dashboard Threat Hunting events for the Windows11 agent, showing alerts for an IP address found in the AlienVault reputation database and netsh active response commands adding and deleting a firewall block.
          :title: Visualize block malicious actor Windows alerts 
          :align: center
          :width: 80%

--- a/source/proof-of-concept-guide/detect-web-attack-sql-injection.rst
+++ b/source/proof-of-concept-guide/detect-web-attack-sql-injection.rst
@@ -95,6 +95,7 @@ You can visualize the alert data in the Wazuh dashboard. To do this, go to the T
 
    .. thumbnail:: /images/poc/SQL-injection-rule-31103.png
       :title: SQL injection rule 31103 alert
+      :alt: Wazuh dashboard Events table showing three SQL injection attempt alerts with rule ID 31103
       :align: center
       :width: 80%
 
@@ -102,5 +103,6 @@ You can visualize the alert data in the Wazuh dashboard. To do this, go to the T
 
    .. thumbnail:: /images/poc/SQL-injection-rule-31106.png
       :title: SQL injection rule 31106 alert
+      :alt: Wazuh dashboard Events table filtered by rule ID 31106 showing successful web attack alerts with HTTP 200 responses
       :align: center
       :width: 80%

--- a/source/proof-of-concept-guide/monitoring-docker.rst
+++ b/source/proof-of-concept-guide/monitoring-docker.rst
@@ -115,6 +115,7 @@ You can visualize the alert data in the Wazuh dashboard. To do this, go to **Doc
 
    .. thumbnail:: /images/poc/docker-alerts.png
       :title: Visualize Docker alerts
+      :alt: Wazuh dashboard Docker module Events view showing a histogram and table of Docker container alerts
       :align: center
       :width: 80%
 

--- a/source/proof-of-concept-guide/poc-detect-hidden-process.rst
+++ b/source/proof-of-concept-guide/poc-detect-hidden-process.rst
@@ -145,6 +145,7 @@ You can visualize the alert data in the Wazuh dashboard. To do this, go to the *
 
    .. thumbnail:: /images/poc/hidden-processes-alerts.png
       :title: Hidden processes alerts
+      :alt: Wazuh dashboard Threat Hunting events table filtered by rule.groups:rootcheck, showing rootcheck alerts such as "Possible Kernel level rootkit" and "Host-based anomaly detection event"
       :align: center
       :width: 80%
 

--- a/source/proof-of-concept-guide/poc-file-integrity-monitoring.rst
+++ b/source/proof-of-concept-guide/poc-file-integrity-monitoring.rst
@@ -87,6 +87,7 @@ You can visualize the alert data in the Wazuh dashboard. To do this, go to the *
 
    .. thumbnail:: /images/poc/fim-alerts-ubuntu.png
          :title: Visualize FIM alerts from Ubuntu system
+         :alt: Wazuh dashboard Events table showing file added, modified, and deleted alerts for the Ubuntu agent AgentLinux
          :align: center
          :width: 80%
 
@@ -94,5 +95,6 @@ You can visualize the alert data in the Wazuh dashboard. To do this, go to the *
 
    .. thumbnail:: /images/poc/fim-alerts-windows.png
          :title: Visualize FIM alerts from Ubuntu system
+         :alt: Wazuh dashboard Events table showing file added, modified, and deleted alerts for the Windows agent WindowsAgent
          :align: center
          :width: 80%

--- a/source/proof-of-concept-guide/poc-vulnerability-detection.rst
+++ b/source/proof-of-concept-guide/poc-vulnerability-detection.rst
@@ -84,6 +84,7 @@ You can visualize the detected vulnerabilities on the Wazuh dashboard. To see a 
 -  Search and select ``vim`` in the **Values** field.
 
 .. thumbnail:: /images/poc/vulnerabilities-inventory.png
+      :alt: Wazuh dashboard Vulnerability Detection Inventory tab listing active CVEs for the vim-enhanced package on the RHEL7 agent
       :title: All active vulnerabilities on Debian. Vulnerable vim package example
       :align: center
       :width: 80%
@@ -97,6 +98,7 @@ To see vulnerability alerts from the last system inventory scan, switch to the *
 Upon installation of the vulnerable Vim package, the active vulnerability alerts can be seen on the Wazuh dashboard by changing the filter to ``data.vulnerability.package.name: vim AND data.vulnerability.status:Active``
 
 .. thumbnail:: /images/poc/vulnerabilities-events-new-vuln.png
+      :alt: Wazuh dashboard Vulnerability Detection Events tab showing active vulnerability alerts for the vim-enhanced package on the RHEL7 agent
       :title: Detected vulnerabilities on Debian. Vulnerable vim package example
       :align: center
       :width: 80%
@@ -104,6 +106,7 @@ Upon installation of the vulnerable Vim package, the active vulnerability alerts
 After removing the vulnerable package from the endpoint, to view the resolved vulnerability alerts, simply change the filter values to ``data.vulnerability.package.name: vim AND data.vulnerability.status:Solved``
 
 .. thumbnail:: /images/poc/vulnerabilities-events-solve-vuln.png
+      :alt: Wazuh dashboard Vulnerability Detection Events tab showing solved vulnerability alerts for the vim-enhanced package on the RHEL7 agent
       :title: Solved vulnerabilities on Debian. Vulnerable vim package example
       :align: center
       :width: 80%

--- a/source/quickstart.rst
+++ b/source/quickstart.rst
@@ -110,6 +110,7 @@ Instructions on how to deploy the Wazuh agent can be found in the Wazuh web user
 
 .. image:: /images/installation/linux.png
       :align: center
+      :alt: Tux, the Linux penguin mascot logo
 
 .. raw:: html
 
@@ -121,6 +122,7 @@ Instructions on how to deploy the Wazuh agent can be found in the Wazuh web user
 
 .. image:: /images/installation/windows-logo.png
       :align: center
+      :alt: Windows logo
 
 .. raw:: html
 
@@ -132,6 +134,7 @@ Instructions on how to deploy the Wazuh agent can be found in the Wazuh web user
 
 .. image:: /images/installation/macOS-logo.png
       :align: center
+      :alt: Apple logo representing macOS
 
 .. raw:: html
 
@@ -144,6 +147,7 @@ Instructions on how to deploy the Wazuh agent can be found in the Wazuh web user
 .. image:: /images/installation/solaris.png
       :align: center
       :width: 150px
+      :alt: Oracle Solaris logo
 
 .. raw:: html
 
@@ -155,6 +159,7 @@ Instructions on how to deploy the Wazuh agent can be found in the Wazuh web user
 
 .. image:: /images/installation/AIX.png
       :align: center
+      :alt: AIX logo
 
 .. raw:: html
 
@@ -166,6 +171,7 @@ Instructions on how to deploy the Wazuh agent can be found in the Wazuh web user
 
 .. image:: /images/installation/hpux.png
       :align: center
+      :alt: HP-UX logo
 
 .. raw:: html
 


### PR DESCRIPTION
## Description
Adds descriptive alt text to images that previously had none (or had the filename/relative path as alt text) across the installation, deployment options, quickstart, and proof-of-concept guide pages.

🤖 Drafted by Claude

## Documentation compilation
- [x] Verify that documentation compiles without warnings.

## Changelog
- [x] Update `CHANGELOG.md`.

## Web optimization & code formatting
- Page references
  - [ ] Update `/_static/js/redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
  - [ ] Update `/llms.txt` if necessary.
- [ ] Add or update meta descriptions.
- [ ] Use three-space indentation in `.rst` files.

## Writing style
- [ ] Use **bold** for UI elements, _italics_ for key terms and emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Follow present tense, active voice, and a semi-formal tone.
- [ ] Write short, clear, and concise sentences.
