### PR TITLE
Fix stray GDPR heading fragments, wrong-domain footer links, a certificate default value, and Google Workspace naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to this project will be documented in this file.
 - **Post-release**: Fixed missing or non-descriptive image alt text in the *Installation guide*, *Deployment options*, *Quickstart*, *Proof of concept guide*, *Integrations guide*, and *Active Response* documentation. ([#10057](https://github.com/wazuh/wazuh-documentation/pull/10057)) ([#10081](https://github.com/wazuh/wazuh-documentation/pull/10081)) ([#10082](https://github.com/wazuh/wazuh-documentation/pull/10082))
 - **Post-release**: Fixed the heading hierarchy in the *Using Wazuh for TSC compliance* documentation by converting two bolded subtopics into real H2 sections. ([#10060](https://github.com/wazuh/wazuh-documentation/pull/10060))
 - **Post-release**: Fixed third-party brand-name casing inconsistencies (CloudTrail, VirusTotal, PyInstaller) in the *Proof of concept guide* documentation. ([#10087](https://github.com/wazuh/wazuh-documentation/pull/10087))
+- **Post-release**: Fixed a stray, garbled label fragment left in the *GDPR* compliance documentation's page titles, which also affected the sitewide sidebar navigation. ([#10090](https://github.com/wazuh/wazuh-documentation/pull/10090))
+- **Post-release**: Fixed the shared site footer's *Getting started* and *Installation guide* links, which pointed at the wrong domain. ([#10090](https://github.com/wazuh/wazuh-documentation/pull/10090))
+- **Post-release**: Corrected the `<certificate>` configuration option's stated default value in the *Indexer integration* documentation. ([#10090](https://github.com/wazuh/wazuh-documentation/pull/10090))
+- **Post-release**: Updated the *User administration* documentation to name the Google identity provider integration by its full product name, Google Workspace. ([#10090](https://github.com/wazuh/wazuh-documentation/pull/10090))
 
 ## [v4.14.6]
 

--- a/source/_themes/wazuh_doc_theme_v3/template-parts/footer.html
+++ b/source/_themes/wazuh_doc_theme_v3/template-parts/footer.html
@@ -50,8 +50,8 @@
                 <div class="footer-title">Documentation</div>
                 <ul>
                   <li><a href="{{ theme_wazuh_doc_url + '/current/quickstart.html' }}">Quickstart</a></li>
-                  <li><a href="{{ theme_wazuh_web_url + '/current/getting-started/index.html' }}">Getting started</a></li>
-                  <li><a href="{{ theme_wazuh_web_url + '/current/installation-guide/index.html' }}">Installation guide</a></li>
+                  <li><a href="{{ theme_wazuh_doc_url + '/current/getting-started/index.html' }}">Getting started</a></li>
+                  <li><a href="{{ theme_wazuh_doc_url + '/current/installation-guide/index.html' }}">Installation guide</a></li>
                 </ul>
               </div>
             </div>

--- a/source/compliance/gdpr/gdpr-II.rst
+++ b/source/compliance/gdpr/gdpr-II.rst
@@ -3,8 +3,8 @@
 .. meta::
   :description: Check out this section to learn more about how to use Wazuh for GDPR II (The General Data Protection Regulation of the European Union). 
   
-GDPR II, Principles <gdpr_II>
-=============================
+GDPR II, Principles
+===================
 
 This chapter describes the GDPR requirements for processing personal data.
 

--- a/source/compliance/gdpr/gdpr-III.rst
+++ b/source/compliance/gdpr/gdpr-III.rst
@@ -3,8 +3,8 @@
 .. meta::
   :description: Check out this section to learn more about how to use Wazuh for GDPR III (The General Data Protection Regulation of the European Union). 
   
-GDPR III, Rights of the data subject <gdpr_III>
-===============================================
+GDPR III, Rights of the data subject
+====================================
 
 In this chapter, the GDPR sets out individuals' rights regarding the management of their personal data by third parties.
 

--- a/source/compliance/gdpr/gdpr-IV.rst
+++ b/source/compliance/gdpr/gdpr-IV.rst
@@ -3,8 +3,8 @@
 .. meta::
   :description: Check out this section to learn more about how to use Wazuh for GDPR IV (The General Data Protection Regulation of the European Union). 
   
-GDPR IV, Controller and processor <gdpr_IV>
-===========================================
+GDPR IV, Controller and processor
+=================================
 
 In this chapter, the GDPR sets out requirements for managing, controlling, and processing personal data.
 

--- a/source/user-manual/manager/indexer-integration.rst
+++ b/source/user-manual/manager/indexer-integration.rst
@@ -138,7 +138,7 @@ Where:
 -  ``<ssl>`` specifies the configuration options for the SSL parameters.
 -  ``<certificate_authorities>`` specifies a list of root certificate file paths for verification. Use the ``ca`` option for setting up each CA certificate file path.
 -  ``<ca>`` specifies the root CA certificate for HTTPS server verifications. The default value is ``/etc/filebeat/certs/root-ca.pem``. The possible value is any valid CA certificate.
--  ``<certificate>`` specifies the path to the Filebeat SSL certificate. The default value is ``/etc/filebeat/certs/filebeat-key.pem``. The possible value is any valid key.
+-  ``<certificate>`` specifies the path to the Filebeat SSL certificate. The default value is ``/etc/filebeat/certs/filebeat.pem``. The possible value is any valid key.
 -  ``<key>`` specifies the certificate key used for authentication. The default value is ``/etc/filebeat/certs/filebeat-key.pem``. The possible value is any valid key.
 
 You can learn more about the available configuration options in the :doc:`indexer </user-manual/reference/ossec-conf/indexer>` section of the reference guide.

--- a/source/user-manual/user-administration/index.rst
+++ b/source/user-manual/user-administration/index.rst
@@ -12,7 +12,7 @@ In the password management section, you can find instructions on how to use the 
 
 The RBAC section provides instructions for creating Wazuh indexer users, also known as internal users, assigning them different roles, and mapping them to the Wazuh server API. Find out how to create an admin user, a read-only user, a custom user, and a user with permission to read and manage only a group of agents.
 
-In the single sign-on section, you can find instructions on how to integrate Wazuh with different Identity Providers to implement Single Sign-On. Find instructions for Okta, Microsoft Entra ID, PingOne, Google, Jumpcloud, OneLogin, and Keycloak.
+In the single sign-on section, you can find instructions on how to integrate Wazuh with different Identity Providers to implement Single Sign-On. Find instructions for Okta, Microsoft Entra ID, PingOne, Google Workspace, Jumpcloud, OneLogin, and Keycloak.
 
 In the Active Directory and LDAP integration section, you can find instructions on how to integrate Wazuh with Active Directory/LDAP to authenticate and authorize users.
 


### PR DESCRIPTION
## Description
Four independent mechanical fixes surfaced by the SEO/AEO/GEO audit (issue #883), each verified against its own ground truth before editing: (1) removed a stray, garbled `<gdpr_x>` fragment left in the H1 heading of the three GDPR pages, which was also leaking into the sitewide sidebar nav; (2) fixed the shared site footer's "Getting started"/"Installation guide" links, which pointed at the marketing domain (`wazuh.com`, 404) instead of `documentation.wazuh.com` — verified with a full clean rebuild and confirmed across all 711 built pages; (3) corrected the `<certificate>` config option's stated default value in the Wazuh indexer connector docs, which had been copy-pasted from the `<key>` option's default and contradicted the adjacent code example; (4) named the Google identity-provider integration by its full product name, "Google Workspace," matching the linked page's own title.

🤖 Drafted by Claude

## Documentation compilation
- [x] Verify that documentation compiles without warnings.

## Changelog
- [ ] Update `CHANGELOG.md`.

## Web optimization & code formatting
- Page references
  - [ ] Update `/_static/js/redirects.js` if necessary ([guide](https://github.com/wazuh/wazuh-documentation/blob/master/NEW_RELEASE.md)).
  - [ ] Update `/llms.txt` if necessary.
- [x] Add or update meta descriptions.
- [x] Use three-space indentation in `.rst` files.

## Writing style
- [x] Use **bold** for UI elements, _italics_ for key terms and emphasis, and `code` font for Bash commands, file names, REST paths, and code.
- [x] Follow present tense, active voice, and a semi-formal tone.
- [x] Write short, clear, and concise sentences.
