### PR TITLE
[4.14] Use absolute breadcrumb item URLs in ReDoc BreadcrumbList JSON-LD

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ sphinx-reredirects==0.1.5
 sphinx-markdown-builder==0.6.9
 requests==2.33.0
 pythonmonkey==1.3.2
+PyYAML==6.0.2

--- a/source/_themes/wazuh_doc_theme_v3/redoc-master.html
+++ b/source/_themes/wazuh_doc_theme_v3/redoc-master.html
@@ -138,9 +138,40 @@
                 "backgroundColor": "#fff"
 #}
 
-{%- block htmltitle -%}
-<title>API reference{{ titlesuffix }}</title>
-{% endblock htmltitle -%}
+{#
+  Note: no htmltitle block override here (anymore) - inheriting layout.html's
+  default <title>{{ pagetitle|e }}{{ titlesuffix }}</title> keeps it aligned
+  with the og:title/twitter:title below instead of diverging with a
+  hardcoded "API reference" string (SEO title-tag finding).
+#}
+
+{% block head %}
+{{ super() }}
+{#
+  layout.html skips its JSON-LD block for these pages (they're in
+  special_pages), so emit the same TechArticle + BreadcrumbList pair here
+  instead of touching that shared list (SEO json-ld-structured-data finding).
+#}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org", "@type": "TechArticle",
+  "headline": {{ (title|striptags)|tojson }}, "description": {{ page_scope.file_meta_desc|tojson }},
+  "url": {{ page_scope.page_url|tojson }}, "inLanguage": {{ language|tojson }},
+  "author": {"@type": "Organization", "name": "Wazuh"},
+  "publisher": {"@type": "Organization", "name": "Wazuh", "url": {{ theme_wazuh_doc_url|tojson }}}
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org", "@type": "BreadcrumbList",
+  "itemListElement": [
+    {%- for item in parents %}{% if not loop.first %},{% endif %}
+    {"@type": "ListItem", "position": {{ loop.index }}, "name": {{ item.title|tojson }}, "item": {{ item.link|tojson }}}
+    {%- endfor %}
+  ]
+}
+</script>
+{% endblock head %}
 
 {% block body %}
 <div class="loading">
@@ -183,9 +214,21 @@
 
 {%- block main_column -%}
 <div id="central-column">
-  
+
   {# Main content #}
   <main role="main" data-pagefind-body>
+    {#
+      Static fallback content for non-JS fetchers (SEO heading-structure /
+      GEO js-only-content findings) - the ReDoc SPA below otherwise leaves
+      the served HTML with no heading or text at all. Wrapped in <noscript>
+      so JS-capable browsers never render it (avoiding a duplicate/mismatched
+      <h1> once ReDoc mounts its own); it's still present as plain markup in
+      the raw HTML for crawlers/fetchers that don't execute JS.
+    #}
+    <noscript>
+      <h1>{{ pagetitle|e }}</h1>
+      <p>{{ page_scope.file_meta_desc|e }}</p>
+    </noscript>
     {%- block redoc %}
     {% endblock redoc %}
   </main>

--- a/source/_themes/wazuh_doc_theme_v3/redoc-master.html
+++ b/source/_themes/wazuh_doc_theme_v3/redoc-master.html
@@ -224,10 +224,29 @@
       so JS-capable browsers never render it (avoiding a duplicate/mismatched
       <h1> once ReDoc mounts its own); it's still present as plain markup in
       the raw HTML for crawlers/fetchers that don't execute JS.
+
+      api_endpoint_summary (endpoint_groups + auth_summary) is built in
+      conf.py straight from this page's own OpenAPI spec - see
+      build_api_endpoint_summary() - so it can't drift out of sync with the
+      spec the way hand-written prose could (GEO "summary of key
+      endpoints/auth model" recommendation).
     #}
     <noscript>
       <h1>{{ pagetitle|e }}</h1>
       <p>{{ page_scope.file_meta_desc|e }}</p>
+      {%- if api_endpoint_summary %}
+      {%- if api_endpoint_summary.auth_summary %}
+      <p>{{ api_endpoint_summary.auth_summary|e }}</p>
+      {%- endif %}
+      {%- if api_endpoint_summary.endpoint_groups %}
+      <p>Endpoint groups covered by this API:</p>
+      <ul>
+        {%- for group in api_endpoint_summary.endpoint_groups %}
+        <li>{{ group|e }}</li>
+        {%- endfor %}
+      </ul>
+      {%- endif %}
+      {%- endif %}
     </noscript>
     {%- block redoc %}
     {% endblock redoc %}

--- a/source/_themes/wazuh_doc_theme_v3/redoc-master.html
+++ b/source/_themes/wazuh_doc_theme_v3/redoc-master.html
@@ -151,6 +151,9 @@
   layout.html skips its JSON-LD block for these pages (they're in
   special_pages), so emit the same TechArticle + BreadcrumbList pair here
   instead of touching that shared list (SEO json-ld-structured-data finding).
+  breadcrumb_items_absolute (computed in conf.py's absolutize_breadcrumb_parents,
+  same as layout.html uses) carries absolute item URLs, unlike parents' relative
+  link entries which are not valid BreadcrumbList item values.
 #}
 <script type="application/ld+json">
 {
@@ -165,8 +168,8 @@
 {
   "@context": "https://schema.org", "@type": "BreadcrumbList",
   "itemListElement": [
-    {%- for item in parents %}{% if not loop.first %},{% endif %}
-    {"@type": "ListItem", "position": {{ loop.index }}, "name": {{ item.title|tojson }}, "item": {{ item.link|tojson }}}
+    {%- for item in breadcrumb_items_absolute %}{% if not loop.first %},{% endif %}
+    {"@type": "ListItem", "position": {{ loop.index }}, "name": {{ item.title|tojson }}, "item": {{ item.item|tojson }}}
     {%- endfor %}
   ]
 }

--- a/source/conf.py
+++ b/source/conf.py
@@ -23,6 +23,11 @@ try:
 except ImportError:
     atexit.register(print,"\nThe module jsmin is not available. Please, make sure you install all the required modules listed in requirements.txt.")
     sys.exit()
+try:
+    import yaml
+except ImportError:
+    atexit.register(print,"\nThe module PyYAML is not available. Please, make sure you install all the required modules listed in requirements.txt.")
+    sys.exit()
 from requests.utils import requote_uri
 sys.path.append(os.path.abspath("_variables"))
 from settings import version, is_latest_release, is_prerelease, release, api_tag, apiURL, apiURL_indexer, apiURL_server
@@ -564,6 +569,84 @@ if (tags.has("production")):
 if (tags.has("dev")):
     docu_environment = "dev"
 
+# -- API endpoint/auth summaries (for the ReDoc pages' noscript fallback) ----
+# Computed once in setup() from each page's own OpenAPI/YAML spec, keyed by
+# pagename; see manage_assets() below for how it reaches the templates.
+api_endpoint_summaries = {}
+
+def describe_security_schemes(security_schemes):
+    ''' Turns an OpenAPI components.securitySchemes mapping into one short,
+    human-readable sentence describing how to authenticate. '''
+    descriptions = []
+    for scheme in (security_schemes or {}).values():
+        if not isinstance(scheme, dict):
+            continue
+        scheme_type = scheme.get('type')
+        if scheme_type == 'http':
+            http_scheme = (scheme.get('scheme') or '').lower()
+            if http_scheme == 'basic':
+                descriptions.append('HTTP Basic credentials')
+            elif http_scheme == 'bearer':
+                bearer_format = scheme.get('bearerFormat')
+                descriptions.append('a Bearer %s token' % bearer_format if bearer_format else 'a Bearer token')
+            else:
+                descriptions.append('HTTP %s authentication' % (http_scheme or scheme_type))
+        elif scheme_type == 'apiKey':
+            key_location = scheme.get('in', 'header')
+            key_name = scheme.get('name')
+            if key_name:
+                descriptions.append('an API key sent in the "%s" %s' % (key_name, key_location))
+            else:
+                descriptions.append('an API key sent via %s' % key_location)
+        elif scheme_type:
+            descriptions.append(scheme_type)
+    # De-duplicate while keeping order (server/indexer specs repeat "http" schemes)
+    descriptions = list(dict.fromkeys(descriptions))
+    if not descriptions:
+        return ''
+    return 'Authentication uses ' + ' or '.join(descriptions) + '.'
+
+def extract_endpoint_groups(spec):
+    ''' Returns the spec's endpoint group names: the top-level `tags` list
+    when the spec declares one (server/indexer specs), otherwise the unique
+    per-operation `tags` values (the cloud spec has no top-level list). '''
+    tags = spec.get('tags')
+    if isinstance(tags, list) and tags:
+        names = [tag.get('name') for tag in tags if isinstance(tag, dict) and tag.get('name')]
+        if names:
+            return names
+    names = []
+    for path_item in (spec.get('paths') or {}).values():
+        if not isinstance(path_item, dict):
+            continue
+        for operation in path_item.values():
+            if not isinstance(operation, dict):
+                continue
+            for tag in operation.get('tags') or []:
+                if tag not in names:
+                    names.append(tag)
+    return names
+
+def build_api_endpoint_summary(spec_path):
+    ''' Parses one OpenAPI/YAML spec file into {endpoint_groups, auth_summary}
+    for the ReDoc pages' static noscript fallback (GEO js-only-content /
+    "summary of key endpoints/auth model" finding). Returns None - rather
+    than failing the build - if the spec is missing or unparseable; the
+    template simply skips the extra fallback content in that case. '''
+    try:
+        with open(spec_path, 'r', encoding='utf-8') as spec_file:
+            spec = yaml.safe_load(spec_file)
+    except (OSError, yaml.YAMLError) as exc:
+        print('Could not read API spec at %s for endpoint summary: %s' % (spec_path, exc))
+        return None
+    if not isinstance(spec, dict):
+        return None
+    security_schemes = ((spec.get('components') or {}).get('securitySchemes')) or {}
+    return {
+        'endpoint_groups': extract_endpoint_groups(spec),
+        'auth_summary': describe_security_schemes(security_schemes),
+    }
+
 def setup(app):
 
     current_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), theme_assets_path)
@@ -591,6 +674,15 @@ def setup(app):
         if download_needed == True:
             print ('Downloading ' + 'spec-'+api_tag+'.yaml')
             spec_path, url_retrieve_headers = urlretrieve(apiURL, server_api_spec_path)
+
+        # Build the endpoint/auth-model summaries used by the ReDoc pages'
+        # noscript fallback, straight from each page's own committed/downloaded
+        # spec file - no separate spec source of truth to keep in sync.
+        api_endpoint_summaries['user-manual/api/reference'] = build_api_endpoint_summary(server_api_spec_path)
+        api_endpoint_summaries['user-manual/indexer-api/reference'] = build_api_endpoint_summary(
+            os.path.join(static_path_str, 'indexer-api-spec', 'spec.yml'))
+        api_endpoint_summaries['cloud-service/apis/reference'] = build_api_endpoint_summary(
+            os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'resources', 'cloud', 'spec.yml'))
 
         # Minify redirects.js
         if html_theme_options['include_version_selector'] == True:
@@ -761,6 +853,7 @@ def manage_assets(app, pagename, templatename, context, doctree):
     # Add it to the page's context
     context['get_css_by_page'] = get_css_by_page
     context['get_js_by_page'] = get_js_by_page
+    context['api_endpoint_summary'] = api_endpoint_summaries.get(pagename)
 
 exclude_doc = ["not_found"]
 list_compiled_html = []

--- a/source/conf.py
+++ b/source/conf.py
@@ -726,22 +726,17 @@ def setup(app):
 
 def absolutize_breadcrumb_parents(app, pagename, templatename, context, doctree):
     ''' Runs once per page, computing an absolute-URL version of each BreadcrumbList
-        parent for the JSON-LD structured data emitted in layout.html. Sphinx's
-        `parents` context entries carry a `link` that is a scheme-less, relative URI
-        computed relative to the *current* page (via `sphinx.util.osutil.relative_uri()`),
-        which is not valid as-is inside a `BreadcrumbList.itemListElement[].item` value.
-        Stored under a new context key (`breadcrumb_items_absolute`) so the original
-        `parents` list -- consumed as-is by the visible breadcrumb nav in
-        template-parts/breadcrumbs.html -- is left untouched. '''
-    special_pages = ['index', 'not_found', 'search']
-    if version >= '4.0':
-        special_pages += [
-            'cloud-service/apis/reference',
-            'user-manual/api/reference',
-            'user-manual/indexer-api/reference'
-        ]
-
-    if pagename in special_pages or pagename == 'moved-content':
+        parent for the JSON-LD structured data emitted in layout.html and
+        redoc-master.html. Sphinx's `parents` context entries carry a `link` that is
+        a scheme-less, relative URI computed relative to the *current* page (via
+        `sphinx.util.osutil.relative_uri()`), which is not valid as-is inside a
+        `BreadcrumbList.itemListElement[].item` value. Stored under a new context
+        key (`breadcrumb_items_absolute`) so the original `parents` list -- consumed
+        as-is by the visible breadcrumb nav in template-parts/breadcrumbs.html -- is
+        left untouched. Runs for the ReDoc API reference pages too: they emit their
+        own JSON-LD (layout.html skips them as they're in its special_pages list),
+        but still need this absolute-URL breadcrumb data. '''
+    if pagename in ['index', 'not_found', 'search'] or pagename == 'moved-content':
         return
 
     sitemap_version = version


### PR DESCRIPTION
## Description
Fixes SEO/GEO issues on the three ReDoc API reference pages (`cloud-service/apis/reference`, `user-manual/api/reference`, `user-manual/indexer-api/reference`), which render via a client-side SPA and previously served near-empty HTML to crawlers:

- Add `TechArticle` + `BreadcrumbList` JSON-LD, a stable `<title>` tag, and a `<noscript>` static heading/description fallback for non-JS fetchers.
- Generate an endpoints/auth-model summary from each page's own OpenAPI spec at build time, and include it in the static fallback so it can't drift from the spec.
- Fix the `BreadcrumbList` JSON-LD to use absolute item URLs (`breadcrumb_items_absolute`, same as `layout.html`) instead of page-relative ones, which aren't valid structured-data values.
- Merge in latest `4.14`.

## Documentation compilation
- [x] Verify that documentation compiles without warnings.

## Changelog
- [ ] Update `CHANGELOG.md`.

## Web optimization & code formatting
- Page references
  - [ ] Update `/_static/js/redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
  - [ ] Update `/llms.txt` if necessary.
- [ ] Add or update meta descriptions.
- [ ] Use three-space indentation in `.rst` files.

## Writing style
- [ ] Use **bold** for UI elements, _italics_ for key terms and emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [ ] Follow present tense, active voice, and a semi-formal tone.
- [ ] Write short, clear, and concise sentences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)