### PR TITLE
Remove obsolete msg_sent from Wazuh 5.0 agent state reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@ All notable changes to this project will be documented in this file.
 - Updated the *Getting started* documentation to Wazuh 5.0, covering the dashboard screenshot gallery and the *Architecture* section's component communication and required ports. ([#10069](https://github.com/wazuh/wazuh-documentation/pull/10069)) ([#10073](https://github.com/wazuh/wazuh-documentation/pull/10073))
 - Updated the *Using Wazuh for HIPAA compliance* documentation in *Regulatory compliance* to Wazuh 5.0. ([#10083](https://github.com/wazuh/wazuh-documentation/pull/10083))
 
+### Fixed
+
+- Fixed the Wazuh 5.0 agent state-file reference so it no longer lists the obsolete `msg_sent` field. ([#10084](https://github.com/wazuh/wazuh-documentation/pull/10084))
+
 ### Removed
 
 - Removed all `agent-auth` references as this tool is now deprecated. ([#8718](https://github.com/wazuh/wazuh/pull/8718))

--- a/source/user-manual/reference/statistics-files/wazuh-agentd-state.rst
+++ b/source/user-manual/reference/statistics-files/wazuh-agentd-state.rst
@@ -36,9 +36,6 @@ The content differs slightly between agent versions.
    # Number of generated events
    msg_count='324'
 
-   # Number of messages (events + control messages) sent to the manager
-   msg_sent='0'
-
    # Number of events currently buffered
    # Always empty: the HTTPS accumulator reports occupancy as a ladder,
    # not as a count


### PR DESCRIPTION
Closes #10068

## Summary

- Removes the obsolete `msg_sent` field from the Wazuh 5.0 agent state-file example.
- Preserves `msg_sent` in the Wazuh 4.x example, where the field is still valid.
- Leaves the `wazuh-remoted` reference unchanged because commit `01b6c6f17` already updated it to `metrics.messages.sent_breakdown`.
- Records the correction in the v5.0.0 changelog.

## Rationale

[`wazuh/wazuh#38801`](https://github.com/wazuh/wazuh/pull/38801) removed `msg_sent` from the Wazuh 5.0 agent state file after the HTTPS transport replaced its only writer. The current example still shows `msg_sent='0'`, which makes the reference disagree with the generated 5.0 state file.

The fix targets `5.0.0`, the oldest affected documentation branch. The current `5.0.1` branch contains the same stale block and follows the repository's established `5.0.0`-to-`5.0.1` merge-forward process.

## Verification

- `make.bat html` on `5.0.0`: succeeded without warnings (315 source files).
- `make.bat html` on `5.0.1` with the same source change: succeeded without warnings (306 source files).
- `make.bat html` after the final changelog commit: succeeded without warnings.
- `git diff --check`: passed.
- Confirmed `msg_sent` remains only in the Wazuh 4.x sample.

## Scope

No pages, anchors, redirects, metadata, or `llms.txt` entries are added or moved.
