### PR TITLE
Fix third-party brand-name casing inconsistencies (CloudTrail, VirusTotal, PyInstaller)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - **Post-release**: Clarified the LDAPS connection success step and updated its screenshot in the *Active Directory and LDAP integration* documentation. ([#10039](https://github.com/wazuh/wazuh-documentation/pull/10039))
 - **Post-release**: Fixed missing or non-descriptive image alt text in the *Installation guide*, *Deployment options*, *Quickstart*, *Proof of concept guide*, *Integrations guide*, and *Active Response* documentation. ([#10057](https://github.com/wazuh/wazuh-documentation/pull/10057)) ([#10081](https://github.com/wazuh/wazuh-documentation/pull/10081)) ([#10082](https://github.com/wazuh/wazuh-documentation/pull/10082))
 - **Post-release**: Fixed the heading hierarchy in the *Using Wazuh for TSC compliance* documentation by converting two bolded subtopics into real H2 sections. ([#10060](https://github.com/wazuh/wazuh-documentation/pull/10060))
+- **Post-release**: Fixed third-party brand-name casing inconsistencies (CloudTrail, VirusTotal, PyInstaller) in the *Proof of concept guide* documentation. ([#10087](https://github.com/wazuh/wazuh-documentation/pull/10087))
 
 ## [v4.14.6]
 

--- a/source/proof-of-concept-guide/aws-infrastructure-monitoring.rst
+++ b/source/proof-of-concept-guide/aws-infrastructure-monitoring.rst
@@ -16,7 +16,7 @@ Infrastructure
 +--------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Cloud service      | Description                                                                                                                                                                                                                                                                           |
 +====================+=======================================================================================================================================================================================================================================================================================+
-| Amazon CloudTrail  | AWS Cloudtrail, like all other supported AWS services, requires setting the :ref:`necessary policies <cloudtrail_policy_configuration>` for user permissions and providing a valid authentication method. In this PoC, we use the :ref:`profile authentication <aws_profile>` method. |
+| Amazon CloudTrail  | AWS CloudTrail, like all other supported AWS services, requires setting the :ref:`necessary policies <cloudtrail_policy_configuration>` for user permissions and providing a valid authentication method. In this PoC, we use the :ref:`profile authentication <aws_profile>` method. |
 +--------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 Configuration
@@ -36,7 +36,7 @@ CloudTrail
 The image below shows how to create a new CloudTrail service and attach a new S3 bucket.
 
 .. thumbnail:: /images/poc/cloudtrail.gif
-   :title: Creating a Cloudtrail service
+   :title: Creating a CloudTrail service
    :alt: Animated walkthrough of creating a new AWS CloudTrail trail and attaching a new S3 bucket in the AWS console
    :align: center
    :width: 80%
@@ -70,7 +70,7 @@ Wazuh server
 Test the configuration
 ----------------------
 
-Once you configure Cloudtrail, you can generate events by simply creating a new IAM user account using the IAM service. This generates an event that Wazuh processes. 
+Once you configure CloudTrail, you can generate events by simply creating a new IAM user account using the IAM service. This generates an event that Wazuh processes. 
 
 The Wazuh default ruleset parses AWS logs and generates alerts automatically. The alerts appear as soon as Wazuh receives the logs from the AWS S3 bucket.
 

--- a/source/proof-of-concept-guide/detect-remove-malware-virustotal.rst
+++ b/source/proof-of-concept-guide/detect-remove-malware-virustotal.rst
@@ -128,7 +128,7 @@ Perform the following steps on the Wazuh server to alert for changes in the endp
           </rule>
       </group>
 
-#. Add the following configuration to the Wazuh server ``/var/ossec/etc/ossec.conf`` file to enable the Virustotal integration. Replace ``<YOUR_VIRUS_TOTAL_API_KEY>`` with your `VirusTotal API key <https://developers.virustotal.com/reference>`__. This allows to trigger a VirusTotal query whenever any of the rules ``100200`` and ``100201`` are triggered:
+#. Add the following configuration to the Wazuh server ``/var/ossec/etc/ossec.conf`` file to enable the VirusTotal integration. Replace ``<YOUR_VIRUS_TOTAL_API_KEY>`` with your `VirusTotal API key <https://developers.virustotal.com/reference>`__. This allows to trigger a VirusTotal query whenever any of the rules ``100200`` and ``100201`` are triggered:
 
    .. code-block:: xml
 
@@ -240,7 +240,7 @@ Perform the following steps to configure Wazuh to monitor near real-time changes
       > pip install pyinstaller
       > pyinstaller --version
 
-   You use Pyinstaller here to convert the active response Python script into an executable application that can run on a Windows endpoint.
+   You use PyInstaller here to convert the active response Python script into an executable application that can run on a Windows endpoint.
 
 #. Create an active response script ``remove-threat.py`` to remove a file from the Windows endpoint:
 


### PR DESCRIPTION
## Description
Standardizes three third-party brand/product names to their official casing where they appeared inconsistently within the same page: `CloudTrail` (AWS Infrastructure Monitoring PoC), `VirusTotal` and `PyInstaller` (VirusTotal malware detection PoC).

🤖 Drafted by Claude

## Documentation compilation
- [x] Verify that documentation compiles without warnings.

## Changelog
- [ ] Update `CHANGELOG.md`.

## Web optimization & code formatting
- Page references
  - [ ] Update `/_static/js/redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
  - [ ] Update `/llms.txt` if necessary.
- [x] Add or update meta descriptions.
- [x] Use three-space indentation in `.rst` files.

## Writing style
- [x] Use **bold** for UI elements, _italics_ for key terms and emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Follow present tense, active voice, and a semi-formal tone.
- [x] Write short, clear, and concise sentences.
