### PR TITLE
Update 4.10.5 release notes

### DIFF
--- a/source/_variables/replacements.py
+++ b/source/_variables/replacements.py
@@ -147,7 +147,7 @@ custom_replacements = {
     "|WAZUH_REVISION_HPUX|" : "1",
     #
     # === OpenSearch
-    "|OPENSEARCH_DASHBOARDS_VERSION|": "2.16.0",
+    "|OPENSEARCH_DASHBOARDS_VERSION|": "2.19.6",
     #
     # === Elastic
     # --- Filebeat

--- a/source/release-notes/release-4-10-5.rst
+++ b/source/release-notes/release-4-10-5.rst
@@ -13,12 +13,29 @@ What's new
 
 This release includes new features or enhancements as the following:
 
+Wazuh dashboard
+^^^^^^^^^^^^^^^
+
+-  `#8576 <https://github.com/wazuh/wazuh-dashboard-plugins/pull/8576>`__ Removed the unnecessary ``axios`` plugin dependency, provided by the OpenSearch Dashboards platform.
+-  `#8582 <https://github.com/wazuh/wazuh-dashboard-plugins/pull/8582>`__ Removed the unnecessary ``follow-redirects`` plugin dependency and upgraded the ``dompurify`` and ``swagger-client`` dependencies.
+-  `#8978 <https://github.com/wazuh/wazuh-dashboard-plugins/pull/8978>`__ Upgraded ``jsdom`` and its dependencies (``lodash`` to ``4.18.1``, ``form-data`` to ``3.0.5``).
 
 Resolved issues
 ---------------
 
 This release resolves known issues as the following:
 
+Wazuh manager
+^^^^^^^^^^^^^
+
+-  `#36243 <https://github.com/wazuh/wazuh/issues/36243>`__ Hardened RSA decryption to reject malformed ciphertext blobs.
+-  `#38375 <https://github.com/wazuh/wazuh/pull/38375>`__ Improved cluster merged file parameter validation to prevent directory escape.
+-  `#38376 <https://github.com/wazuh/wazuh/pull/38376>`__ Improved ``tmp_file`` path validation in cluster DAPI.
+-  `#38377 <https://github.com/wazuh/wazuh/pull/38377>`__ Improved cluster non-merged file path validation during worker file processing.
+-  `#38378 <https://github.com/wazuh/wazuh/pull/38378>`__ Improved cluster worker file path validation.
+-  `#38379 <https://github.com/wazuh/wazuh/pull/38379>`__ Improved destination path validation when uploading CDB list, rule, and decoder files.
+-  `#38380 <https://github.com/wazuh/wazuh/pull/38380>`__ Improved cluster master validation of the files received from worker nodes.
+-  `#38381 <https://github.com/wazuh/wazuh/pull/38381>`__ Fixed a remote-command configuration validation bypass where upper- or mixed-case XML element names let ``localfile`` and ``wodle`` command blocks pass the ``remote_commands`` restriction.
 
 Changelogs
 ----------


### PR DESCRIPTION
## Description
Updates the 4.10.5 release notes for the RC 1 stage, sourced from the `wazuh/wazuh` and `wazuh/wazuh-dashboard-plugins` changelogs (`v4.10.4...v4.10.5-rc1` and the `4.10.5` branch respectively), and bumps `|OPENSEARCH_DASHBOARDS_VERSION|` from `2.16.0` to `2.19.6` to match the bundled version reported in wazuh-dashboard-plugins' own changelog.

🤖 Drafted by Claude

## Documentation compilation
- [x] Verify that documentation compiles without warnings.

## Changelog
- [ ] Update `CHANGELOG.md`.

## Web optimization & code formatting
- Page references
  - [ ] Update `/_static/js/redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
  - [ ] Update `/llms.txt` if necessary.
- [x] Add or update meta descriptions.
- [x] Use three-space indentation in `.rst` files.

## Writing style
- [x] Use **bold** for UI elements, _italics_ for key terms and emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Follow present tense, active voice, and a semi-formal tone.
- [x] Write short, clear, and concise sentences.
