### PR TITLE
Fix relative BreadcrumbList URLs in structured data

### DIFF
--- a/source/_themes/wazuh_doc_theme_v3/layout.html
+++ b/source/_themes/wazuh_doc_theme_v3/layout.html
@@ -252,8 +252,8 @@
       {
         "@context": "https://schema.org", "@type": "BreadcrumbList",
         "itemListElement": [
-          {%- for item in parents %}{% if not loop.first %},{% endif %}
-          {"@type": "ListItem", "position": {{ loop.index }}, "name": {{ item.title|tojson }}, "item": {{ item.link|tojson }}}
+          {%- for item in breadcrumb_items_absolute %}{% if not loop.first %},{% endif %}
+          {"@type": "ListItem", "position": {{ loop.index }}, "name": {{ item.title|tojson }}, "item": {{ item.item|tojson }}}
           {%- endfor %}
         ]
       }

--- a/source/conf.py
+++ b/source/conf.py
@@ -18,6 +18,7 @@ import time
 import json
 import atexit
 from urllib.request import urlretrieve
+from urllib.parse import urljoin
 try:
     from jsmin import jsmin
 except ImportError:
@@ -628,6 +629,42 @@ def setup(app):
     patch_markdown_translator_unhandled_nodes()
 
     app.connect('html-page-context', pagefind_custom_weights)
+
+    app.connect('html-page-context', absolutize_breadcrumb_parents)
+
+def absolutize_breadcrumb_parents(app, pagename, templatename, context, doctree):
+    ''' Runs once per page, computing an absolute-URL version of each BreadcrumbList
+        parent for the JSON-LD structured data emitted in layout.html. Sphinx's
+        `parents` context entries carry a `link` that is a scheme-less, relative URI
+        computed relative to the *current* page (via `sphinx.util.osutil.relative_uri()`),
+        which is not valid as-is inside a `BreadcrumbList.itemListElement[].item` value.
+        Stored under a new context key (`breadcrumb_items_absolute`) so the original
+        `parents` list -- consumed as-is by the visible breadcrumb nav in
+        template-parts/breadcrumbs.html -- is left untouched. '''
+    special_pages = ['index', 'not_found', 'search']
+    if version >= '4.0':
+        special_pages += [
+            'cloud-service/apis/reference',
+            'user-manual/api/reference',
+            'user-manual/indexer-api/reference'
+        ]
+
+    if pagename in special_pages or pagename == 'moved-content':
+        return
+
+    sitemap_version = version
+    if is_latest_release == True:
+        sitemap_version = 'current'
+
+    base_url = html_theme_options.get('wazuh_doc_url') + '/' + sitemap_version + '/' + pagename + '.html'
+
+    breadcrumb_items_absolute = []
+    for item in context.get('parents', []):
+        breadcrumb_items_absolute.append({
+            'title': item['title'],
+            'item': urljoin(base_url, item['link'])
+        })
+    context['breadcrumb_items_absolute'] = breadcrumb_items_absolute
 
 def pagefind_custom_weights(app, pagename, templatename, context, doctree):
     ''' Runs once per page, inserting the attribute to customize the weights of certain elements in the Pagefind search index '''


### PR DESCRIPTION
## Description
Fixes the `BreadcrumbList` JSON-LD block emitted on every page: it previously used Sphinx's raw `parents[].link`, a relative-to-the-current-page URI, instead of an absolute canonical URL. Adds a `html-page-context` hook in `conf.py` that resolves each breadcrumb ancestor to an absolute URL via `urllib.parse.urljoin`, and points `layout.html`'s `BreadcrumbList` loop at the new resolved list instead of `parents` directly — the visible breadcrumb navigation (`template-parts/breadcrumbs.html`) is untouched and still uses relative links, as intended.

**This is a shared-template change affecting every page's structured data — please review closely.** Verified via a full `make clean && make html` (0 new warnings) plus manual inspection of the built output: the 4 originally-flagged pages (`proof-of-concept-guide/poc-detect-hidden-process`, `poc-file-integrity-monitoring`, `poc-vulnerability-detection`, `user-manual/agent/index`) now emit absolute, correct `BreadcrumbList` items; 3 unrelated control pages (`quickstart` — zero toctree ancestors, `getting-started/architecture` — 1-level nesting, `user-manual/agent/agent-management/labels` — 3-level nesting) all still render valid JSON-LD with unaffected `TechArticle` blocks and unaffected relative visible-breadcrumb navigation. `quickstart.html`'s `BreadcrumbList` correctly keeps an empty `itemListElement` — it has no toctree ancestors above site root, which is expected, not a defect.

One follow-up worth noting, not blocking: the fix duplicates `layout.html`'s `special_pages` list into a new `conf.py` function (needed to gate the hook on the identical condition the template uses to render the block at all) — a future edit to one without the other would desync them.

🤖 Drafted by Claude

## Documentation compilation
- [x] Verify that documentation compiles without warnings.

## Changelog
- [ ] Update `CHANGELOG.md`.

## Web optimization & code formatting
- Page references
  - [ ] Update `/_static/js/redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
  - [ ] Update `/llms.txt` if necessary.
- [ ] Add or update meta descriptions.
- [ ] Use three-space indentation in `.rst` files.

## Writing style
- [ ] Use **bold** for UI elements, _italics_ for key terms and emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Follow present tense, active voice, and a semi-formal tone.
- [ ] Write short, clear, and concise sentences.
