### PR TITLE
Add missing alt text to Active Response workflow diagram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,8 @@ All notable changes to this project will be documented in this file.
 - **Post-release**: Added guidance about matching the Wazuh manager version to the existing cluster nodes in the *Adding new Wazuh server nodes* documentation. ([#10007](https://github.com/wazuh/wazuh-documentation/pull/10007))
 - **Post-release**: Fixed a duplicate heading in the *Architecture* documentation's component communication section, separating the Wazuh dashboard's connections to the Wazuh server and Wazuh indexer. ([#10038](https://github.com/wazuh/wazuh-documentation/pull/10038))
 - **Post-release**: Clarified the LDAPS connection success step and updated its screenshot in the *Active Directory and LDAP integration* documentation. ([#10039](https://github.com/wazuh/wazuh-documentation/pull/10039))
-- **Post-release**: Fixed missing or non-descriptive image alt text in the *Installation guide*, *Deployment options*, *Quickstart*, and *Proof of concept guide* documentation. ([#10057](https://github.com/wazuh/wazuh-documentation/pull/10057))
+- **Post-release**: Fixed missing or non-descriptive image alt text in the *Installation guide*, *Deployment options*, *Quickstart*, *Proof of concept guide*, *Integrations guide*, and *Active Response* documentation. ([#10057](https://github.com/wazuh/wazuh-documentation/pull/10057)) ([#10081](https://github.com/wazuh/wazuh-documentation/pull/10081)) ([#10082](https://github.com/wazuh/wazuh-documentation/pull/10082))
 - **Post-release**: Fixed the heading hierarchy in the *Using Wazuh for TSC compliance* documentation by converting two bolded subtopics into real H2 sections. ([#10060](https://github.com/wazuh/wazuh-documentation/pull/10060))
-- **Post-release**: Fixed missing image alt text in the *Integrations guide* documentation. ([#10081](https://github.com/wazuh/wazuh-documentation/pull/10081))
-- **Post-release**: Fixed missing image alt text in the *Active Response* documentation. ([#10082](https://github.com/wazuh/wazuh-documentation/pull/10082))
 
 ## [v4.14.6]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - **Post-release**: Fixed missing or non-descriptive image alt text in the *Installation guide*, *Deployment options*, *Quickstart*, and *Proof of concept guide* documentation. ([#10057](https://github.com/wazuh/wazuh-documentation/pull/10057))
 - **Post-release**: Fixed the heading hierarchy in the *Using Wazuh for TSC compliance* documentation by converting two bolded subtopics into real H2 sections. ([#10060](https://github.com/wazuh/wazuh-documentation/pull/10060))
 - **Post-release**: Fixed missing image alt text in the *Integrations guide* documentation. ([#10081](https://github.com/wazuh/wazuh-documentation/pull/10081))
+- **Post-release**: Fixed missing image alt text in the *Active Response* documentation. ([#10082](https://github.com/wazuh/wazuh-documentation/pull/10082))
 
 ## [v4.14.6]
 

--- a/source/user-manual/capabilities/active-response/index.rst
+++ b/source/user-manual/capabilities/active-response/index.rst
@@ -27,6 +27,7 @@ The image below shows the Active Response workflow.
 
 .. thumbnail:: /images/manual/active-response/active-response-workflow.png
    :title: Active Response workflow
+   :alt: Diagram of the Active Response workflow, showing the numbered steps between the Wazuh agent on a monitored host and the Wazuh manager on the Wazuh server, from event collection through rule matching to execution of the active response script and logging of the results.
    :align: center
    :width: 100%
 


### PR DESCRIPTION
## Description
Adds a descriptive `:alt:` text to the Active Response workflow diagram on the Active Response capability page, which previously rendered with empty `alt=""` on both the inline image and its auto-generated lightbox duplicate.

🤖 Drafted by Claude

## Documentation compilation
- [x] Verify that documentation compiles without warnings.

## Changelog
- [x] Update `CHANGELOG.md`.

## Web optimization & code formatting
- Page references
  - [x] Update `/_static/js/redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
  - [x] Update `/llms.txt` if necessary.
- [x] Add or update meta descriptions.
- [x] Use three-space indentation in `.rst` files.

## Writing style
- [x] Use **bold** for UI elements, _italics_ for key terms and emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Follow present tense, active voice, and a semi-formal tone.
- [x] Write short, clear, and concise sentences.
