### PR TITLE
Fix heading hierarchy on the TSC compliance page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - **Post-release**: Added guidance about matching the Wazuh manager version to the existing cluster nodes in the *Adding new Wazuh server nodes* documentation. ([#10007](https://github.com/wazuh/wazuh-documentation/pull/10007))
 - **Post-release**: Fixed a duplicate heading in the *Architecture* documentation's component communication section, separating the Wazuh dashboard's connections to the Wazuh server and Wazuh indexer. ([#10038](https://github.com/wazuh/wazuh-documentation/pull/10038))
 - **Post-release**: Clarified the LDAPS connection success step and updated its screenshot in the *Active Directory and LDAP integration* documentation. ([#10039](https://github.com/wazuh/wazuh-documentation/pull/10039))
+- **Post-release**: Fixed the heading hierarchy in the *Using Wazuh for TSC compliance* documentation by converting two bolded subtopics into real H2 sections. ([#10060](https://github.com/wazuh/wazuh-documentation/pull/10060))
 
 ## [v4.14.6]
 

--- a/source/compliance/tsc/index.rst
+++ b/source/compliance/tsc/index.rst
@@ -10,31 +10,33 @@ The American Institute of Certified Professional Accountants (AICPA) developed t
 
 The Trust Services Criteria (TSC) created by the Assurance Services Executive Committee (ASEC) of the AICPA presents control evaluation benchmarks. These evaluation benchmarks include metrics for security, availability, processing integrity, confidentiality, and privacy of information and systems across an entire entity. These metrics also relate to granular aspects of the entity, such as a division, an operational procedure, or a particular type of information used by the entity. The AICPA defines the common criteria as a set of controls that apply to the five Trust Services Criteria categories. 
 
--  **The COSO Principles and Common Criteria**
+The COSO Principles and Common Criteria
+---------------------------------------
 
-   The Committee of Sponsoring Organizations (COSO) internal control framework provides a systematic approach for organizations to manage risk and improve performance. It includes a detailed framework for evaluating and improving an entity's internal control structure.
+The Committee of Sponsoring Organizations (COSO) internal control framework provides a systematic approach for organizations to manage risk and improve performance. It includes a detailed framework for evaluating and improving an entity's internal control structure.
 
-   TSC common criteria (CC) provides a framework for assessing and certifying the security of information technology (IT) products and systems. It defines a set of security standards and evaluation guidelines that organizations can adopt to assess the security of IT products and systems.
+TSC common criteria (CC) provides a framework for assessing and certifying the security of information technology (IT) products and systems. It defines a set of security standards and evaluation guidelines that organizations can adopt to assess the security of IT products and systems.
 
-   It's important to note that though both frameworks intersect, they are different. The TSC framework and COSO principles evaluate the effectiveness of an organization's internal controls and risk management processes. While the COSO principles prioritize the entity's overall internal control and risk management, the TSC common criteria focus primarily on the security of IT products and systems. It achieves this by providing a set of specific criteria for evaluating controls related to security, availability, processing integrity, confidentiality, and privacy.
+It's important to note that though both frameworks intersect, they are different. The TSC framework and COSO principles evaluate the effectiveness of an organization's internal controls and risk management processes. While the COSO principles prioritize the entity's overall internal control and risk management, the TSC common criteria focus primarily on the security of IT products and systems. It achieves this by providing a set of specific criteria for evaluating controls related to security, availability, processing integrity, confidentiality, and privacy.
 
-   Providing security to IT products and systems is a key element in improving an entity's overall risk management strategy and internal control structure. These criteria focus on the logical and physical protection of information, systems, and networks. The common criteria (CC) are organized into nine subsections, which are:
+Providing security to IT products and systems is a key element in improving an entity's overall risk management strategy and internal control structure. These criteria focus on the logical and physical protection of information, systems, and networks. The common criteria (CC) are organized into nine subsections, which are:
 
-   -  CC1: Control environment
-   -  CC2: Communication and Information
-   -  CC3: Risk Management and Design and Implementation of Controls
-   -  CC4: Control Activities
-   -  CC5: Monitoring of Controls
-   -  CC6: Logical and Physical Access Controls
-   -  CC7: System Operations
-   -  CC8: Change Management
-   -  CC9: Risk Mitigation
+-  CC1: Control environment
+-  CC2: Communication and Information
+-  CC3: Risk Management and Design and Implementation of Controls
+-  CC4: Control Activities
+-  CC5: Monitoring of Controls
+-  CC6: Logical and Physical Access Controls
+-  CC7: System Operations
+-  CC8: Change Management
+-  CC9: Risk Mitigation
 
-   In summary, SOC 2, TSC, COSO, and CC are all frameworks and standards organizations use to manage risks and ensure the effectiveness of their internal controls. SOC 2 and TSC focus on the security, availability, processing integrity, confidentiality, and privacy of an organization's systems and services. COSO provides a broader framework for enterprise risk management and internal control, while CC offers a method for evaluating the security features of IT products and systems. Organizations may use a combination of these frameworks and standards to develop a comprehensive risk management and compliance strategy.
+In summary, SOC 2, TSC, COSO, and CC are all frameworks and standards organizations use to manage risks and ensure the effectiveness of their internal controls. SOC 2 and TSC focus on the security, availability, processing integrity, confidentiality, and privacy of an organization's systems and services. COSO provides a broader framework for enterprise risk management and internal control, while CC offers a method for evaluating the security features of IT products and systems. Organizations may use a combination of these frameworks and standards to develop a comprehensive risk management and compliance strategy.
 
--  **TSC additional criteria**
+TSC additional criteria
+-----------------------
 
-   The TSC additional criteria are an extension of the common criteria. Organizations can use these additional criteria to address precise security requirements not defined by the conventional TSC common criteria.
+The TSC additional criteria are an extension of the common criteria. Organizations can use these additional criteria to address precise security requirements not defined by the conventional TSC common criteria.
 
 Wazuh assists with these criteria by performing log collection, file integrity monitoring, configuration assessment, threat detection, vulnerability assessment, and automated threat response.
 


### PR DESCRIPTION
## Description
Promotes the *Using Wazuh for TSC compliance* page's two bold pseudo-headings ("The COSO Principles and Common Criteria" and "TSC additional criteria") to real H2 sections, giving the page a proper H1 > H2 hierarchy.

🤖 Drafted by Claude

## Documentation compilation
- [x] Verify that documentation compiles without warnings.

## Changelog
- [x] Update `CHANGELOG.md`.

## Web optimization & code formatting
- Page references
  - [ ] Update `/_static/js/redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
  - [ ] Update `/llms.txt` if necessary.
- [ ] Add or update meta descriptions.
- [ ] Use three-space indentation in `.rst` files.

## Writing style
- [ ] Use **bold** for UI elements, _italics_ for key terms and emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Follow present tense, active voice, and a semi-formal tone.
- [ ] Write short, clear, and concise sentences.
