### PR TITLE
Add missing alt text to integrations-guide diagrams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - **Post-release**: Clarified the LDAPS connection success step and updated its screenshot in the *Active Directory and LDAP integration* documentation. ([#10039](https://github.com/wazuh/wazuh-documentation/pull/10039))
 - **Post-release**: Fixed missing or non-descriptive image alt text in the *Installation guide*, *Deployment options*, *Quickstart*, and *Proof of concept guide* documentation. ([#10057](https://github.com/wazuh/wazuh-documentation/pull/10057))
 - **Post-release**: Fixed the heading hierarchy in the *Using Wazuh for TSC compliance* documentation by converting two bolded subtopics into real H2 sections. ([#10060](https://github.com/wazuh/wazuh-documentation/pull/10060))
+- **Post-release**: Fixed missing image alt text in the *Integrations guide* documentation. ([#10081](https://github.com/wazuh/wazuh-documentation/pull/10081))
 
 ## [v4.14.6]
 

--- a/source/integrations-guide/index.rst
+++ b/source/integrations-guide/index.rst
@@ -41,6 +41,7 @@ Wazuh indexer integration
 
 .. thumbnail:: /images/integrations/indexer-integration-diagram.png
    :title: Wazuh indexer integration diagram
+   :alt: Wazuh indexer integration diagram
    :align: center
    :width: 80%
 
@@ -57,6 +58,7 @@ Wazuh server integration
 
 .. thumbnail:: /images/integrations/server-integration-diagram.png
    :title: Wazuh server integration diagram
+   :alt: Wazuh server integration diagram
    :align: center
    :width: 80%
 
@@ -84,6 +86,7 @@ In the Wazuh indexer integration alternative, the forwarder executes periodic qu
 
 .. thumbnail:: /images/integrations/indexer-queries-diagram.png
    :title: Wazuh indexer queries diagram
+   :alt: Wazuh indexer queries diagram
    :align: center
    :width: 80%
 
@@ -93,6 +96,7 @@ Similarly, checking for new alerts periodically means that the alerts reach the 
 
 .. thumbnail:: /images/integrations/alerts-file-checking-diagram.png
    :title: Alerts file checking diagram
+   :alt: Alerts file checking diagram
    :align: center
    :width: 80%
 


### PR DESCRIPTION
## Description
Adds descriptive `:alt:` text to the 4 integration diagrams on the Integrations guide index page, which previously rendered with empty `alt=""` on both the inline image and its auto-generated lightbox duplicate.

🤖 Drafted by Claude

## Documentation compilation
- [x] Verify that documentation compiles without warnings.

## Changelog
- [x] Update `CHANGELOG.md`.

## Web optimization & code formatting
- Page references
  - [x] Update `/_static/js/redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
  - [x] Update `/llms.txt` if necessary.
- [x] Add or update meta descriptions.
- [x] Use three-space indentation in `.rst` files.

## Writing style
- [x] Use **bold** for UI elements, _italics_ for key terms and emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Follow present tense, active voice, and a semi-formal tone.
- [x] Write short, clear, and concise sentences.
