### PR TITLE
docs: update API password requirements and example

### DIFF
--- a/source/user-manual/api/api-examples.rst
+++ b/source/user-manual/api/api-examples.rst
@@ -43,11 +43,11 @@ The command returns output similar to the following example:
 POST
 ^^^^
 
-The following POST request to the Wazuh server API creates a new user on the Wazuh server by specifying the username ``test_user`` and password ``Test_user12`` in the request body.
+The following POST request to the Wazuh server API creates a new user on the Wazuh server by specifying the username ``test_user`` and password ``Test_user123`` in the request body.
 
 .. code-block:: console
 
-   # curl -k -X POST "https://localhost:55000/security/users" -H  "Authorization: Bearer $TOKEN" -H  "Content-Type: application/json" -d "{\"username\":\"test_user\",\"password\":\"Test_user12\"}"
+   # curl -k -X POST "https://localhost:55000/security/users" -H  "Authorization: Bearer $TOKEN" -H  "Content-Type: application/json" -d "{\"username\":\"test_user\",\"password\":\"Test_user123\"}"
 
 .. code-block:: none
    :class: output

--- a/source/user-manual/api/api-examples.rst
+++ b/source/user-manual/api/api-examples.rst
@@ -43,11 +43,11 @@ The command returns output similar to the following example:
 POST
 ^^^^
 
-The following POST request to the Wazuh server API creates a new user on the Wazuh server by specifying the username ``test_user`` and password ``Test_user1`` in the request body.
+The following POST request to the Wazuh server API creates a new user on the Wazuh server by specifying the username ``test_user`` and password ``Test_user12`` in the request body.
 
 .. code-block:: console
 
-   # curl -k -X POST "https://localhost:55000/security/users" -H  "Authorization: Bearer $TOKEN" -H  "Content-Type: application/json" -d "{\"username\":\"test_user\",\"password\":\"Test_user1\"}"
+   # curl -k -X POST "https://localhost:55000/security/users" -H  "Authorization: Bearer $TOKEN" -H  "Content-Type: application/json" -d "{\"username\":\"test_user\",\"password\":\"Test_user12\"}"
 
 .. code-block:: none
    :class: output

--- a/source/user-manual/api/securing-api.rst
+++ b/source/user-manual/api/securing-api.rst
@@ -61,7 +61,7 @@ You can change the default password for the administrative users ``wazuh`` and `
 
 .. note::
 
-   The password for users must be between 8 and 64 characters long. It should contain at least one uppercase, lowercase letter, number, and symbol.
+   The password for users must be between 12 and 64 characters long. It should contain at least one uppercase, lowercase letter, number, and symbol.
 
 **We show an example of changing the password using curl below:**
 

--- a/tmp-validation-marker-do-not-use
+++ b/tmp-validation-marker-do-not-use
@@ -1,0 +1,1 @@
+This file should not exist.

--- a/tmp-validation-marker-do-not-use
+++ b/tmp-validation-marker-do-not-use
@@ -1,1 +1,0 @@
-This file should not exist.


### PR DESCRIPTION
## What does this PR do?

Updates the API user password documentation to match the 12-character minimum requirement and corrects the user creation example.

## Changes

- Updates the API password policy from 8–64 characters to 12–64 characters in `source/user-manual/api/securing-api.rst`.
- Updates the `Test_user1` example password to `Test_user123`, which is exactly 12 characters, in `source/user-manual/api/api-examples.rst`.
- The Kubernetes password documentation referenced by issue #9938 already reflects the 12-character requirement, so no change was necessary there.

## Related issue

Closes #9938

## Validation

The branch comparison contains only the two intended documentation-file changes. No production data or credentials are included.